### PR TITLE
[Feat] TUI: resume shortcut, in-detail search, and timestamps

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::Role;
 
 pub struct ClaudeCodeAdapter;
@@ -17,6 +17,13 @@ impl SourceAdapter for ClaudeCodeAdapter {
     }
     fn label(&self) -> &str {
         "CC"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "claude".to_string(),
+            args: vec!["--resume".to_string(), source_id.to_string()],
+        })
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::Role;
 
 pub struct CodexAdapter;
@@ -16,6 +16,13 @@ impl SourceAdapter for CodexAdapter {
     }
     fn label(&self) -> &str {
         "CDX"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "codex".to_string(),
+            args: vec!["resume".to_string(), source_id.to_string()],
+        })
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -8,6 +8,7 @@ pub trait SourceAdapter {
     fn id(&self) -> &str;
     fn label(&self) -> &str;
     fn scan(&self) -> anyhow::Result<Vec<RawSession>>;
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand>;
 }
 
 pub struct RawSession {
@@ -25,12 +26,33 @@ pub struct RawMessage {
     pub timestamp: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ResumeCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl ResumeCommand {
+    pub fn display(&self) -> String {
+        let mut out = self.program.clone();
+        for arg in &self.args {
+            out.push(' ');
+            out.push_str(arg);
+        }
+        out
+    }
+}
+
 pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
     vec![
         Box::new(claude_code::ClaudeCodeAdapter),
         Box::new(opencode::OpenCodeAdapter),
         Box::new(codex::CodexAdapter),
     ]
+}
+
+pub fn resume_command_for(source: &str, source_id: &str) -> Option<ResumeCommand> {
+    all_adapters().iter().find(|a| a.id() == source).and_then(|a| a.resume_command(source_id))
 }
 
 pub fn source_labels() -> Vec<(String, String)> {

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::adapters::{RawMessage, RawSession, SourceAdapter};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::Role;
 
 pub struct OpenCodeAdapter;
@@ -15,6 +15,13 @@ impl SourceAdapter for OpenCodeAdapter {
     }
     fn label(&self) -> &str {
         "OC"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "opencode".to_string(),
+            args: vec!["--session".to_string(), source_id.to_string()],
+        })
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,7 +523,40 @@ fn cmd_tui() -> Result<()> {
     drop(_guard);
     terminal.show_cursor()?;
 
+    if let Some((command, cwd)) = app.exec_on_exit.take() {
+        exec_resume(command, cwd)?;
+    }
+
     Ok(())
+}
+
+#[cfg(unix)]
+fn exec_resume(command: adapters::ResumeCommand, cwd: Option<String>) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let mut cmd = std::process::Command::new(&command.program);
+    cmd.args(&command.args);
+    if let Some(ref dir) = cwd
+        && std::path::Path::new(dir).is_dir()
+    {
+        cmd.current_dir(dir);
+    }
+    let err = cmd.exec();
+    Err(anyhow::anyhow!("failed to exec {}: {err}", command.program))
+}
+
+#[cfg(not(unix))]
+fn exec_resume(command: adapters::ResumeCommand, cwd: Option<String>) -> Result<()> {
+    let mut cmd = std::process::Command::new(&command.program);
+    cmd.args(&command.args);
+    if let Some(ref dir) = cwd
+        && std::path::Path::new(dir).is_dir()
+    {
+        cmd.current_dir(dir);
+    }
+    let status =
+        cmd.status().map_err(|e| anyhow::anyhow!("failed to run {}: {e}", command.program))?;
+    std::process::exit(status.code().unwrap_or(0));
 }
 
 fn generate_title(messages: &[adapters::RawMessage]) -> String {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -90,6 +90,9 @@ pub struct App {
     pub viewing_search_input: Option<String>,
     pub viewing_search_input_cursor: usize,
     pub viewing_search_status: Option<String>,
+    pub viewing_sanitized_lines: Vec<Vec<String>>,
+    pub viewing_content_lower: Vec<String>,
+    pub viewing_match_cache: Vec<usize>,
 }
 
 impl App {
@@ -137,6 +140,9 @@ impl App {
             viewing_search_input: None,
             viewing_search_input_cursor: 0,
             viewing_search_status: None,
+            viewing_sanitized_lines: Vec::new(),
+            viewing_content_lower: Vec::new(),
+            viewing_match_cache: Vec::new(),
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -387,6 +393,9 @@ impl App {
                 self.viewing_selected_msg = 0;
                 self.viewing_search_query.clear();
                 self.viewing_search_status = None;
+                self.viewing_sanitized_lines.clear();
+                self.viewing_content_lower.clear();
+                self.viewing_match_cache.clear();
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 if self.viewing_selected_msg > 0 {
@@ -437,17 +446,18 @@ impl App {
                 self.viewing_search_input_cursor = 0;
             }
             KeyCode::Enter => {
-                let query = input.trim().to_string();
+                let query = input.clone();
                 self.viewing_search_input = None;
                 self.viewing_search_input_cursor = 0;
                 if query.is_empty() {
                     self.viewing_search_query.clear();
                     self.viewing_search_status = None;
+                    self.viewing_match_cache.clear();
                     return;
                 }
                 self.viewing_search_query = query;
-                let matches = self.viewing_match_indices();
-                if matches.is_empty() {
+                self.recompute_viewing_matches();
+                if self.viewing_match_cache.is_empty() {
                     self.viewing_search_status = Some("No match".to_string());
                     return;
                 }
@@ -465,6 +475,32 @@ impl App {
                     self.viewing_search_input_cursor = prev;
                 }
             }
+            KeyCode::Left => {
+                if self.viewing_search_input_cursor > 0 {
+                    let prev = input[..self.viewing_search_input_cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    self.viewing_search_input_cursor = prev;
+                }
+            }
+            KeyCode::Right => {
+                if self.viewing_search_input_cursor < input.len() {
+                    let next = input[self.viewing_search_input_cursor..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(i, _)| self.viewing_search_input_cursor + i)
+                        .unwrap_or(input.len());
+                    self.viewing_search_input_cursor = next;
+                }
+            }
+            KeyCode::Home => {
+                self.viewing_search_input_cursor = 0;
+            }
+            KeyCode::End => {
+                self.viewing_search_input_cursor = input.len();
+            }
             KeyCode::Char(c) => {
                 input.insert(self.viewing_search_input_cursor, c);
                 self.viewing_search_input_cursor += c.len_utf8();
@@ -473,38 +509,44 @@ impl App {
         }
     }
 
-    pub fn viewing_match_indices(&self) -> Vec<usize> {
-        if self.viewing_search_query.is_empty() {
-            return Vec::new();
-        }
-        let needle = self.viewing_search_query.to_lowercase();
-        self.viewing_messages
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| m.content.to_lowercase().contains(&needle))
-            .map(|(i, _)| i)
-            .collect()
-    }
-
-    fn jump_viewing_match(&mut self, forward: bool) {
+    fn recompute_viewing_matches(&mut self) {
+        self.viewing_match_cache.clear();
         if self.viewing_search_query.is_empty() {
             return;
         }
-        let matches = self.viewing_match_indices();
-        if matches.is_empty() {
-            self.viewing_search_status = Some("No match".to_string());
+        let needle = self.viewing_search_query.to_lowercase();
+        for (i, lower) in self.viewing_content_lower.iter().enumerate() {
+            if lower.contains(&needle) {
+                self.viewing_match_cache.push(i);
+            }
+        }
+    }
+
+    pub fn viewing_match_indices(&self) -> &[usize] {
+        &self.viewing_match_cache
+    }
+
+    fn jump_viewing_match(&mut self, forward: bool) {
+        if self.viewing_search_query.is_empty() || self.viewing_match_cache.is_empty() {
+            if !self.viewing_search_query.is_empty() {
+                self.viewing_search_status = Some("No match".to_string());
+            }
             return;
         }
         let current = self.viewing_selected_msg;
         let next = if forward {
-            matches.iter().find(|&&i| i > current).copied().or_else(|| matches.first().copied())
+            self.viewing_match_cache
+                .iter()
+                .find(|&&i| i > current)
+                .copied()
+                .or_else(|| self.viewing_match_cache.first().copied())
         } else {
-            matches
+            self.viewing_match_cache
                 .iter()
                 .rev()
                 .find(|&&i| i < current)
                 .copied()
-                .or_else(|| matches.last().copied())
+                .or_else(|| self.viewing_match_cache.last().copied())
         };
         if let Some(idx) = next {
             self.viewing_selected_msg = idx;
@@ -783,12 +825,18 @@ impl App {
         if let Some(result) = self.results.get(self.selected_index)
             && let Ok(msgs) = store.get_messages(&result.session.id)
         {
+            self.viewing_sanitized_lines = msgs
+                .iter()
+                .map(|m| m.content.lines().map(crate::utils::sanitize_line).collect())
+                .collect();
+            self.viewing_content_lower = msgs.iter().map(|m| m.content.to_lowercase()).collect();
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;
             self.viewing_search_query.clear();
             self.viewing_search_input = None;
             self.viewing_search_input_cursor = 0;
             self.viewing_search_status = None;
+            self.viewing_match_cache.clear();
             self.mode = AppMode::Viewing;
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -86,6 +86,10 @@ pub struct App {
     pub settings_selected: usize,
     pub pending_resume: Option<PendingResume>,
     pub exec_on_exit: Option<(ResumeCommand, Option<String>)>,
+    pub viewing_search_query: String,
+    pub viewing_search_input: Option<String>,
+    pub viewing_search_input_cursor: usize,
+    pub viewing_search_status: Option<String>,
 }
 
 impl App {
@@ -129,6 +133,10 @@ impl App {
             settings_selected: 0,
             pending_resume: None,
             exec_on_exit: None,
+            viewing_search_query: String::new(),
+            viewing_search_input: None,
+            viewing_search_input_cursor: 0,
+            viewing_search_status: None,
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -363,6 +371,11 @@ impl App {
     }
 
     fn handle_viewing_key(&mut self, key: KeyEvent) {
+        if self.viewing_search_input.is_some() {
+            self.handle_viewing_search_input(key);
+            return;
+        }
+
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
             self.start_resume_confirmation(ResumeOrigin::Viewing);
             return;
@@ -372,6 +385,8 @@ impl App {
                 self.mode = AppMode::Search;
                 self.viewing_messages.clear();
                 self.viewing_selected_msg = 0;
+                self.viewing_search_query.clear();
+                self.viewing_search_status = None;
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 if self.viewing_selected_msg > 0 {
@@ -397,7 +412,103 @@ impl App {
             KeyCode::Char('e') => {
                 self.start_export();
             }
+            KeyCode::Char('/') => {
+                self.viewing_search_input = Some(String::new());
+                self.viewing_search_input_cursor = 0;
+                self.viewing_search_status = None;
+            }
+            KeyCode::Char('n') => {
+                self.jump_viewing_match(true);
+            }
+            KeyCode::Char('N') => {
+                self.jump_viewing_match(false);
+            }
             _ => {}
+        }
+    }
+
+    fn handle_viewing_search_input(&mut self, key: KeyEvent) {
+        let Some(input) = self.viewing_search_input.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                self.viewing_search_input = None;
+                self.viewing_search_input_cursor = 0;
+            }
+            KeyCode::Enter => {
+                let query = input.trim().to_string();
+                self.viewing_search_input = None;
+                self.viewing_search_input_cursor = 0;
+                if query.is_empty() {
+                    self.viewing_search_query.clear();
+                    self.viewing_search_status = None;
+                    return;
+                }
+                self.viewing_search_query = query;
+                let matches = self.viewing_match_indices();
+                if matches.is_empty() {
+                    self.viewing_search_status = Some("No match".to_string());
+                    return;
+                }
+                self.viewing_search_status = None;
+                self.jump_viewing_match(true);
+            }
+            KeyCode::Backspace => {
+                if self.viewing_search_input_cursor > 0 {
+                    let prev = input[..self.viewing_search_input_cursor]
+                        .char_indices()
+                        .last()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    input.replace_range(prev..self.viewing_search_input_cursor, "");
+                    self.viewing_search_input_cursor = prev;
+                }
+            }
+            KeyCode::Char(c) => {
+                input.insert(self.viewing_search_input_cursor, c);
+                self.viewing_search_input_cursor += c.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn viewing_match_indices(&self) -> Vec<usize> {
+        if self.viewing_search_query.is_empty() {
+            return Vec::new();
+        }
+        let needle = self.viewing_search_query.to_lowercase();
+        self.viewing_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| m.content.to_lowercase().contains(&needle))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn jump_viewing_match(&mut self, forward: bool) {
+        if self.viewing_search_query.is_empty() {
+            return;
+        }
+        let matches = self.viewing_match_indices();
+        if matches.is_empty() {
+            self.viewing_search_status = Some("No match".to_string());
+            return;
+        }
+        let current = self.viewing_selected_msg;
+        let next = if forward {
+            matches.iter().find(|&&i| i > current).copied().or_else(|| matches.first().copied())
+        } else {
+            matches
+                .iter()
+                .rev()
+                .find(|&&i| i < current)
+                .copied()
+                .or_else(|| matches.last().copied())
+        };
+        if let Some(idx) = next {
+            self.viewing_selected_msg = idx;
+            self.viewing_search_status = None;
         }
     }
 
@@ -674,6 +785,10 @@ impl App {
         {
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;
+            self.viewing_search_query.clear();
+            self.viewing_search_input = None;
+            self.viewing_search_input_cursor = 0;
+            self.viewing_search_status = None;
             self.mode = AppMode::Viewing;
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -722,8 +722,12 @@ impl App {
             .collect();
         let source = self.source_label_for(&session.source);
 
-        let home = dirs::home_dir().map(|h| h.display().to_string()).unwrap_or_default();
-        self.export_path = format!("{home}/recall-{source}-{safe_title}.txt");
+        let cwd = std::env::current_dir()
+            .ok()
+            .map(|p| p.display().to_string())
+            .or_else(|| dirs::home_dir().map(|h| h.display().to_string()))
+            .unwrap_or_default();
+        self.export_path = format!("{cwd}/recall-{source}-{safe_title}.txt");
         self.export_cursor = self.export_path.len();
         self.mode = AppMode::ExportInput;
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -35,6 +35,26 @@ pub struct PendingResume {
     pub origin: ResumeOrigin,
 }
 
+pub struct SanitizedLine {
+    pub text: String,
+    pub lower: String,
+}
+
+fn build_viewing_caches(msgs: &[Message]) -> Vec<Vec<SanitizedLine>> {
+    msgs.iter()
+        .map(|m| {
+            m.content
+                .lines()
+                .map(|line| {
+                    let text = crate::utils::sanitize_line(line);
+                    let lower = text.to_lowercase();
+                    SanitizedLine { text, lower }
+                })
+                .collect()
+        })
+        .collect()
+}
+
 #[derive(PartialEq)]
 pub enum PanelFocus {
     SessionList,
@@ -90,8 +110,7 @@ pub struct App {
     pub viewing_search_input: Option<String>,
     pub viewing_search_input_cursor: usize,
     pub viewing_search_status: Option<String>,
-    pub viewing_sanitized_lines: Vec<Vec<String>>,
-    pub viewing_content_lower: Vec<String>,
+    pub viewing_sanitized_lines: Vec<Vec<SanitizedLine>>,
     pub viewing_match_cache: Vec<usize>,
 }
 
@@ -141,7 +160,6 @@ impl App {
             viewing_search_input_cursor: 0,
             viewing_search_status: None,
             viewing_sanitized_lines: Vec::new(),
-            viewing_content_lower: Vec::new(),
             viewing_match_cache: Vec::new(),
         };
         app.reset_search_defaults();
@@ -394,7 +412,6 @@ impl App {
                 self.viewing_search_query.clear();
                 self.viewing_search_status = None;
                 self.viewing_sanitized_lines.clear();
-                self.viewing_content_lower.clear();
                 self.viewing_match_cache.clear();
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -515,8 +532,8 @@ impl App {
             return;
         }
         let needle = self.viewing_search_query.to_lowercase();
-        for (i, lower) in self.viewing_content_lower.iter().enumerate() {
-            if lower.contains(&needle) {
+        for (i, msg_lines) in self.viewing_sanitized_lines.iter().enumerate() {
+            if msg_lines.iter().any(|l| l.lower.contains(&needle)) {
                 self.viewing_match_cache.push(i);
             }
         }
@@ -825,11 +842,7 @@ impl App {
         if let Some(result) = self.results.get(self.selected_index)
             && let Ok(msgs) = store.get_messages(&result.session.id)
         {
-            self.viewing_sanitized_lines = msgs
-                .iter()
-                .map(|m| m.content.lines().map(crate::utils::sanitize_line).collect())
-                .collect();
-            self.viewing_content_lower = msgs.iter().map(|m| m.content.to_lowercase()).collect();
+            self.viewing_sanitized_lines = build_viewing_caches(&msgs);
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;
             self.viewing_search_query.clear();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -21,11 +21,18 @@ pub enum AppMode {
     ConfirmResume,
 }
 
+#[derive(Clone, Copy)]
+pub enum ResumeOrigin {
+    Search,
+    Viewing,
+}
+
 pub struct PendingResume {
     pub command: ResumeCommand,
     pub source_label: String,
     pub session_title: String,
     pub cwd: Option<String>,
+    pub origin: ResumeOrigin,
 }
 
 #[derive(PartialEq)]
@@ -272,7 +279,7 @@ impl App {
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
-            self.start_resume_confirmation();
+            self.start_resume_confirmation(ResumeOrigin::Search);
             return;
         }
 
@@ -356,6 +363,10 @@ impl App {
     }
 
     fn handle_viewing_key(&mut self, key: KeyEvent) {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+            self.start_resume_confirmation(ResumeOrigin::Viewing);
+            return;
+        }
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
                 self.mode = AppMode::Search;
@@ -390,7 +401,7 @@ impl App {
         }
     }
 
-    fn start_resume_confirmation(&mut self) {
+    fn start_resume_confirmation(&mut self, origin: ResumeOrigin) {
         let Some(result) = self.results.get(self.selected_index) else {
             return;
         };
@@ -404,6 +415,7 @@ impl App {
             source_label: self.source_label_for(&session.source).to_string(),
             session_title: session.title.clone(),
             cwd: session.directory.clone(),
+            origin,
         });
         self.mode = AppMode::ConfirmResume;
     }
@@ -419,8 +431,12 @@ impl App {
                 }
             }
             KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                self.pending_resume = None;
-                self.mode = AppMode::Search;
+                let origin =
+                    self.pending_resume.take().map(|p| p.origin).unwrap_or(ResumeOrigin::Search);
+                self.mode = match origin {
+                    ResumeOrigin::Search => AppMode::Search,
+                    ResumeOrigin::Viewing => AppMode::Viewing,
+                };
             }
             _ => {}
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use crate::adapters::{ResumeCommand, resume_command_for};
 use crate::config::AppConfig;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::Store;
@@ -17,6 +18,14 @@ pub enum AppMode {
     Viewing,
     ExportInput,
     Settings,
+    ConfirmResume,
+}
+
+pub struct PendingResume {
+    pub command: ResumeCommand,
+    pub source_label: String,
+    pub session_title: String,
+    pub cwd: Option<String>,
 }
 
 #[derive(PartialEq)]
@@ -68,6 +77,8 @@ pub struct App {
     pub background_status: BackgroundJobStatus,
     pub semantic_last_refresh: Instant,
     pub settings_selected: usize,
+    pub pending_resume: Option<PendingResume>,
+    pub exec_on_exit: Option<(ResumeCommand, Option<String>)>,
 }
 
 impl App {
@@ -109,6 +120,8 @@ impl App {
             background_status,
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
+            pending_resume: None,
+            exec_on_exit: None,
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -183,6 +196,7 @@ impl App {
             AppMode::Viewing => self.handle_viewing_key(key),
             AppMode::ExportInput => self.handle_export_key(key),
             AppMode::Settings => self.handle_settings_key(key, store, engine, provider),
+            AppMode::ConfirmResume => self.handle_confirm_resume_key(key),
         }
     }
 
@@ -254,6 +268,11 @@ impl App {
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
             self.mode = AppMode::Settings;
             self.settings_selected = 0;
+            return;
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
+            self.start_resume_confirmation();
             return;
         }
 
@@ -366,6 +385,42 @@ impl App {
             }
             KeyCode::Char('e') => {
                 self.start_export();
+            }
+            _ => {}
+        }
+    }
+
+    fn start_resume_confirmation(&mut self) {
+        let Some(result) = self.results.get(self.selected_index) else {
+            return;
+        };
+        let session = &result.session;
+        let Some(command) = resume_command_for(&session.source, &session.source_id) else {
+            self.status_message = Some(format!("Resume not supported for {}", session.source));
+            return;
+        };
+        self.pending_resume = Some(PendingResume {
+            command,
+            source_label: self.source_label_for(&session.source).to_string(),
+            session_title: session.title.clone(),
+            cwd: session.directory.clone(),
+        });
+        self.mode = AppMode::ConfirmResume;
+    }
+
+    fn handle_confirm_resume_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                if let Some(pending) = self.pending_resume.take() {
+                    self.exec_on_exit = Some((pending.command, pending.cwd));
+                    self.should_quit = true;
+                } else {
+                    self.mode = AppMode::Search;
+                }
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.pending_resume = None;
+                self.mode = AppMode::Search;
             }
             _ => {}
         }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
-use crate::tui::app::{App, AppMode, PanelFocus, SortOrder};
+use crate::tui::app::{App, AppMode, PanelFocus, ResumeOrigin, SortOrder};
 use crate::types::{MatchSource, Role};
 
 fn scroll_offset(selected_line_start: usize, inner_height: usize) -> u16 {
@@ -32,7 +32,10 @@ pub fn render(f: &mut Frame, app: &App) {
             render_settings(f, app);
         }
         AppMode::ConfirmResume => {
-            render_search(f, app);
+            match app.pending_resume.as_ref().map(|p| p.origin) {
+                Some(ResumeOrigin::Viewing) => render_viewing(f, app),
+                _ => render_search(f, app),
+            }
             render_confirm_resume(f, app);
         }
     }
@@ -323,6 +326,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" copy  ", Style::default().fg(Color::DarkGray)),
         Span::styled("e", Style::default().fg(Color::Yellow)),
         Span::styled(" export  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
+        Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Esc", Style::default().fg(Color::Yellow)),
         Span::styled(" back  ", Style::default().fg(Color::DarkGray)),
         Span::styled("q", Style::default().fg(Color::Yellow)),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -238,10 +238,15 @@ fn render_preview(f: &mut Frame, app: &App, area: Rect) {
 
         let bg = if selected { Color::DarkGray } else { Color::Reset };
 
-        lines.push(Line::from(Span::styled(
+        let time_str = crate::utils::format_message_time(msg.timestamp);
+        let mut header = vec![Span::styled(
             prefix,
             Style::default().fg(color).bg(bg).add_modifier(Modifier::BOLD),
-        )));
+        )];
+        if !time_str.is_empty() {
+            header.push(Span::styled(time_str, Style::default().fg(Color::DarkGray).bg(bg)));
+        }
+        lines.push(Line::from(header));
 
         let text: String = msg.content.chars().take(300).collect();
         for line in text.lines().take(6) {
@@ -300,10 +305,18 @@ fn render_viewing(f: &mut Frame, app: &App) {
 
         let bg = if selected { Color::DarkGray } else { Color::Reset };
 
-        lines.push(Line::from(Span::styled(
+        let time_str = crate::utils::format_message_time(msg.timestamp);
+        let mut header = vec![Span::styled(
             format!("── {prefix} ──"),
             Style::default().fg(color).bg(bg).add_modifier(Modifier::BOLD),
-        )));
+        )];
+        if !time_str.is_empty() {
+            header.push(Span::styled(
+                format!("  {time_str}"),
+                Style::default().fg(Color::DarkGray).bg(bg),
+            ));
+        }
+        lines.push(Line::from(header));
 
         for line in msg.content.lines() {
             lines.push(Line::from(Span::styled(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -360,9 +360,10 @@ fn render_viewing(f: &mut Frame, app: &App) {
         lines.push(Line::from(header));
 
         let body_style = Style::default().fg(Color::White).bg(bg);
-        for line in msg.content.lines() {
-            let line = crate::utils::sanitize_line(line);
-            let spans = highlight_spans(&line, &needle_lower, body_style);
+        let empty: Vec<String> = Vec::new();
+        let cached_lines = app.viewing_sanitized_lines.get(i).unwrap_or(&empty);
+        for line in cached_lines {
+            let spans = highlight_spans(line, &needle_lower, body_style);
             lines.push(Line::from(spans));
         }
         lines.push(Line::from(""));
@@ -420,7 +421,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
     };
 
     if let Some(ref input) = app.viewing_search_input {
-        let cursor_x = outer[1].x + 2 + UnicodeWidthStr::width(input.as_str()) as u16;
+        let cursor_byte = app.viewing_search_input_cursor.min(input.len());
+        let cursor_x = outer[1].x + 2 + UnicodeWidthStr::width(&input[..cursor_byte]) as u16;
         f.set_cursor_position((cursor_x, outer[1].y));
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -289,6 +289,7 @@ fn render_preview(f: &mut Frame, app: &App, area: Rect) {
 
         let text: String = msg.content.chars().take(300).collect();
         for line in text.lines().take(6) {
+            let line = crate::utils::sanitize_line(line);
             lines.push(Line::from(Span::styled(
                 format!("  {line}"),
                 Style::default().fg(Color::White).bg(bg),
@@ -360,7 +361,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
 
         let body_style = Style::default().fg(Color::White).bg(bg);
         for line in msg.content.lines() {
-            let spans = highlight_spans(line, &needle_lower, body_style);
+            let line = crate::utils::sanitize_line(line);
+            let spans = highlight_spans(&line, &needle_lower, body_style);
             lines.push(Line::from(spans));
         }
         lines.push(Line::from(""));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -9,6 +9,45 @@ use crate::db::search::TimeRange;
 use crate::tui::app::{App, AppMode, PanelFocus, ResumeOrigin, SortOrder};
 use crate::types::{MatchSource, Role};
 
+fn highlight_spans(text: &str, needle_lower: &str, base: Style) -> Vec<Span<'static>> {
+    if needle_lower.is_empty() {
+        return vec![Span::styled(text.to_string(), base)];
+    }
+    let hay = text.to_lowercase();
+    if hay.len() != text.len() {
+        return vec![Span::styled(text.to_string(), base)];
+    }
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut cursor = 0usize;
+    let match_style =
+        Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD);
+    while cursor < text.len() {
+        match hay[cursor..].find(needle_lower) {
+            Some(rel) => {
+                let start = cursor + rel;
+                let end = start + needle_lower.len();
+                if !text.is_char_boundary(start) || !text.is_char_boundary(end) {
+                    spans.push(Span::styled(text[cursor..].to_string(), base));
+                    break;
+                }
+                if start > cursor {
+                    spans.push(Span::styled(text[cursor..start].to_string(), base));
+                }
+                spans.push(Span::styled(text[start..end].to_string(), match_style));
+                cursor = end;
+            }
+            None => {
+                spans.push(Span::styled(text[cursor..].to_string(), base));
+                break;
+            }
+        }
+    }
+    if spans.is_empty() {
+        spans.push(Span::styled(text.to_string(), base));
+    }
+    spans
+}
+
 fn scroll_offset(selected_line_start: usize, inner_height: usize) -> u16 {
     if inner_height == 0 {
         0
@@ -291,6 +330,7 @@ fn render_viewing(f: &mut Frame, app: &App) {
 
     let mut lines: Vec<Line> = Vec::new();
     let mut selected_line_start: usize = 0;
+    let needle_lower = app.viewing_search_query.to_lowercase();
 
     for (i, msg) in app.viewing_messages.iter().enumerate() {
         let selected = i == app.viewing_selected_msg;
@@ -318,11 +358,10 @@ fn render_viewing(f: &mut Frame, app: &App) {
         }
         lines.push(Line::from(header));
 
+        let body_style = Style::default().fg(Color::White).bg(bg);
         for line in msg.content.lines() {
-            lines.push(Line::from(Span::styled(
-                line.to_string(),
-                Style::default().fg(Color::White).bg(bg),
-            )));
+            let spans = highlight_spans(line, &needle_lower, body_style);
+            lines.push(Line::from(spans));
         }
         lines.push(Line::from(""));
     }
@@ -335,6 +374,10 @@ fn render_viewing(f: &mut Frame, app: &App) {
     let help_spans = vec![
         Span::styled(" ↑/↓", Style::default().fg(Color::Yellow)),
         Span::styled(" messages  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("/", Style::default().fg(Color::Yellow)),
+        Span::styled(" find  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("n/N", Style::default().fg(Color::Yellow)),
+        Span::styled(" next/prev  ", Style::default().fg(Color::DarkGray)),
         Span::styled("c", Style::default().fg(Color::Yellow)),
         Span::styled(" copy  ", Style::default().fg(Color::DarkGray)),
         Span::styled("e", Style::default().fg(Color::Yellow)),
@@ -347,11 +390,37 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" quit", Style::default().fg(Color::DarkGray)),
     ];
 
-    let status_line = if let Some(ref msg) = app.status_message {
+    let status_line = if let Some(ref input) = app.viewing_search_input {
+        Line::from(vec![
+            Span::styled(" /", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(input.clone(), Style::default().fg(Color::White)),
+        ])
+    } else if let Some(ref msg) = app.status_message {
         Line::from(vec![Span::styled(format!(" {msg}"), Style::default().fg(Color::Green))])
+    } else if let Some(ref note) = app.viewing_search_status {
+        Line::from(vec![Span::styled(
+            format!(" {note}: \"{}\"", app.viewing_search_query),
+            Style::default().fg(Color::Red),
+        )])
+    } else if !app.viewing_search_query.is_empty() {
+        let matches = app.viewing_match_indices();
+        let total = matches.len();
+        let current_pos =
+            matches.iter().position(|&i| i == app.viewing_selected_msg).map(|n| n + 1).unwrap_or(0);
+        let mut spans = help_spans.clone();
+        spans.push(Span::styled(
+            format!("  [{current_pos}/{total} \"{}\"]", app.viewing_search_query),
+            Style::default().fg(Color::Yellow),
+        ));
+        Line::from(spans)
     } else {
         Line::from(help_spans)
     };
+
+    if let Some(ref input) = app.viewing_search_input {
+        let cursor_x = outer[1].x + 2 + UnicodeWidthStr::width(input.as_str()) as u16;
+        f.set_cursor_position((cursor_x, outer[1].y));
+    }
 
     f.render_widget(Paragraph::new(status_line), outer[1]);
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -31,6 +31,10 @@ pub fn render(f: &mut Frame, app: &App) {
             render_search(f, app);
             render_settings(f, app);
         }
+        AppMode::ConfirmResume => {
+            render_search(f, app);
+            render_confirm_resume(f, app);
+        }
     }
 }
 
@@ -397,6 +401,75 @@ fn render_settings(f: &mut Frame, app: &App) {
     f.render_widget(widget, popup);
 }
 
+fn render_confirm_resume(f: &mut Frame, app: &App) {
+    let Some(pending) = app.pending_resume.as_ref() else {
+        return;
+    };
+
+    let area = f.area();
+    let width = area.width.clamp(40, 76);
+    let height: u16 = 9;
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let popup = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .title(" Resume session ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .style(Style::default().bg(Color::Black));
+
+    let title: String = pending.session_title.chars().take(width as usize - 10).collect();
+    let command_text: String =
+        pending.command.display().chars().take(width as usize - 14).collect();
+    let cwd_text: String = pending
+        .cwd
+        .as_deref()
+        .unwrap_or("-")
+        .chars()
+        .rev()
+        .take(width as usize - 10)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(" Source:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                pending.source_label.clone(),
+                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("   "),
+            Span::styled(title, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled(" Cwd:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(cwd_text, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled(" Command: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                command_text,
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  [Y] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("confirm & exec     ", Style::default().fg(Color::White)),
+            Span::styled("[N] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("cancel", Style::default().fg(Color::White)),
+        ]),
+    ];
+
+    let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(Clear, popup);
+    f.render_widget(widget, popup);
+}
+
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let semantic_span = if app.semantic_progress.total_sessions > 0 {
         let mut text = format!(
@@ -440,6 +513,8 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled(" detail  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Tab", Style::default().fg(Color::Yellow)),
                     Span::styled(" filter  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
+                    Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Ctrl+S", Style::default().fg(Color::Yellow)),
                     Span::styled(" settings  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Esc", Style::default().fg(Color::Yellow)),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -6,14 +6,13 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
-use crate::tui::app::{App, AppMode, PanelFocus, ResumeOrigin, SortOrder};
+use crate::tui::app::{App, AppMode, PanelFocus, ResumeOrigin, SanitizedLine, SortOrder};
 use crate::types::{MatchSource, Role};
 
-fn highlight_spans(text: &str, needle_lower: &str, base: Style) -> Vec<Span<'static>> {
+fn highlight_spans(text: &str, hay: &str, needle_lower: &str, base: Style) -> Vec<Span<'static>> {
     if needle_lower.is_empty() {
         return vec![Span::styled(text.to_string(), base)];
     }
-    let hay = text.to_lowercase();
     if hay.len() != text.len() {
         return vec![Span::styled(text.to_string(), base)];
     }
@@ -360,10 +359,10 @@ fn render_viewing(f: &mut Frame, app: &App) {
         lines.push(Line::from(header));
 
         let body_style = Style::default().fg(Color::White).bg(bg);
-        let empty: Vec<String> = Vec::new();
+        let empty: Vec<SanitizedLine> = Vec::new();
         let cached_lines = app.viewing_sanitized_lines.get(i).unwrap_or(&empty);
-        for line in cached_lines {
-            let spans = highlight_spans(line, &needle_lower, body_style);
+        for sl in cached_lines {
+            let spans = highlight_spans(&sl.text, &sl.lower, &needle_lower, body_style);
             lines.push(Line::from(spans));
         }
         lines.push(Line::from(""));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,15 @@ pub fn parse_since(s: &str) -> Option<i64> {
     Some(now - n * multiplier)
 }
 
+pub fn format_message_time(ts: Option<i64>) -> String {
+    let Some(ts) = ts else {
+        return String::new();
+    };
+    chrono::DateTime::from_timestamp_millis(ts)
+        .map(|dt| dt.with_timezone(&chrono::Local).format("%m-%d %H:%M").to_string())
+        .unwrap_or_default()
+}
+
 pub fn f32_slice_to_bytes(data: &[f32]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(data.len() * 4);
     for &f in data {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,20 @@ pub fn parse_since(s: &str) -> Option<i64> {
     Some(now - n * multiplier)
 }
 
+pub fn sanitize_line(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    for c in line.chars() {
+        if c == '\t' {
+            out.push_str("    ");
+        } else if c.is_control() {
+            continue;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 pub fn format_message_time(ts: Option<i64>) -> String {
     let Some(ts) = ts else {
         return String::new();


### PR DESCRIPTION
### What's changed?

- **Ctrl+R resume** (sessions list and detail view): opens a confirmation modal showing source, cwd, and the exact CLI to run; on confirm, exits Recall and `exec`s the target CLI (`claude --resume`, `codex resume`, `opencode --session`). Adapter trait gains `resume_command`, so new sources need no TUI changes.
- **Per-message timestamps** in preview and detail view, formatted `MM-DD HH:MM` in local time, skipped gracefully when a message has no timestamp.
- **Vi-style `/` search in detail view**: `/` opens a status-bar input, Enter confirms, Esc cancels; `n`/`N` jump to next/previous match with wrap-around; hlsearch highlights every occurrence across matching messages; status bar shows `[i/n "query"]` or `No match`. Case-insensitive substring, message-level granularity, Unicode-safe fallback when `to_lowercase` changes byte length.
- **Export default path** fixed to use the current working directory instead of `$HOME`, with home as fallback.
- **Tab rendering fix**: Claude Code's `Read` tool output uses `<lineno>\t<content>`, which ratatui's Paragraph was rendering as single-cell tabs while the terminal treated them as tab stops — causing visible character overlap. Sanitize each render line: tabs become four spaces, other control chars are dropped.

### Why

- Make it trivial to jump from a Recall search result back into the original AI coding session without copy-pasting session IDs.
- Surface per-message time to orient within long conversations.
- Let users find content inside a single long conversation without falling back to an external pager.
- Fix the garbled viewing output that showed up whenever a message contained `Read`-tool style tab-indented content.