### PR TITLE
[Refactor] make metal default on macos via target-specific deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,9 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-15
             artifact: recall-macos-x86_64
-            features: metal
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: recall-macos-aarch64
-            features: metal
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: recall-windows-x86_64
@@ -41,14 +39,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build
-        shell: bash
-        run: |
-          FEATURES="${{ matrix.features }}"
-          if [ -n "$FEATURES" ]; then
-            cargo build --release --target ${{ matrix.target }} --features "$FEATURES"
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "accelerate-src"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,7 +227,6 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
- "accelerate-src",
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
@@ -242,7 +235,6 @@ dependencies = [
  "float8",
  "gemm 0.19.0",
  "half",
- "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -289,7 +281,6 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
- "accelerate-src",
  "candle-core",
  "candle-metal-kernels",
  "half",
@@ -308,7 +299,6 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
- "accelerate-src",
  "byteorder",
  "candle-core",
  "candle-nn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ repository = "https://github.com/samzong/Recall"
 clap = { version = "4", features = ["derive"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlite-vec = "0.1"
-candle-core = "0.10"
-candle-nn = "0.10"
-candle-transformers = "0.10"
 hf-hub = { version = "0.5", features = ["ureq"] }
 tokenizers = { version = "0.22", default-features = false }
 serde = { version = "1", features = ["derive"] }
@@ -29,11 +26,19 @@ crossterm = "0.28"
 unicode-width = "0.2"
 fs2 = "0.4"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { version = "0.10", features = ["metal"] }
+candle-nn = { version = "0.10", features = ["metal"] }
+candle-transformers = { version = "0.10", features = ["metal"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+candle-core = "0.10"
+candle-nn = "0.10"
+candle-transformers = "0.10"
+
 [features]
 default = []
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
-accelerate = ["candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
 
 [profile.release]
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,15 @@ RESET := \033[0m
 
 .DEFAULT_GOAL := help
 
-# Enable Metal automatically on macOS — without it Candle silently falls
-# back to CPU and embedding throughput drops ~6x on Apple Silicon.
-ifeq ($(shell uname -s),Darwin)
-CARGO_RUN_FEATURES := --features metal
-endif
-
 # ── Build ────────────────────────────────────────────────────────────────────
 
 .PHONY: build release
 
 build: ## Debug build
-	$(CARGO) build $(CARGO_RUN_FEATURES)
+	$(CARGO) build
 
 release: ## Release build (LTO + strip)
-	$(CARGO) build --release $(CARGO_RUN_FEATURES)
+	$(CARGO) build --release
 
 # ── Quality ──────────────────────────────────────────────────────────────────
 
@@ -67,14 +61,14 @@ uninstall: ## Remove installed binary
 .PHONY: run sync search
 
 run: ## Launch TUI
-	$(CARGO) run $(CARGO_RUN_FEATURES)
+	$(CARGO) run
 
 sync: ## Incremental sync (use FORCE=1 to reprocess all)
-	$(CARGO) run $(CARGO_RUN_FEATURES) -- sync $(if $(FORCE),--force,)
+	$(CARGO) run -- sync $(if $(FORCE),--force,)
 
 search: ## Search sessions (Q="query")
 	@test -n "$(Q)" || { printf 'Usage: make search Q="query"\n'; exit 1; }
-	$(CARGO) run $(CARGO_RUN_FEATURES) -- search "$(Q)"
+	$(CARGO) run -- search "$(Q)"
 
 # ── Release ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### What's changed?

- `Cargo.toml`: move `candle-core`/`candle-nn`/`candle-transformers` into `[target.'cfg(target_os = "macos")'.dependencies]` with `features = ["metal"]`, and a matching `cfg(not(target_os = "macos"))` block without metal. Drop the now-unused `metal` and `accelerate` local features; keep `cuda` as an opt-in for Linux GPU users.
- `Makefile`: remove the `ifeq ($(shell uname -s),Darwin)` hack and all `$(CARGO_RUN_FEATURES)` references from `build`/`release`/`run`/`sync`/`search` targets.
- `.github/workflows/release.yml`: drop the `features: metal` matrix field on the two macOS jobs and simplify the Build step to a single `cargo build --release --target ${{ matrix.target }}`.
- `Cargo.lock`: regenerated by cargo after the dependency restructure.

### Why

Metal backend activation was expressed in three places — a local cargo feature, a Makefile `uname` branch, and a CI matrix field — and all three had to agree for macOS users to get a Metal-linked binary. Any path that bypassed `make` (naked `cargo build`, `cargo install`, rust-analyzer, IDE builds, new contributors) silently fell back to CPU, which Candle handles without an error. That fallback is ~6x slower on Apple Silicon.

Cargo's `[target.'cfg(...)'.dependencies]` supports the `features` field natively, which is the intended way to express a platform-default backend. After the move, `cargo metadata` on macOS resolves `candle-core`/`candle-nn`/`candle-transformers` with `enabled features: ['default', 'metal']` and pulls `candle-metal-kernels` into the graph without any flags, and naked `cargo build --release` produces a binary that links `Metal.framework`, `Foundation.framework`, and `libobjc.A.dylib` — identical to the `/opt/homebrew/bin/recall` distributed via the homebrew tap.

Linux CI is unaffected: on `ubuntu-latest`, `cfg(target_os = "macos")` doesn't match, so candle resolves without metal and `make check` keeps passing.

### Verification

- `cargo metadata --format-version=1` on macOS shows `candle-core@0.10.2`, `candle-nn@0.10.2`, `candle-transformers@0.10.2` all with `enabled features: ['default', 'metal']`, plus `candle-metal-kernels@0.10.2` in the resolved graph.
- `make check` — fmt ✓, clippy ✓, 34 tests ✓.
- Naked `cargo build --release` (no Makefile, no feature flags) → `otool -L target/release/recall` shows `/System/Library/Frameworks/Metal.framework`, `Foundation.framework`, `libobjc.A.dylib`.