### PR TITLE
[Perf] codex: make sync incremental via shared file_scan helper

### DIFF
--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -118,8 +118,13 @@ fn parse_codex_session_for_entry(
     entry: FileScanEntry,
     mtime_ms: i64,
 ) -> anyhow::Result<Option<RawSession>> {
-    let Some(mut raw) = parse_codex_session(&entry.stat_target)? else {
-        return Ok(None);
+    let mut raw = match parse_codex_session(&entry.stat_target) {
+        Ok(Some(raw)) => raw,
+        Ok(None) => return Ok(None),
+        Err(e) => {
+            debug!("failed to parse codex session {}: {e}", entry.stat_target.display());
+            return Ok(None);
+        }
     };
     raw.source_id = entry.session_id;
     raw.updated_at = Some(mtime_ms);
@@ -397,6 +402,31 @@ mod tests {
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
         assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_keeps_going_when_one_file_is_unreadable() {
+        use std::io::Write as _;
+
+        let root = temp_codex_root("unreadable");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let good_uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        write_codex_rollout(&sessions_dir, good_uuid, "still here");
+
+        let bad_uuid = "019a4c02-e8f4-7270-bdab-7f19273b237e";
+        let bad_path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{bad_uuid}.jsonl"));
+        let mut f = fs::File::create(&bad_path).unwrap();
+        f.write_all(&[0xFF, 0xFE, 0xFD, 0xFC]).unwrap();
+
+        let store = setup_store();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, good_uuid);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -1,11 +1,15 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+};
+use crate::db::store::Store;
 use crate::types::Role;
 
 pub struct CodexAdapter;
@@ -26,52 +30,111 @@ impl SourceAdapter for CodexAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-        let codex_dir = home.join(".codex");
-        if !codex_dir.exists() {
-            debug!("~/.codex not found, skipping Codex");
+        let Some(codex_dir) = resolve_codex_dir()? else {
             return Ok(vec![]);
-        }
+        };
+        let sessions_dir = codex_dir.join("sessions");
+        let archived_dir = codex_dir.join("archived_sessions");
 
         let mut sessions = Vec::new();
-
-        let sessions_dir = codex_dir.join("sessions");
-        if sessions_dir.exists() {
-            sessions.extend(scan_dir(&sessions_dir));
+        for entry in collect_codex_entries(&[&sessions_dir, &archived_dir]) {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                continue;
+            };
+            if let Some(raw) = parse_codex_session_for_entry(entry, mtime_ms)? {
+                sessions.push(raw);
+            }
         }
-
-        let archived_dir = codex_dir.join("archived_sessions");
-        if archived_dir.exists() {
-            sessions.extend(scan_dir(&archived_dir));
-        }
-
         Ok(sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(codex_dir) = resolve_codex_dir()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+        let result = scan_for_sync_impl(&codex_dir, store, since_ts)?;
+        Ok(Some(result))
     }
 }
 
-fn scan_dir(dir: &Path) -> Vec<RawSession> {
-    let mut sessions = Vec::new();
+fn resolve_codex_dir() -> anyhow::Result<Option<PathBuf>> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let dir = home.join(".codex");
+    if !dir.exists() {
+        debug!("~/.codex not found, skipping Codex");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
 
-    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
-        let path = entry.path();
-        let ext = path.extension().and_then(|e| e.to_str());
-        if ext != Some("jsonl") && ext != Some("json") {
+fn scan_for_sync_impl(
+    codex_dir: &Path,
+    store: &Store,
+    since_ts: Option<i64>,
+) -> anyhow::Result<SyncScanResult> {
+    let sessions_dir = codex_dir.join("sessions");
+    let archived_dir = codex_dir.join("archived_sessions");
+    let entries = collect_codex_entries(&[&sessions_dir, &archived_dir]);
+    file_scan::run_file_scan(store, "codex", since_ts, entries, parse_codex_session_for_entry)
+}
+
+fn collect_codex_entries(base_dirs: &[&Path]) -> Vec<FileScanEntry> {
+    let mut entries = Vec::new();
+    for dir in base_dirs {
+        if !dir.exists() {
             continue;
         }
-        if !path.is_file() {
-            continue;
-        }
-
-        match parse_codex_session(path) {
-            Ok(Some(session)) => sessions.push(session),
-            Ok(None) => {}
-            Err(e) => {
-                debug!("failed to parse codex session {}: {e}", path.display());
+        for walk_entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+            let path = walk_entry.path();
+            let ext = path.extension().and_then(|e| e.to_str());
+            if ext != Some("jsonl") && ext != Some("json") {
+                continue;
             }
+            if !path.is_file() {
+                continue;
+            }
+            let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) if !s.is_empty() => s,
+                _ => continue,
+            };
+            let Some(session_id) = extract_session_id_from_filename(stem) else {
+                continue;
+            };
+            entries.push(FileScanEntry {
+                session_id,
+                stat_target: path.to_path_buf(),
+                directory: None,
+            });
         }
     }
+    entries
+}
 
-    sessions
+fn parse_codex_session_for_entry(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+) -> anyhow::Result<Option<RawSession>> {
+    let Some(mut raw) = parse_codex_session(&entry.stat_target)? else {
+        return Ok(None);
+    };
+    raw.source_id = entry.session_id;
+    raw.updated_at = Some(mtime_ms);
+    Ok(Some(raw))
+}
+
+fn extract_session_id_from_filename(stem: &str) -> Option<String> {
+    if stem.len() < 37 {
+        return None;
+    }
+    let (prefix, tail) = stem.split_at(stem.len() - 36);
+    if !prefix.ends_with('-') {
+        return None;
+    }
+    uuid::Uuid::try_parse(tail).ok().map(|_| tail.to_string())
 }
 
 fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
@@ -214,4 +277,144 @@ fn parse_timestamp(v: &Value) -> Option<i64> {
         .and_then(|t| t.as_str())
         .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
         .map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn temp_codex_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "recall-cdx-test-{}-{}",
+            label,
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_codex_rollout(sessions_dir: &Path, session_uuid: &str, text: &str) -> PathBuf {
+        fs::create_dir_all(sessions_dir).unwrap();
+        let filename = format!("rollout-2026-04-13T10-00-00-{session_uuid}.jsonl");
+        let path = sessions_dir.join(filename);
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": session_uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let msg = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:30Z",
+            "payload": {
+                "type": "user_message",
+                "message": text
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{msg}").unwrap();
+        path
+    }
+
+    fn make_existing_session(source_id: &str, updated_at: i64, message_count: u32) -> Session {
+        Session {
+            id: format!("internal-{source_id}"),
+            source: "codex".to_string(),
+            source_id: source_id.to_string(),
+            title: "existing".to_string(),
+            directory: None,
+            started_at: 0,
+            updated_at: Some(updated_at),
+            message_count,
+            entrypoint: None,
+        }
+    }
+
+    #[test]
+    fn extract_session_id_from_filename_happy_path() {
+        let stem = "rollout-2025-11-04T07-16-24-019a4c01-e8f4-7270-bdab-7f19273b237e";
+        assert_eq!(
+            extract_session_id_from_filename(stem),
+            Some("019a4c01-e8f4-7270-bdab-7f19273b237e".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_session_id_from_filename_rejects_non_uuid_tail() {
+        assert_eq!(extract_session_id_from_filename("short"), None);
+        assert_eq!(extract_session_id_from_filename("rollout-no-uuid-at-end"), None);
+        let non_hex_tail = "rollout-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+        assert_eq!(extract_session_id_from_filename(non_hex_tail), None);
+        let no_separator = "rolloutX019a4c01-e8f4-7270-bdab-7f19273b237e";
+        assert_eq!(extract_session_id_from_filename(no_separator), None);
+        let bad_dash_layout = "rollout-019a4c01Xe8f4-7270-bdab-7f19273b237e";
+        assert_eq!(extract_session_id_from_filename(bad_dash_layout), None);
+    }
+
+    #[test]
+    fn scan_for_sync_skips_unchanged_session() {
+        let root = temp_codex_root("skip");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        let path = write_codex_rollout(&sessions_dir, uuid, "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_reparses_when_mtime_changes() {
+        let root = temp_codex_root("mismatch");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        let path = write_codex_rollout(&sessions_dir, uuid, "hi");
+        let actual_mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_picks_up_new_session() {
+        let root = temp_codex_root("new");
+        let sessions_dir = root.join("archived_sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        write_codex_rollout(&sessions_dir, uuid, "fresh");
+
+        let store = setup_store();
+
+        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
 }


### PR DESCRIPTION
### What's changed?

- Refactor `CodexAdapter` onto `adapters::file_scan` so `recall sync` skips unchanged rollout files instead of re-parsing every transcript.
- Implement `SourceAdapter::scan_for_sync` via `file_scan::run_file_scan`, using file mtime as `updated_at` so the shared scan can short-circuit on match.
- Derive the stable session id from the rollout filename UUID suffix so it stays in sync with the source on disk.
- Extract `resolve_codex_dir` to share directory resolution between full scan and incremental sync.
- Add unit tests covering the filename UUID parser and the incremental skip / mtime-change / new-file paths against a temp Codex root.

### Why

- Completes the incremental-sync rollout started in #7 (OpenCode) and #8 (Claude Code), bringing the Codex adapter to the same baseline so `recall sync` stays O(changed files) across all three sources.
- Re-parsing every rollout on each sync is wasted work once the session's mtime has not moved; sharing `file_scan` keeps all file-backed adapters on one code path and one set of invariants.