### PR TITLE
[Perf] Make Claude Code sync incremental via shared file_scan helper

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+};
+use crate::db::store::Store;
 use crate::types::Role;
 
 pub struct ClaudeCodeAdapter;
@@ -27,20 +31,37 @@ impl SourceAdapter for ClaudeCodeAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-        let claude_dir = home.join(".claude");
-        if !claude_dir.exists() {
-            debug!("~/.claude not found, skipping Claude Code");
+        let Some(claude_dir) = resolve_claude_dir()? else {
             return Ok(vec![]);
+        };
+        let session_index = load_session_index(&claude_dir);
+
+        let mut sessions = Vec::new();
+        let mut entries = collect_project_entries(&claude_dir, &session_index);
+        entries.extend(collect_transcript_entries(&claude_dir));
+
+        for entry in entries {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                continue;
+            };
+            if let Some(raw) = parse_claude_session_file(entry, mtime_ms, &session_index)? {
+                sessions.push(raw);
+            }
         }
 
-        let session_index = load_session_index(&claude_dir);
-        let mut sessions = Vec::new();
-
-        sessions.extend(scan_projects(&claude_dir, &session_index));
-        sessions.extend(scan_transcripts(&claude_dir));
-
         Ok(sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(claude_dir) = resolve_claude_dir()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+        let result = scan_for_sync_impl(&claude_dir, store, since_ts)?;
+        Ok(Some(result))
     }
 }
 
