### PR TITLE
perf: make OpenCode sync incremental and restore safe scans

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -5,12 +5,23 @@ pub mod gemini;
 pub mod kiro;
 pub mod opencode;
 
+use crate::db::store::Store;
 use crate::types::Role;
 
 pub trait SourceAdapter {
     fn id(&self) -> &str;
     fn label(&self) -> &str;
     fn scan(&self) -> anyhow::Result<Vec<RawSession>>;
+    fn scan_summary(&self) -> anyhow::Result<Option<SourceScanSummary>> {
+        Ok(None)
+    }
+    fn scan_for_sync(
+        &self,
+        _store: &Store,
+        _since_ts: Option<i64>,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        Ok(None)
+    }
     fn resume_command(&self, source_id: &str) -> Option<ResumeCommand>;
 }
 
@@ -27,6 +38,24 @@ pub struct RawMessage {
     pub role: Role,
     pub content: String,
     pub timestamp: Option<i64>,
+}
+
+#[derive(Default)]
+pub struct SyncScanStats {
+    pub skipped_sessions: u32,
+    pub filtered_sessions: u32,
+}
+
+pub struct SyncScanResult {
+    pub sessions: Vec<RawSession>,
+    pub stats: SyncScanStats,
+}
+
+pub struct SourceScanSummary {
+    pub sessions: usize,
+    pub messages: usize,
+    pub oldest_started_at: Option<i64>,
+    pub newest_started_at: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -150,7 +150,14 @@ fn load_session_rows(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result
         stmt.query_map([], map_session_row)?
     };
 
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    let mut sessions = Vec::new();
+    for row in rows {
+        match row {
+            Ok(session) => sessions.push(session),
+            Err(err) => debug!("skipping malformed OpenCode session row: {err}"),
+        }
+    }
+    Ok(sessions)
 }
 
 fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
@@ -548,6 +555,24 @@ mod tests {
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "good");
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn load_session_rows_skips_malformed_session_rows() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "good", 220, 100, "hello");
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('bad', 'Bad', NULL, 100, 220)",
+            [],
+        )
+        .unwrap();
+
+        let sessions = load_session_rows(&conn, None).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "good");
         drop(conn);
         let _ = std::fs::remove_file(path);
     }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -13,7 +13,9 @@ use crate::types::Role;
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 const PARSED_PART_FILTER_SQL: &str = "
-    json_extract(m.data, '$.role') IN ('user', 'assistant')
+    json_valid(m.data)
+    AND json_valid(p.data)
+    AND json_extract(m.data, '$.role') IN ('user', 'assistant')
     AND (
         (json_extract(p.data, '$.type') = 'text'
             AND NULLIF(TRIM(CAST(json_extract(p.data, '$.text') AS TEXT)), '') IS NOT NULL)
@@ -206,6 +208,7 @@ fn load_message_chunk(
          FROM message m
          JOIN part p ON p.message_id = m.id
          WHERE m.session_id IN ({placeholders})
+           AND {PARSED_PART_FILTER_SQL}
          ORDER BY m.time_created, p.id"
     );
 
@@ -218,8 +221,8 @@ fn load_message_chunk(
         Ok((session_id, role, part_data, timestamp))
     })?;
 
