### PR TITLE
[Refactor] embedding: enable metal on macOS, fix tokenizer/batch overhead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,21 @@ RESET := \033[0m
 
 .DEFAULT_GOAL := help
 
+# Enable Metal automatically on macOS — without it Candle silently falls
+# back to CPU and embedding throughput drops ~6x on Apple Silicon.
+ifeq ($(shell uname -s),Darwin)
+CARGO_RUN_FEATURES := --features metal
+endif
+
 # ── Build ────────────────────────────────────────────────────────────────────
 
 .PHONY: build release
 
 build: ## Debug build
-	$(CARGO) build
+	$(CARGO) build $(CARGO_RUN_FEATURES)
 
 release: ## Release build (LTO + strip)
-	$(CARGO) build --release
+	$(CARGO) build --release $(CARGO_RUN_FEATURES)
 
 # ── Quality ──────────────────────────────────────────────────────────────────
 
@@ -61,17 +67,17 @@ uninstall: ## Remove installed binary
 .PHONY: run index sync search
 
 run: ## Launch TUI
-	$(CARGO) run
+	$(CARGO) run $(CARGO_RUN_FEATURES)
 
 index: ## Full index
-	$(CARGO) run -- index
+	$(CARGO) run $(CARGO_RUN_FEATURES) -- index
 
 sync: ## Incremental sync
-	$(CARGO) run -- sync
+	$(CARGO) run $(CARGO_RUN_FEATURES) -- sync
 
 search: ## Search sessions (Q="query")
 	@test -n "$(Q)" || { printf 'Usage: make search Q="query"\n'; exit 1; }
-	$(CARGO) run -- search "$(Q)"
+	$(CARGO) run $(CARGO_RUN_FEATURES) -- search "$(Q)"
 
 # ── Maintenance ──────────────────────────────────────────────────────────────
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,228 @@
+use std::time::Instant;
+
+use anyhow::Result;
+use rusqlite::OptionalExtension;
+
+use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
+use crate::db::store::Store;
+use crate::embedding::EmbeddingProvider;
+use crate::semantic::build_embedding_text;
+use crate::utils::f32_slice_to_bytes;
+
+pub fn run_semantic() -> Result<()> {
+    println!("=== Recall Semantic Pipeline Benchmark ===\n");
+
+    let store = Store::open()?;
+
+    let pending_pick: Option<(String, String, i64)> = store
+        .conn
+        .query_row(
+            "SELECT m.session_id, COALESCE(s.title, m.session_id) AS title, COUNT(*) AS cnt
+             FROM messages m
+             JOIN sessions s ON s.id = m.session_id
+             LEFT JOIN message_vec mv ON mv.message_id = m.id
+             WHERE m.role = 'user' AND LENGTH(m.content) > 2 AND mv.message_id IS NULL
+             GROUP BY m.session_id
+             ORDER BY cnt DESC
+             LIMIT 1",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+        )
+        .optional()?;
+
+    let (session_id, title, has_pending) = match pending_pick {
+        Some((id, t, _)) => (id, t, true),
+        None => {
+            println!("No pending sessions found. Falling back to largest indexed session.\n");
+            let fb: (String, String, i64) = store.conn.query_row(
+                "SELECT m.session_id, COALESCE(s.title, m.session_id) AS title, COUNT(*) AS cnt
+                 FROM messages m
+                 JOIN sessions s ON s.id = m.session_id
+                 WHERE m.role = 'user' AND LENGTH(m.content) > 2
+                 GROUP BY m.session_id
+                 ORDER BY cnt DESC
+                 LIMIT 1",
+                [],
+                |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                },
+            )?;
+            (fb.0, fb.1, false)
+        }
+    };
+
+    println!("Target session: {title}");
+    println!("  session_id : {session_id}");
+    println!("  has_pending: {has_pending}\n");
+
+    println!("[1/5] Cold model load ...");
+    let t0 = Instant::now();
+    let provider = EmbeddingProvider::new(false)?;
+    let load_ms = t0.elapsed().as_millis();
+    println!("      {load_ms} ms  (device: {})\n", provider.device_name());
+
+    println!("[2/5] pending_embeddable_messages query ...");
+    let t0 = Instant::now();
+    let pending = store.pending_embeddable_messages(&session_id)?;
+    let query_us = t0.elapsed().as_micros();
+    println!("      {query_us} us  ({} rows)\n", pending.len());
+
+    let messages: Vec<(i64, String)> = if pending.is_empty() {
+        println!("      (using embeddable_messages fallback for inference test)\n");
+        store.embeddable_messages(&session_id)?
+    } else {
+        pending
+    };
+
+    if messages.is_empty() {
+        println!("No messages available to bench, aborting.");
+        return Ok(());
+    }
+
+    println!("[3/5] build_embedding_text ...");
+    let t0 = Instant::now();
+    let texts: Vec<String> =
+        messages.iter().map(|(_, c)| build_embedding_text(&title, c)).collect();
+    let build_us = t0.elapsed().as_micros();
+    let avg_len: usize =
+        texts.iter().map(|t| t.chars().count()).sum::<usize>() / texts.len().max(1);
+    println!("      {build_us} us  ({} texts, avg {} chars)\n", texts.len(), avg_len);
+
+    println!("[4/5] Inference wall clock vs batch size");
+    println!("      n = {} texts", texts.len());
+    if texts.len() < 32 {
+        println!("      note: n < 32, sweep will not reveal batch-size effects\n");
+    } else {
+        println!();
+    }
+    println!("      {:<10}{:<14}{:<14}throughput", "batch", "total_ms", "ms/msg");
+    println!("      {:<10}{:<14}{:<14}----------", "-----", "--------", "------");
+
+    let mut last_embeddings: Option<Vec<Vec<f32>>> = None;
+    for bs in [4usize, 8, 16, 32, 64, 128, 256] {
+        let t0 = Instant::now();
+        let embs = provider.embed_documents_with_batch(&texts, bs)?;
+        let elapsed = t0.elapsed();
+        let total_ms = elapsed.as_millis();
+        let per_msg = elapsed.as_secs_f64() * 1000.0 / texts.len() as f64;
+        let thr = texts.len() as f64 / elapsed.as_secs_f64();
+        println!("      {:<10}{:<14}{:<14.2}{:.1} msg/s", bs, total_ms, per_msg, thr);
+        last_embeddings = Some(embs);
+    }
+    println!();
+
+    println!("[5/5] DB upsert cost  (rollback-only, no data written)");
+    if !has_pending {
+        println!("      skipped: target session is already fully embedded, A/B would collide\n");
+    } else {
+        let embeddings = last_embeddings.expect("sweep produced embeddings");
+        let items: Vec<(i64, &[f32])> = messages
+            .iter()
+            .zip(embeddings.iter())
+            .map(|((id, _), emb)| (*id, emb.as_slice()))
+            .collect();
+
+        let current_us = time_upsert_current(&store, &items)?;
+        let plain_us = time_upsert_plain(&store, &items)?;
+
+        println!("      {:<32}{:>12} us", "current (DELETE + INSERT)", current_us);
+        println!("      {:<32}{:>12} us", "alt     (plain INSERT)", plain_us);
+        let diff = current_us as i128 - plain_us as i128;
+        println!("      {:<32}{:>12} us", "diff", diff);
+        if current_us > 0 {
+            let pct = (diff.max(0) as f64) * 100.0 / current_us as f64;
+            println!("      savings vs current: {pct:.1}%");
+        }
+        println!();
+    }
+
+    println!("=== Summary ===");
+    println!("  cold model load : {load_ms} ms  (one-time per process)");
+    println!("  pending query   : {query_us} us");
+    println!("  text build      : {build_us} us");
+    println!("  DB upsert       : typically < 1% of inference (see above)");
+    println!("  dominant cost   : inference wall clock — see sweep table\n");
+
+    Ok(())
+}
+
+pub fn run_search(query: &str) -> Result<()> {
+    println!("=== Recall Search Cold-Path Benchmark ===\n");
+    println!("  query: {query}\n");
+
+    let t_open = Instant::now();
+    let store = Store::open()?;
+    let open_ms = t_open.elapsed().as_millis();
+
+    let t_load = Instant::now();
+    let provider = EmbeddingProvider::new(false)?;
+    let load_ms = t_load.elapsed().as_millis();
+
+    let t_embed = Instant::now();
+    let query_embedding = provider
+        .embed_query(&[query])?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("empty query embedding"))?;
+    let embed_ms = t_embed.elapsed().as_millis();
+
+    let engine = SearchEngine::new(&store.conn);
+    let filters = SearchFilters { sources: None, time_range: TimeRange::All, directory: None };
+
+    let t_search = Instant::now();
+    let results = engine.hybrid_search(query, Some(&query_embedding), &filters, 20)?;
+    let search_ms = t_search.elapsed().as_millis();
+
+    let total_ms = open_ms + load_ms + embed_ms + search_ms;
+
+    println!("  {:<18}{:>10}  {:>7}", "step", "ms", "%");
+    println!("  {:<18}{:>10}  {:>7}", "----", "--", "-");
+    let row = |name: &str, ms: u128| {
+        let pct = if total_ms > 0 { (ms as f64) * 100.0 / total_ms as f64 } else { 0.0 };
+        println!("  {name:<18}{ms:>10}  {pct:>6.1}%");
+    };
+    row("store open", open_ms);
+    row("model load", load_ms);
+    row("query embed", embed_ms);
+    row("hybrid_search", search_ms);
+    println!("  {:<18}{:>10}", "total", total_ms);
+    println!("\n  ({} results)\n", results.len());
+
+    Ok(())
+}
+
+fn time_upsert_current(store: &Store, items: &[(i64, &[f32])]) -> Result<u128> {
+    store.conn.execute_batch("BEGIN")?;
+    let t0 = Instant::now();
+    {
+        let mut del = store.conn.prepare("DELETE FROM message_vec WHERE message_id = ?1")?;
+        let mut ins = store
+            .conn
+            .prepare("INSERT INTO message_vec (message_id, embedding) VALUES (?1, ?2)")?;
+        for &(message_id, embedding) in items {
+            let blob = f32_slice_to_bytes(embedding);
+            del.execute(rusqlite::params![message_id])?;
+            ins.execute(rusqlite::params![message_id, blob])?;
+        }
+    }
+    let us = t0.elapsed().as_micros();
+    store.conn.execute_batch("ROLLBACK")?;
+    Ok(us)
+}
+
+fn time_upsert_plain(store: &Store, items: &[(i64, &[f32])]) -> Result<u128> {
+    store.conn.execute_batch("BEGIN")?;
+    let t0 = Instant::now();
+    {
+        let mut ins = store
+            .conn
+            .prepare("INSERT INTO message_vec (message_id, embedding) VALUES (?1, ?2)")?;
+        for &(message_id, embedding) in items {
+            let blob = f32_slice_to_bytes(embedding);
+            ins.execute(rusqlite::params![message_id, blob])?;
+        }
+    }
+    let us = t0.elapsed().as_micros();
+    store.conn.execute_batch("ROLLBACK")?;
+    Ok(us)
+}

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -4,7 +4,7 @@ use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{BertModel, Config, DTYPE};
 use hf_hub::{Repo, RepoType};
 use std::path::PathBuf;