@@ -48,6 +69,30 @@ struct SessionMeta {
     cwd: Option<String>,
     started_at: i64,
     entrypoint: Option<String>,
+}
+
+fn resolve_claude_dir() -> anyhow::Result<Option<PathBuf>> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let dir = home.join(".claude");
+    if !dir.exists() {
+        debug!("~/.claude not found, skipping Claude Code");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+fn scan_for_sync_impl(
+    claude_dir: &Path,
+    store: &Store,
+    since_ts: Option<i64>,
+) -> anyhow::Result<SyncScanResult> {
+    let session_index = load_session_index(claude_dir);
+    let mut entries = collect_project_entries(claude_dir, &session_index);
+    entries.extend(collect_transcript_entries(claude_dir));
+
+    file_scan::run_file_scan(store, "claude-code", since_ts, entries, |entry, mtime_ms| {
+        parse_claude_session_file(entry, mtime_ms, &session_index)
+    })
 }
 
 fn load_session_index(claude_dir: &Path) -> HashMap<String, SessionMeta> {
@@ -90,16 +135,16 @@ fn load_session_index(claude_dir: &Path) -> HashMap<String, SessionMeta> {
     index
 }
 
-fn scan_projects(
+fn collect_project_entries(
     claude_dir: &Path,
     session_index: &HashMap<String, SessionMeta>,
-) -> Vec<RawSession> {
+) -> Vec<FileScanEntry> {
     let projects_dir = claude_dir.join("projects");
     if !projects_dir.exists() {
         return vec![];
     }
 
-    let mut sessions = Vec::new();
+    let mut entries = Vec::new();
 
     let project_dirs = match fs::read_dir(&projects_dir) {
         Ok(e) => e,
@@ -116,7 +161,7 @@ fn scan_projects(
         }
 
         let dir_name = project_entry.file_name().to_string_lossy().to_string();
-        let directory = project_key_to_path(&dir_name);
+        let directory_hint = project_key_to_path(&dir_name);
 
         let jsonl_files = match fs::read_dir(&project_path) {
             Ok(e) => e,
@@ -128,84 +173,85 @@ fn scan_projects(
             if file_path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
-
-            let session_id =
-                file_path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
-
-            let meta = session_index.get(&session_id);
-
-            let messages = match parse_conversation_jsonl(&file_path) {
-                Ok(m) => m,
-                Err(e) => {
-                    debug!("failed to parse {}: {e}", file_path.display());
-                    continue;
-                }
+            let session_id = match file_path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) if !s.is_empty() => s.to_string(),
+                _ => continue,
             };
 
-            if messages.is_empty() {
-                continue;
-            }
+            let meta_cwd = session_index.get(&session_id).and_then(|m| m.cwd.clone());
+            let directory = meta_cwd.or_else(|| Some(directory_hint.clone()));
 
-            let started_at = meta
-                .map(|m| m.started_at)
-                .or_else(|| messages.first().and_then(|m| m.timestamp))
-                .unwrap_or(0);
-
-            sessions.push(RawSession {
-                source_id: session_id,
-                directory: meta.and_then(|m| m.cwd.clone()).or_else(|| Some(directory.clone())),
-                started_at,
-                updated_at: messages.last().and_then(|m| m.timestamp),
-                entrypoint: meta.and_then(|m| m.entrypoint.clone()),
-                messages,
-            });
+            entries.push(FileScanEntry { session_id, stat_target: file_path, directory });
         }
     }
 
-    sessions
+    entries
 }
 
-fn scan_transcripts(claude_dir: &Path) -> Vec<RawSession> {
+fn collect_transcript_entries(claude_dir: &Path) -> Vec<FileScanEntry> {
     let transcripts_dir = claude_dir.join("transcripts");
     if !transcripts_dir.exists() {
         return vec![];
     }
 
-    let mut sessions = Vec::new();
+    let mut entries = Vec::new();
 
     for entry in WalkDir::new(&transcripts_dir).into_iter().filter_map(|e| e.ok()) {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
-
-        let session_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
-
-        let messages = match parse_conversation_jsonl(path) {
-            Ok(m) => m,
-            Err(e) => {
-                debug!("failed to parse transcript {}: {e}", path.display());
-                continue;
-            }
-        };
-
-        if messages.is_empty() {
+        if !path.is_file() {
             continue;
         }
+        let session_id = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => continue,
+        };
 
-        let started_at = messages.first().and_then(|m| m.timestamp).unwrap_or(0);
-
-        sessions.push(RawSession {
-            source_id: session_id,
+        entries.push(FileScanEntry {
+            session_id,
+            stat_target: path.to_path_buf(),
             directory: None,
-            started_at,
-            updated_at: messages.last().and_then(|m| m.timestamp),
-            entrypoint: None,
-            messages,
         });
     }
 
-    sessions
+    entries
+}
+
+fn parse_claude_session_file(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+    session_index: &HashMap<String, SessionMeta>,
+) -> anyhow::Result<Option<RawSession>> {
+    let messages = match parse_conversation_jsonl(&entry.stat_target) {
+        Ok(m) => m,
+        Err(e) => {
+            debug!("failed to parse {}: {e}", entry.stat_target.display());
+            return Ok(None);
+        }
+    };
+
+    if messages.is_empty() {
+        return Ok(None);
+    }
+
+    let meta = session_index.get(&entry.session_id);
+    let started_at = meta
+        .map(|m| m.started_at)
+        .or_else(|| messages.first().and_then(|m| m.timestamp))
+        .unwrap_or(0);
+    let directory = meta.and_then(|m| m.cwd.clone()).or(entry.directory);
+    let entrypoint = meta.and_then(|m| m.entrypoint.clone());
+
+    Ok(Some(RawSession {
+        source_id: entry.session_id,
+        directory,
+        started_at,
+        updated_at: Some(mtime_ms),
+        entrypoint,
+        messages,
+    }))
 }
 
 fn parse_conversation_jsonl(path: &Path) -> anyhow::Result<Vec<RawMessage>> {
@@ -317,4 +363,157 @@ fn project_key_to_path(key: &str) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn temp_claude_root(label: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("recall-cc-test-{}-{}", label, uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_user_jsonl(project_dir: &Path, session_id: &str, text: &str) -> PathBuf {
+        fs::create_dir_all(project_dir).unwrap();
+        let path = project_dir.join(format!("{session_id}.jsonl"));
+        let line = serde_json::json!({
+            "type": "user",
+            "message": {"content": text},
+            "timestamp": "2026-04-13T10:00:00Z"
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{line}").unwrap();
+        path
+    }
+
+    fn make_existing_session(source_id: &str, updated_at: i64, message_count: u32) -> Session {
+        Session {
+            id: format!("internal-{source_id}"),
+            source: "claude-code".to_string(),
+            source_id: source_id.to_string(),
+            title: "existing".to_string(),
+            directory: None,
+            started_at: 0,
+            updated_at: Some(updated_at),
+            message_count,
+            entrypoint: None,
+        }
+    }
+
+    #[test]
+    fn parse_claude_session_file_sets_updated_at_to_mtime() {
+        let root = temp_claude_root("parse");
+        let project = root.join("projects").join("-tmp-foo");
+        let path = write_user_jsonl(&project, "abc-123", "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "abc-123".to_string(),
+            stat_target: path.clone(),
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let session_index = HashMap::new();
+        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+
+        assert_eq!(raw.source_id, "abc-123");
+        assert_eq!(raw.updated_at, Some(mtime));
+        assert_eq!(raw.directory.as_deref(), Some("/tmp/foo"));
+        assert_eq!(raw.messages.len(), 1);
+        assert_eq!(raw.messages[0].content, "hello");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_project_entries_walks_nested_projects() {
+        let root = temp_claude_root("collect");
+        let p1 = root.join("projects").join("-tmp-foo");
+        let p2 = root.join("projects").join("-tmp-bar");
+        write_user_jsonl(&p1, "sess-1", "a");
+        write_user_jsonl(&p2, "sess-2", "b");
+
+        let session_index = HashMap::new();
+        let entries = collect_project_entries(&root, &session_index);
+        assert_eq!(entries.len(), 2);
+        let ids: Vec<_> = entries.iter().map(|e| e.session_id.clone()).collect();
+        assert!(ids.contains(&"sess-1".to_string()));
+        assert!(ids.contains(&"sess-2".to_string()));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_skips_unchanged_session() {
+        let root = temp_claude_root("skip");
+        let project = root.join("projects").join("-tmp-proj");
+        let path = write_user_jsonl(&project, "sess-skip", "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session("sess-skip", mtime, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_reparses_when_mtime_diverges() {
+        let root = temp_claude_root("mismatch");
+        let project = root.join("projects").join("-tmp-proj");
+        let path = write_user_jsonl(&project, "sess-stale", "hi");
+        let actual_mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store
+            .insert_session(&make_existing_session("sess-stale", actual_mtime - 1_000, 1))
+            .unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "sess-stale");
+        assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_picks_up_new_session() {
+        let root = temp_claude_root("new");
+        let project = root.join("projects").join("-tmp-proj");
+        write_user_jsonl(&project, "sess-fresh", "fresh");
+
+        let store = setup_store();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "sess-fresh");
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn project_key_to_path_decodes_dashes() {
+        assert_eq!(project_key_to_path("-tmp-foo"), "/tmp/foo");
+        assert_eq!(
+            project_key_to_path("-Users-x-git-samzong-Recall"),
+            "/Users/x/git/samzong/Recall"
+        );
+    }
 }

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -1,0 +1,247 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use anyhow::Result;
+
+use crate::adapters::{RawSession, SyncScanResult, SyncScanStats};
+use crate::db::store::Store;
+
+pub struct FileScanEntry {
+    pub session_id: String,
+    pub stat_target: PathBuf,
+    pub directory: Option<String>,
+}
+
+pub fn run_file_scan<I, F>(
+    store: &Store,
+    source_id: &str,
+    since_ts: Option<i64>,
+    entries: I,
+    parse_fn: F,
+) -> Result<SyncScanResult>
+where
+    I: IntoIterator<Item = FileScanEntry>,
+    F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
+{
+    let existing = store.session_meta_map(source_id)?;
+    let mut sessions = Vec::new();
+    let mut stats = SyncScanStats::default();
+
+    for entry in entries {
+        let Some(mtime_ms) = stat_mtime_ms(&entry.stat_target) else {
+            continue;
+        };
+
+        if let Some(cutoff) = since_ts
+            && mtime_ms < cutoff
+        {
+            stats.filtered_sessions += 1;
+            continue;
+        }
+
+        if let Some((old_updated_at, _)) = existing.get(&entry.session_id)
+            && *old_updated_at == Some(mtime_ms)
+        {
+            stats.skipped_sessions += 1;
+            continue;
+        }
+
+        if let Some(raw) = parse_fn(entry, mtime_ms)? {
+            sessions.push(raw);
+        }
+    }
+
+    Ok(SyncScanResult { sessions, stats })
+}
+
+pub fn stat_mtime_ms(path: &Path) -> Option<i64> {
+    let meta = fs::metadata(path).ok()?;
+    let mtime = meta.modified().ok()?;
+    let duration = mtime.duration_since(UNIX_EPOCH).ok()?;
+    Some(duration.as_millis() as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::adapters::{RawMessage, RawSession};
+    use crate::db::{schema, store::Store};
+    use crate::types::{Role, Session};
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn make_session(
+        id: &str,
+        source_id: &str,
+        updated_at: Option<i64>,
+        message_count: u32,
+    ) -> Session {
+        Session {
+            id: id.to_string(),
+            source: "test-source".to_string(),
+            source_id: source_id.to_string(),
+            title: "existing".to_string(),
+            directory: None,
+            started_at: 0,
+            updated_at,
+            message_count,
+            entrypoint: None,
+        }
+    }
+
+    fn temp_file_with_mtime(name: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("recall-filescan-{}-{}", name, uuid::Uuid::new_v4()));
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "dummy").unwrap();
+        path
+    }
+
+    fn stub_raw_session(source_id: &str, mtime_ms: i64) -> RawSession {
+        RawSession {
+            source_id: source_id.to_string(),
+            directory: None,
+            started_at: mtime_ms,
+            updated_at: Some(mtime_ms),
+            entrypoint: None,
+            messages: vec![RawMessage {
+                role: Role::User,
+                content: "hi".to_string(),
+                timestamp: Some(mtime_ms),
+            }],
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_empty_result() {
+        let store = setup_store();
+        let result =
+            run_file_scan(&store, "test-source", None, Vec::<FileScanEntry>::new(), |_, _| {
+                panic!("parse should not be called")
+            })
+            .unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.stats.filtered_sessions, 0);
+    }
+
+    #[test]
+    fn new_entry_triggers_parse_fn() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("new");
+        let entry = FileScanEntry {
+            session_id: "sess-new".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+
+        let result = run_file_scan(&store, "test-source", None, vec![entry], |entry, mtime_ms| {
+            Ok(Some(stub_raw_session(&entry.session_id, mtime_ms)))
+        })
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "sess-new");
+        assert_eq!(result.stats.skipped_sessions, 0);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn matching_mtime_skips_without_parsing() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("skip");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        store.insert_session(&make_session("s1", "sess-skip", Some(mtime_ms), 1)).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "sess-skip".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+
+        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
+            panic!("parse should not be called for skipped entry")
+        })
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn mtime_mismatch_triggers_reparse() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("mismatch");
+        let actual_mtime = stat_mtime_ms(&path).unwrap();
+        let stale_mtime = actual_mtime - 1_000;
+        store.insert_session(&make_session("s2", "sess-stale", Some(stale_mtime), 1)).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "sess-stale".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+
+        let result = run_file_scan(&store, "test-source", None, vec![entry], |entry, mtime_ms| {
+            assert_eq!(mtime_ms, actual_mtime);
+            Ok(Some(stub_raw_session(&entry.session_id, mtime_ms)))
+        })
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn since_ts_filters_old_entries() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("old");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        let future_cutoff = mtime_ms + 10_000_000;
+
+        let entry = FileScanEntry {
+            session_id: "sess-old".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+
+        let result =
+            run_file_scan(&store, "test-source", Some(future_cutoff), vec![entry], |_, _| {
+                panic!("parse should not be called for filtered entry")
+            })
+            .unwrap();
+
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.filtered_sessions, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_stat_target_is_skipped_silently() {
+        let store = setup_store();
+        let bogus =
+            std::env::temp_dir().join(format!("recall-filescan-bogus-{}", uuid::Uuid::new_v4()));
+        let entry = FileScanEntry {
+            session_id: "sess-missing".to_string(),
+            stat_target: bogus,
+            directory: None,
+        };
+
+        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
+            panic!("parse should not be called for missing stat target")
+        })
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.stats.filtered_sessions, 0);
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,6 +1,7 @@
 pub mod claude_code;
 pub mod codex;
 pub mod copilot;
+pub mod file_scan;
 pub mod gemini;
 pub mod kiro;
 pub mod opencode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,8 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
             println!("  Found {} sessions", raw_sessions.len());
         }
 
+        let mut existing_meta = store.session_meta_map(source_id)?;
+
         for raw in raw_sessions {
             if let Some(cutoff) = since_ts {
                 let ts = raw.updated_at.unwrap_or(raw.started_at);
@@ -339,8 +341,8 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
 
             let msg_count = raw.messages.len() as u32;
 
-            match store.session_meta(source_id, &raw.source_id)? {
-                Some((old_updated_at, old_msg_count)) => {
+            match existing_meta.get(&raw.source_id) {
+                Some(&(old_updated_at, old_msg_count)) => {
                     let changed = old_msg_count != msg_count
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
                     if !changed && !force {
@@ -375,6 +377,8 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
             };
 
             store.insert_session(&session)?;
+            existing_meta
+                .insert(session.source_id.clone(), (session.updated_at, session.message_count));
 
             let messages: Vec<Message> = raw
                 .messages


### PR DESCRIPTION
### What's changed?

- Extract mtime-based scan loop into new `src/adapters/file_scan.rs` with `FileScanEntry`, `run_file_scan`, and `stat_mtime_ms`, shared by file-backed adapters.
- Refactor `ClaudeCodeAdapter` to split entry collection from parsing and implement `SourceAdapter::scan_for_sync` on top of `file_scan`, so unchanged transcripts are skipped by mtime instead of re-parsed on every run.
- Use file mtime as `updated_at` so stored sessions can be short-circuited when nothing has changed.
- Cache session meta per source during sync in `main.rs` via `session_meta_map` and update it in-memory, removing one DB round-trip per session.
- Add unit tests covering `parse_claude_session_file`, nested project traversal, and the unchanged-session skip path.

### Why

- Full scans re-parsed every Claude Code transcript on every `sync`, which scales poorly as history grows. This mirrors the incremental path already established for OpenCode in #7 and removes the last always-full-scan adapter in the common sync loop.