### PR TITLE
[Feat] add search eval harness and tune hybrid retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .claude/
 .fastembed_cache/
 recall-*.txt
+search-eval.json

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,13 +1,18 @@
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::Result;
 use rusqlite::OptionalExtension;
+use serde::Deserialize;
 
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::Store;
 use crate::embedding::EmbeddingProvider;
 use crate::semantic::build_embedding_text;
+use crate::types::SearchResult;
 use crate::utils::f32_slice_to_bytes;
+
+const EVAL_TOP_K_MAX: usize = 20;
 
 pub fn run_semantic() -> Result<()> {
     println!("=== Recall Semantic Pipeline Benchmark ===\n");
@@ -225,4 +230,340 @@ fn time_upsert_plain(store: &Store, items: &[(i64, &[f32])]) -> Result<u128> {
     let us = t0.elapsed().as_micros();
     store.conn.execute_batch("ROLLBACK")?;
     Ok(us)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExpectedSession {
+    pub source: String,
+    pub source_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalEntry {
+    pub query: String,
+    pub expected: Vec<ExpectedSession>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvalFailure {
+    pub query: String,
+    pub rank: Option<usize>,
+    pub expected: Vec<ExpectedSession>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResultSummary {
+    pub rank: usize,
+    pub source: String,
+    pub source_id: String,
+    pub title: String,
+    pub match_label: &'static str,
+    pub is_expected: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryDetail {
+    pub query: String,
+    pub total_expected: usize,
+    pub hits_in_top_k: usize,
+    pub best_rank: Option<usize>,
+    pub top_results: Vec<ResultSummary>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EvalReport {
+    pub total: usize,
+    pub hit_at_5: usize,
+    pub hit_at_10: usize,
+    pub mrr_sum: f64,
+    pub failures: Vec<EvalFailure>,
+    pub details: Vec<QueryDetail>,
+}
+
+impl EvalReport {
+    pub fn mrr(&self) -> f64 {
+        if self.total == 0 { 0.0 } else { self.mrr_sum / self.total as f64 }
+    }
+
+    pub fn hit_at_5_pct(&self) -> f64 {
+        pct(self.hit_at_5, self.total)
+    }
+
+    pub fn hit_at_10_pct(&self) -> f64 {
+        pct(self.hit_at_10, self.total)
+    }
+}
+
+fn pct(num: usize, denom: usize) -> f64 {
+    if denom == 0 { 0.0 } else { (num as f64) * 100.0 / denom as f64 }
+}
+
+pub fn evaluate<F>(
+    engine: &SearchEngine,
+    entries: &[EvalEntry],
+    embedder: F,
+    top_k_max: usize,
+) -> Result<EvalReport>
+where
+    F: Fn(&str) -> Option<Vec<f32>>,
+{
+    let filters = SearchFilters { sources: None, time_range: TimeRange::All, directory: None };
+    let mut report = EvalReport { total: entries.len(), ..Default::default() };
+
+    for entry in entries {
+        let emb = embedder(&entry.query);
+        let results = engine.hybrid_search(&entry.query, emb.as_deref(), &filters, top_k_max)?;
+        let best_rank = find_best_rank(&results, &entry.expected);
+        let hits_in_top_k = count_expected_hits(&results, &entry.expected);
+
+        report.details.push(QueryDetail {
+            query: entry.query.clone(),
+            total_expected: entry.expected.len(),
+            hits_in_top_k,
+            best_rank,
+            top_results: build_result_summaries(&results, &entry.expected, 5),
+        });
+
+        match best_rank {
+            Some(rank) => {
+                if rank <= 5 {
+                    report.hit_at_5 += 1;
+                }
+                if rank <= 10 {
+                    report.hit_at_10 += 1;
+                }
+                report.mrr_sum += 1.0 / rank as f64;
+                if rank > 5 {
+                    report.failures.push(EvalFailure {
+                        query: entry.query.clone(),
+                        rank: Some(rank),
+                        expected: entry.expected.clone(),
+                    });
+                }
+            }
+            None => {
+                report.failures.push(EvalFailure {
+                    query: entry.query.clone(),
+                    rank: None,
+                    expected: entry.expected.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+fn find_best_rank(results: &[SearchResult], expected: &[ExpectedSession]) -> Option<usize> {
+    for (i, result) in results.iter().enumerate() {
+        if is_expected(result, expected) {
+            return Some(i + 1);
+        }
+    }
+    None
+}
+
+fn count_expected_hits(results: &[SearchResult], expected: &[ExpectedSession]) -> usize {
+    results.iter().filter(|r| is_expected(r, expected)).count()
+}
+
+fn is_expected(result: &SearchResult, expected: &[ExpectedSession]) -> bool {
+    expected
+        .iter()
+        .any(|e| e.source == result.session.source && e.source_id == result.session.source_id)
+}
+
+fn build_result_summaries(
+    results: &[SearchResult],
+    expected: &[ExpectedSession],
+    limit: usize,
+) -> Vec<ResultSummary> {
+    results
+        .iter()
+        .take(limit)
+        .enumerate()
+        .map(|(i, r)| ResultSummary {
+            rank: i + 1,
+            source: r.session.source.clone(),
+            source_id: r.session.source_id.clone(),
+            title: r.session.title.clone(),
+            match_label: match r.match_source {
+                crate::types::MatchSource::Fts => "FTS",
+                crate::types::MatchSource::Vector => "VEC",
+                crate::types::MatchSource::Hybrid => "HYB",
+            },
+            is_expected: is_expected(r, expected),
+        })
+        .collect()
+}
+
+pub fn run_eval(dataset_override: Option<&str>, verbose: bool) -> Result<()> {
+    let dataset_path = resolve_dataset_path(dataset_override)?;
+    let entries = load_dataset(&dataset_path)?;
+
+    if entries.is_empty() {
+        println!("No entries in dataset: {}", dataset_path.display());
+        return Ok(());
+    }
+
+    let store = Store::open()?;
+    let progress = store.semantic_progress().unwrap_or_default();
+    let engine = SearchEngine::new(&store.conn);
+
+    let provider_opt = if progress.done_sessions > 0 || progress.processing_sessions > 0 {
+        match EmbeddingProvider::new(false) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                println!("Embedding unavailable: {e}");
+                println!("Falling back to FTS-only evaluation.");
+                println!();
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mode = if provider_opt.is_some() { "hybrid (FTS + vector)" } else { "fts-only" };
+
+    println!("Search Evaluation");
+    println!("  dataset : {}", dataset_path.display());
+    println!("  mode    : {mode}");
+    println!("  entries : {}", entries.len());
+    println!();
+
+    let embedder = |q: &str| -> Option<Vec<f32>> {
+        let provider = provider_opt.as_ref()?;
+        provider.embed_query(&[q]).ok()?.into_iter().next()
+    };
+
+    let report = evaluate(&engine, &entries, embedder, EVAL_TOP_K_MAX)?;
+    print_report(&report, EVAL_TOP_K_MAX, verbose);
+
+    Ok(())
+}
+
+fn print_report(report: &EvalReport, top_k_max: usize, verbose: bool) {
+    if verbose {
+        print_per_query_details(report, top_k_max);
+    }
+
+    println!("Metrics");
+    println!("  Hit@5   {}/{} ({:.1}%)", report.hit_at_5, report.total, report.hit_at_5_pct());
+    println!("  Hit@10  {}/{} ({:.1}%)", report.hit_at_10, report.total, report.hit_at_10_pct());
+    println!("  MRR     {:.3}", report.mrr());
+    println!();
+
+    if verbose || report.failures.is_empty() {
+        return;
+    }
+
+    println!("Failures (rank > 5 or not in top-{top_k_max})");
+    for failure in &report.failures {
+        let rank_label = match failure.rank {
+            Some(r) => format!("rank {r:<3}"),
+            None => "miss    ".to_string(),
+        };
+        println!("  [{rank_label}] {}", failure.query);
+        for expected in &failure.expected {
+            println!("             expected {}/{}", expected.source, expected.source_id);
+        }
+    }
+}
+
+fn print_per_query_details(report: &EvalReport, top_k_max: usize) {
+    for (idx, detail) in report.details.iter().enumerate() {
+        let rank_label = match detail.best_rank {
+            Some(r) => format!("rank {r}/{top_k_max}"),
+            None => "MISS".to_string(),
+        };
+        println!("[{}/{}] {}", idx + 1, report.total, detail.query);
+        println!(
+            "  {} | {}/{} expected in top-{}",
+            rank_label, detail.hits_in_top_k, detail.total_expected, top_k_max
+        );
+        println!("  top-{}:", detail.top_results.len());
+        for r in &detail.top_results {
+            let marker = if r.is_expected { '*' } else { ' ' };
+            let title_short = shorten_title(&r.title, 70);
+            println!(
+                "    {rank:>2}. {marker} {lbl} {src}/{sid}",
+                rank = r.rank,
+                marker = marker,
+                lbl = r.match_label,
+                src = r.source,
+                sid = r.source_id,
+            );
+            println!("         {title_short}");
+        }
+        println!();
+    }
+}
+
+fn shorten_title(title: &str, max_chars: usize) -> String {
+    let flat: String =
+        title.chars().map(|c| if c.is_whitespace() || c.is_control() { ' ' } else { c }).collect();
+    let normalized: String = flat.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.chars().count() <= max_chars {
+        normalized
+    } else {
+        let head: String = normalized.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{head}...")
+    }
+}
+
+fn resolve_dataset_path(override_path: Option<&str>) -> Result<PathBuf> {
+    if let Some(p) = override_path {
+        return Ok(PathBuf::from(p));
+    }
+    let data_dir = dirs::data_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?
+        .join("recall");
+    Ok(data_dir.join("search-eval.json"))
+}
+
+fn load_dataset(path: &Path) -> Result<Vec<EvalEntry>> {
+    if !path.exists() {
+        anyhow::bail!(
+            "dataset not found: {}\nCreate one from search-eval.example.json or pass --dataset <PATH>.",
+            path.display()
+        );
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let entries: Vec<EvalEntry> = serde_json::from_str(&raw)?;
+    Ok(entries)
+}
+
+pub fn dump_sessions() -> Result<()> {
+    let store = Store::open()?;
+    let mut stmt = store.conn.prepare(
+        "SELECT source, source_id, started_at, title FROM sessions ORDER BY started_at DESC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (source, source_id, started_at, title) = row?;
+        let ts = chrono::DateTime::from_timestamp_millis(started_at)
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let flat_title = flatten_for_tsv(&title);
+        println!("{source}\t{source_id}\t{ts}\t{flat_title}");
+    }
+
+    Ok(())
+}
+
+fn flatten_for_tsv(s: &str) -> String {
+    let replaced: String =
+        s.chars().map(|c| if c.is_whitespace() || c.is_control() { ' ' } else { c }).collect();
+    replaced.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -52,13 +52,13 @@ impl<'a> SearchEngine<'a> {
         filters: &SearchFilters,
         limit: usize,
     ) -> anyhow::Result<Vec<SearchResult>> {
-        let fetch_size = limit * 3;
+        let fetch_size = limit * 20;
         let fts_hits = self.fts_search(query, filters, fetch_size)?;
         let vec_hits = match embedding {
             Some(e) => self.vec_search(e, filters, fetch_size)?,
             None => vec![],
         };
-        let merged = rrf_merge(&fts_hits, &vec_hits, 60);
+        let merged = rrf_merge(&fts_hits, &vec_hits, 10);
 
         let session_ids: Vec<&str> =
             merged.iter().take(limit).map(|(id, _, _)| id.as_str()).collect();
@@ -92,7 +92,7 @@ impl<'a> SearchEngine<'a> {
 
         let mut sql = String::from(
             "SELECT m.session_id, SUBSTR(m.content, 1, 200) AS snip,
-                    SUM(messages_fts.rank) AS total_rank
+                    MIN(messages_fts.rank) AS best_rank
              FROM messages_fts
              JOIN messages m ON m.id = messages_fts.rowid
              JOIN sessions s ON s.id = m.session_id
@@ -103,7 +103,7 @@ impl<'a> SearchEngine<'a> {
         let mut param_idx = 2;
         apply_filters(&mut sql, &mut params, &mut param_idx, filters);
 
-        sql.push_str(&format!(" GROUP BY m.session_id ORDER BY total_rank LIMIT {limit}"));
+        sql.push_str(&format!(" GROUP BY m.session_id ORDER BY best_rank LIMIT {limit}"));
 
         let param_refs: Vec<&dyn rusqlite::types::ToSql> =
             params.iter().map(|p| p.as_ref()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,15 @@ enum Commands {
     BenchSearch {
         query: String,
     },
+    #[command(hide = true, name = "__bench-eval")]
+    BenchEval {
+        #[arg(long)]
+        dataset: Option<String>,
+        #[arg(short, long)]
+        verbose: bool,
+    },
+    #[command(hide = true, name = "__bench-dump-sessions")]
+    BenchDumpSessions,
     Search {
         query: String,
         #[arg(long)]
@@ -66,6 +75,10 @@ fn main() -> Result<()> {
         Some(Commands::BackgroundWorker { sync_first }) => cmd_background_worker(sync_first)?,
         Some(Commands::BenchSemantic) => recall::bench::run_semantic()?,
         Some(Commands::BenchSearch { query }) => recall::bench::run_search(&query)?,
+        Some(Commands::BenchEval { dataset, verbose }) => {
+            recall::bench::run_eval(dataset.as_deref(), verbose)?
+        }
+        Some(Commands::BenchDumpSessions) => recall::bench::dump_sessions()?,
         Some(Commands::Search { query, source, time }) => {
             cmd_search(&query, source.as_deref(), time.as_deref())?
         }
@@ -630,17 +643,7 @@ fn exec_resume(command: adapters::ResumeCommand, cwd: Option<String>) -> Result<
 }
 
 fn generate_title(messages: &[adapters::RawMessage]) -> String {
-    let first_user_msg = messages.iter().find(|m| m.role == Role::User);
-    match first_user_msg {
-        Some(msg) => {
-            let text = msg.content.trim();
-            if text.chars().count() > 80 {
-                let truncated: String = text.chars().take(77).collect();
-                format!("{truncated}...")
-            } else {
-                text.to_string()
-            }
-        }
-        None => "Untitled".to_string(),
-    }
+    let user_contents: Vec<&str> =
+        messages.iter().filter(|m| m.role == Role::User).map(|m| m.content.as_str()).collect();
+    utils::title_from_user_messages(&user_contents)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,3 +62,120 @@ pub fn f32_slice_to_bytes(data: &[f32]) -> Vec<u8> {
     }
     bytes
 }
+
+const TITLE_MAX_CHARS: usize = 80;
+const TITLE_TRUNCATE_TAIL: usize = 77;
+
+pub fn title_from_user_messages(user_contents: &[&str]) -> String {
+    let chosen = user_contents
+        .iter()
+        .copied()
+        .find(|c| !is_noise_first_message(c))
+        .or_else(|| user_contents.first().copied())
+        .unwrap_or("");
+
+    let trimmed = chosen.trim();
+    if trimmed.is_empty() {
+        return "Untitled".to_string();
+    }
+    if trimmed.chars().count() > TITLE_MAX_CHARS {
+        let truncated: String = trimmed.chars().take(TITLE_TRUNCATE_TAIL).collect();
+        format!("{truncated}...")
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn is_noise_first_message(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with("<command-message>")
+        || trimmed.starts_with("<local-command-caveat>")
+        || trimmed.starts_with("# New session -")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn title_empty_input_returns_untitled() {
+        assert_eq!(title_from_user_messages(&[]), "Untitled");
+    }
+
+    #[test]
+    fn title_single_plain_message_returned_verbatim() {
+        assert_eq!(title_from_user_messages(&["fix the parser bug"]), "fix the parser bug");
+    }
+
+    #[test]
+    fn title_trims_whitespace() {
+        assert_eq!(title_from_user_messages(&["  hello world  "]), "hello world");
+    }
+
+    #[test]
+    fn title_long_message_is_truncated_with_ellipsis() {
+        let long = "a".repeat(200);
+        let result = title_from_user_messages(&[&long]);
+        assert!(result.ends_with("..."));
+        assert_eq!(result.chars().count(), 80);
+    }
+
+    #[test]
+    fn title_skips_command_message_noise() {
+        let msgs = [
+            "<command-message>ship</command-message>\n<command-name>/ship</command-name>",
+            "actually implement the feature",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "actually implement the feature");
+    }
+
+    #[test]
+    fn title_skips_local_command_caveat_noise() {
+        let msgs = [
+            "<local-command-caveat>Caveat: ignore this wrapper</local-command-caveat>",
+            "real intent here",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "real intent here");
+    }
+
+    #[test]
+    fn title_skips_opencode_new_session_header() {
+        let msgs = [
+            "# New session - 2026-04-08T03:29:50.987Z\n\n**Session ID:** ses_abc",
+            "debug the sync pipeline",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "debug the sync pipeline");
+    }
+
+    #[test]
+    fn title_skips_multiple_noise_messages_in_a_row() {
+        let msgs = [
+            "<command-message>ship</command-message>",
+            "<command-message>review</command-message>",
+            "explain the regression",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "explain the regression");
+    }
+
+    #[test]
+    fn title_falls_back_to_first_when_all_are_noise() {
+        let msgs = [
+            "<command-message>ship</command-message>",
+            "<command-message>review</command-message>",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "<command-message>ship</command-message>");
+    }
+
+    #[test]
+    fn title_does_not_misclassify_plain_markdown_heading() {
+        let msgs = ["# Design notes\nthinking about the search pipeline"];
+        let result = title_from_user_messages(&msgs);
+        assert!(result.starts_with("# Design notes"));
+    }
+
+    #[test]
+    fn title_detects_noise_with_leading_whitespace() {
+        let msgs = ["   <command-message>ship</command-message>", "real content"];
+        assert_eq!(title_from_user_messages(&msgs), "real content");
+    }
+}


### PR DESCRIPTION
### What's changed?

- New hidden subcommands `__bench-eval` and `__bench-dump-sessions` that score retrieval quality (Hit@5, Hit@10, MRR) over a user-maintained dataset at `$DATA/recall/search-eval.json`; dump-sessions emits `source\tsource_id\tstarted_at\ttitle` rows for building one. Dataset file is gitignored.
- `evaluate()` is generic over the embedder closure so runs still work FTS-only when the vector index is cold or empty.
- Hybrid retrieval tuned in `src/db/search.rs`:
  - `fetch_size` raised from `limit * 3` to `limit * 20` so RRF sees enough candidates.
  - RRF `k` dropped from 60 to 10 for sharper preference toward top-ranked hits.
  - FTS session dedup switched from `SUM(messages_fts.rank)` to `MIN(messages_fts.rank)` so one strong hit is not buried by noisy siblings in the same session.
- Session title derivation extracted into `utils::title_from_user_messages`, now skips `<command-message>`, `<local-command-caveat>`, and opencode `# New session -` headers so eval output and TUI listings show the real first user intent. Covered by unit tests.

### Why

Without a reproducible eval harness, retrieval quality regressions are invisible. The tuning changes are informed by eyeballing hybrid\_search output on real sessions: the old RRF window was too narrow to recover true positives that FTS and vector disagreed on, and `SUM(rank)` penalized sessions where the best match sat alongside unrelated chatter. Cleaning up titles was needed so failure listings name the session a human would recognize, not `<command-message>ship</command-message>`.