-use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer};
+use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 
 const MODEL_ID: &str = "intfloat/multilingual-e5-small";
 
@@ -23,8 +23,15 @@ impl EmbeddingProvider {
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], DTYPE, &device)? };
         let model = BertModel::load(vb, &config)?;
 
-        let tokenizer =
+        let mut tokenizer =
             Tokenizer::from_file(&tokenizer_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+        tokenizer.with_padding(Some(PaddingParams {
+            strategy: PaddingStrategy::BatchLongest,
+            ..Default::default()
+        }));
+        tokenizer
+            .with_truncation(Some(TruncationParams { max_length: 512, ..Default::default() }))
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         Ok(Self { model, tokenizer, device })
     }
@@ -36,12 +43,20 @@ impl EmbeddingProvider {
     }
 
     pub fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        const BATCH_SIZE: usize = 64;
         let prefixed: Vec<String> = texts.iter().map(|t| format!("passage: {t}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+        self.embed_batch(&refs)
+    }
+
+    pub fn embed_documents_with_batch(
+        &self,
+        texts: &[String],
+        batch_size: usize,
+    ) -> Result<Vec<Vec<f32>>> {
+        let bs = batch_size.max(1);
         let mut all = Vec::with_capacity(texts.len());
-        for chunk in prefixed.chunks(BATCH_SIZE) {
-            let refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
-            all.extend(self.embed_batch(&refs)?);
+        for chunk in texts.chunks(bs) {
+            all.extend(self.embed_documents(chunk)?);
         }
         Ok(all)
     }
@@ -51,18 +66,10 @@ impl EmbeddingProvider {
             return Ok(vec![]);
         }
 
-        let mut tokenizer = self.tokenizer.clone();
-        if let Some(pp) = tokenizer.get_padding_mut() {
-            pp.strategy = PaddingStrategy::BatchLongest;
-        } else {
-            tokenizer.with_padding(Some(PaddingParams {
-                strategy: PaddingStrategy::BatchLongest,
-                ..Default::default()
-            }));
-        }
-
-        let encodings =
-            tokenizer.encode_batch(texts.to_vec(), true).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let encodings = self
+            .tokenizer
+            .encode_batch(texts.to_vec(), true)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         let token_ids = encodings
             .iter()
@@ -88,12 +95,7 @@ impl EmbeddingProvider {
         let norm = pooled.sqr()?.sum_keepdim(1)?.sqrt()?;
         let normalized = pooled.broadcast_div(&norm)?;
 
-        let (batch, _dim) = normalized.dims2()?;
-        let mut result = Vec::with_capacity(batch);
-        for i in 0..batch {
-            result.push(normalized.get(i)?.to_vec1::<f32>()?);
-        }
-        Ok(result)
+        Ok(normalized.to_vec2::<f32>()?)
     }
 
     pub fn device_name(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adapters;
+pub mod bench;
 pub mod config;
 pub mod db;
 pub mod embedding;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ enum Commands {
         #[arg(long)]
         sync_first: bool,
     },
+    #[command(hide = true, name = "__bench-semantic")]
+    BenchSemantic,
+    #[command(hide = true, name = "__bench-search")]
+    BenchSearch {
+        query: String,
+    },
     Search {
         query: String,
         #[arg(long)]
@@ -55,6 +61,8 @@ fn main() -> Result<()> {
         Some(Commands::Index) => cmd_index(false)?,
         Some(Commands::Sync) => cmd_index(true)?,
         Some(Commands::BackgroundWorker { sync_first }) => cmd_background_worker(sync_first)?,
+        Some(Commands::BenchSemantic) => recall::bench::run_semantic()?,
+        Some(Commands::BenchSearch { query }) => recall::bench::run_search(&query)?,
         Some(Commands::Search { query, source, time }) => {
             cmd_search(&query, source.as_deref(), time.as_deref())?
         }

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -8,14 +8,8 @@ use fs2::FileExt;
 use crate::db::store::Store;
 use crate::embedding::EmbeddingProvider;
 
-const SESSION_EMBED_BATCH: usize = 64;
+const SESSION_EMBED_BATCH: usize = 8;
 const BACKGROUND_JOB: &str = "pipeline";
-
-pub struct SemanticRunOutcome {
-    pub title: String,
-    pub units_done: u64,
-    pub units_total: u64,
-}
 
 pub fn ensure_background_worker(sync_first: bool) -> Result<()> {
     let exe = std::env::current_exe()?;
@@ -56,30 +50,27 @@ where
             return Err(err);
         }
     };
+    store.set_background_job_state(
+        BACKGROUND_JOB,
+        "semantic",
+        Some(&format!("starting on {}", provider.device_name())),
+    )?;
 
-    while let Some(outcome) = process_next_session(&store, &provider)? {
-        let detail = format!("{} ({}/{})", outcome.title, outcome.units_done, outcome.units_total);
-        store.set_background_job_state(BACKGROUND_JOB, "semantic", Some(&detail))?;
-    }
+    while process_next_session(&store, &provider)? {}
 
     store.clear_background_job_state(BACKGROUND_JOB)?;
     Ok(())
 }
 
-fn process_next_session(
-    store: &Store,
-    provider: &EmbeddingProvider,
-) -> Result<Option<SemanticRunOutcome>> {
+fn process_next_session(store: &Store, provider: &EmbeddingProvider) -> Result<bool> {
     let Some(job) = store.claim_next_session_embedding_job()? else {
-        return Ok(None);
+        return Ok(false);
     };
 
-    store.set_background_job_state(BACKGROUND_JOB, "semantic", Some(&job.title))?;
-    let result = process_session(store, provider, &job);
-    match result {
-        Ok(outcome) => {
+    match process_session(store, provider, &job) {
+        Ok(()) => {
             store.complete_session_embedding(&job.session_id)?;
-            Ok(Some(outcome))
+            Ok(true)
         }
         Err(err) => {
             let message = format!("{err:#}");
@@ -94,19 +85,14 @@ fn process_session(
     store: &Store,
     provider: &EmbeddingProvider,
     job: &crate::types::SemanticSessionJob,
-) -> Result<SemanticRunOutcome> {
+) -> Result<()> {
     let pending = store.pending_embeddable_messages(&job.session_id)?;
+    let mut units_done = store.embedded_message_count(&job.session_id)?;
     if pending.is_empty() {
-        let units_done = store.embedded_message_count(&job.session_id)?;
-        return Ok(SemanticRunOutcome {
-            title: job.title.clone(),
-            units_done,
-            units_total: job.units_total,
-        });
+        return Ok(());
     }
 
-    let mut units_done = store.embedded_message_count(&job.session_id)?;
-
+    let device = provider.device_name();
     for chunk in pending.chunks(SESSION_EMBED_BATCH) {
         let texts: Vec<String> =
             chunk.iter().map(|(_, content)| build_embedding_text(&job.title, content)).collect();
@@ -119,14 +105,14 @@ fn process_session(
         store.upsert_embeddings(&items)?;
         units_done += chunk.len() as u64;
         store.update_session_embedding_progress(&job.session_id, units_done)?;
-        let detail = format!("{} ({}/{})", job.title, units_done, job.units_total);
+        let detail = format!("{} ({}/{}) • {device}", job.title, units_done, job.units_total);
         store.set_background_job_state(BACKGROUND_JOB, "semantic", Some(&detail))?;
     }
 
-    Ok(SemanticRunOutcome { title: job.title.clone(), units_done, units_total: job.units_total })
+    Ok(())
 }
 
-fn build_embedding_text(title: &str, content: &str) -> String {
+pub(crate) fn build_embedding_text(title: &str, content: &str) -> String {
     let text = format!("{title}: {content}");
     if text.chars().count() > 500 { text.chars().take(500).collect() } else { text }
 }


### PR DESCRIPTION
### What's changed?

- 9.5x embedding throughput on Apple Silicon (6 -> 57 msg/s on M4 Pro); a 38k-message backfill drops from ~110 min to ~12 min.
- Makefile auto-enables `--features metal` on macOS for build/release/run/index/sync. check/test/lint stay feature-free so the Linux CI matrix is untouched.
- `EmbeddingProvider::new()` sets padding strategy and a 512-token truncation cap once. The per-batch `tokenizer.clone()` is gone and the dead inner chunk loop in `embed_documents` is removed.
- `SESSION_EMBED_BATCH` drops from 64 to 8. The bench sweep shows throughput is monotonically decreasing in batch size on Metal because BatchLongest padding lets the longest outlier dominate O(n^2) attention.
- `embed_documents_with_batch` is now a thin chunking wrapper over `embed_documents`, and `embed_batch` uses `Tensor::to_vec2` instead of a per-row `get(i).to_vec1()` loop (fewer device->host syncs, small but real on small batches).
- Worker loop simplified: `SemanticRunOutcome` struct removed along with the pre/post-session state writes that were overwritten by the per-batch progress update (~2560 redundant SQLite writes eliminated per full backfill). `build_embedding_text` is now a single `pub(crate)` definition in `semantic.rs` shared with `bench.rs`.
- Active candle device is surfaced in the background-worker progress state so the TUI shows Metal vs CPU without running the bench.
- Adds the previously-uncommitted bench harness (`src/bench.rs` with `__bench-semantic` and `__bench-search` hidden CLI commands) that this work was measured against.

### Why

- `make release` on macOS silently fell back to CPU because `candle-metal` was a non-default feature, which was the single biggest source of slow embedding throughput on Apple Silicon.
- Without a 512-token truncation cap, CJK or code-dense messages could exceed BERT's 512 position embeddings and either panic or emit garbage vectors. The char-level 500-cut stays as the throughput pre-filter; the token cap is a correctness safety net.
- The bench harness exposed that larger batches were slower on Metal due to padding blow-up, leading to the batch-size tuning.
- The pre/post-session worker state writes became dead intermediate data once per-batch progress was in place; removing them tightens the worker state machine and drops ~2560 no-op SQLite writes across a 38k-message backfill.

### Verification

- `make check` — 34/34 tests pass, clippy clean, fmt clean.
- `target/release/recall __bench-semantic` on M4 Pro / macOS 26.4:
  - device: Metal, cold load 279 ms
  - batch sweep (4/8/16/32/64/128/256): 68.0 / 58.8 / 49.4 / 42.8 / 38.0 / 33.7 / 31.7 msg/s
  - production `SESSION_EMBED_BATCH=8` -> 58.8 msg/s, stable across repeated runs