### PR TITLE
[Feat] add GitHub Copilot CLI adapter

### DIFF
--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -1,0 +1,218 @@
+use std::collections::HashMap;
+use std::fs;
+
+use serde_json::Value;
+use tracing::debug;
+
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+use crate::types::Role;
+
+pub struct CopilotAdapter;
+
+impl SourceAdapter for CopilotAdapter {
+    fn id(&self) -> &str {
+        "copilot-cli"
+    }
+    fn label(&self) -> &str {
+        "CPL"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "copilot".to_string(),
+            args: vec![format!("--resume={source_id}")],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+        let sessions_dir = home.join(".copilot/session-state");
+        if !sessions_dir.exists() {
+            debug!("~/.copilot/session-state not found, skipping Copilot CLI");
+            return Ok(vec![]);
+        }
+
+        let entries = match fs::read_dir(&sessions_dir) {
+            Ok(e) => e,
+            Err(e) => {
+                debug!("cannot read {}: {e}", sessions_dir.display());
+                return Ok(vec![]);
+            }
+        };
+
+        let mut sessions = Vec::new();
+
+        for entry in entries.flatten() {
+            let session_dir = entry.path();
+            if !session_dir.is_dir() {
+                continue;
+            }
+            let events_path = session_dir.join("events.jsonl");
+            if !events_path.is_file() {
+                continue;
+            }
+            let fallback_id =
+                session_dir.file_name().and_then(|n| n.to_str()).unwrap_or("unknown").to_string();
+
+            let content = match fs::read_to_string(&events_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    debug!("failed to read {}: {e}", events_path.display());
+                    continue;
+                }
+            };
+
+            match parse_copilot_events(&content, &fallback_id) {
+                Ok(Some(session)) => sessions.push(session),
+                Ok(None) => {}
+                Err(e) => {
+                    debug!("failed to parse copilot session {}: {e}", events_path.display());
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+}
+
+pub fn parse_copilot_events(
+    content: &str,
+    fallback_id: &str,
+) -> anyhow::Result<Option<RawSession>> {
+    let mut session_id: Option<String> = None;
+    let mut directory: Option<String> = None;
+    let mut meta_started_at: Option<i64> = None;
+    let mut tool_names: HashMap<String, String> = HashMap::new();
+    let mut messages = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let event_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let timestamp = parse_timestamp(&v);
+
+        match event_type {
+            "session.start" => {
+                if let Some(data) = v.get("data") {
+                    session_id = data.get("sessionId").and_then(|s| s.as_str()).map(String::from);
+                    meta_started_at = data
+                        .get("startTime")
+                        .and_then(|t| t.as_str())
+                        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                        .map(|dt| dt.timestamp_millis());
+                    directory = data
+                        .get("context")
+                        .and_then(|c| c.get("cwd"))
+                        .and_then(|c| c.as_str())
+                        .map(String::from);
+                }
+            }
+            "user.message" => {
+                let Some(data) = v.get("data") else { continue };
+                let content =
+                    data.get("content").and_then(|c| c.as_str()).unwrap_or("").trim().to_string();
+                if content.is_empty() {
+                    continue;
+                }
+                messages.push(RawMessage { role: Role::User, content, timestamp });
+            }
+            "assistant.message" => {
+                let Some(data) = v.get("data") else { continue };
+                let prose =
+                    data.get("content").and_then(|c| c.as_str()).unwrap_or("").trim().to_string();
+                let tool_text = extract_tool_requests(data.get("toolRequests"));
+                let content = match (prose.is_empty(), tool_text.is_empty()) {
+                    (true, true) => continue,
+                    (false, true) => prose,
+                    (true, false) => tool_text,
+                    (false, false) => format!("{prose}\n{tool_text}"),
+                };
+                messages.push(RawMessage { role: Role::Assistant, content, timestamp });
+            }
+            "tool.execution_start" => {
+                if let Some(data) = v.get("data")
+                    && let (Some(id), Some(name)) = (
+                        data.get("toolCallId").and_then(|s| s.as_str()),
+                        data.get("toolName").and_then(|s| s.as_str()),
+                    )
+                {
+                    tool_names.insert(id.to_string(), name.to_string());
+                }
+            }
+            "tool.execution_complete" => {
+                let Some(data) = v.get("data") else { continue };
+                let Some(result) = data.get("result") else { continue };
+                let text = result
+                    .get("detailedContent")
+                    .and_then(|c| c.as_str())
+                    .or_else(|| result.get("content").and_then(|c| c.as_str()))
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if text.is_empty() {
+                    continue;
+                }
+                let tool_name = data
+                    .get("toolCallId")
+                    .and_then(|s| s.as_str())
+                    .and_then(|id| tool_names.get(id).cloned())
+                    .unwrap_or_else(|| "tool".to_string());
+                messages.push(RawMessage {
+                    role: Role::Assistant,
+                    content: format!("[{tool_name}] {text}"),
+                    timestamp,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    if messages.is_empty() {
+        return Ok(None);
+    }
+
+    let source_id = session_id.unwrap_or_else(|| fallback_id.to_string());
+    let started_at =
+        meta_started_at.or_else(|| messages.first().and_then(|m| m.timestamp)).unwrap_or(0);
+    let updated_at = messages.last().and_then(|m| m.timestamp);
+
+    Ok(Some(RawSession {
+        source_id,
+        directory,
+        started_at,
+        updated_at,
+        entrypoint: None,
+        messages,
+    }))
+}
+
+fn extract_tool_requests(tool_requests: Option<&Value>) -> String {
+    let Some(arr) = tool_requests.and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    for req in arr {
+        let name = req.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+        let args = req
+            .get("arguments")
+            .map(|a| serde_json::to_string(a).unwrap_or_default())
+            .unwrap_or_default();
+        parts.push(format!("[{name}] {args}"));
+    }
+    parts.join("\n")
+}
+
+fn parse_timestamp(v: &Value) -> Option<i64> {
+    v.get("timestamp")
+        .and_then(|t| t.as_str())
+        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+        .map(|dt| dt.timestamp_millis())
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude_code;
 pub mod codex;
+pub mod copilot;
 pub mod gemini;
 pub mod kiro;
 pub mod opencode;
@@ -52,6 +53,7 @@ pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(codex::CodexAdapter),
         Box::new(gemini::GeminiAdapter),
         Box::new(kiro::KiroAdapter),
+        Box::new(copilot::CopilotAdapter),
     ]
 }
 
@@ -60,11 +62,5 @@ pub fn resume_command_for(source: &str, source_id: &str) -> Option<ResumeCommand
 }
 
 pub fn source_labels() -> Vec<(String, String)> {
-    vec![
-        ("claude-code".to_string(), "CC".to_string()),
-        ("opencode".to_string(), "OC".to_string()),
-        ("codex".to_string(), "CDX".to_string()),
-        ("gemini-cli".to_string(), "GEM".to_string()),
-        ("kiro-cli".to_string(), "KIRO".to_string()),
-    ]
+    all_adapters().iter().map(|a| (a.id().to_string(), a.label().to_string())).collect()
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,3 +1,4 @@
+use recall::adapters::copilot::parse_copilot_events;
 use recall::adapters::gemini::parse_gemini_session;
 use recall::adapters::kiro::parse_kiro_conversation;
 use recall::config::AppConfig;
@@ -539,6 +540,82 @@ fn kiro_parser_tool_use_results_text_and_json() {
 fn kiro_parser_empty_history_returns_none() {
     let json = r#"{"history": []}"#;
     assert!(parse_kiro_conversation("c", "/proj", json, 0, 0).unwrap().is_none());
+}
+
+#[test]
+fn copilot_parser_plain_conversation() {
+    let jsonl = r#"{"type":"session.start","data":{"sessionId":"sess-1","startTime":"2026-02-26T06:29:59.692Z","context":{"cwd":"/Users/x/proj","repository":"x/proj","branch":"main"}},"id":"e1","timestamp":"2026-02-26T06:29:59.802Z","parentId":null}
+{"type":"user.message","data":{"content":"how do I run tests","transformedContent":"wrapped","attachments":[]},"id":"e2","timestamp":"2026-02-26T06:30:00.000Z","parentId":"e1"}
+{"type":"assistant.message","data":{"messageId":"m1","content":"Run make check","toolRequests":[]},"id":"e3","timestamp":"2026-02-26T06:30:01.000Z","parentId":"e2"}"#;
+
+    let session = parse_copilot_events(jsonl, "fallback").unwrap().unwrap();
+    assert_eq!(session.source_id, "sess-1");
+    assert_eq!(session.directory.as_deref(), Some("/Users/x/proj"));
+    assert_eq!(session.messages.len(), 2);
+    assert!(matches!(session.messages[0].role, Role::User));
+    assert_eq!(session.messages[0].content, "how do I run tests");
+    assert!(matches!(session.messages[1].role, Role::Assistant));
+    assert_eq!(session.messages[1].content, "Run make check");
+}
+
+#[test]
+fn copilot_parser_indexes_tool_requests_and_results() {
+    let jsonl = r##"{"type":"session.start","data":{"sessionId":"sess-2","startTime":"2026-02-26T06:29:59.692Z","context":{"cwd":"/proj"}},"id":"e1","timestamp":"2026-02-26T06:29:59.802Z","parentId":null}
+{"type":"assistant.message","data":{"messageId":"m1","content":"Let me read the file.","toolRequests":[{"toolCallId":"tc1","name":"read_file","arguments":{"path":"/tmp/README.md"},"type":"function"}]},"id":"e2","timestamp":"2026-02-26T06:30:00.000Z","parentId":"e1"}
+{"type":"tool.execution_start","data":{"toolCallId":"tc1","toolName":"read_file","arguments":{"path":"/tmp/README.md"}},"id":"e3","timestamp":"2026-02-26T06:30:00.100Z","parentId":"e2"}
+{"type":"tool.execution_complete","data":{"toolCallId":"tc1","success":true,"result":{"content":"short summary","detailedContent":"# My Project\nHello world."}},"id":"e4","timestamp":"2026-02-26T06:30:00.500Z","parentId":"e3"}"##;
+
+    let session = parse_copilot_events(jsonl, "fallback").unwrap().unwrap();
+    assert_eq!(session.messages.len(), 2);
+    let assistant = &session.messages[0];
+    assert!(
+        assistant.content.contains("Let me read the file"),
+        "prose preserved: {}",
+        assistant.content
+    );
+    assert!(assistant.content.contains("[read_file]"), "tool name indexed: {}", assistant.content);
+    assert!(
+        assistant.content.contains("/tmp/README.md"),
+        "tool args indexed: {}",
+        assistant.content
+    );
+    let tool_result = &session.messages[1];
+    assert!(
+        tool_result.content.contains("[read_file]"),
+        "tool result tagged with name: {}",
+        tool_result.content
+    );
+    assert!(
+        tool_result.content.contains("Hello world"),
+        "detailedContent preferred over content: {}",
+        tool_result.content
+    );
+}
+
+#[test]
+fn copilot_parser_skips_empty_and_unknown() {
+    let jsonl = r#"{"type":"session.start","data":{"sessionId":"s","startTime":"2026-02-26T06:29:59.692Z","context":{"cwd":"/p"}},"id":"e1","timestamp":"2026-02-26T06:29:59.802Z"}
+{"type":"session.info","data":{"msg":"anything"},"id":"e2","timestamp":"2026-02-26T06:30:00.000Z"}
+{"type":"user.message","data":{"content":"   "},"id":"e3","timestamp":"2026-02-26T06:30:01.000Z"}
+{"type":"assistant.message","data":{"messageId":"m","content":"","toolRequests":[]},"id":"e4","timestamp":"2026-02-26T06:30:02.000Z"}
+{"type":"user.message","data":{"content":"real question"},"id":"e5","timestamp":"2026-02-26T06:30:03.000Z"}"#;
+
+    let session = parse_copilot_events(jsonl, "fallback").unwrap().unwrap();
+    assert_eq!(session.messages.len(), 1, "empty and unknown events should be skipped");
+    assert_eq!(session.messages[0].content, "real question");
+}
+
+#[test]
+fn copilot_parser_empty_returns_none() {
+    let jsonl = r#"{"type":"session.start","data":{"sessionId":"s","startTime":"2026-02-26T06:29:59.692Z"},"id":"e1","timestamp":"2026-02-26T06:29:59.802Z"}"#;
+    assert!(parse_copilot_events(jsonl, "fallback").unwrap().is_none());
+}
+
+#[test]
+fn copilot_parser_falls_back_to_dir_id_when_session_missing() {
+    let jsonl = r#"{"type":"user.message","data":{"content":"hi"},"id":"e1","timestamp":"2026-02-26T06:30:00.000Z"}"#;
+    let session = parse_copilot_events(jsonl, "dir-uuid").unwrap().unwrap();
+    assert_eq!(session.source_id, "dir-uuid");
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- New `copilot-cli` source adapter scanning `~/.copilot/session-state/*/events.jsonl`
- Parses `session.start`, `user.message`, `assistant.message` (with `toolRequests`), `tool.execution_start`/`tool.execution_complete` events
- Tool-call arguments and results indexed inline with tool names (via `toolCallId` → `toolName` map) for richer search coverage
- Resume command: `copilot --resume=<session-id>`
- `source_labels()` refactored to derive from `all_adapters()` instead of a parallel hardcoded list — future adapters only need to touch `all_adapters()`
- 5 new parser unit tests in `tests/regression.rs` covering plain conversations, tool requests + results, empty/unknown event filtering, empty-session `None`, and session-id fallback

### Why

- GitHub Copilot CLI is now a first-class agentic coding CLI; Recall users who use it alongside Claude Code / Codex / Gemini / Kiro / OpenCode want cross-tool search
- Copilot's per-session `events.jsonl` data model maps cleanly onto the existing `RawSession` / `RawMessage` types — no schema changes, no new dependencies
- The `source_labels()` refactor closes an extensibility debt: adding an adapter used to require edits in two places; now it only requires `all_adapters()`
- Verified end-to-end against real local data: 6 sessions / 365 messages indexed, FTS search correctly returns the latest session, tool calls and results both surface in results