### PR TITLE
[Perf] copilot: make sync incremental via shared file_scan helper

### DIFF
--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 use tracing::debug;
 
-use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+};
+use crate::db::store::Store;
 use crate::types::Role;
 
 pub struct CopilotAdapter;
@@ -25,54 +31,139 @@ impl SourceAdapter for CopilotAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-        let sessions_dir = home.join(".copilot/session-state");
-        if !sessions_dir.exists() {
-            debug!("~/.copilot/session-state not found, skipping Copilot CLI");
+        let Some(sessions_dir) = resolve_copilot_dir()? else {
             return Ok(vec![]);
-        }
-
-        let entries = match fs::read_dir(&sessions_dir) {
-            Ok(e) => e,
-            Err(e) => {
-                debug!("cannot read {}: {e}", sessions_dir.display());
-                return Ok(vec![]);
-            }
         };
 
         let mut sessions = Vec::new();
-
-        for entry in entries.flatten() {
-            let session_dir = entry.path();
-            if !session_dir.is_dir() {
+        for entry in collect_copilot_entries(&sessions_dir) {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
                 continue;
-            }
-            let events_path = session_dir.join("events.jsonl");
-            if !events_path.is_file() {
-                continue;
-            }
-            let fallback_id =
-                session_dir.file_name().and_then(|n| n.to_str()).unwrap_or("unknown").to_string();
-
-            let content = match fs::read_to_string(&events_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    debug!("failed to read {}: {e}", events_path.display());
-                    continue;
-                }
             };
-
-            match parse_copilot_events(&content, &fallback_id) {
-                Ok(Some(session)) => sessions.push(session),
-                Ok(None) => {}
-                Err(e) => {
-                    debug!("failed to parse copilot session {}: {e}", events_path.display());
-                }
+            if let Some(raw) = parse_copilot_session_for_entry(entry, mtime_ms)? {
+                sessions.push(raw);
             }
         }
-
         Ok(sessions)
     }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(sessions_dir) = resolve_copilot_dir()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+        let result = scan_for_sync_impl(&sessions_dir, store, since_ts)?;
+        Ok(Some(result))
+    }
+}
+
+fn resolve_copilot_dir() -> anyhow::Result<Option<PathBuf>> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let dir = home.join(".copilot/session-state");
+    if !dir.exists() {
+        debug!("~/.copilot/session-state not found, skipping Copilot CLI");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+fn scan_for_sync_impl(
+    sessions_dir: &Path,
+    store: &Store,
+    since_ts: Option<i64>,
+) -> anyhow::Result<SyncScanResult> {
+    let entries = collect_copilot_entries(sessions_dir);
+    file_scan::run_file_scan(
+        store,
+        "copilot-cli",
+        since_ts,
+        entries,
+        parse_copilot_session_for_entry,
+    )
+}
+
+fn collect_copilot_entries(sessions_dir: &Path) -> Vec<FileScanEntry> {
+    let mut entries = Vec::new();
+    let read = match fs::read_dir(sessions_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            debug!("cannot read {}: {e}", sessions_dir.display());
+            return entries;
+        }
+    };
+
+    for dir_entry in read.flatten() {
+        let session_dir = dir_entry.path();
+        if !session_dir.is_dir() {
+            continue;
+        }
+        let events_path = session_dir.join("events.jsonl");
+        if !events_path.is_file() {
+            continue;
+        }
+        let dir_name = match session_dir.file_name().and_then(|n| n.to_str()) {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => continue,
+        };
+        let session_id = peek_copilot_session_id(&events_path).unwrap_or_else(|| dir_name.clone());
+
+        entries.push(FileScanEntry { session_id, stat_target: events_path, directory: None });
+    }
+    entries
+}
+
+fn peek_copilot_session_id(events_path: &Path) -> Option<String> {
+    let file = fs::File::open(events_path).ok()?;
+    let reader = BufReader::new(file);
+    for (idx, line) in reader.lines().enumerate() {
+        if idx >= 16 {
+            break;
+        }
+        let Ok(line) = line else { continue };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v.get("type").and_then(|t| t.as_str()) == Some("session.start") {
+            return v
+                .get("data")
+                .and_then(|d| d.get("sessionId"))
+                .and_then(|s| s.as_str())
+                .map(String::from);
+        }
+    }
+    None
+}
+
+fn parse_copilot_session_for_entry(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+) -> anyhow::Result<Option<RawSession>> {
+    let content = match fs::read_to_string(&entry.stat_target) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("failed to read {}: {e}", entry.stat_target.display());
+            return Ok(None);
+        }
+    };
+    let mut raw = match parse_copilot_events(&content, &entry.session_id) {
+        Ok(Some(raw)) => raw,
+        Ok(None) => return Ok(None),
+        Err(e) => {
+            debug!("failed to parse copilot session {}: {e}", entry.stat_target.display());
+            return Ok(None);
+        }
+    };
+    raw.source_id = entry.session_id;
+    raw.updated_at = Some(mtime_ms);
+    Ok(Some(raw))
 }
 
 pub fn parse_copilot_events(
@@ -215,4 +306,225 @@ fn parse_timestamp(v: &Value) -> Option<i64> {
         .and_then(|t| t.as_str())
         .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
         .map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn temp_copilot_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "recall-cpl-test-{}-{}",
+            label,
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_copilot_session(
+        sessions_dir: &Path,
+        dir_name: &str,
+        session_id: &str,
+        user_text: &str,
+    ) -> PathBuf {
+        let session_dir = sessions_dir.join(dir_name);
+        fs::create_dir_all(&session_dir).unwrap();
+        let events_path = session_dir.join("events.jsonl");
+
+        let start = serde_json::json!({
+            "type": "session.start",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "data": {
+                "sessionId": session_id,
+                "startTime": "2026-04-13T10:00:00Z",
+                "context": { "cwd": "/tmp/foo" }
+            }
+        });
+        let user = serde_json::json!({
+            "type": "user.message",
+            "timestamp": "2026-04-13T10:00:05Z",
+            "data": { "content": user_text }
+        });
+
+        let mut f = fs::File::create(&events_path).unwrap();
+        writeln!(f, "{start}").unwrap();
+        writeln!(f, "{user}").unwrap();
+        events_path
+    }
+
+    fn make_existing_session(source_id: &str, updated_at: i64, message_count: u32) -> Session {
+        Session {
+            id: format!("internal-{source_id}"),
+            source: "copilot-cli".to_string(),
+            source_id: source_id.to_string(),
+            title: "existing".to_string(),
+            directory: None,
+            started_at: 0,
+            updated_at: Some(updated_at),
+            message_count,
+            entrypoint: None,
+        }
+    }
+
+    #[test]
+    fn peek_copilot_session_id_reads_session_start() {
+        let root = temp_copilot_root("peek");
+        let sessions_dir = root.join("session-state");
+        let uuid = "f3eca837-818f-44d7-9158-bf242901f960";
+        let events_path = write_copilot_session(&sessions_dir, "dir-alias", uuid, "hello");
+
+        assert_eq!(peek_copilot_session_id(&events_path), Some(uuid.to_string()));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn peek_copilot_session_id_falls_back_when_no_session_start() {
+        let root = temp_copilot_root("peek-missing");
+        let sessions_dir = root.join("session-state");
+        let dir = sessions_dir.join("dir-alias");
+        fs::create_dir_all(&dir).unwrap();
+        let events_path = dir.join("events.jsonl");
+        let msg = serde_json::json!({
+            "type": "user.message",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "data": { "content": "hi" }
+        });
+        let mut f = fs::File::create(&events_path).unwrap();
+        writeln!(f, "{msg}").unwrap();
+
+        assert_eq!(peek_copilot_session_id(&events_path), None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_copilot_entries_skips_dirs_without_events() {
+        let root = temp_copilot_root("collect-skip");
+        let sessions_dir = root.join("session-state");
+        fs::create_dir_all(sessions_dir.join("empty-dir")).unwrap();
+        write_copilot_session(
+            &sessions_dir,
+            "good-dir",
+            "f3eca837-818f-44d7-9158-bf242901f960",
+            "hello",
+        );
+
+        let entries = collect_copilot_entries(&sessions_dir);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, "f3eca837-818f-44d7-9158-bf242901f960");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_skips_unchanged_session() {
+        let root = temp_copilot_root("skip");
+        let sessions_dir = root.join("session-state");
+        let uuid = "f3eca837-818f-44d7-9158-bf242901f960";
+        let events_path = write_copilot_session(&sessions_dir, "dir-1", uuid, "hello");
+        let mtime = file_scan::stat_mtime_ms(&events_path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_reparses_when_mtime_changes() {
+        let root = temp_copilot_root("mismatch");
+        let sessions_dir = root.join("session-state");
+        let uuid = "f3eca837-818f-44d7-9158-bf242901f960";
+        let events_path = write_copilot_session(&sessions_dir, "dir-1", uuid, "hi");
+        let actual_mtime = file_scan::stat_mtime_ms(&events_path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_picks_up_new_session() {
+        let root = temp_copilot_root("new");
+        let sessions_dir = root.join("session-state");
+        let uuid = "f3eca837-818f-44d7-9158-bf242901f960";
+        write_copilot_session(&sessions_dir, "dir-1", uuid, "fresh");
+
+        let store = setup_store();
+
+        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_falls_back_to_dir_name_when_session_start_missing() {
+        let root = temp_copilot_root("fallback");
+        let sessions_dir = root.join("session-state");
+        let dir_name = "0b247666-6f95-49e5-b68f-b05eb338e9c2";
+        let session_dir = sessions_dir.join(dir_name);
+        fs::create_dir_all(&session_dir).unwrap();
+        let events_path = session_dir.join("events.jsonl");
+        let user = serde_json::json!({
+            "type": "user.message",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "data": { "content": "legacy" }
+        });
+        let mut f = fs::File::create(&events_path).unwrap();
+        writeln!(f, "{user}").unwrap();
+
+        let store = setup_store();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, dir_name);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_keeps_going_when_one_file_is_unreadable() {
+        let root = temp_copilot_root("unreadable");
+        let sessions_dir = root.join("session-state");
+
+        let good_uuid = "f3eca837-818f-44d7-9158-bf242901f960";
+        write_copilot_session(&sessions_dir, "good-dir", good_uuid, "still here");
+
+        let bad_dir = sessions_dir.join("bad-dir");
+        fs::create_dir_all(&bad_dir).unwrap();
+        let bad_events = bad_dir.join("events.jsonl");
+        let mut f = fs::File::create(&bad_events).unwrap();
+        f.write_all(&[0xFF, 0xFE, 0xFD, 0xFC]).unwrap();
+
+        let store = setup_store();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, good_uuid);
+
+        let _ = fs::remove_dir_all(&root);
+    }
 }


### PR DESCRIPTION
### What's changed?

- Wire the Copilot CLI adapter into the shared `file_scan` path so `sync` skips unchanged `events.jsonl` files by mtime instead of re-parsing every session on every run
- Split `scan()` into `resolve_copilot_dir` + `collect_copilot_entries`; add `scan_for_sync()` backed by `file_scan::run_file_scan`
- Peek the leading `session.start` event to stabilize `source_id` across directory renames, falling back to the directory name when absent
- Move `session_id`/`updated_at` assignment into the per-entry parse so the mtime-based skip matches what actually gets stored
- Add unit tests covering: unchanged-skip, reparse on mtime change, new-session pickup, fallback id, and resilience to unreadable files

### Why

- Full reparse on every `sync` is wasteful once a user accumulates many Copilot CLI sessions, mirroring the motivation behind the earlier claude-code (#8), codex (#9), and opencode (#7) incremental-sync PRs
- Copilot was the last remaining adapter still forcing a full rescan each run; this closes the gap so all four sources share the same `file_scan` fast-path