-    for row in msg_rows.flatten() {
-        let (session_id, role_str, part_data, timestamp) = row;
+    for row in msg_rows {
+        let (session_id, role_str, part_data, timestamp) = row?;
         let Some(role) = parse_role(role_str.as_deref()) else {
             continue;
         };
@@ -281,10 +284,10 @@ fn parse_part_content(part_data: &str) -> Option<String> {
     let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
     match part_type {
-        "text" => part.get("text").and_then(|t| t.as_str()).and_then(|text| {
-            let trimmed = text.trim();
-            if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
-        }),
+        "text" => part
+            .get("text")
+            .and_then(|t| t.as_str())
+            .and_then(|text| if text.trim().is_empty() { None } else { Some(text.to_string()) }),
         "tool-invocation" | "tool-result" => {
             let name = part.get("toolName").and_then(|n| n.as_str()).unwrap_or("tool");
             if let Some(input) = part.get("input") {
@@ -305,6 +308,7 @@ fn scan_for_sync_conn(
 ) -> anyhow::Result<SyncScanResult> {
     let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
     let sessions = load_session_rows(conn, since_ts)?;
+    let existing = store.session_meta_map(source_id)?;
     let current_counts = load_message_counts(
         conn,
         &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
@@ -314,19 +318,15 @@ fn scan_for_sync_conn(
     let mut candidates = Vec::new();
 
     for session in sessions {
-        match store.session_meta(source_id, &session.id)? {
-            Some((old_updated_at, old_message_count)) => {
-                let current_message_count = current_counts.get(&session.id).copied().unwrap_or(0);
-                let unchanged = session.time_updated == old_updated_at
-                    && current_message_count == old_message_count;
-                if unchanged {
-                    stats.skipped_sessions += 1;
-                    continue;
-                }
-                candidates.push(session);
+        if let Some(&(old_updated_at, old_message_count)) = existing.get(&session.id) {
+            let current_message_count = current_counts.get(&session.id).copied().unwrap_or(0);
+            if session.time_updated == old_updated_at && current_message_count == old_message_count
+            {
+                stats.skipped_sessions += 1;
+                continue;
             }
-            None => candidates.push(session),
         }
+        candidates.push(session);
     }
 
     let sessions = scan_session_messages(conn, candidates)?;
@@ -517,5 +517,45 @@ mod tests {
         assert_eq!(summary.newest_started_at, Some(200));
         drop(conn);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incremental_scan_tolerates_malformed_json_rows() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "good", 220, 100, "hello");
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('bad', 'Bad', '/tmp/project', 100, 220)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('bad', '{\"role\":\"user\"}', 110)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, 'not-json')",
+            rusqlite::params![message_id],
+        )
+        .unwrap();
+
+        let store = setup_store();
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "good");
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn parse_part_content_preserves_non_blank_whitespace() {
+        let parsed = parse_part_content("{\"type\":\"text\",\"text\":\"  hello  \"}");
+        assert_eq!(parsed.as_deref(), Some("  hello  "));
+        assert_eq!(parse_part_content("{\"type\":\"text\",\"text\":\"   \"}"), None);
     }
 }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -1,18 +1,43 @@
 use std::collections::HashMap;
 
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, params_from_iter};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SourceScanSummary, SyncScanResult,
+    SyncScanStats,
+};
+use crate::db::store::Store;
 use crate::types::Role;
 
+const MAX_SQL_VARS_PER_BATCH: usize = 900;
+const PARSED_PART_FILTER_SQL: &str = "
+    json_extract(m.data, '$.role') IN ('user', 'assistant')
+    AND (
+        (json_extract(p.data, '$.type') = 'text'
+            AND NULLIF(TRIM(CAST(json_extract(p.data, '$.text') AS TEXT)), '') IS NOT NULL)
+        OR (json_extract(p.data, '$.type') = 'tool-invocation'
+            AND json_type(p.data, '$.input') IS NOT NULL)
+        OR (json_extract(p.data, '$.type') = 'tool-result'
+            AND json_type(p.data, '$.result') IS NOT NULL)
+    )
+";
+
 pub struct OpenCodeAdapter;
+
+struct SessionRow {
+    id: String,
+    directory: String,
+    time_created: i64,
+    time_updated: Option<i64>,
+}
 
 impl SourceAdapter for OpenCodeAdapter {
     fn id(&self) -> &str {
         "opencode"
     }
+
     fn label(&self) -> &str {
         "OC"
     }
@@ -25,101 +50,472 @@ impl SourceAdapter for OpenCodeAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let db_path = dirs::home_dir()
-            .ok_or_else(|| anyhow::anyhow!("no home dir"))?
-            .join(".local/share/opencode/opencode.db");
-
-        if !db_path.exists() {
-            debug!("OpenCode DB not found at {}, skipping", db_path.display());
+        let Some(conn) = open_opencode_db()? else {
             return Ok(vec![]);
+        };
+        let sessions = load_session_rows(&conn, None)?;
+        scan_session_messages(&conn, sessions)
+    }
+
+    fn scan_summary(&self) -> anyhow::Result<Option<SourceScanSummary>> {
+        let Some(conn) = open_opencode_db()? else {
+            return Ok(Some(SourceScanSummary {
+                sessions: 0,
+                messages: 0,
+                oldest_started_at: None,
+                newest_started_at: None,
+            }));
+        };
+
+        let sessions: usize =
+            conn.query_row("SELECT COUNT(*) FROM session", [], |row| row.get(0))?;
+        let oldest_started_at =
+            conn.query_row("SELECT MIN(time_created) FROM session", [], |row| row.get(0))?;
+        let newest_started_at =
+            conn.query_row("SELECT MAX(time_created) FROM session", [], |row| row.get(0))?;
+        let messages = count_total_parsed_messages(&conn)?;
+
+        Ok(Some(SourceScanSummary { sessions, messages, oldest_started_at, newest_started_at }))
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(conn) = open_opencode_db()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+
+        Ok(Some(scan_for_sync_conn(&conn, store, since_ts, self.id())?))
+    }
+}
+
+fn open_opencode_db() -> anyhow::Result<Option<Connection>> {
+    let db_path = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("no home dir"))?
+        .join(".local/share/opencode/opencode.db");
+
+    if !db_path.exists() {
+        debug!("OpenCode DB not found at {}, skipping", db_path.display());
+        return Ok(None);
+    }
+
+    Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map(Some)
+        .map_err(Into::into)
+}
+
+fn count_filtered_sessions(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<u32> {
+    let Some(cutoff) = since_ts else {
+        return Ok(0);
+    };
+
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM session
+         WHERE COALESCE(time_updated, time_created) < ?1",
+        rusqlite::params![cutoff],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count as u32)
+    .map_err(Into::into)
+}
+
+fn count_total_parsed_messages(conn: &Connection) -> anyhow::Result<usize> {
+    let sql = format!(
+        "SELECT COUNT(*)
+         FROM message m
+         JOIN part p ON p.message_id = m.id
+         WHERE {PARSED_PART_FILTER_SQL}"
+    );
+    conn.query_row(&sql, [], |row| row.get(0)).map_err(Into::into)
+}
+
+fn load_session_rows(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<Vec<SessionRow>> {
+    let sql = if since_ts.is_some() {
+        "SELECT id, directory, time_created, time_updated
+         FROM session
+         WHERE COALESCE(time_updated, time_created) >= ?1"
+    } else {
+        "SELECT id, directory, time_created, time_updated FROM session"
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let rows = if let Some(cutoff) = since_ts {
+        stmt.query_map(rusqlite::params![cutoff], map_session_row)?
+    } else {
+        stmt.query_map([], map_session_row)?
+    };
+
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
+    Ok(SessionRow {
+        id: row.get(0)?,
+        directory: row.get(1)?,
+        time_created: row.get(2)?,
+        time_updated: row.get(3)?,
+    })
+}
+
+fn scan_session_messages(
+    conn: &Connection,
+    sessions: Vec<SessionRow>,
+) -> anyhow::Result<Vec<RawSession>> {
+    if sessions.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let session_ids: Vec<String> = sessions.iter().map(|session| session.id.clone()).collect();
+    let mut session_messages: HashMap<String, Vec<RawMessage>> = HashMap::new();
+
+    for chunk in session_ids.chunks(MAX_SQL_VARS_PER_BATCH) {
+        load_message_chunk(conn, chunk, &mut session_messages)?;
+    }
+
+    let mut raw_sessions = Vec::new();
+    for session in sessions {
+        let messages = session_messages.remove(&session.id).unwrap_or_default();
+        if messages.is_empty() {
+            continue;
         }
 
-        let conn = Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        raw_sessions.push(RawSession {
+            source_id: session.id,
+            directory: Some(session.directory),
+            started_at: session.time_created,
+            updated_at: session.time_updated,
+            entrypoint: None,
+            messages,
+        });
+    }
 
-        let mut session_stmt =
-            conn.prepare("SELECT id, title, directory, time_created, time_updated FROM session")?;
+    Ok(raw_sessions)
+}
 
-        let session_rows: Vec<(String, String, String, i64, Option<i64>)> = session_stmt
-            .query_map([], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?))
-            })?
-            .filter_map(|r| r.ok())
-            .collect();
+fn load_message_chunk(
+    conn: &Connection,
+    session_ids: &[String],
+    session_messages: &mut HashMap<String, Vec<RawMessage>>,
+) -> anyhow::Result<()> {
+    let placeholders = std::iter::repeat_n("?", session_ids.len()).collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "SELECT m.session_id, json_extract(m.data, '$.role') AS role, p.data, m.time_created
+         FROM message m
+         JOIN part p ON p.message_id = m.id
+         WHERE m.session_id IN ({placeholders})
+         ORDER BY m.time_created, p.id"
+    );
 
-        let mut msg_stmt = conn.prepare(
-            "SELECT m.session_id, json_extract(m.data, '$.role') AS role,
-                    p.data, m.time_created
+    let mut stmt = conn.prepare(&sql)?;
+    let msg_rows = stmt.query_map(params_from_iter(session_ids.iter()), |row| {
+        let session_id: String = row.get(0)?;
+        let role: Option<String> = row.get(1)?;
+        let part_data: String = row.get(2)?;
+        let timestamp: Option<i64> = row.get(3)?;
+        Ok((session_id, role, part_data, timestamp))
+    })?;
+
+    for row in msg_rows.flatten() {
+        let (session_id, role_str, part_data, timestamp) = row;
+        let Some(role) = parse_role(role_str.as_deref()) else {
+            continue;
+        };
+        let Some(content) = parse_part_content(&part_data) else {
+            continue;
+        };
+
+        session_messages.entry(session_id).or_default().push(RawMessage {
+            role,
+            content,
+            timestamp,
+        });
+    }
+
+    Ok(())
+}
+
+fn load_message_counts(
+    conn: &Connection,
+    session_ids: &[String],
+) -> anyhow::Result<HashMap<String, u32>> {
+    let mut counts = HashMap::new();
+
+    for chunk in session_ids.chunks(MAX_SQL_VARS_PER_BATCH) {
+        let placeholders = std::iter::repeat_n("?", chunk.len()).collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT m.session_id, COUNT(*)
              FROM message m
              JOIN part p ON p.message_id = m.id
-             ORDER BY m.time_created, p.id",
-        )?;
+             WHERE m.session_id IN ({placeholders})
+               AND {PARSED_PART_FILTER_SQL}
+             GROUP BY m.session_id"
+        );
 
-        let mut session_messages: HashMap<String, Vec<RawMessage>> = HashMap::new();
-
-        let msg_rows = msg_stmt.query_map([], |row| {
-            let session_id: String = row.get(0)?;
-            let role: Option<String> = row.get(1)?;
-            let part_data: String = row.get(2)?;
-            let timestamp: Option<i64> = row.get(3)?;
-            Ok((session_id, role, part_data, timestamp))
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(chunk.iter()), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u32))
         })?;
 
-        for row in msg_rows.flatten() {
-            let (session_id, role_str, part_data, timestamp) = row;
-
-            let role = match role_str.as_deref() {
-                Some("user") => Role::User,
-                Some("assistant") => Role::Assistant,
-                _ => continue,
-            };
-
-            let part: Value = match serde_json::from_str(&part_data) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-
-            let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
-            let text = match part_type {
-                "text" => match part.get("text").and_then(|t| t.as_str()) {
-                    Some(t) if !t.is_empty() => t.to_string(),
-                    _ => continue,
-                },
-                "tool-invocation" | "tool-result" => {
-                    let name = part.get("toolName").and_then(|n| n.as_str()).unwrap_or("tool");
-                    if let Some(input) = part.get("input") {
-                        format!("[{name}] {input}")
-                    } else if let Some(result) = part.get("result") {
-                        format!("[{name}] {result}")
-                    } else {
-                        continue;
-                    }
-                }
-                _ => continue,
-            };
-
-            session_messages.entry(session_id).or_default().push(RawMessage {
-                role,
-                content: text,
-                timestamp,
-            });
+        for row in rows {
+            let (session_id, count) = row?;
+            counts.insert(session_id, count);
         }
+    }
 
-        let mut sessions = Vec::new();
-        for (id, _title, directory, time_created, time_updated) in session_rows {
-            let messages = session_messages.remove(&id).unwrap_or_default();
-            if messages.is_empty() {
-                continue;
+    Ok(counts)
+}
+
+fn parse_role(role: Option<&str>) -> Option<Role> {
+    match role {
+        Some("user") => Some(Role::User),
+        Some("assistant") => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn parse_part_content(part_data: &str) -> Option<String> {
+    let part: Value = serde_json::from_str(part_data).ok()?;
+    let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+    match part_type {
+        "text" => part.get("text").and_then(|t| t.as_str()).and_then(|text| {
+            let trimmed = text.trim();
+            if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+        }),
+        "tool-invocation" | "tool-result" => {
+            let name = part.get("toolName").and_then(|n| n.as_str()).unwrap_or("tool");
+            if let Some(input) = part.get("input") {
+                Some(format!("[{name}] {input}"))
+            } else {
+                part.get("result").map(|result| format!("[{name}] {result}"))
             }
-            sessions.push(RawSession {
-                source_id: id,
-                directory: Some(directory),
-                started_at: time_created,
-                updated_at: time_updated,
-                entrypoint: None,
-                messages,
-            });
         }
+        _ => None,
+    }
+}
 
-        Ok(sessions)
+fn scan_for_sync_conn(
+    conn: &Connection,
+    store: &Store,
+    since_ts: Option<i64>,
+    source_id: &str,
+) -> anyhow::Result<SyncScanResult> {
+    let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
+    let sessions = load_session_rows(conn, since_ts)?;
+    let current_counts = load_message_counts(
+        conn,
+        &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
+    )?;
+
+    let mut stats = SyncScanStats { filtered_sessions, ..Default::default() };
+    let mut candidates = Vec::new();
+
+    for session in sessions {
+        match store.session_meta(source_id, &session.id)? {
+            Some((old_updated_at, old_message_count)) => {
+                let current_message_count = current_counts.get(&session.id).copied().unwrap_or(0);
+                let unchanged = session.time_updated == old_updated_at
+                    && current_message_count == old_message_count;
+                if unchanged {
+                    stats.skipped_sessions += 1;
+                    continue;
+                }
+                candidates.push(session);
+            }
+            None => candidates.push(session),
+        }
+    }
+
+    let sessions = scan_session_messages(conn, candidates)?;
+    Ok(SyncScanResult { sessions, stats })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+
+    fn make_session(
+        id: &str,
+        source_id: &str,
+        updated_at: Option<i64>,
+        message_count: u32,
+    ) -> Session {
+        Session {
+            id: id.to_string(),
+            source: "opencode".to_string(),
+            source_id: source_id.to_string(),
+            title: "existing".to_string(),
+            directory: Some("/tmp/project".to_string()),
+            started_at: 100,
+            updated_at,
+            message_count,
+            entrypoint: None,
+        }
+    }
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn setup_opencode_db() -> (PathBuf, Connection) {
+        let path =
+            std::env::temp_dir().join(format!("recall-opencode-test-{}.db", uuid::Uuid::new_v4()));
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created INTEGER,
+                time_updated INTEGER
+            );
+            CREATE TABLE message (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                time_created INTEGER
+            );
+            CREATE TABLE part (
+                id INTEGER PRIMARY KEY,
+                message_id INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            ",
+        )
+        .unwrap();
+        (path, conn)
+    }
+
+    fn insert_session_with_message(
+        conn: &Connection,
+        id: &str,
+        updated_at: i64,
+        time_created: i64,
+        text: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES (?1, 'Test', '/tmp/project', ?2, ?3)",
+            rusqlite::params![id, time_created, updated_at],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES (?1, '{\"role\":\"user\"}', ?2)",
+            rusqlite::params![id, time_created + 10],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![message_id, format!("{{\"type\":\"text\",\"text\":\"{text}\"}}")],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn incremental_scan_skips_sessions_with_matching_updated_at_and_message_count() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 200, 100, "hello");
+
+        let store = setup_store();
+        store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        assert!(result.sessions.is_empty());
+        assert_eq!(result.stats.skipped_sessions, 1);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incremental_scan_resyncs_same_updated_at_when_message_count_changes() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 200, 100, "hello");
+        insert_session_with_message(&conn, "s1-second", 200, 100, "shadow");
+        conn.execute("DELETE FROM session WHERE id = 's1-second'", []).unwrap();
+        conn.execute("UPDATE message SET session_id = 's1' WHERE session_id = 's1-second'", [])
+            .unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "s1");
+        assert_eq!(result.sessions[0].messages.len(), 2);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incremental_scan_returns_updated_sessions_only() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 220, 100, "hello");
+        insert_session_with_message(&conn, "s2", 150, 100, "world");
+
+        let store = setup_store();
+        store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
+        store.insert_session(&make_session("local-s2", "s2", Some(150), 1)).unwrap();
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        assert_eq!(result.stats.skipped_sessions, 1);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "s1");
+        assert_eq!(result.sessions[0].messages.len(), 1);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incremental_scan_counts_filtered_sessions_for_time_scope() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "old", 120, 100, "old");
+        insert_session_with_message(&conn, "new", 220, 200, "new");
+
+        let store = setup_store();
+        let result = scan_for_sync_conn(&conn, &store, Some(200), "opencode").unwrap();
+
+        assert_eq!(result.stats.filtered_sessions, 1);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "new");
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn summary_reports_counts_without_full_scan() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 220, 100, "hello");
+        insert_session_with_message(&conn, "s2", 250, 200, "world");
+
+        let summary = SourceScanSummary {
+            sessions: conn.query_row("SELECT COUNT(*) FROM session", [], |row| row.get(0)).unwrap(),
+            messages: count_total_parsed_messages(&conn).unwrap(),
+            oldest_started_at: conn
+                .query_row("SELECT MIN(time_created) FROM session", [], |row| row.get(0))
+                .unwrap(),
+            newest_started_at: conn
+                .query_row("SELECT MAX(time_created) FROM session", [], |row| row.get(0))
+                .unwrap(),
+        };
+
+        assert_eq!(summary.sessions, 2);
+        assert_eq!(summary.messages, 2);
+        assert_eq!(summary.oldest_started_at, Some(100));
+        assert_eq!(summary.newest_started_at, Some(200));
+        drop(conn);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use chrono::Utc;
 use rusqlite::Connection;
