### PR TITLE
feat: add Gemini CLI and Kiro CLI adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Type to search. Results update in real-time with hybrid ranking: FTS5 keyword ma
 
 - `Tab` — cycle filters (source → time → sort)
 - `Enter` — open full conversation
+- `Ctrl+R` — resume the selected session in its original CLI (see [Resume](#resume) below)
 - `Ctrl+S` — settings (toggle sources, sync window)
 - `q` / `Esc` — back / quit
 
@@ -40,8 +41,10 @@ In conversation view:
 
 - `j` / `k` — scroll messages
 - `g` / `G` — jump to first / last message
+- `/` — search within the conversation; `n` / `N` — next / previous match
 - `c` — copy current message to clipboard
 - `e` — export session to file
+- `Ctrl+R` — resume this session in its original CLI
 
 ### CLI Search
 
@@ -52,15 +55,25 @@ recall search "refactor" --source cc --time 7d
 
 ## Supported Sources
 
-| Source | Label | Data Location |
-|--------|-------|---------------|
-| Claude Code | CC | `~/.claude/projects/`, `~/.claude/transcripts/` |
-| OpenCode | OC | `~/.local/share/opencode/opencode.db` |
-| Codex | CDX | `~/.codex/sessions/` |
-| Gemini CLI | GEM | `~/.gemini/tmp/*/chats/` |
-| Kiro CLI | KIRO | `<data_dir>/kiro-cli/data.sqlite3` |
+| Source | Label | Data Location | Resume |
+|--------|-------|---------------|--------|
+| Claude Code | CC | `~/.claude/projects/`, `~/.claude/transcripts/` | yes |
+| OpenCode | OC | `~/.local/share/opencode/opencode.db` | yes |
+| Codex | CDX | `~/.codex/sessions/` | yes |
+| Gemini CLI | GEM | `~/.gemini/tmp/*/chats/` | no |
+| Kiro CLI | KIRO | `<data_dir>/kiro-cli/data.sqlite3` | no |
 
 Missing tools are skipped automatically.
+
+### Resume
+
+`Ctrl+R` on a selected session re-launches its original CLI to continue the
+conversation. Sources marked `no` above don't support this: their CLIs do not
+expose a way to resume a specific conversation by ID. Gemini CLI's `--resume`
+flag takes `latest` or an index from `--list-sessions` rather than the internal
+session ID. Kiro CLI's `chat --resume` only rewinds to the most recent
+conversation in the current directory, with no per-session selector. Recall
+surfaces a status message instead of launching the wrong conversation.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recall
 
-Search all your AI coding sessions in one place. Recall indexes conversations from Claude Code, OpenCode, and Codex into a local SQLite database, then lets you search them with a fast TUI powered by hybrid FTS + semantic retrieval.
+Search all your AI coding sessions in one place. Recall indexes conversations from Claude Code, OpenCode, Codex, Gemini CLI, and Kiro CLI into a local SQLite database, then lets you search them with a fast TUI powered by hybrid FTS + semantic retrieval.
 
 [![Recall TUI](recall.png)](https://asciinema.org/a/909453)
 
@@ -57,6 +57,8 @@ recall search "refactor" --source cc --time 7d
 | Claude Code | CC | `~/.claude/projects/`, `~/.claude/transcripts/` |
 | OpenCode | OC | `~/.local/share/opencode/opencode.db` |
 | Codex | CDX | `~/.codex/sessions/` |
+| Gemini CLI | GEM | `~/.gemini/tmp/*/chats/` |
+| Kiro CLI | KIRO | `<data_dir>/kiro-cli/data.sqlite3` |
 
 Missing tools are skipped automatically.
 

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -1,0 +1,162 @@
+use std::fs;
+
+use serde_json::Value;
+use tracing::debug;
+use walkdir::WalkDir;
+
+use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::types::Role;
+
+pub struct GeminiAdapter;
+
+impl SourceAdapter for GeminiAdapter {
+    fn id(&self) -> &str {
+        "gemini-cli"
+    }
+    fn label(&self) -> &str {
+        "GEM"
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+
+        // Gemini CLI stores sessions under ~/.gemini/tmp/{project}/chats/
+        let gemini_tmp = home.join(".gemini/tmp");
+        if !gemini_tmp.exists() {
+            debug!("~/.gemini/tmp not found, skipping Gemini CLI");
+            return Ok(vec![]);
+        }
+
+        let mut sessions = Vec::new();
+
+        for entry in WalkDir::new(&gemini_tmp).into_iter().filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if !path.is_file() {
+                continue;
+            }
+            // Only parse files inside a "chats" directory
+            if !path.parent().is_some_and(|p| p.file_name().is_some_and(|n| n == "chats")) {
+                continue;
+            }
+
+            match parse_gemini_session(path) {
+                Ok(Some(session)) => sessions.push(session),
+                Ok(None) => {}
+                Err(e) => {
+                    debug!("failed to parse gemini session {}: {e}", path.display());
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+}
+
+fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSession>> {
+    let content = fs::read_to_string(path)?;
+    let doc: Value = serde_json::from_str(&content)?;
+
+    let session_id = doc
+        .get("sessionId")
+        .and_then(|s| s.as_str())
+        .unwrap_or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+        })
+        .to_string();
+
+    let started_at = doc
+        .get("startTime")
+        .and_then(|t| t.as_str())
+        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or(0);
+
+    let updated_at = doc
+        .get("lastUpdated")
+        .and_then(|t| t.as_str())
+        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+        .map(|dt| dt.timestamp_millis());
+
+    // Derive project directory from path: ~/.gemini/tmp/{project}/chats/session.json
+    let directory = path
+        .parent() // chats/
+        .and_then(|p| p.parent()) // {project}/
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(String::from);
+
+    let messages_arr = match doc.get("messages").and_then(|m| m.as_array()) {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut messages = Vec::new();
+
+    for msg in messages_arr {
+        let msg_type = msg.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let role = match msg_type {
+            "user" => Role::User,
+            "gemini" => Role::Assistant,
+            _ => continue,
+        };
+
+        let timestamp = msg
+            .get("timestamp")
+            .and_then(|t| t.as_str())
+            .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+            .map(|dt| dt.timestamp_millis());
+
+        // User messages have content as array of {text}, assistant has content as string
+        let content = match role {
+            Role::User => extract_user_content(msg.get("content")),
+            Role::Assistant => msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string(),
+        };
+
+        if content.is_empty() {
+            continue;
+        }
+
+        messages.push(RawMessage {
+            role,
+            content,
+            timestamp,
+        });
+    }
+
+    if messages.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(RawSession {
+        source_id: session_id,
+        directory,
+        started_at,
+        updated_at,
+        entrypoint: None,
+        messages,
+    }))
+}
+
+/// Extract text from user content array: [{"text": "..."}, ...]
+fn extract_user_content(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::Array(arr)) => {
+            let parts: Vec<&str> = arr
+                .iter()
+                .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                .collect();
+            parts.join("\n")
+        }
+        Some(Value::String(s)) => s.clone(),
+        _ => String::new(),
+    }
+}

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::Role;
 
 pub struct GeminiAdapter;
@@ -16,6 +16,10 @@ impl SourceAdapter for GeminiAdapter {
     }
     fn label(&self) -> &str {
         "GEM"
+    }
+
+    fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        None
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -38,7 +38,7 @@ impl SourceAdapter for GeminiAdapter {
                 continue;
             }
             // Only parse files inside a "chats" directory
-            if !path.parent().is_some_and(|p| p.file_name().is_some_and(|n| n == "chats")) {
+            if path.parent().is_none_or(|p| p.file_name().is_none_or(|n| n != "chats")) {
                 continue;
             }
 
@@ -62,11 +62,7 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
     let session_id = doc
         .get("sessionId")
         .and_then(|s| s.as_str())
-        .unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-        })
+        .unwrap_or_else(|| path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown"))
         .to_string();
 
     let started_at = doc
@@ -114,22 +110,16 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
         // User messages have content as array of {text}, assistant has content as string
         let content = match role {
             Role::User => extract_user_content(msg.get("content")),
-            Role::Assistant => msg
-                .get("content")
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string(),
+            Role::Assistant => {
+                msg.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string()
+            }
         };
 
         if content.is_empty() {
             continue;
         }
 
-        messages.push(RawMessage {
-            role,
-            content,
-            timestamp,
-        });
+        messages.push(RawMessage { role, content, timestamp });
     }
 
     if messages.is_empty() {
@@ -150,10 +140,8 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
 fn extract_user_content(content: Option<&Value>) -> String {
     match content {
         Some(Value::Array(arr)) => {
-            let parts: Vec<&str> = arr
-                .iter()
-                .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
-                .collect();
+            let parts: Vec<&str> =
+                arr.iter().filter_map(|item| item.get("text").and_then(|t| t.as_str())).collect();
             parts.join("\n")
         }
         Some(Value::String(s)) => s.clone(),

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use serde_json::Value;
 use tracing::debug;
@@ -20,7 +21,6 @@ impl SourceAdapter for GeminiAdapter {
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
 
-        // Gemini CLI stores sessions under ~/.gemini/tmp/{project}/chats/
         let gemini_tmp = home.join(".gemini/tmp");
         if !gemini_tmp.exists() {
             debug!("~/.gemini/tmp not found, skipping Gemini CLI");
@@ -37,12 +37,11 @@ impl SourceAdapter for GeminiAdapter {
             if !path.is_file() {
                 continue;
             }
-            // Only parse files inside a "chats" directory
             if path.parent().is_none_or(|p| p.file_name().is_none_or(|n| n != "chats")) {
                 continue;
             }
 
-            match parse_gemini_session(path) {
+            match parse_gemini_session_file(path) {
                 Ok(Some(session)) => sessions.push(session),
                 Ok(None) => {}
                 Err(e) => {
@@ -55,15 +54,17 @@ impl SourceAdapter for GeminiAdapter {
     }
 }
 
-fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSession>> {
+fn parse_gemini_session_file(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let content = fs::read_to_string(path)?;
-    let doc: Value = serde_json::from_str(&content)?;
+    let fallback_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown");
+    parse_gemini_session(&content, fallback_id)
+}
 
-    let session_id = doc
-        .get("sessionId")
-        .and_then(|s| s.as_str())
-        .unwrap_or_else(|| path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown"))
-        .to_string();
+pub fn parse_gemini_session(json: &str, fallback_id: &str) -> anyhow::Result<Option<RawSession>> {
+    let doc: Value = serde_json::from_str(json)?;
+
+    let session_id =
+        doc.get("sessionId").and_then(|s| s.as_str()).unwrap_or(fallback_id).to_string();
 
     let started_at = doc
         .get("startTime")
@@ -77,14 +78,6 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
         .and_then(|t| t.as_str())
         .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
         .map(|dt| dt.timestamp_millis());
-
-    // Derive project directory from path: ~/.gemini/tmp/{project}/chats/session.json
-    let directory = path
-        .parent() // chats/
-        .and_then(|p| p.parent()) // {project}/
-        .and_then(|p| p.file_name())
-        .and_then(|n| n.to_str())
-        .map(String::from);
 
     let messages_arr = match doc.get("messages").and_then(|m| m.as_array()) {
         Some(arr) => arr,
@@ -107,17 +100,20 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
             .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
             .map(|dt| dt.timestamp_millis());
 
-        // User messages have content as array of {text}, assistant has content as string
-        let content = match role {
-            Role::User => extract_user_content(msg.get("content")),
-            Role::Assistant => {
-                msg.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string()
-            }
+        let prose = msg.get("content").and_then(|c| c.as_str()).unwrap_or("").trim().to_string();
+
+        let tool_text = if matches!(role, Role::Assistant) {
+            extract_tool_calls(msg.get("toolCalls"))
+        } else {
+            String::new()
         };
 
-        if content.is_empty() {
-            continue;
-        }
+        let content = match (prose.is_empty(), tool_text.is_empty()) {
+            (true, true) => continue,
+            (false, true) => prose,
+            (true, false) => tool_text,
+            (false, false) => format!("{prose}\n{tool_text}"),
+        };
 
         messages.push(RawMessage { role, content, timestamp });
     }
@@ -128,7 +124,7 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
 
     Ok(Some(RawSession {
         source_id: session_id,
-        directory,
+        directory: None,
         started_at,
         updated_at,
         entrypoint: None,
@@ -136,15 +132,40 @@ fn parse_gemini_session(path: &std::path::Path) -> anyhow::Result<Option<RawSess
     }))
 }
 
-/// Extract text from user content array: [{"text": "..."}, ...]
-fn extract_user_content(content: Option<&Value>) -> String {
-    match content {
-        Some(Value::Array(arr)) => {
-            let parts: Vec<&str> =
-                arr.iter().filter_map(|item| item.get("text").and_then(|t| t.as_str())).collect();
-            parts.join("\n")
+fn extract_tool_calls(tool_calls: Option<&Value>) -> String {
+    let Some(arr) = tool_calls.and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    for call in arr {
+        let name = call.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+        let args = call
+            .get("args")
+            .map(|a| serde_json::to_string(a).unwrap_or_default())
+            .unwrap_or_default();
+        let result_text = extract_tool_result(call.get("result"));
+
+        let mut part = format!("[{name}] {args}");
+        if !result_text.is_empty() {
+            part.push_str(" -> ");
+            part.push_str(&result_text);
         }
-        Some(Value::String(s)) => s.clone(),
-        _ => String::new(),
+        parts.push(part);
     }
+    parts.join("\n")
+}
+
+fn extract_tool_result(result: Option<&Value>) -> String {
+    let Some(arr) = result.and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    for item in arr {
+        if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+            parts.push(text.to_string());
+        }
+    }
+    parts.join("\n")
 }

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::Role;
 
 pub struct KiroAdapter;
@@ -13,6 +13,10 @@ impl SourceAdapter for KiroAdapter {
     }
     fn label(&self) -> &str {
         "KIRO"
+    }
+
+    fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        None
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -1,0 +1,218 @@
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use tracing::debug;
+
+use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::types::Role;
+
+pub struct KiroAdapter;
+
+impl SourceAdapter for KiroAdapter {
+    fn id(&self) -> &str {
+        "kiro-cli"
+    }
+    fn label(&self) -> &str {
+        "KIRO"
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let db_path = kiro_db_path()?;
+
+        if !db_path.exists() {
+            debug!(
+                "Kiro CLI DB not found at {}, skipping",
+                db_path.display()
+            );
+            return Ok(vec![]);
+        }
+
+        let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+
+        // conversations_v2 schema:
+        //   key TEXT (cwd path), conversation_id TEXT, value TEXT (JSON),
+        //   created_at INTEGER (ms), updated_at INTEGER (ms)
+        let mut stmt = conn.prepare(
+            "SELECT key, conversation_id, value, created_at, updated_at
+             FROM conversations_v2
+             ORDER BY updated_at DESC",
+        )?;
+
+        let rows: Vec<(String, String, String, i64, i64)> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut sessions = Vec::new();
+
+        for (cwd, conversation_id, value_json, created_at, updated_at) in rows {
+            match parse_kiro_conversation(&conversation_id, &cwd, &value_json, created_at, updated_at)
+            {
+                Ok(Some(session)) => sessions.push(session),
+                Ok(None) => {}
+                Err(e) => {
+                    debug!(
+                        "failed to parse kiro conversation {}: {e}",
+                        conversation_id
+                    );
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+}
+
+fn kiro_db_path() -> anyhow::Result<std::path::PathBuf> {
+    // macOS: ~/Library/Application Support/kiro-cli/data.sqlite3
+    // Linux: ~/.local/share/kiro-cli/data.sqlite3
+    if cfg!(target_os = "macos") {
+        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+        Ok(home.join("Library/Application Support/kiro-cli/data.sqlite3"))
+    } else {
+        let data_dir =
+            dirs::data_dir().ok_or_else(|| anyhow::anyhow!("no data dir"))?;
+        Ok(data_dir.join("kiro-cli/data.sqlite3"))
+    }
+}
+
+fn parse_kiro_conversation(
+    conversation_id: &str,
+    cwd: &str,
+    value_json: &str,
+    created_at: i64,
+    updated_at: i64,
+) -> anyhow::Result<Option<RawSession>> {
+    let doc: Value = serde_json::from_str(value_json)?;
+
+    let history = match doc.get("history").and_then(|h| h.as_array()) {
+        Some(arr) => arr,
+        None => return Ok(None),
+    };
+
+    let mut messages = Vec::new();
+
+    for turn in history {
+        // Each turn has "user" and "assistant" objects
+        if let Some(user_obj) = turn.get("user") {
+            let content = extract_user_content(user_obj);
+            let timestamp = parse_kiro_timestamp(user_obj.get("timestamp"));
+
+            if !content.is_empty() {
+                messages.push(RawMessage {
+                    role: Role::User,
+                    content,
+                    timestamp,
+                });
+            }
+        }
+
+        if let Some(assistant_obj) = turn.get("assistant") {
+            let content = extract_assistant_content(assistant_obj);
+            // Assistant timestamp from request_metadata
+            let timestamp = turn
+                .get("request_metadata")
+                .and_then(|m| m.get("request_start_timestamp_ms"))
+                .and_then(|t| t.as_i64());
+
+            if !content.is_empty() {
+                messages.push(RawMessage {
+                    role: Role::Assistant,
+                    content,
+                    timestamp,
+                });
+            }
+        }
+    }
+
+    if messages.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(RawSession {
+        source_id: conversation_id.to_string(),
+        directory: Some(cwd.to_string()),
+        started_at: created_at,
+        updated_at: Some(updated_at),
+        entrypoint: None,
+        messages,
+    }))
+}
+
+/// Extract user prompt text from Kiro user object.
+/// Content can be: {"Prompt": {"prompt": "..."}} or {"ToolResult": {...}}
+fn extract_user_content(user_obj: &Value) -> String {
+    let content = match user_obj.get("content") {
+        Some(c) => c,
+        None => return String::new(),
+    };
+
+    // Most common: {"Prompt": {"prompt": "..."}}
+    if let Some(prompt_obj) = content.get("Prompt") {
+        if let Some(text) = prompt_obj.get("prompt").and_then(|p| p.as_str()) {
+            return text.to_string();
+        }
+    }
+
+    // Tool result: {"ToolResult": {"tool_use_id": "...", "content": [...]}}
+    if let Some(tool_result) = content.get("ToolResult") {
+        let tool_id = tool_result
+            .get("tool_use_id")
+            .and_then(|t| t.as_str())
+            .unwrap_or("tool");
+        if let Some(arr) = tool_result.get("content").and_then(|c| c.as_array()) {
+            let parts: Vec<String> = arr
+                .iter()
+                .filter_map(|item| {
+                    if let Some(text_obj) = item.get("text") {
+                        text_obj.get("text").and_then(|t| t.as_str()).map(String::from)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !parts.is_empty() {
+                return format!("[{tool_id}] {}", parts.join("\n"));
+            }
+        }
+    }
+
+    String::new()
+}
+
+/// Extract assistant response text from Kiro assistant object.
+/// Can be: {"Response": {"content": "..."}} or {"ToolUse": {...}}
+fn extract_assistant_content(assistant_obj: &Value) -> String {
+    // Response: {"Response": {"content": "..."}}
+    if let Some(response) = assistant_obj.get("Response") {
+        if let Some(text) = response.get("content").and_then(|c| c.as_str()) {
+            return text.to_string();
+        }
+    }
+
+    // ToolUse: {"ToolUse": {"name": "...", "input": {...}}}
+    if let Some(tool_use) = assistant_obj.get("ToolUse") {
+        let name = tool_use
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("tool");
+        if let Some(input) = tool_use.get("input") {
+            return format!("[{name}] {input}");
+        }
+    }
+
+    String::new()
+}
+
+fn parse_kiro_timestamp(ts: Option<&Value>) -> Option<i64> {
+    ts.and_then(|t| t.as_str())
+        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+        .map(|dt| dt.timestamp_millis())
+}

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -25,30 +25,44 @@ impl SourceAdapter for KiroAdapter {
 
         let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
 
-        // conversations_v2 schema:
-        //   key TEXT (cwd path), conversation_id TEXT, value TEXT (JSON),
-        //   created_at INTEGER (ms), updated_at INTEGER (ms)
+        let has_table = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='conversations_v2'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .is_ok();
+        if !has_table {
+            debug!("Kiro CLI DB missing conversations_v2 table, skipping");
+            return Ok(vec![]);
+        }
+
         let mut stmt = conn.prepare(
             "SELECT key, conversation_id, value, created_at, updated_at
              FROM conversations_v2
              ORDER BY updated_at DESC",
         )?;
 
-        let rows = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, i64>(4)?,
-                ))
-            })?
-            .filter_map(|r| r.ok());
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })?;
 
         let mut sessions = Vec::new();
 
-        for (cwd, conversation_id, value_json, created_at, updated_at) in rows {
+        for row in rows {
+            let (cwd, conversation_id, value_json, created_at, updated_at) = match row {
+                Ok(t) => t,
+                Err(e) => {
+                    debug!("failed to read kiro row: {e}");
+                    continue;
+                }
+            };
             match parse_kiro_conversation(
                 &conversation_id,
                 &cwd,
@@ -59,7 +73,7 @@ impl SourceAdapter for KiroAdapter {
                 Ok(Some(session)) => sessions.push(session),
                 Ok(None) => {}
                 Err(e) => {
-                    debug!("failed to parse kiro conversation {}: {e}", conversation_id);
+                    debug!("failed to parse kiro conversation {conversation_id}: {e}");
                 }
             }
         }
@@ -73,7 +87,7 @@ fn kiro_db_path() -> anyhow::Result<std::path::PathBuf> {
     Ok(data_dir.join("kiro-cli/data.sqlite3"))
 }
 
-fn parse_kiro_conversation(
+pub fn parse_kiro_conversation(
     conversation_id: &str,
     cwd: &str,
     value_json: &str,
@@ -90,11 +104,9 @@ fn parse_kiro_conversation(
     let mut messages = Vec::new();
 
     for turn in history {
-        // Each turn has "user" and "assistant" objects
         if let Some(user_obj) = turn.get("user") {
             let content = extract_user_content(user_obj);
             let timestamp = parse_kiro_timestamp(user_obj.get("timestamp"));
-
             if !content.is_empty() {
                 messages.push(RawMessage { role: Role::User, content, timestamp });
             }
@@ -102,12 +114,10 @@ fn parse_kiro_conversation(
 
         if let Some(assistant_obj) = turn.get("assistant") {
             let content = extract_assistant_content(assistant_obj);
-            // Assistant timestamp from request_metadata
             let timestamp = turn
                 .get("request_metadata")
                 .and_then(|m| m.get("request_start_timestamp_ms"))
                 .and_then(|t| t.as_i64());
-
             if !content.is_empty() {
                 messages.push(RawMessage { role: Role::Assistant, content, timestamp });
             }
@@ -128,59 +138,70 @@ fn parse_kiro_conversation(
     }))
 }
 
-/// Extract user prompt text from Kiro user object.
-/// Content can be: {"Prompt": {"prompt": "..."}} or {"ToolResult": {...}}
 fn extract_user_content(user_obj: &Value) -> String {
     let content = match user_obj.get("content") {
         Some(c) => c,
         None => return String::new(),
     };
 
-    // Most common: {"Prompt": {"prompt": "..."}}
     if let Some(prompt_obj) = content.get("Prompt")
         && let Some(text) = prompt_obj.get("prompt").and_then(|p| p.as_str())
     {
         return text.to_string();
     }
 
-    // Tool result: {"ToolResult": {"tool_use_id": "...", "content": [...]}}
-    if let Some(tool_result) = content.get("ToolResult") {
-        let tool_id = tool_result.get("tool_use_id").and_then(|t| t.as_str()).unwrap_or("tool");
-        if let Some(arr) = tool_result.get("content").and_then(|c| c.as_array()) {
-            let parts: Vec<String> = arr
-                .iter()
-                .filter_map(|item| {
-                    if let Some(text_obj) = item.get("text") {
-                        text_obj.get("text").and_then(|t| t.as_str()).map(String::from)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            if !parts.is_empty() {
-                return format!("[{tool_id}] {}", parts.join("\n"));
+    if let Some(tool_results) = content.get("ToolUseResults")
+        && let Some(arr) = tool_results.get("tool_use_results").and_then(|v| v.as_array())
+    {
+        let mut parts = Vec::new();
+        for result in arr {
+            let Some(inner) = result.get("content").and_then(|c| c.as_array()) else {
+                continue;
+            };
+            for item in inner {
+                if let Some(text) = item.get("Text").and_then(|t| t.as_str()) {
+                    parts.push(text.to_string());
+                } else if let Some(json_val) = item.get("Json")
+                    && let Ok(s) = serde_json::to_string(json_val)
+                {
+                    parts.push(s);
+                }
             }
+        }
+        if !parts.is_empty() {
+            return parts.join("\n");
         }
     }
 
     String::new()
 }
 
-/// Extract assistant response text from Kiro assistant object.
-/// Can be: {"Response": {"content": "..."}} or {"ToolUse": {...}}
 fn extract_assistant_content(assistant_obj: &Value) -> String {
-    // Response: {"Response": {"content": "..."}}
     if let Some(response) = assistant_obj.get("Response")
         && let Some(text) = response.get("content").and_then(|c| c.as_str())
     {
         return text.to_string();
     }
 
-    // ToolUse: {"ToolUse": {"name": "...", "input": {...}}}
     if let Some(tool_use) = assistant_obj.get("ToolUse") {
-        let name = tool_use.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
-        if let Some(input) = tool_use.get("input") {
-            return format!("[{name}] {input}");
+        let mut parts = Vec::new();
+        if let Some(prose) = tool_use.get("content").and_then(|c| c.as_str())
+            && !prose.is_empty()
+        {
+            parts.push(prose.to_string());
+        }
+        if let Some(tool_uses) = tool_use.get("tool_uses").and_then(|v| v.as_array()) {
+            for tu in tool_uses {
+                let name = tu.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+                let args = tu
+                    .get("args")
+                    .map(|a| serde_json::to_string(a).unwrap_or_default())
+                    .unwrap_or_default();
+                parts.push(format!("[{name}] {args}"));
+            }
+        }
+        if !parts.is_empty() {
+            return parts.join("\n");
         }
     }
 

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -19,10 +19,7 @@ impl SourceAdapter for KiroAdapter {
         let db_path = kiro_db_path()?;
 
         if !db_path.exists() {
-            debug!(
-                "Kiro CLI DB not found at {}, skipping",
-                db_path.display()
-            );
+            debug!("Kiro CLI DB not found at {}, skipping", db_path.display());
             return Ok(vec![]);
         }
 
@@ -37,31 +34,32 @@ impl SourceAdapter for KiroAdapter {
              ORDER BY updated_at DESC",
         )?;
 
-        let rows: Vec<(String, String, String, i64, i64)> = stmt
+        let rows = stmt
             .query_map([], |row| {
                 Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
                 ))
             })?
-            .filter_map(|r| r.ok())
-            .collect();
+            .filter_map(|r| r.ok());
 
         let mut sessions = Vec::new();
 
         for (cwd, conversation_id, value_json, created_at, updated_at) in rows {
-            match parse_kiro_conversation(&conversation_id, &cwd, &value_json, created_at, updated_at)
-            {
+            match parse_kiro_conversation(
+                &conversation_id,
+                &cwd,
+                &value_json,
+                created_at,
+                updated_at,
+            ) {
                 Ok(Some(session)) => sessions.push(session),
                 Ok(None) => {}
                 Err(e) => {
-                    debug!(
-                        "failed to parse kiro conversation {}: {e}",
-                        conversation_id
-                    );
+                    debug!("failed to parse kiro conversation {}: {e}", conversation_id);
                 }
             }
         }
@@ -71,16 +69,8 @@ impl SourceAdapter for KiroAdapter {
 }
 
 fn kiro_db_path() -> anyhow::Result<std::path::PathBuf> {
-    // macOS: ~/Library/Application Support/kiro-cli/data.sqlite3
-    // Linux: ~/.local/share/kiro-cli/data.sqlite3
-    if cfg!(target_os = "macos") {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-        Ok(home.join("Library/Application Support/kiro-cli/data.sqlite3"))
-    } else {
-        let data_dir =
-            dirs::data_dir().ok_or_else(|| anyhow::anyhow!("no data dir"))?;
-        Ok(data_dir.join("kiro-cli/data.sqlite3"))
-    }
+    let data_dir = dirs::data_dir().ok_or_else(|| anyhow::anyhow!("no data dir"))?;
+    Ok(data_dir.join("kiro-cli/data.sqlite3"))
 }
 
 fn parse_kiro_conversation(
@@ -106,11 +96,7 @@ fn parse_kiro_conversation(
             let timestamp = parse_kiro_timestamp(user_obj.get("timestamp"));
 
             if !content.is_empty() {
-                messages.push(RawMessage {
-                    role: Role::User,
-                    content,
-                    timestamp,
-                });
+                messages.push(RawMessage { role: Role::User, content, timestamp });
             }
         }
 
@@ -123,11 +109,7 @@ fn parse_kiro_conversation(
                 .and_then(|t| t.as_i64());
 
             if !content.is_empty() {
-                messages.push(RawMessage {
-                    role: Role::Assistant,
-                    content,
-                    timestamp,
-                });
+                messages.push(RawMessage { role: Role::Assistant, content, timestamp });
             }
         }
     }
@@ -155,18 +137,15 @@ fn extract_user_content(user_obj: &Value) -> String {
     };
 
     // Most common: {"Prompt": {"prompt": "..."}}
-    if let Some(prompt_obj) = content.get("Prompt") {
-        if let Some(text) = prompt_obj.get("prompt").and_then(|p| p.as_str()) {
-            return text.to_string();
-        }
+    if let Some(prompt_obj) = content.get("Prompt")
+        && let Some(text) = prompt_obj.get("prompt").and_then(|p| p.as_str())
+    {
+        return text.to_string();
     }
 
     // Tool result: {"ToolResult": {"tool_use_id": "...", "content": [...]}}
     if let Some(tool_result) = content.get("ToolResult") {
-        let tool_id = tool_result
-            .get("tool_use_id")
-            .and_then(|t| t.as_str())
-            .unwrap_or("tool");
+        let tool_id = tool_result.get("tool_use_id").and_then(|t| t.as_str()).unwrap_or("tool");
         if let Some(arr) = tool_result.get("content").and_then(|c| c.as_array()) {
             let parts: Vec<String> = arr
                 .iter()
@@ -191,18 +170,15 @@ fn extract_user_content(user_obj: &Value) -> String {
 /// Can be: {"Response": {"content": "..."}} or {"ToolUse": {...}}
 fn extract_assistant_content(assistant_obj: &Value) -> String {
     // Response: {"Response": {"content": "..."}}
-    if let Some(response) = assistant_obj.get("Response") {
-        if let Some(text) = response.get("content").and_then(|c| c.as_str()) {
-            return text.to_string();
-        }
+    if let Some(response) = assistant_obj.get("Response")
+        && let Some(text) = response.get("content").and_then(|c| c.as_str())
+    {
+        return text.to_string();
     }
 
     // ToolUse: {"ToolUse": {"name": "...", "input": {...}}}
     if let Some(tool_use) = assistant_obj.get("ToolUse") {
-        let name = tool_use
-            .get("name")
-            .and_then(|n| n.as_str())
-            .unwrap_or("tool");
+        let name = tool_use.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
         if let Some(input) = tool_use.get("input") {
             return format!("[{name}] {input}");
         }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,5 +1,7 @@
 pub mod claude_code;
 pub mod codex;
+pub mod gemini;
+pub mod kiro;
 pub mod opencode;
 
 use crate::types::Role;
@@ -30,6 +32,8 @@ pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(claude_code::ClaudeCodeAdapter),
         Box::new(opencode::OpenCodeAdapter),
         Box::new(codex::CodexAdapter),
+        Box::new(gemini::GeminiAdapter),
+        Box::new(kiro::KiroAdapter),
     ]
 }
 
@@ -38,5 +42,7 @@ pub fn source_labels() -> Vec<(String, String)> {
         ("claude-code".to_string(), "CC".to_string()),
         ("opencode".to_string(), "OC".to_string()),
         ("codex".to_string(), "CDX".to_string()),
+        ("gemini-cli".to_string(), "GEM".to_string()),
+        ("kiro-cli".to_string(), "KIRO".to_string()),
     ]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,16 +53,14 @@ impl SyncWindow {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AppConfig {
-    pub enabled_sources: Vec<String>,
+    #[serde(default)]
+    pub disabled_sources: Vec<String>,
+    #[serde(default, rename = "enabled_sources", skip_serializing_if = "Vec::is_empty")]
+    legacy_enabled_sources: Vec<String>,
+    #[serde(default)]
     pub sync_window: SyncWindow,
-}
-
-impl Default for AppConfig {
-    fn default() -> Self {
-        Self { enabled_sources: Vec::new(), sync_window: SyncWindow::All }
-    }
 }
 
 impl AppConfig {
@@ -73,9 +71,7 @@ impl AppConfig {
         }
 
         let content = std::fs::read_to_string(path)?;
-        let mut config: Self = serde_json::from_str(&content)?;
-        config.enabled_sources.sort();
-        config.enabled_sources.dedup();
+        let config: Self = serde_json::from_str(&content)?;
         Ok(config)
     }
 
@@ -93,20 +89,20 @@ impl AppConfig {
     }
 
     pub fn normalize_sources(&mut self, known_sources: &[(String, String)]) {
-        if self.enabled_sources.is_empty() {
-            self.enabled_sources = known_sources.iter().map(|(id, _)| id.clone()).collect();
-        } else {
-            self.enabled_sources.retain(|id| known_sources.iter().any(|(known, _)| known == id));
-            if self.enabled_sources.is_empty() {
-                self.enabled_sources = known_sources.iter().map(|(id, _)| id.clone()).collect();
-            }
+        self.legacy_enabled_sources.clear();
+
+        self.disabled_sources.retain(|id| known_sources.iter().any(|(known, _)| known == id));
+        self.disabled_sources.sort();
+        self.disabled_sources.dedup();
+
+        let enabled_count = known_sources.len().saturating_sub(self.disabled_sources.len());
+        if enabled_count == 0 {
+            self.disabled_sources.clear();
         }
-        self.enabled_sources.sort();
-        self.enabled_sources.dedup();
     }
 
     pub fn is_source_enabled(&self, source_id: &str) -> bool {
-        self.enabled_sources.iter().any(|id| id == source_id)
+        !self.disabled_sources.iter().any(|id| id == source_id)
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -537,15 +537,17 @@ impl App {
             self.config.sync_window = self.config.sync_window.next();
         } else if let Some((source_id, _)) = self.all_sources.get(self.settings_selected - 1) {
             if self.config.is_source_enabled(source_id) {
-                if self.config.enabled_sources.len() == 1 {
+                let enabled_count =
+                    self.all_sources.len().saturating_sub(self.config.disabled_sources.len());
+                if enabled_count <= 1 {
                     self.status_message = Some("At least one source must stay enabled".to_string());
                     return;
                 }
-                self.config.enabled_sources.retain(|id| id != source_id);
+                self.config.disabled_sources.push(source_id.clone());
+                self.config.disabled_sources.sort();
+                self.config.disabled_sources.dedup();
             } else {
-                self.config.enabled_sources.push(source_id.clone());
-                self.config.enabled_sources.sort();
-                self.config.enabled_sources.dedup();
+                self.config.disabled_sources.retain(|id| id != source_id);
             }
         }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,6 @@
 use recall::adapters::gemini::parse_gemini_session;
 use recall::adapters::kiro::parse_kiro_conversation;
+use recall::config::AppConfig;
 use recall::db::schema;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::Store;
@@ -538,4 +539,84 @@ fn kiro_parser_tool_use_results_text_and_json() {
 fn kiro_parser_empty_history_returns_none() {
     let json = r#"{"history": []}"#;
     assert!(parse_kiro_conversation("c", "/proj", json, 0, 0).unwrap().is_none());
+}
+
+#[test]
+fn config_migrates_legacy_enabled_sources() {
+    let legacy_json = r#"{
+        "enabled_sources": ["claude-code", "codex", "opencode"],
+        "sync_window": "week"
+    }"#;
+    let mut config: AppConfig = serde_json::from_str(legacy_json).unwrap();
+
+    let known = vec![
+        ("claude-code".to_string(), "CC".to_string()),
+        ("opencode".to_string(), "OC".to_string()),
+        ("codex".to_string(), "CDX".to_string()),
+        ("gemini-cli".to_string(), "GEM".to_string()),
+        ("kiro-cli".to_string(), "KIRO".to_string()),
+    ];
+    config.normalize_sources(&known);
+
+    assert!(config.is_source_enabled("claude-code"));
+    assert!(config.is_source_enabled("opencode"));
+    assert!(config.is_source_enabled("codex"));
+    assert!(
+        config.is_source_enabled("gemini-cli"),
+        "newly-added adapter should be enabled after migration"
+    );
+    assert!(
+        config.is_source_enabled("kiro-cli"),
+        "newly-added adapter should be enabled after migration"
+    );
+
+    let round_tripped = serde_json::to_string(&config).unwrap();
+    assert!(
+        !round_tripped.contains("enabled_sources"),
+        "legacy field must not be re-serialized: {round_tripped}"
+    );
+}
+
+#[test]
+fn config_disables_persist_across_reloads() {
+    let mut known = vec![
+        ("claude-code".to_string(), "CC".to_string()),
+        ("gemini-cli".to_string(), "GEM".to_string()),
+    ];
+
+    let mut config = AppConfig::default();
+    config.normalize_sources(&known);
+    config.disabled_sources.push("gemini-cli".to_string());
+
+    let json = serde_json::to_string(&config).unwrap();
+    let mut reloaded: AppConfig = serde_json::from_str(&json).unwrap();
+    reloaded.normalize_sources(&known);
+
+    assert!(reloaded.is_source_enabled("claude-code"));
+    assert!(
+        !reloaded.is_source_enabled("gemini-cli"),
+        "explicit disable must survive a save/load cycle"
+    );
+
+    known.push(("kiro-cli".to_string(), "KIRO".to_string()));
+    reloaded.normalize_sources(&known);
+    assert!(
+        reloaded.is_source_enabled("kiro-cli"),
+        "a brand new adapter should default to enabled"
+    );
+    assert!(
+        !reloaded.is_source_enabled("gemini-cli"),
+        "previously disabled adapter must stay disabled"
+    );
+}
+
+#[test]
+fn config_drops_obsolete_disabled_entries() {
+    let mut config = AppConfig::default();
+    config.disabled_sources = vec!["ghost-adapter".to_string(), "claude-code".to_string()];
+    let known = vec![("claude-code".to_string(), "CC".to_string())];
+    config.normalize_sources(&known);
+
+    assert!(!config.disabled_sources.iter().any(|id| id == "ghost-adapter"));
+    assert!(config.is_source_enabled("claude-code"), "cleared to avoid zero-source state");
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,3 +1,5 @@
+use recall::adapters::gemini::parse_gemini_session;
+use recall::adapters::kiro::parse_kiro_conversation;
 use recall::db::schema;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::Store;
@@ -344,4 +346,196 @@ fn sync_detects_updated_timestamp() {
     let changed = old_msg_count != new_msg_count
         || (new_updated_at.is_some() && new_updated_at != old_updated_at);
     assert!(changed, "sync must detect updated_at change even when message count is same");
+}
+
+#[test]
+fn gemini_parser_plain_conversation() {
+    let json = r#"{
+        "sessionId": "abc-123",
+        "projectHash": "deadbeef",
+        "startTime": "2025-11-13T13:48:00.000Z",
+        "lastUpdated": "2025-11-13T14:00:00.000Z",
+        "messages": [
+            {"id": 0, "type": "user", "content": "hello", "timestamp": "2025-11-13T13:48:05.000Z"},
+            {"id": 1, "type": "gemini", "content": "hi there", "timestamp": "2025-11-13T13:48:10.000Z"}
+        ]
+    }"#;
+
+    let session = parse_gemini_session(json, "fallback").unwrap().unwrap();
+    assert_eq!(session.source_id, "abc-123");
+    assert_eq!(session.directory, None, "gemini has no resolvable cwd");
+    assert_eq!(session.messages.len(), 2);
+    assert!(matches!(session.messages[0].role, Role::User));
+    assert_eq!(session.messages[0].content, "hello");
+    assert!(matches!(session.messages[1].role, Role::Assistant));
+    assert_eq!(session.messages[1].content, "hi there");
+}
+
+#[test]
+fn gemini_parser_indexes_tool_calls() {
+    let json = r##"{
+        "sessionId": "xyz",
+        "startTime": "2025-11-13T13:48:00.000Z",
+        "messages": [
+            {"id": 0, "type": "user", "content": "read README", "timestamp": "2025-11-13T13:48:00.000Z"},
+            {
+                "id": 1,
+                "type": "gemini",
+                "content": "Let me read the file.",
+                "timestamp": "2025-11-13T13:48:05.000Z",
+                "toolCalls": [{
+                    "id": "t1",
+                    "name": "read_file",
+                    "args": {"path": "/tmp/README.md"},
+                    "result": [{"text": "# My Project\nHello world."}]
+                }]
+            }
+        ]
+    }"##;
+
+    let session = parse_gemini_session(json, "fallback").unwrap().unwrap();
+    let assistant = &session.messages[1];
+    assert!(
+        assistant.content.contains("Let me read the file"),
+        "prose preserved: {}",
+        assistant.content
+    );
+    assert!(assistant.content.contains("[read_file]"), "tool name indexed: {}", assistant.content);
+    assert!(
+        assistant.content.contains("/tmp/README.md"),
+        "tool args indexed: {}",
+        assistant.content
+    );
+    assert!(
+        assistant.content.contains("Hello world"),
+        "tool result indexed: {}",
+        assistant.content
+    );
+}
+
+#[test]
+fn gemini_parser_skips_info_messages() {
+    let json = r#"{
+        "sessionId": "s",
+        "startTime": "2025-11-13T13:48:00.000Z",
+        "messages": [
+            {"id": 0, "type": "info", "content": "CLI update available"},
+            {"id": 1, "type": "user", "content": "hi", "timestamp": "2025-11-13T13:48:05.000Z"}
+        ]
+    }"#;
+
+    let session = parse_gemini_session(json, "fallback").unwrap().unwrap();
+    assert_eq!(session.messages.len(), 1, "info messages should be skipped");
+    assert_eq!(session.messages[0].content, "hi");
+}
+
+#[test]
+fn gemini_parser_empty_returns_none() {
+    let json = r#"{"sessionId": "s", "messages": []}"#;
+    assert!(parse_gemini_session(json, "fallback").unwrap().is_none());
+}
+
+#[test]
+fn kiro_parser_prompt_and_response() {
+    let json = r#"{
+        "history": [{
+            "user": {
+                "content": {"Prompt": {"prompt": "how use skill"}},
+                "timestamp": "2026-04-11T00:34:50.549369+08:00"
+            },
+            "assistant": {
+                "Response": {"message_id": "m1", "content": "Skills are markdown files."}
+            },
+            "request_metadata": {"request_start_timestamp_ms": 1775838890550}
+        }]
+    }"#;
+
+    let session =
+        parse_kiro_conversation("conv1", "/Users/x/proj", json, 1000, 2000).unwrap().unwrap();
+    assert_eq!(session.source_id, "conv1");
+    assert_eq!(session.directory.as_deref(), Some("/Users/x/proj"));
+    assert_eq!(session.started_at, 1000);
+    assert_eq!(session.updated_at, Some(2000));
+    assert_eq!(session.messages.len(), 2);
+    assert_eq!(session.messages[0].content, "how use skill");
+    assert_eq!(session.messages[1].content, "Skills are markdown files.");
+    assert_eq!(session.messages[1].timestamp, Some(1775838890550));
+}
+
+#[test]
+fn kiro_parser_assistant_tool_use() {
+    let json = r#"{
+        "history": [{
+            "user": {
+                "content": {"Prompt": {"prompt": "analyze project"}}
+            },
+            "assistant": {
+                "ToolUse": {
+                    "message_id": "m1",
+                    "content": "Let me look around.",
+                    "tool_uses": [
+                        {"id": "t1", "name": "fs_read", "args": {"path": "/src"}},
+                        {"id": "t2", "name": "execute_bash", "args": {"command": "ls"}}
+                    ]
+                }
+            },
+            "request_metadata": {"request_start_timestamp_ms": 1775838890550}
+        }]
+    }"#;
+
+    let session = parse_kiro_conversation("c", "/proj", json, 0, 0).unwrap().unwrap();
+    let assistant = &session.messages[1];
+    assert!(
+        assistant.content.contains("Let me look around"),
+        "prose preserved: {}",
+        assistant.content
+    );
+    assert!(assistant.content.contains("[fs_read]"), "first tool indexed: {}", assistant.content);
+    assert!(
+        assistant.content.contains("[execute_bash]"),
+        "second tool indexed: {}",
+        assistant.content
+    );
+    assert!(assistant.content.contains("/src"), "fs_read args indexed: {}", assistant.content);
+}
+
+#[test]
+fn kiro_parser_tool_use_results_text_and_json() {
+    let json = r#"{
+        "history": [{
+            "user": {
+                "content": {
+                    "ToolUseResults": {
+                        "tool_use_results": [
+                            {
+                                "tool_use_id": "t1",
+                                "content": [{"Text": "file contents here"}]
+                            },
+                            {
+                                "tool_use_id": "t2",
+                                "content": [{"Json": {"status": "ok", "rows": 42}}]
+                            }
+                        ]
+                    }
+                }
+            },
+            "assistant": {"Response": {"message_id": "m", "content": "done"}}
+        }]
+    }"#;
+
+    let session = parse_kiro_conversation("c", "/proj", json, 0, 0).unwrap().unwrap();
+    let user_msg = &session.messages[0];
+    assert!(
+        user_msg.content.contains("file contents here"),
+        "Text variant indexed: {}",
+        user_msg.content
+    );
+    assert!(user_msg.content.contains("\"status\""), "Json variant indexed: {}", user_msg.content);
+    assert!(user_msg.content.contains("42"), "Json values indexed: {}", user_msg.content);
+}
+
+#[test]
+fn kiro_parser_empty_history_returns_none() {
+    let json = r#"{"history": []}"#;
+    assert!(parse_kiro_conversation("c", "/proj", json, 0, 0).unwrap().is_none());
 }


### PR DESCRIPTION
## Summary

Adds two new source adapters for searching AI coding sessions:

- **Gemini CLI** (`GEM`): Parses JSON session files from `~/.gemini/tmp/{project}/chats/`
- **Kiro CLI** (`KIRO`): Reads SQLite database at `~/Library/Application Support/kiro-cli/data.sqlite3`

### Changes

- `src/adapters/gemini.rs` — 145 LOC, file-based JSON parser
- `src/adapters/kiro.rs` — 198 LOC, SQLite-based parser (macOS + Linux paths)
- `src/adapters/mod.rs` — registered both in `all_adapters()` + `source_labels()`

### Gemini CLI Format

Sessions stored as individual JSON files with `sessionId`, `startTime`, `messages[]` array. User messages have `content: [{text}]`, assistant messages have `content: string`. Includes `thoughts` and `tokens` metadata.

### Kiro CLI Format

SQLite `conversations_v2` table with `key` (cwd), `conversation_id`, JSON `value` containing `history[]` of `{user, assistant}` turns. User content is `{Prompt: {prompt}}` or `{ToolResult: {...}}`. Assistant is `{Response: {content}}` or `{ToolUse: {...}}`.

### Testing

Tested locally with real data:

```
Source            Sessions  Messages  Range
CC (claude-code)      4136     90094  2026-02-09 -> 2026-04-09
CDX (codex)            512     41130  2026-03-07 -> 2026-04-09
GEM (gemini-cli)      5222     10737  2026-02-13 -> 2026-04-10
KIRO (kiro-cli)       5165     11174  2025-12-26 -> 2026-04-09
Total                15035    153135
```

All 18 existing tests pass. No new dependencies added.