@@ -46,6 +48,16 @@ impl Store {
             Some(row) => Ok(Some((row.get(0)?, row.get(1)?))),
             None => Ok(None),
         }
+    }
+
+    pub fn session_meta_map(&self, source: &str) -> Result<HashMap<String, (Option<i64>, u32)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source_id, updated_at, message_count FROM sessions WHERE source = ?1",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![source], |row| {
+            Ok((row.get::<_, String>(0)?, (row.get(1)?, row.get(2)?)))
+        })?;
+        rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
     pub fn insert_session(&self, session: &Session) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,25 +103,50 @@ fn cmd_info() -> Result<()> {
         let label =
             labels.iter().find(|(k, _)| k == id).map(|(_, v)| v.as_str()).unwrap_or(id).to_string();
 
-        match adapter.scan() {
-            Ok(sessions) => {
-                let session_count = sessions.len();
-                let message_count: usize = sessions.iter().map(|s| s.messages.len()).sum();
-                let oldest = sessions.iter().map(|s| s.started_at).min();
-                let newest = sessions.iter().map(|s| s.started_at).max();
-
-                grand_sessions += session_count;
-                grand_messages += message_count;
+        match adapter.scan_summary() {
+            Ok(Some(summary)) => {
+                grand_sessions += summary.sessions;
+                grand_messages += summary.messages;
 
                 rows.push(SourceSummary {
                     label,
                     id: id.to_string(),
-                    sessions: session_count,
-                    messages: message_count,
-                    range: format_date_range(oldest, newest),
+                    sessions: summary.sessions,
+                    messages: summary.messages,
+                    range: format_date_range(summary.oldest_started_at, summary.newest_started_at),
                     error: None,
                 });
             }
+            Ok(None) => match adapter.scan() {
+                Ok(sessions) => {
+                    let session_count = sessions.len();
+                    let message_count: usize = sessions.iter().map(|s| s.messages.len()).sum();
+                    let oldest = sessions.iter().map(|s| s.started_at).min();
+                    let newest = sessions.iter().map(|s| s.started_at).max();
+
+                    grand_sessions += session_count;
+                    grand_messages += message_count;
+
+                    rows.push(SourceSummary {
+                        label,
+                        id: id.to_string(),
+                        sessions: session_count,
+                        messages: message_count,
+                        range: format_date_range(oldest, newest),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    rows.push(SourceSummary {
+                        label,
+                        id: id.to_string(),
+                        sessions: 0,
+                        messages: 0,
+                        range: "-".to_string(),
+                        error: Some(e.to_string()),
+                    });
+                }
+            },
             Err(e) => {
                 rows.push(SourceSummary {
                     label,
@@ -271,13 +296,34 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
         if verbose {
             println!("Scanning {label}...");
         }
-        let raw_sessions = match adapter.scan() {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("Error scanning {label}: {e}");
-                continue;
+        let optimized = if force {
+            None
+        } else {
+            match adapter.scan_for_sync(&store, since_ts) {
+                Ok(scan) => scan,
+                Err(e) => {
+                    eprintln!("Error scanning {label}: {e}");
+                    continue;
+                }
             }
         };
+        let (raw_sessions, pre_skipped, pre_filtered) = match optimized {
+            Some(scan) => {
+                (scan.sessions, scan.stats.skipped_sessions, scan.stats.filtered_sessions)
+            }
+            None => {
+                let raw_sessions = match adapter.scan() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("Error scanning {label}: {e}");
+                        continue;
+                    }
+                };
+                (raw_sessions, 0, 0)
+            }
+        };
+        skipped += pre_skipped;
+        filtered_out += pre_filtered;
         if verbose {
             println!("  Found {} sessions", raw_sessions.len());
         }


### PR DESCRIPTION
## Summary
- make OpenCode sync incremental by skipping unchanged sessions before loading message parts
- preserve sync correctness by requiring both `updated_at` and `message_count` to match before skipping
- restore safe full scans and `info` summaries by avoiding oversized SQLite `IN (...)` queries

## Verification
- `make check`
- `target/debug/recall info`
- `time target/debug/recall sync -v`

## Notes
- adds OpenCode adapter tests for unchanged skip, updated-session reload, time-scope filtering, and summary behavior
