### PR TITLE
[Feat] Add local token usage reporting

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,8 +1,12 @@
 # Adding a New Source Adapter
 
-Recall discovers AI coding sessions through **source adapters**. Each adapter knows how to find and parse one tool's session data. Adding a new one requires exactly two files touched.
+Recall discovers AI coding sessions through **source adapters**. A source adapter is
+the single entry point for a tool. Search is the base capability; usage is an
+optional extension on the same adapter.
 
-## 1. Create the adapter
+Start with search. Add usage only when the tool exposes token data.
+
+## 1. Add Search Support
 
 Create `src/adapters/<tool>.rs`:
 
@@ -27,15 +31,15 @@ impl SourceAdapter for MyToolAdapter {
 
         let mut sessions = Vec::new();
 
-        // Parse session files / databases here...
+        // Parse session files or databases here...
         // For each session found:
-        sessions.push(RawSession {
-            source_id: "unique-session-id".to_string(),  // tool's native session ID
-            directory: Some("/path/to/project".to_string()),
-            started_at: 1700000000000,                    // Unix timestamp in milliseconds
-            updated_at: None,
-            entrypoint: None,
-            messages: vec![
+        sessions.push(RawSession::search_only(
+            "unique-session-id",                         // tool's native session ID
+            Some("/path/to/project".to_string()),
+            1700000000000,                               // Unix timestamp in milliseconds
+            None,
+            None,
+            vec![
                 RawMessage {
                     role: Role::User,
                     content: "user message text".to_string(),
@@ -47,7 +51,7 @@ impl SourceAdapter for MyToolAdapter {
                     timestamp: None,
                 },
             ],
-        });
+        ));
 
         Ok(sessions)
     }
@@ -75,7 +79,7 @@ pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
 
 That's it. The DB schema, search engine, TUI source filter, and CLI `--source` flag all pick it up automatically.
 
-## Contract
+## Search Contract
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
@@ -85,12 +89,73 @@ That's it. The DB schema, search engine, TUI source filter, and CLI `--source` f
 | `started_at` | `i64` | yes | Unix timestamp in **milliseconds**. |
 | `messages` | `Vec<RawMessage>` | yes | Ordered by time. Only `User` and `Assistant` roles. |
 
+## Optional: Add Usage Support
+
+Usage is not a separate adapter. It is token data attached to the same
+`RawSession`.
+
+Add a parser version:
+
+```rust
+const USAGE_PARSER_VERSION: u32 = 1;
+
+impl SourceAdapter for MyToolAdapter {
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
+    }
+
+    // ...
+}
+```
+
+Then attach usage events to the session:
+
+```rust
+let usage_events = vec![/* RawUsageEvent values parsed from the same tool data */];
+
+sessions.push(
+    RawSession::search_only(source_id, directory, started_at, updated_at, entrypoint, messages)
+        .with_usage(usage_events, USAGE_PARSER_VERSION),
+);
+```
+
+If the adapter uses file mtimes to skip unchanged sessions, pass the same parser
+version into file scanning:
+
+```rust
+file_scan::run_file_scan_with_options(
+    store,
+    "my-tool",
+    since_ts,
+    file_scan::FileScanOptions {
+        usage_parser_version: Some(USAGE_PARSER_VERSION),
+    },
+    entries,
+    parse_my_tool_session_for_entry,
+)
+```
+
+This lets Recall backfill usage when the usage parser changes, even when the
+session messages did not change.
+
+Usage event rules:
+
+| Field | Notes |
+|-------|-------|
+| `event_key` | Stable and unique within the session. |
+| `model` / `provider` | Use source data. Use `unknown` only when the source does not record it. |
+| token fields | Split into input, output, cache read, cache write, and reasoning tokens. |
+| `token_source` | `Observed` for source-reported values, `Derived` for deltas from counters, `Estimated` only for estimates. |
+| `parser_version` | Set to `USAGE_PARSER_VERSION`; bump it when usage parsing changes. |
+
 ## Guidelines
 
 - If the tool is not installed, return `Ok(vec![])` -- never error on missing data.
 - Open external databases read-only (`SQLITE_OPEN_READ_ONLY`) to avoid locking the user's data.
 - Extract only `text` content. Skip tool calls, images, and internal metadata.
 - Use `tracing::warn!` for recoverable parse errors, skip the session, and continue.
+- Do not add usage support until the source exposes real token data.
+- Do not create a separate usage adapter for the same tool.
 
 ## Verify
 
@@ -98,6 +163,7 @@ That's it. The DB schema, search engine, TUI source filter, and CLI `--source` f
 make check                  # must pass before push — same gate as CI
 cargo run -- sync -v        # should show "Scanning MT..." with session count
 make search Q="test --source mt"
+cargo run -- usage --source my-tool   # only when usage support was added
 make run                    # TUI filter should include MT
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ recall info          # index stats and worker status
 ## License
 
 [MIT](LICENSE)
+
+## Acknowledgements
+
+Thanks to [tokscale](https://github.com/junhoyeo/tokscale) for the usage dashboard reference and token accounting behavior.

--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -241,14 +241,14 @@ fn parse_antigravity_transcript_reader<R: BufRead>(
 
     let started_at = messages.first().and_then(|message| message.timestamp).unwrap_or(0);
 
-    Ok(Some(RawSession {
-        source_id: fallback_id.to_string(),
-        directory: None,
+    Ok(Some(RawSession::search_only(
+        fallback_id.to_string(),
+        None,
         started_at,
-        updated_at: messages.last().and_then(|message| message.timestamp),
-        entrypoint: None,
+        messages.last().and_then(|message| message.timestamp),
+        None,
         messages,
-    }))
+    )))
 }
 
 fn extract_user_request(content: &str) -> String {

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -12,9 +12,11 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::Role;
+use crate::types::{RawUsageEvent, Role, TokenSource};
 
 pub struct ClaudeCodeAdapter;
+
+const USAGE_PARSER_VERSION: u32 = 4;
 
 impl SourceAdapter for ClaudeCodeAdapter {
     fn id(&self) -> &str {
@@ -29,6 +31,10 @@ impl SourceAdapter for ClaudeCodeAdapter {
             program: "claude".to_string(),
             args: vec!["--resume".to_string(), source_id.to_string()],
         })
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
@@ -91,9 +97,14 @@ fn scan_for_sync_impl(
     let mut entries = collect_project_entries(claude_dir, &session_index);
     entries.extend(collect_transcript_entries(claude_dir));
 
-    file_scan::run_file_scan(store, "claude-code", since_ts, entries, |entry, mtime_ms| {
-        parse_claude_session_file(entry, mtime_ms, &session_index)
-    })
+    file_scan::run_file_scan_with_options(
+        store,
+        "claude-code",
+        since_ts,
+        file_scan::FileScanOptions { usage_parser_version: Some(USAGE_PARSER_VERSION) },
+        entries,
+        |entry, mtime_ms| parse_claude_session_file(entry, mtime_ms, &session_index),
+    )
 }
 
 fn load_session_index(claude_dir: &Path) -> HashMap<String, SessionMeta> {
@@ -164,14 +175,12 @@ fn collect_project_entries(
         let dir_name = project_entry.file_name().to_string_lossy().to_string();
         let directory_hint = project_key_to_path(&dir_name);
 
-        let jsonl_files = match fs::read_dir(&project_path) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        for file_entry in jsonl_files.flatten() {
+        for file_entry in WalkDir::new(&project_path).into_iter().filter_map(|e| e.ok()) {
             let file_path = file_entry.path();
             if file_path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if !file_path.is_file() {
                 continue;
             }
             let session_id = match file_path.file_stem().and_then(|s| s.to_str()) {
@@ -182,7 +191,11 @@ fn collect_project_entries(
             let meta_cwd = session_index.get(&session_id).and_then(|m| m.cwd.clone());
             let directory = meta_cwd.or_else(|| Some(directory_hint.clone()));
 
-            entries.push(FileScanEntry { session_id, stat_target: file_path, directory });
+            entries.push(FileScanEntry {
+                session_id,
+                stat_target: file_path.to_path_buf(),
+                directory,
+            });
         }
     }
 
@@ -225,22 +238,23 @@ fn parse_claude_session_file(
     mtime_ms: i64,
     session_index: &HashMap<String, SessionMeta>,
 ) -> anyhow::Result<Option<RawSession>> {
-    let messages = match parse_conversation_jsonl(&entry.stat_target) {
-        Ok(m) => m,
+    let parsed = match parse_conversation_jsonl(&entry.stat_target, mtime_ms) {
+        Ok(parsed) => parsed,
         Err(e) => {
             debug!("failed to parse {}: {e}", entry.stat_target.display());
             return Ok(None);
         }
     };
 
-    if messages.is_empty() {
+    if parsed.messages.is_empty() && parsed.usage_events.is_empty() {
         return Ok(None);
     }
 
     let meta = session_index.get(&entry.session_id);
     let started_at = meta
         .map(|m| m.started_at)
-        .or_else(|| messages.first().and_then(|m| m.timestamp))
+        .or_else(|| parsed.messages.first().and_then(|m| m.timestamp))
+        .or_else(|| parsed.usage_events.first().map(|event| event.timestamp))
         .unwrap_or(0);
     let directory = meta.and_then(|m| m.cwd.clone()).or(entry.directory);
     let entrypoint = meta.and_then(|m| m.entrypoint.clone());
@@ -251,16 +265,29 @@ fn parse_claude_session_file(
         started_at,
         updated_at: Some(mtime_ms),
         entrypoint,
-        messages,
+        messages: parsed.messages,
+        usage_events: parsed.usage_events,
+        usage_parser_version: Some(USAGE_PARSER_VERSION),
     }))
 }
 
-fn parse_conversation_jsonl(path: &Path) -> anyhow::Result<Vec<RawMessage>> {
+struct ParsedConversation {
+    messages: Vec<RawMessage>,
+    usage_events: Vec<RawUsageEvent>,
+}
+
+fn parse_conversation_jsonl(
+    path: &Path,
+    fallback_timestamp: i64,
+) -> anyhow::Result<ParsedConversation> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
+    let mut usage_events: Vec<RawUsageEvent> = Vec::new();
+    let mut usage_index: HashMap<String, usize> = HashMap::new();
+    let source_path = path.to_string_lossy().to_string();
 
-    for line in reader.lines() {
+    for (line_index, line) in reader.lines().enumerate() {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {
@@ -285,20 +312,93 @@ fn parse_conversation_jsonl(path: &Path) -> anyhow::Result<Vec<RawMessage>> {
         };
 
         let text = extract_content(message.get("content"));
-        if text.is_empty() {
-            continue;
-        }
-
         let timestamp = v
             .get("timestamp")
             .and_then(|t| t.as_str())
             .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
             .map(|dt| dt.timestamp_millis());
 
-        messages.push(RawMessage { role, content: text, timestamp });
+        let message_seq = if !text.is_empty() { Some(messages.len() as u32) } else { None };
+        if role == Role::Assistant
+            && let Some(event) = extract_claude_usage_event(
+                &v,
+                message,
+                timestamp.unwrap_or(fallback_timestamp),
+                line_index as u32,
+                message_seq,
+                &source_path,
+            )
+        {
+            if let Some(existing_index) = usage_index.get(&event.event_key).copied() {
+                merge_claude_usage_event(&mut usage_events[existing_index], event);
+            } else {
+                usage_index.insert(event.event_key.clone(), usage_events.len());
+                usage_events.push(event);
+            }
+        }
+
+        if !text.is_empty() {
+            messages.push(RawMessage { role, content: text, timestamp });
+        }
     }
 
-    Ok(messages)
+    Ok(ParsedConversation { messages, usage_events })
+}
+
+fn extract_claude_usage_event(
+    row: &Value,
+    message: &Value,
+    timestamp: i64,
+    event_seq: u32,
+    message_seq: Option<u32>,
+    source_path: &str,
+) -> Option<RawUsageEvent> {
+    let usage = message.get("usage")?;
+    let input_tokens = usage.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+    let output_tokens = usage.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+    let cache_read_tokens =
+        usage.get("cache_read_input_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+    let cache_write_tokens =
+        usage.get("cache_creation_input_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+
+    let model = message.get("model").and_then(|v| v.as_str()).filter(|v| !v.trim().is_empty())?;
+
+    let request_id = row.get("requestId").and_then(|v| v.as_str());
+    let message_id = message.get("id").and_then(|v| v.as_str());
+    let event_key = match (request_id, message_id) {
+        (Some(request_id), Some(message_id)) => format!("assistant:{request_id}:{message_id}"),
+        (Some(request_id), None) => format!("assistant:{request_id}:line:{event_seq}"),
+        (None, Some(message_id)) => format!("assistant:{message_id}:line:{event_seq}"),
+        (None, None) => format!("line:{event_seq}"),
+    };
+
+    Some(RawUsageEvent {
+        event_key,
+        event_seq,
+        message_seq,
+        timestamp,
+        model: model.to_string(),
+        provider: "anthropic".to_string(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        reasoning_tokens: 0,
+        token_source: TokenSource::Observed,
+        parser_version: USAGE_PARSER_VERSION,
+        source_path: Some(source_path.to_string()),
+        raw_usage_json: Some(usage.to_string()),
+    })
+}
+
+fn merge_claude_usage_event(existing: &mut RawUsageEvent, next: RawUsageEvent) {
+    existing.input_tokens = existing.input_tokens.max(next.input_tokens);
+    existing.output_tokens = existing.output_tokens.max(next.output_tokens);
+    existing.cache_read_tokens = existing.cache_read_tokens.max(next.cache_read_tokens);
+    existing.cache_write_tokens = existing.cache_write_tokens.max(next.cache_write_tokens);
+    existing.reasoning_tokens = existing.reasoning_tokens.max(next.reasoning_tokens);
+    existing.timestamp = existing.timestamp.max(next.timestamp);
+    existing.raw_usage_json = next.raw_usage_json;
 }
 
 fn extract_content(content: Option<&Value>) -> String {
@@ -401,6 +501,71 @@ mod tests {
         path
     }
 
+    fn write_usage_jsonl(project_dir: &Path, session_id: &str) -> PathBuf {
+        fs::create_dir_all(project_dir).unwrap();
+        let path = project_dir.join(format!("{session_id}.jsonl"));
+        let first = serde_json::json!({
+            "type": "assistant",
+            "requestId": "req-1",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "message": {
+                "id": "msg-1",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "partial"}],
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 50,
+                    "cache_creation_input_tokens": 5
+                }
+            }
+        });
+        let second = serde_json::json!({
+            "type": "assistant",
+            "requestId": "req-1",
+            "timestamp": "2026-04-13T10:00:02Z",
+            "message": {
+                "id": "msg-1",
+                "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "complete"}],
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 30,
+                    "cache_read_input_tokens": 50,
+                    "cache_creation_input_tokens": 5
+                }
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{first}").unwrap();
+        writeln!(f, "{second}").unwrap();
+        path
+    }
+
+    fn write_usage_only_jsonl(project_dir: &Path, session_id: &str) -> PathBuf {
+        fs::create_dir_all(project_dir).unwrap();
+        let path = project_dir.join(format!("{session_id}.jsonl"));
+        let line = serde_json::json!({
+            "type": "assistant",
+            "requestId": "req-usage-only",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "message": {
+                "id": "msg-usage-only",
+                "model": "claude-opus-4-7",
+                "content": [],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 30,
+                    "cache_creation_input_tokens": 40
+                }
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{line}").unwrap();
+        path
+    }
+
     fn make_existing_session(source_id: &str, updated_at: i64, message_count: u32) -> Session {
         Session {
             id: format!("internal-{source_id}"),
@@ -440,19 +605,112 @@ mod tests {
     }
 
     #[test]
+    fn parse_claude_session_file_extracts_deduped_usage() {
+        let root = temp_claude_root("usage");
+        let project = root.join("projects").join("-tmp-foo");
+        let path = write_usage_jsonl(&project, "usage-session");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "usage-session".to_string(),
+            stat_target: path,
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let session_index = HashMap::new();
+        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+
+        assert_eq!(raw.usage_events.len(), 1);
+        let event = &raw.usage_events[0];
+        assert_eq!(event.event_key, "assistant:req-1:msg-1");
+        assert_eq!(event.model, "claude-sonnet-4-5");
+        assert_eq!(event.provider, "anthropic");
+        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.output_tokens, 30);
+        assert_eq!(event.cache_read_tokens, 50);
+        assert_eq!(event.cache_write_tokens, 5);
+        assert_eq!(event.token_source, TokenSource::Observed);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_claude_session_file_keeps_usage_without_searchable_messages() {
+        let root = temp_claude_root("usage-only");
+        let project = root.join("projects").join("-tmp-foo");
+        let path = write_usage_only_jsonl(&project, "usage-only-session");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "usage-only-session".to_string(),
+            stat_target: path,
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let session_index = HashMap::new();
+        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+
+        assert!(raw.messages.is_empty());
+        assert_eq!(raw.started_at, 1_776_074_400_000);
+        assert_eq!(raw.usage_events.len(), 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_claude_session_file_keeps_zero_token_usage_events() {
+        let root = temp_claude_root("zero-usage");
+        let project = root.join("projects").join("-tmp-foo");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("zero-session.jsonl");
+        let line = serde_json::json!({
+            "type": "assistant",
+            "requestId": "req-zero",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "message": {
+                "id": "msg-zero",
+                "model": "gpt-5.5",
+                "content": [{"type": "text", "text": "zero"}],
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0
+                }
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{line}").unwrap();
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "zero-session".to_string(),
+            stat_target: path,
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let raw = parse_claude_session_file(entry, mtime, &HashMap::new()).unwrap().unwrap();
+
+        assert_eq!(raw.usage_events.len(), 1);
+        assert_eq!(raw.usage_events[0].model, "gpt-5.5");
+        assert_eq!(raw.usage_events[0].input_tokens, 0);
+        assert_eq!(raw.usage_events[0].output_tokens, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn collect_project_entries_walks_nested_projects() {
         let root = temp_claude_root("collect");
         let p1 = root.join("projects").join("-tmp-foo");
         let p2 = root.join("projects").join("-tmp-bar");
+        let nested = p1.join("parent-session").join("subagents");
         write_user_jsonl(&p1, "sess-1", "a");
         write_user_jsonl(&p2, "sess-2", "b");
+        write_user_jsonl(&nested, "agent-a123", "nested");
 
         let session_index = HashMap::new();
         let entries = collect_project_entries(&root, &session_index);
-        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.len(), 3);
         let ids: Vec<_> = entries.iter().map(|e| e.session_id.clone()).collect();
         assert!(ids.contains(&"sess-1".to_string()));
         assert!(ids.contains(&"sess-2".to_string()));
+        assert!(ids.contains(&"agent-a123".to_string()));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -466,6 +724,15 @@ mod tests {
 
         let store = setup_store();
         store.insert_session(&make_existing_session("sess-skip", mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "claude-code",
+                "sess-skip",
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
 
         let result = scan_for_sync_impl(&root, &store, None).unwrap();
         assert_eq!(result.sessions.len(), 0);

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -132,14 +132,14 @@ fn parse_cline_task(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<Optio
 
     let directory = extract_directory(&entry.stat_target);
 
-    Ok(Some(RawSession {
-        source_id: entry.session_id,
+    Ok(Some(RawSession::search_only(
+        entry.session_id,
         directory,
         started_at,
-        updated_at: Some(mtime_ms),
-        entrypoint: None,
+        Some(mtime_ms),
+        None,
         messages,
-    }))
+    )))
 }
 
 fn load_ui_messages(path: &Path) -> anyhow::Result<Vec<RawMessage>> {

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -11,9 +11,11 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::Role;
+use crate::types::{RawUsageEvent, Role, TokenSource};
 
 pub struct CodexAdapter;
+
+const USAGE_PARSER_VERSION: u32 = 4;
 
 impl SourceAdapter for CodexAdapter {
     fn id(&self) -> &str {
@@ -28,6 +30,10 @@ impl SourceAdapter for CodexAdapter {
             program: "codex".to_string(),
             args: vec!["resume".to_string(), source_id.to_string()],
         })
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
@@ -80,7 +86,14 @@ fn scan_for_sync_impl(
     let sessions_dir = codex_dir.join("sessions");
     let archived_dir = codex_dir.join("archived_sessions");
     let entries = collect_codex_entries(&[&sessions_dir, &archived_dir]);
-    file_scan::run_file_scan(store, "codex", since_ts, entries, parse_codex_session_for_entry)
+    file_scan::run_file_scan_with_options(
+        store,
+        "codex",
+        since_ts,
+        file_scan::FileScanOptions { usage_parser_version: Some(USAGE_PARSER_VERSION) },
+        entries,
+        parse_codex_session_for_entry,
+    )
 }
 
 fn collect_codex_entries(base_dirs: &[&Path]) -> Vec<FileScanEntry> {
@@ -146,12 +159,22 @@ fn extract_session_id_from_filename(stem: &str) -> Option<String> {
 fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
+    let fallback_timestamp = file_scan::stat_mtime_ms(path).unwrap_or(0);
     let mut meta_id: Option<String> = None;
     let mut meta_cwd: Option<String> = None;
     let mut meta_timestamp: Option<i64> = None;
     let mut messages = Vec::new();
+    let mut usage_events = Vec::new();
+    let mut current_model: Option<String> = None;
+    let mut provider: Option<String> = None;
+    let mut previous_totals: Option<CodexUsageTotals> = None;
+    let mut pending_model_usage_indices: Vec<usize> = Vec::new();
+    let mut forked_child_waiting_for_turn_context = false;
+    let mut forked_child_inherited_baseline: Option<CodexUsageTotals> = None;
+    let mut forked_child_inherited_reported_total: Option<i64> = None;
+    let source_path = path.to_string_lossy().to_string();
 
-    for line in reader.lines() {
+    for (line_index, line) in reader.lines().enumerate() {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {
@@ -164,22 +187,122 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
 
         let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
+        let payload = v.get("payload");
+        let payload_type =
+            payload.and_then(|p| p.get("type")).and_then(|t| t.as_str()).unwrap_or("");
+        let is_token_count = msg_type == "event_msg" && payload_type == "token_count";
+        let event_has_model = payload.and_then(extract_codex_model).is_some()
+            || (is_token_count
+                && payload.and_then(|p| p.get("info")).and_then(extract_codex_model).is_some());
+
+        if !pending_model_usage_indices.is_empty()
+            && !event_has_model
+            && !is_token_count
+            && msg_type != "session_meta"
+        {
+            pending_model_usage_indices.clear();
+        }
+
+        if forked_child_waiting_for_turn_context {
+            if msg_type == "turn_context" {
+                forked_child_waiting_for_turn_context = false;
+            } else {
+                if is_token_count && let Some(info) = payload.and_then(|p| p.get("info")) {
+                    remember_forked_child_inherited_baseline(
+                        &mut previous_totals,
+                        &mut forked_child_inherited_baseline,
+                        &mut forked_child_inherited_reported_total,
+                        info,
+                    );
+                }
+                continue;
+            }
+        }
+
         match msg_type {
             "session_meta" => {
-                if let Some(payload) = v.get("payload") {
+                if let Some(payload) = payload {
                     meta_id = payload.get("id").and_then(|s| s.as_str()).map(String::from);
                     meta_cwd = payload.get("cwd").and_then(|s| s.as_str()).map(String::from);
+                    provider = payload
+                        .get("model_provider")
+                        .and_then(|s| s.as_str())
+                        .filter(|s| !s.trim().is_empty())
+                        .map(String::from)
+                        .or(provider);
+                    if let Some(model) = extract_codex_model(payload) {
+                        current_model = Some(model.clone());
+                        apply_pending_codex_model(
+                            &mut usage_events,
+                            &mut pending_model_usage_indices,
+                            &model,
+                        );
+                    }
                     meta_timestamp = payload
                         .get("timestamp")
                         .and_then(|t| t.as_str())
                         .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
                         .map(|dt| dt.timestamp_millis());
+                    if payload.get("forked_from_id").and_then(|s| s.as_str()).is_some() {
+                        forked_child_waiting_for_turn_context = true;
+                        forked_child_inherited_baseline = None;
+                        forked_child_inherited_reported_total = None;
+                    }
+                }
+            }
+            "turn_context" => {
+                if let Some(payload) = payload
+                    && let Some(model) = extract_codex_model(payload)
+                {
+                    current_model = Some(model.clone());
+                    apply_pending_codex_model(
+                        &mut usage_events,
+                        &mut pending_model_usage_indices,
+                        &model,
+                    );
                 }
             }
             "event_msg" => {
-                if let Some(payload) = v.get("payload") {
-                    let payload_type = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if let Some(payload) = payload {
                     match payload_type {
+                        "token_count" => {
+                            if let Some(info) = payload.get("info") {
+                                let total_usage = info
+                                    .get("total_token_usage")
+                                    .and_then(CodexUsageTotals::from_usage);
+                                if forked_child_matches_inherited_baseline(
+                                    forked_child_inherited_baseline,
+                                    forked_child_inherited_reported_total,
+                                    info,
+                                    total_usage,
+                                ) {
+                                    if let Some(total) = total_usage {
+                                        previous_totals = Some(total);
+                                    }
+                                    forked_child_inherited_baseline = None;
+                                    forked_child_inherited_reported_total = None;
+                                    continue;
+                                }
+                                forked_child_inherited_baseline = None;
+                                forked_child_inherited_reported_total = None;
+                            }
+                            if let Some(event) = extract_codex_usage_event(
+                                payload,
+                                line_index as u32,
+                                &mut previous_totals,
+                                parse_timestamp(&v).unwrap_or(fallback_timestamp),
+                                provider.as_deref().unwrap_or("openai"),
+                                current_model.as_deref(),
+                                &source_path,
+                            ) {
+                                if event.model == "unknown" {
+                                    pending_model_usage_indices.push(usage_events.len());
+                                } else {
+                                    current_model = Some(event.model.clone());
+                                }
+                                usage_events.push(event);
+                            }
+                        }
                         "user_message" => {
                             if let Some(text) = payload.get("message").and_then(|m| m.as_str())
                                 && !text.is_empty()
@@ -228,7 +351,7 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
         }
     }
 
-    if messages.is_empty() {
+    if messages.is_empty() && usage_events.is_empty() {
         return Ok(None);
     }
 
@@ -236,16 +359,23 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
         path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown").to_string()
     });
 
-    let started_at =
-        meta_timestamp.or_else(|| messages.first().and_then(|m| m.timestamp)).unwrap_or(0);
+    let started_at = meta_timestamp
+        .or_else(|| messages.first().and_then(|m| m.timestamp))
+        .or_else(|| usage_events.first().map(|event| event.timestamp))
+        .unwrap_or(0);
 
     Ok(Some(RawSession {
         source_id,
         directory: meta_cwd,
         started_at,
-        updated_at: messages.last().and_then(|m| m.timestamp),
+        updated_at: messages
+            .last()
+            .and_then(|m| m.timestamp)
+            .or_else(|| usage_events.last().map(|event| event.timestamp)),
         entrypoint: None,
         messages,
+        usage_events,
+        usage_parser_version: Some(USAGE_PARSER_VERSION),
     }))
 }
 
@@ -277,6 +407,227 @@ fn extract_content_array(content: Option<&Value>) -> String {
             parts.join("\n")
         }
         _ => String::new(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CodexUsageTotals {
+    input: i64,
+    output: i64,
+    cached: i64,
+    reasoning: i64,
+}
+
+impl CodexUsageTotals {
+    fn from_usage(value: &Value) -> Option<Self> {
+        let input = value.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+        let output = value.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+        let cached = value
+            .get("cached_input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0)
+            .max(value.get("cache_read_input_tokens").and_then(|v| v.as_i64()).unwrap_or(0))
+            .max(0);
+        let reasoning =
+            value.get("reasoning_output_tokens").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
+
+        if input == 0 && output == 0 && cached == 0 && reasoning == 0 {
+            return None;
+        }
+
+        Some(Self { input, output, cached, reasoning })
+    }
+
+    fn delta_from(self, previous: Self) -> Option<Self> {
+        if self.input < previous.input
+            || self.output < previous.output
+            || self.cached < previous.cached
+            || self.reasoning < previous.reasoning
+        {
+            return None;
+        }
+
+        Some(Self {
+            input: self.input - previous.input,
+            output: self.output - previous.output,
+            cached: self.cached - previous.cached,
+            reasoning: self.reasoning - previous.reasoning,
+        })
+    }
+
+    fn saturating_add(self, other: Self) -> Self {
+        Self {
+            input: self.input.saturating_add(other.input),
+            output: self.output.saturating_add(other.output),
+            cached: self.cached.saturating_add(other.cached),
+            reasoning: self.reasoning.saturating_add(other.reasoning),
+        }
+    }
+
+    fn total(self) -> i64 {
+        self.input
+            .saturating_add(self.output)
+            .saturating_add(self.cached)
+            .saturating_add(self.reasoning)
+    }
+
+    fn looks_like_stale_regression(self, previous: Self, last: Self) -> bool {
+        let previous_total = previous.total();
+        let current_total = self.total();
+        let last_total = last.total();
+
+        if previous_total <= 0 || current_total <= 0 || last_total <= 0 {
+            return false;
+        }
+
+        current_total.saturating_mul(100) >= previous_total.saturating_mul(98)
+            || current_total.saturating_add(last_total.saturating_mul(2)) >= previous_total
+    }
+}
+
+fn reported_total_tokens(usage: &Value) -> Option<i64> {
+    usage.get("total_tokens").and_then(|v| v.as_i64()).filter(|total| *total >= 0)
+}
+
+fn remember_forked_child_inherited_baseline(
+    previous_totals: &mut Option<CodexUsageTotals>,
+    inherited_baseline: &mut Option<CodexUsageTotals>,
+    inherited_reported_total: &mut Option<i64>,
+    info: &Value,
+) {
+    let Some(total_usage) = info.get("total_token_usage") else {
+        return;
+    };
+    let Some(total) = CodexUsageTotals::from_usage(total_usage) else {
+        return;
+    };
+
+    *previous_totals = Some(total);
+    *inherited_baseline = Some(total);
+    *inherited_reported_total = reported_total_tokens(total_usage);
+}
+
+fn forked_child_matches_inherited_baseline(
+    inherited_baseline: Option<CodexUsageTotals>,
+    inherited_reported_total: Option<i64>,
+    info: &Value,
+    total_usage: Option<CodexUsageTotals>,
+) -> bool {
+    if let (Some(total_usage), Some(baseline)) =
+        (info.get("total_token_usage"), inherited_reported_total)
+        && reported_total_tokens(total_usage) == Some(baseline)
+    {
+        return true;
+    }
+
+    if let (Some(total), Some(baseline)) = (total_usage, inherited_baseline) {
+        return total == baseline;
+    }
+
+    false
+}
+
+fn extract_codex_usage_event(
+    payload: &Value,
+    event_seq: u32,
+    previous_totals: &mut Option<CodexUsageTotals>,
+    timestamp: i64,
+    provider: &str,
+    current_model: Option<&str>,
+    source_path: &str,
+) -> Option<RawUsageEvent> {
+    let info = payload.get("info")?;
+    let total_usage = info.get("total_token_usage").and_then(CodexUsageTotals::from_usage);
+    let last_usage = info.get("last_token_usage").and_then(CodexUsageTotals::from_usage);
+
+    let (tokens, next_totals) = match (total_usage, last_usage, *previous_totals) {
+        (Some(total), Some(last), Some(previous)) => {
+            if total == previous {
+                return None;
+            }
+            if total.delta_from(previous).is_none()
+                && total.looks_like_stale_regression(previous, last)
+            {
+                return None;
+            }
+            (last, Some(total))
+        }
+        (Some(total), Some(last), None) => (last, Some(total)),
+        (Some(total), None, Some(previous)) => {
+            if total == previous {
+                return None;
+            }
+            let delta = total.delta_from(previous)?;
+            (delta, Some(total))
+        }
+        (Some(total), None, None) => (total, Some(total)),
+        (None, Some(last), Some(previous)) => (last, Some(previous.saturating_add(last))),
+        (None, Some(last), None) => (last, None),
+        (None, None, _) => return None,
+    };
+
+    let cache_read_tokens = tokens.cached.min(tokens.input).max(0);
+    let input_tokens = tokens.input.saturating_sub(cache_read_tokens).max(0);
+    let output_tokens = tokens.output.max(0);
+    let reasoning_tokens = tokens.reasoning.max(0);
+    if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
+        return None;
+    }
+
+    *previous_totals = next_totals;
+
+    let model = extract_codex_model(payload)
+        .or_else(|| extract_codex_model(info))
+        .or_else(|| current_model.map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    Some(RawUsageEvent {
+        event_key: format!("token_count:{event_seq}"),
+        event_seq,
+        message_seq: None,
+        timestamp,
+        model,
+        provider: provider.to_string(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens: 0,
+        reasoning_tokens,
+        token_source: TokenSource::Derived,
+        parser_version: USAGE_PARSER_VERSION,
+        source_path: Some(source_path.to_string()),
+        raw_usage_json: Some(info.to_string()),
+    })
+}
+
+fn extract_codex_model(value: &Value) -> Option<String> {
+    value
+        .get("model")
+        .or_else(|| value.get("model_name"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            value
+                .get("model_info")
+                .and_then(|info| info.get("slug"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.trim().is_empty())
+                .map(str::to_string)
+        })
+}
+
+fn apply_pending_codex_model(
+    usage_events: &mut [RawUsageEvent],
+    pending_indices: &mut Vec<usize>,
+    model: &str,
+) {
+    for index in pending_indices.drain(..) {
+        if let Some(event) = usage_events.get_mut(index)
+            && event.model == "unknown"
+        {
+            event.model = model.to_string();
+        }
     }
 }
 
@@ -336,6 +687,117 @@ mod tests {
         path
     }
 
+    fn write_codex_usage_rollout(sessions_dir: &Path, session_uuid: &str) -> PathBuf {
+        fs::create_dir_all(sessions_dir).unwrap();
+        let filename = format!("rollout-2026-04-13T10-00-00-{session_uuid}.jsonl");
+        let path = sessions_dir.join(filename);
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": session_uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo",
+                "model_provider": "openai"
+            }
+        });
+        let usage1 = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 10,
+                        "cached_input_tokens": 2,
+                        "output_tokens": 3,
+                        "reasoning_output_tokens": 1
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 10,
+                        "cached_input_tokens": 2,
+                        "output_tokens": 3,
+                        "reasoning_output_tokens": 1
+                    }
+                }
+            }
+        });
+        let turn_context = serde_json::json!({
+            "type": "turn_context",
+            "payload": {"model": "gpt-5-codex"}
+        });
+        let usage2 = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:02Z",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 15,
+                        "cached_input_tokens": 3,
+                        "output_tokens": 5,
+                        "reasoning_output_tokens": 1
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 5,
+                        "cached_input_tokens": 1,
+                        "output_tokens": 2,
+                        "reasoning_output_tokens": 0
+                    }
+                }
+            }
+        });
+        let msg = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:30Z",
+            "payload": {
+                "type": "user_message",
+                "message": "hello"
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{usage1}").unwrap();
+        writeln!(f, "{turn_context}").unwrap();
+        writeln!(f, "{usage2}").unwrap();
+        writeln!(f, "{msg}").unwrap();
+        path
+    }
+
+    fn write_codex_usage_only_rollout(sessions_dir: &Path, session_uuid: &str) -> PathBuf {
+        fs::create_dir_all(sessions_dir).unwrap();
+        let filename = format!("rollout-2026-04-13T10-00-00-{session_uuid}.jsonl");
+        let path = sessions_dir.join(filename);
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": session_uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo",
+                "model_provider": "openai",
+                "model": "gpt-5.5"
+            }
+        });
+        let usage = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 10,
+                        "cached_input_tokens": 2,
+                        "output_tokens": 3,
+                        "reasoning_output_tokens": 1
+                    }
+                }
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{usage}").unwrap();
+        path
+    }
+
     fn make_existing_session(source_id: &str, updated_at: i64, message_count: u32) -> Session {
         Session {
             id: format!("internal-{source_id}"),
@@ -372,6 +834,150 @@ mod tests {
     }
 
     #[test]
+    fn parse_codex_session_extracts_derived_usage_events() {
+        let root = temp_codex_root("usage");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        let path = write_codex_usage_rollout(&sessions_dir, uuid);
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.usage_events.len(), 2);
+        assert_eq!(raw.usage_events[0].model, "gpt-5-codex");
+        assert_eq!(raw.usage_events[0].provider, "openai");
+        assert_eq!(raw.usage_events[0].input_tokens, 8);
+        assert_eq!(raw.usage_events[0].cache_read_tokens, 2);
+        assert_eq!(raw.usage_events[0].output_tokens, 3);
+        assert_eq!(raw.usage_events[0].reasoning_tokens, 1);
+        assert_eq!(raw.usage_events[0].token_source, TokenSource::Derived);
+
+        assert_eq!(raw.usage_events[1].input_tokens, 4);
+        assert_eq!(raw.usage_events[1].cache_read_tokens, 1);
+        assert_eq!(raw.usage_events[1].output_tokens, 2);
+        assert_eq!(raw.usage_events[1].reasoning_tokens, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_usage_without_searchable_messages() {
+        let root = temp_codex_root("usage-only");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2380";
+        let path = write_codex_usage_only_rollout(&sessions_dir, uuid);
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert!(raw.messages.is_empty());
+        assert_eq!(raw.started_at, 1_776_074_400_000);
+        assert_eq!(raw.usage_events.len(), 1);
+        assert_eq!(raw.usage_events[0].model, "gpt-5.5");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_skips_forked_child_inherited_usage_prefix() {
+        let root = temp_codex_root("forked-child");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2381";
+        let path = sessions_dir.join(format!("rollout-2026-05-05T21-51-57-{uuid}.jsonl"));
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:57.992Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"azure","agent_nickname":"parent","cwd":"/repo-parent"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":117500,"cached_input_tokens":115000,"output_tokens":1200,"reasoning_output_tokens":50,"total_tokens":118700},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1700}}}}"#
+        )
+        .unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.directory.as_deref(), Some("/repo-child"));
+        assert_eq!(raw.usage_events.len(), 1);
+        assert_eq!(raw.usage_events[0].model, "gpt-5.5");
+        assert_eq!(raw.usage_events[0].provider, "openai");
+        assert_eq!(raw.usage_events[0].input_tokens, 500);
+        assert_eq!(raw.usage_events[0].cache_read_tokens, 1000);
+        assert_eq!(raw.usage_events[0].output_tokens, 200);
+        assert_eq!(raw.usage_events[0].reasoning_tokens, 50);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_model_less_usage_unknown_after_plain_event() {
+        let root = temp_codex_root("unknown-model");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2382";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-04-13T10:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-04-13T10:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"plain event fixes prior model as unknown"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-04-13T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "{}",
+            r#"{"timestamp":"2026-04-13T10:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#
+        )
+        .unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.usage_events.len(), 2);
+        assert_eq!(raw.usage_events[0].model, "unknown");
+        assert_eq!(raw.usage_events[1].model, "gpt-5-codex");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn scan_for_sync_skips_unchanged_session() {
         let root = temp_codex_root("skip");
         let sessions_dir = root.join("sessions");
@@ -381,6 +987,15 @@ mod tests {
 
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "codex",
+                uuid,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
 
         let result = scan_for_sync_impl(&root, &store, None).unwrap();
         assert_eq!(result.sessions.len(), 0);

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -884,42 +884,16 @@ mod tests {
         let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2381";
         let path = sessions_dir.join(format!("rollout-2026-05-05T21-51-57-{uuid}.jsonl"));
         let mut f = fs::File::create(&path).unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:57.992Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"azure","agent_nickname":"parent","cwd":"/repo-parent"}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":117500,"cached_input_tokens":115000,"output_tokens":1200,"reasoning_output_tokens":50,"total_tokens":118700},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1700}}}}"#
-        )
-        .unwrap();
+        for line in [
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
+            r#"{"timestamp":"2026-05-05T21:51:57.992Z","type":"session_meta","payload":{"id":"parent-session","source":"interactive","model_provider":"azure","agent_nickname":"parent","cwd":"/repo-parent"}}"#,
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":116000,"cached_input_tokens":114000,"output_tokens":1000,"total_tokens":117000},"last_token_usage":{"input_tokens":73000,"cached_input_tokens":72000,"output_tokens":500,"total_tokens":73500}}}}"#,
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":117500,"cached_input_tokens":115000,"output_tokens":1200,"reasoning_output_tokens":50,"total_tokens":118700},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1700}}}}"#,
+        ] {
+            writeln!(f, "{line}").unwrap();
+        }
 
         let raw = parse_codex_session(&path).unwrap().unwrap();
 
@@ -943,30 +917,14 @@ mod tests {
         let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2382";
         let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
         let mut f = fs::File::create(&path).unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-04-13T10:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-04-13T10:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"plain event fixes prior model as unknown"}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-04-13T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#
-        )
-        .unwrap();
-        writeln!(
-            f,
-            "{}",
-            r#"{"timestamp":"2026-04-13T10:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#
-        )
-        .unwrap();
+        for line in [
+            r#"{"timestamp":"2026-04-13T10:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,"output_tokens":3,"reasoning_output_tokens":1}}}}"#,
+            r#"{"timestamp":"2026-04-13T10:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"plain event fixes prior model as unknown"}}"#,
+            r#"{"timestamp":"2026-04-13T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#,
+            r#"{"timestamp":"2026-04-13T10:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15,"cached_input_tokens":3,"output_tokens":5,"reasoning_output_tokens":1},"last_token_usage":{"input_tokens":5,"cached_input_tokens":1,"output_tokens":2,"reasoning_output_tokens":0}}}}"#,
+        ] {
+            writeln!(f, "{line}").unwrap();
+        }
 
         let raw = parse_codex_session(&path).unwrap().unwrap();
 

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -289,14 +289,7 @@ where
         meta_started_at.or_else(|| messages.first().and_then(|m| m.timestamp)).unwrap_or(0);
     let updated_at = messages.last().and_then(|m| m.timestamp);
 
-    Ok(Some(RawSession {
-        source_id,
-        directory,
-        started_at,
-        updated_at,
-        entrypoint: None,
-        messages,
-    }))
+    Ok(Some(RawSession::search_only(source_id, directory, started_at, updated_at, None, messages)))
 }
 
 fn extract_tool_requests(tool_requests: Option<&Value>) -> String {

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -175,14 +175,7 @@ fn parse_cursor_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
         return Ok(None);
     }
 
-    Ok(Some(RawSession {
-        source_id: String::new(),
-        directory: None,
-        started_at: 0,
-        updated_at: None,
-        entrypoint: None,
-        messages,
-    }))
+    Ok(Some(RawSession::search_only(String::new(), None, 0, None, None, messages)))
 }
 
 fn render_content_items(items: &[Value], is_user: bool) -> String {

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -7,6 +7,11 @@ use anyhow::Result;
 use crate::adapters::{RawSession, SyncScanResult, SyncScanStats};
 use crate::db::store::Store;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FileScanOptions {
+    pub usage_parser_version: Option<u32>,
+}
+
 pub struct FileScanEntry {
     pub session_id: String,
     pub stat_target: PathBuf,
@@ -24,7 +29,33 @@ where
     I: IntoIterator<Item = FileScanEntry>,
     F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
 {
+    run_file_scan_with_options(
+        store,
+        source_id,
+        since_ts,
+        FileScanOptions::default(),
+        entries,
+        parse_fn,
+    )
+}
+
+pub fn run_file_scan_with_options<I, F>(
+    store: &Store,
+    source_id: &str,
+    since_ts: Option<i64>,
+    options: FileScanOptions,
+    entries: I,
+    parse_fn: F,
+) -> Result<SyncScanResult>
+where
+    I: IntoIterator<Item = FileScanEntry>,
+    F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
+{
     let existing = store.session_meta_map(source_id)?;
+    let usage_state = match options.usage_parser_version {
+        Some(_) => store.usage_state_meta_map(source_id)?,
+        None => Default::default(),
+    };
     let mut sessions = Vec::new();
     let mut stats = SyncScanStats::default();
 
@@ -42,6 +73,11 @@ where
 
         if let Some((old_updated_at, _)) = existing.get(&entry.session_id)
             && *old_updated_at == Some(mtime_ms)
+            && usage_state_is_current(
+                options.usage_parser_version,
+                usage_state.get(&entry.session_id).copied(),
+                mtime_ms,
+            )
         {
             stats.skipped_sessions += 1;
             continue;
@@ -53,6 +89,20 @@ where
     }
 
     Ok(SyncScanResult { sessions, stats })
+}
+
+fn usage_state_is_current(
+    required_parser_version: Option<u32>,
+    state: Option<crate::db::store::UsageSessionStateMeta>,
+    mtime_ms: i64,
+) -> bool {
+    let Some(required_parser_version) = required_parser_version else {
+        return true;
+    };
+    let Some(state) = state else {
+        return false;
+    };
+    state.parser_version >= required_parser_version && state.source_updated_at == Some(mtime_ms)
 }
 
 pub fn stat_mtime_ms(path: &Path) -> Option<i64> {
@@ -104,18 +154,18 @@ mod tests {
     }
 
     fn stub_raw_session(source_id: &str, mtime_ms: i64) -> RawSession {
-        RawSession {
-            source_id: source_id.to_string(),
-            directory: None,
-            started_at: mtime_ms,
-            updated_at: Some(mtime_ms),
-            entrypoint: None,
-            messages: vec![RawMessage {
+        RawSession::search_only(
+            source_id,
+            None,
+            mtime_ms,
+            Some(mtime_ms),
+            None,
+            vec![RawMessage {
                 role: Role::User,
                 content: "hi".to_string(),
                 timestamp: Some(mtime_ms),
             }],
-        }
+        )
     }
 
     #[test]
@@ -170,6 +220,58 @@ mod tests {
         })
         .unwrap();
 
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn matching_mtime_reparses_until_usage_state_is_current() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("usage-backfill");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        store.insert_session(&make_session("s1", "sess-usage", Some(mtime_ms), 1)).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "sess-usage".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions { usage_parser_version: Some(1) },
+            vec![entry],
+            |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        store
+            .persist_usage_events_for_existing_session(
+                "test-source",
+                "sess-usage",
+                &[],
+                1,
+                Some(mtime_ms),
+            )
+            .unwrap();
+        let entry = FileScanEntry {
+            session_id: "sess-usage".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions { usage_parser_version: Some(1) },
+            vec![entry],
+            |_, _| panic!("current usage state should skip parsing"),
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
         let _ = fs::remove_file(&path);

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -135,14 +135,7 @@ fn parse_gemini_session_value(doc: Value, fallback_id: &str) -> anyhow::Result<O
         return Ok(None);
     }
 
-    Ok(Some(RawSession {
-        source_id: session_id,
-        directory: None,
-        started_at,
-        updated_at,
-        entrypoint: None,
-        messages,
-    }))
+    Ok(Some(RawSession::search_only(session_id, None, started_at, updated_at, None, messages)))
 }
 
 fn extract_tool_calls(tool_calls: Option<&Value>) -> String {

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -132,14 +132,14 @@ pub fn parse_kiro_conversation(
         return Ok(None);
     }
 
-    Ok(Some(RawSession {
-        source_id: conversation_id.to_string(),
-        directory: Some(cwd.to_string()),
-        started_at: created_at,
-        updated_at: Some(updated_at),
-        entrypoint: None,
+    Ok(Some(RawSession::search_only(
+        conversation_id.to_string(),
+        Some(cwd.to_string()),
+        created_at,
+        Some(updated_at),
+        None,
         messages,
-    }))
+    )))
 }
 
 fn extract_user_content(user_obj: &Value) -> String {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -10,7 +10,7 @@ pub mod kiro;
 pub mod opencode;
 
 use crate::db::store::Store;
-use crate::types::Role;
+use crate::types::{RawUsageEvent, Role};
 
 pub trait SourceAdapter {
     fn id(&self) -> &str;
@@ -18,6 +18,9 @@ pub trait SourceAdapter {
     fn scan(&self) -> anyhow::Result<Vec<RawSession>>;
     fn scan_summary(&self) -> anyhow::Result<Option<SourceScanSummary>> {
         Ok(None)
+    }
+    fn usage_parser_version(&self) -> Option<u32> {
+        None
     }
     fn scan_for_sync(
         &self,
@@ -36,6 +39,36 @@ pub struct RawSession {
     pub updated_at: Option<i64>,
     pub entrypoint: Option<String>,
     pub messages: Vec<RawMessage>,
+    pub usage_events: Vec<RawUsageEvent>,
+    pub usage_parser_version: Option<u32>,
+}
+
+impl RawSession {
+    pub fn search_only(
+        source_id: impl Into<String>,
+        directory: Option<String>,
+        started_at: i64,
+        updated_at: Option<i64>,
+        entrypoint: Option<String>,
+        messages: Vec<RawMessage>,
+    ) -> Self {
+        Self {
+            source_id: source_id.into(),
+            directory,
+            started_at,
+            updated_at,
+            entrypoint,
+            messages,
+            usage_events: Vec::new(),
+            usage_parser_version: None,
+        }
+    }
+
+    pub fn with_usage(mut self, usage_events: Vec<RawUsageEvent>, parser_version: u32) -> Self {
+        self.usage_events = usage_events;
+        self.usage_parser_version = Some(parser_version);
+        self
+    }
 }
 
 pub struct RawMessage {

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -191,14 +191,14 @@ fn scan_session_messages(
             continue;
         }
 
-        raw_sessions.push(RawSession {
-            source_id: session.id,
-            directory: Some(session.directory),
-            started_at: session.time_created,
-            updated_at: session.time_updated,
-            entrypoint: None,
+        raw_sessions.push(RawSession::search_only(
+            session.id,
+            Some(session.directory),
+            session.time_created,
+            session.time_updated,
+            None,
             messages,
-        });
+        ));
     }
 
     Ok(raw_sessions)

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,5 +1,7 @@
 use rusqlite::Connection;
 
+const SCHEMA_VERSION: i64 = 4;
+
 #[allow(clippy::missing_transmute_annotations)]
 pub fn register_sqlite_vec() {
     unsafe {
@@ -10,6 +12,23 @@ pub fn register_sqlite_vec() {
 }
 
 pub fn init(conn: &Connection) -> anyhow::Result<()> {
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if version < 1 {
+        migrate_v1(conn)?;
+    }
+    if version < 2 {
+        migrate_v2(conn)?;
+    }
+    if version < 3 {
+        migrate_v3(conn)?;
+    }
+    if version < 4 {
+        migrate_v4(conn)?;
+    }
+    Ok(())
+}
+
+fn migrate_v1(conn: &Connection) -> anyhow::Result<()> {
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS sessions (
@@ -79,7 +98,105 @@ pub fn init(conn: &Connection) -> anyhow::Result<()> {
             detail TEXT,
             updated_at INTEGER NOT NULL
         );
+
+        PRAGMA user_version = 1;
         ",
     )?;
     Ok(())
+}
+
+fn migrate_v2(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS usage_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            source TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            event_key TEXT NOT NULL,
+            event_seq INTEGER NOT NULL,
+            message_seq INTEGER,
+            timestamp INTEGER NOT NULL,
+            model TEXT NOT NULL DEFAULT 'unknown',
+            provider TEXT NOT NULL DEFAULT 'unknown',
+            input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+            output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_read_tokens >= 0),
+            cache_write_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_write_tokens >= 0),
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0 CHECK (reasoning_tokens >= 0),
+            token_source TEXT NOT NULL
+                CHECK (token_source IN ('observed', 'derived', 'estimated')),
+            parser_version INTEGER NOT NULL DEFAULT 1,
+            source_path TEXT,
+            raw_usage_json TEXT,
+            created_at INTEGER NOT NULL,
+            UNIQUE(session_id, event_key)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_usage_events_session
+            ON usage_events(session_id);
+        CREATE INDEX IF NOT EXISTS idx_usage_events_time
+            ON usage_events(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_usage_events_source_time
+            ON usage_events(source, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_usage_events_model_time
+            ON usage_events(model, timestamp);
+
+        PRAGMA user_version = 2;
+        ",
+    )?;
+    Ok(())
+}
+
+fn migrate_v3(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS usage_session_state (
+            session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+            source TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            parser_version INTEGER NOT NULL,
+            source_updated_at INTEGER,
+            event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+            synced_at INTEGER NOT NULL,
+            UNIQUE(source, source_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_usage_session_state_source
+            ON usage_session_state(source, source_id);
+
+        PRAGMA user_version = 3;
+        ",
+    )?;
+    Ok(())
+}
+
+fn migrate_v4(conn: &Connection) -> anyhow::Result<()> {
+    let has_column = |name: &str| -> anyhow::Result<bool> {
+        let mut stmt = conn.prepare("PRAGMA table_info(usage_events)")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+        for row in rows {
+            if row? == name {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    };
+
+    if has_column("cost_usd")? {
+        conn.execute_batch("ALTER TABLE usage_events DROP COLUMN cost_usd;")?;
+    }
+    if has_column("cost_source")? {
+        conn.execute_batch("ALTER TABLE usage_events DROP COLUMN cost_source;")?;
+    }
+    conn.execute_batch("PRAGMA user_version = 4;")?;
+    Ok(())
+}
+
+pub fn schema_version(conn: &Connection) -> anyhow::Result<i64> {
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0)).map_err(Into::into)
+}
+
+pub const fn current_schema_version() -> i64 {
+    SCHEMA_VERSION
 }

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -15,7 +15,7 @@ pub struct SearchFilters {
     pub directory: Option<String>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimeRange {
     Today,
     Week,

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -7,12 +7,19 @@ use rusqlite::OptionalExtension;
 
 use crate::db::search::TimeRange;
 use crate::types::{
-    BackgroundJobStatus, Message, Role, SemanticProgress, SemanticSessionJob, Session,
+    BackgroundJobStatus, Message, RawUsageEvent, Role, SemanticProgress, SemanticSessionJob,
+    Session, UsageEventRecord,
 };
 use crate::utils::f32_slice_to_bytes;
 
 pub struct Store {
     pub conn: Connection,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UsageSessionStateMeta {
+    pub parser_version: u32,
+    pub source_updated_at: Option<i64>,
 }
 
 impl Store {
@@ -64,6 +71,27 @@ impl Store {
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
+    pub fn usage_state_meta_map(
+        &self,
+        source: &str,
+    ) -> Result<HashMap<String, UsageSessionStateMeta>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source_id, parser_version, source_updated_at
+             FROM usage_session_state
+             WHERE source = ?1",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![source], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                UsageSessionStateMeta {
+                    parser_version: row.get(1)?,
+                    source_updated_at: row.get(2)?,
+                },
+            ))
+        })?;
+        rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
+    }
+
     pub fn insert_session(&self, session: &Session) -> Result<()> {
         self.conn.execute(
             "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint)
@@ -105,6 +133,16 @@ impl Store {
     }
 
     pub fn persist_session(&self, session: &Session, messages: &[Message]) -> Result<()> {
+        self.persist_session_with_usage(session, messages, &[], None)
+    }
+
+    pub fn persist_session_with_usage(
+        &self,
+        session: &Session,
+        messages: &[Message],
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: Option<u32>,
+    ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         {
             tx.execute(
@@ -137,6 +175,90 @@ impl Store {
                         msg.seq,
                     ])?;
                 }
+            }
+
+            {
+                tx.execute(
+                    "DELETE FROM usage_events WHERE session_id = ?1",
+                    rusqlite::params![session.id],
+                )?;
+                let created_at = Utc::now().timestamp_millis();
+                let mut stmt = tx.prepare(
+                    "INSERT INTO usage_events (
+                        session_id, source, source_id, event_key, event_seq, message_seq,
+                        timestamp, model, provider, input_tokens, output_tokens,
+                        cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                        token_source, parser_version, source_path, raw_usage_json, created_at
+                     )
+                     VALUES (
+                        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                        ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19
+                     )
+                     ON CONFLICT(session_id, event_key) DO UPDATE SET
+                        event_seq = excluded.event_seq,
+                        message_seq = excluded.message_seq,
+                        timestamp = excluded.timestamp,
+                        model = excluded.model,
+                        provider = excluded.provider,
+                        input_tokens = excluded.input_tokens,
+                        output_tokens = excluded.output_tokens,
+                        cache_read_tokens = excluded.cache_read_tokens,
+                        cache_write_tokens = excluded.cache_write_tokens,
+                        reasoning_tokens = excluded.reasoning_tokens,
+                        token_source = excluded.token_source,
+                        parser_version = excluded.parser_version,
+                        source_path = excluded.source_path,
+                        raw_usage_json = excluded.raw_usage_json",
+                )?;
+                for event in usage_events {
+                    stmt.execute(rusqlite::params![
+                        session.id,
+                        session.source,
+                        session.source_id,
+                        event.event_key,
+                        event.event_seq,
+                        event.message_seq,
+                        event.timestamp,
+                        event.model,
+                        event.provider,
+                        event.input_tokens,
+                        event.output_tokens,
+                        event.cache_read_tokens,
+                        event.cache_write_tokens,
+                        event.reasoning_tokens,
+                        event.token_source.as_str(),
+                        event.parser_version,
+                        event.source_path,
+                        event.raw_usage_json,
+                        created_at,
+                    ])?;
+                }
+            }
+
+            if let Some(parser_version) = usage_parser_version {
+                let synced_at = Utc::now().timestamp_millis();
+                tx.execute(
+                    "INSERT INTO usage_session_state (
+                        session_id, source, source_id, parser_version,
+                        source_updated_at, event_count, synced_at
+                     )
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(source, source_id) DO UPDATE SET
+                        session_id = excluded.session_id,
+                        parser_version = excluded.parser_version,
+                        source_updated_at = excluded.source_updated_at,
+                        event_count = excluded.event_count,
+                        synced_at = excluded.synced_at",
+                    rusqlite::params![
+                        session.id,
+                        session.source,
+                        session.source_id,
+                        parser_version,
+                        session.updated_at,
+                        usage_events.len() as u32,
+                        synced_at,
+                    ],
+                )?;
             }
 
             let units_total: i64 = tx.query_row(
@@ -177,6 +299,98 @@ impl Store {
         }
         tx.commit()?;
         Ok(())
+    }
+
+    pub fn persist_usage_events_for_existing_session(
+        &self,
+        source: &str,
+        source_id: &str,
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: u32,
+        source_updated_at: Option<i64>,
+    ) -> Result<bool> {
+        let session_id = self
+            .conn
+            .query_row(
+                "SELECT id FROM sessions WHERE source = ?1 AND source_id = ?2",
+                rusqlite::params![source, source_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+
+        let Some(session_id) = session_id else {
+            return Ok(false);
+        };
+
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            tx.execute(
+                "DELETE FROM usage_events WHERE session_id = ?1",
+                rusqlite::params![&session_id],
+            )?;
+
+            let created_at = Utc::now().timestamp_millis();
+            let mut stmt = tx.prepare(
+                "INSERT INTO usage_events (
+                    session_id, source, source_id, event_key, event_seq, message_seq,
+                    timestamp, model, provider, input_tokens, output_tokens,
+                    cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                    token_source, parser_version, source_path, raw_usage_json, created_at
+                 )
+                 VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                    ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19
+                 )",
+            )?;
+            for event in usage_events {
+                stmt.execute(rusqlite::params![
+                    &session_id,
+                    source,
+                    source_id,
+                    event.event_key,
+                    event.event_seq,
+                    event.message_seq,
+                    event.timestamp,
+                    event.model,
+                    event.provider,
+                    event.input_tokens,
+                    event.output_tokens,
+                    event.cache_read_tokens,
+                    event.cache_write_tokens,
+                    event.reasoning_tokens,
+                    event.token_source.as_str(),
+                    event.parser_version,
+                    event.source_path,
+                    event.raw_usage_json,
+                    created_at,
+                ])?;
+            }
+
+            tx.execute(
+                "INSERT INTO usage_session_state (
+                    session_id, source, source_id, parser_version,
+                    source_updated_at, event_count, synced_at
+                 )
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(source, source_id) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    parser_version = excluded.parser_version,
+                    source_updated_at = excluded.source_updated_at,
+                    event_count = excluded.event_count,
+                    synced_at = excluded.synced_at",
+                rusqlite::params![
+                    &session_id,
+                    source,
+                    source_id,
+                    usage_parser_version,
+                    source_updated_at,
+                    usage_events.len() as u32,
+                    Utc::now().timestamp_millis(),
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(true)
     }
 
     pub fn upsert_embeddings(&self, items: &[(i64, &[f32])]) -> Result<()> {
@@ -498,6 +712,69 @@ impl Store {
             rusqlite::params![source, source_id],
         )?;
         Ok(())
+    }
+
+    pub fn list_usage_events(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+    ) -> Result<Vec<UsageEventRecord>> {
+        let mut sql = String::from(
+            "SELECT session_id, source, source_id, event_key, timestamp, model, provider,
+                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                    reasoning_tokens, token_source
+             FROM usage_events
+             WHERE 1 = 1",
+        );
+
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1;
+
+        if let Some(cutoff) = time_range.millis_ago() {
+            sql.push_str(&format!(" AND timestamp >= ?{param_idx}"));
+            params.push(Box::new(cutoff));
+            param_idx += 1;
+        }
+
+        if let Some(source_ids) = sources
+            && !source_ids.is_empty()
+        {
+            sql.push_str(" AND source IN (");
+            for (i, source_id) in source_ids.iter().enumerate() {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("?{param_idx}"));
+                params.push(Box::new(source_id.clone()));
+                param_idx += 1;
+            }
+            sql.push(')');
+        }
+
+        sql.push_str(" ORDER BY timestamp ASC, source ASC, event_seq ASC");
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok(UsageEventRecord {
+                session_id: row.get(0)?,
+                source: row.get(1)?,
+                source_id: row.get(2)?,
+                event_key: row.get(3)?,
+                timestamp: row.get(4)?,
+                model: row.get(5)?,
+                provider: row.get(6)?,
+                input_tokens: row.get(7)?,
+                output_tokens: row.get(8)?,
+                cache_read_tokens: row.get(9)?,
+                cache_write_tokens: row.get(10)?,
+                reasoning_tokens: row.get(11)?,
+                token_source: row.get(12)?,
+            })
+        })?;
+
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     pub fn get_messages(&self, session_id: &str) -> Result<Vec<Message>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod embedding;
 pub mod semantic;
 pub mod tui;
 pub mod types;
+pub mod usage;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ use recall::adapters;
 use recall::config::AppConfig;
 use recall::db;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
-use recall::db::store::Store;
+use recall::db::store::{Store, UsageSessionStateMeta};
 use recall::embedding::EmbeddingProvider;
 use recall::semantic;
 use recall::types::{self, Message, Role, Session};
+use recall::usage::{self, UsageFilters};
 use recall::utils;
 
 #[derive(Parser)]
@@ -55,6 +56,14 @@ enum Commands {
         #[arg(long)]
         time: Option<String>,
     },
+    Usage {
+        #[arg(long, help = "Output usage report as JSON")]
+        json: bool,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long)]
+        time: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -81,6 +90,9 @@ fn main() -> Result<()> {
         Some(Commands::BenchDumpSessions) => recall::bench::dump_sessions()?,
         Some(Commands::Search { query, source, time }) => {
             cmd_search(&query, source.as_deref(), time.as_deref())?
+        }
+        Some(Commands::Usage { json, source, time }) => {
+            cmd_usage(json, source.as_deref(), time.as_deref())?
         }
         None => cmd_tui()?,
     }
@@ -281,12 +293,33 @@ fn cmd_sync(force: bool, verbose: bool) -> Result<()> {
 }
 
 fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
+    run_sync_job_inner(SyncRunOptions { force, verbose, emit: true, usage_only: false })
+}
+
+fn run_usage_sync_job() -> Result<()> {
+    run_sync_job_inner(SyncRunOptions {
+        force: false,
+        verbose: false,
+        emit: false,
+        usage_only: true,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SyncRunOptions {
+    force: bool,
+    verbose: bool,
+    emit: bool,
+    usage_only: bool,
+}
+
+fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let store = Store::open()?;
     let all = adapters::all_adapters();
     let labels = adapters::source_labels();
     let mut config = AppConfig::load_or_default();
     config.normalize_sources(&labels);
-    let since_ts = config.sync_window.to_since_cutoff();
+    let since_ts = if options.usage_only { None } else { config.sync_window.to_since_cutoff() };
 
     let mut new_sessions = 0u32;
     let mut updated_sessions = 0u32;
@@ -299,23 +332,29 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
         let source_id = adapter.id();
         let label = adapter.label();
 
+        if options.usage_only && adapter.usage_parser_version().is_none() {
+            continue;
+        }
+
         if !config.is_source_enabled(source_id) {
-            if verbose {
+            if options.verbose {
                 println!("Skipping {label} (filtered)");
             }
             continue;
         }
 
-        if verbose {
+        if options.verbose {
             println!("Scanning {label}...");
         }
-        let optimized = if force {
+        let optimized = if options.force {
             None
         } else {
             match adapter.scan_for_sync(&store, since_ts) {
                 Ok(scan) => scan,
                 Err(e) => {
-                    eprintln!("Error scanning {label}: {e}");
+                    if options.emit {
+                        eprintln!("Error scanning {label}: {e}");
+                    }
                     continue;
                 }
             }
@@ -328,7 +367,9 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
                 let raw_sessions = match adapter.scan() {
                     Ok(s) => s,
                     Err(e) => {
-                        eprintln!("Error scanning {label}: {e}");
+                        if options.emit {
+                            eprintln!("Error scanning {label}: {e}");
+                        }
                         continue;
                     }
                 };
@@ -337,11 +378,12 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
         };
         skipped += pre_skipped;
         filtered_out += pre_filtered;
-        if verbose {
+        if options.verbose {
             println!("  Found {} sessions", raw_sessions.len());
         }
 
         let mut existing_meta = store.session_meta_map(source_id)?;
+        let mut existing_usage_meta = store.usage_state_meta_map(source_id)?;
 
         for raw in raw_sessions {
             if let Some(cutoff) = since_ts {
@@ -353,17 +395,45 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
             }
 
             let msg_count = raw.messages.len() as u32;
+            let usage_backfill_needed = raw.usage_parser_version.is_some_and(|version| {
+                !usage_state_is_current(
+                    version,
+                    existing_usage_meta.get(&raw.source_id).copied(),
+                    raw.updated_at,
+                )
+            });
 
             match existing_meta.get(&raw.source_id) {
                 Some(&(old_updated_at, old_msg_count)) => {
-                    let changed = old_msg_count != msg_count
+                    let content_changed = old_msg_count != msg_count
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
-                    if !changed && !force {
+                    if !content_changed && usage_backfill_needed && !options.force {
+                        if let Some(parser_version) = raw.usage_parser_version
+                            && store.persist_usage_events_for_existing_session(
+                                source_id,
+                                &raw.source_id,
+                                &raw.usage_events,
+                                parser_version,
+                                raw.updated_at,
+                            )?
+                        {
+                            existing_usage_meta.insert(
+                                raw.source_id.clone(),
+                                UsageSessionStateMeta {
+                                    parser_version,
+                                    source_updated_at: raw.updated_at,
+                                },
+                            );
+                            reprocessed_sessions += 1;
+                        }
+                        continue;
+                    }
+                    if !content_changed && !options.force {
                         skipped += 1;
                         continue;
                     }
                     store.delete_session_data(source_id, &raw.source_id)?;
-                    if changed {
+                    if content_changed {
                         updated_sessions += 1;
                     } else {
                         reprocessed_sessions += 1;
@@ -402,9 +472,20 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
                 })
                 .collect();
 
-            store.persist_session(&session, &messages)?;
+            store.persist_session_with_usage(
+                &session,
+                &messages,
+                &raw.usage_events,
+                raw.usage_parser_version,
+            )?;
             existing_meta
                 .insert(session.source_id.clone(), (session.updated_at, session.message_count));
+            if let Some(parser_version) = raw.usage_parser_version {
+                existing_usage_meta.insert(
+                    session.source_id.clone(),
+                    UsageSessionStateMeta { parser_version, source_updated_at: session.updated_at },
+                );
+            }
             total_messages += msg_count;
         }
 
@@ -413,9 +494,9 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
 
     let touched = new_sessions + updated_sessions + reprocessed_sessions;
 
-    if verbose {
+    if options.verbose {
         println!();
-        if force {
+        if options.force {
             print!(
                 "Force sync: {new_sessions} new, {updated_sessions} updated, {reprocessed_sessions} reprocessed, {total_messages} messages"
             );
@@ -448,7 +529,8 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
                 progress.failed_sessions
             );
         }
-    } else if force {
+    } else if !options.emit {
+    } else if options.force {
         println!("Reprocessed {touched} sessions, {total_messages} messages");
     } else if touched == 0 {
         println!("Up to date.");
@@ -457,6 +539,17 @@ fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn usage_state_is_current(
+    required_parser_version: u32,
+    state: Option<UsageSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    state.is_some_and(|state| {
+        state.parser_version >= required_parser_version
+            && state.source_updated_at == source_updated_at
+    })
 }
 
 fn cmd_background_worker(sync_first: bool) -> Result<()> {
@@ -535,6 +628,117 @@ fn cmd_search(query: &str, source_filter: Option<&str>, time_filter: Option<&str
     }
 
     Ok(())
+}
+
+fn cmd_usage(json: bool, source_filter: Option<&str>, time_filter: Option<&str>) -> Result<()> {
+    run_usage_sync_job()?;
+
+    let store = Store::open()?;
+    let sources = adapters::source_labels();
+    let filters = UsageFilters {
+        sources: resolve_source_filter(source_filter, &sources)?,
+        time_range: parse_time_range(time_filter),
+    };
+    let report = usage::build_usage_report(&store, &filters)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!("Usage");
+    println!("  Total tokens  {}", format_usage_number(report.summary.tokens.total_tokens));
+    println!("  Sessions      {}", report.summary.sessions);
+
+    if !report.by_source.is_empty() {
+        println!();
+        println!("By source");
+        for source in report.by_source.iter().take(10) {
+            println!(
+                "  {:<14} {:>12} tokens  {:>4} sessions",
+                source.source,
+                format_usage_number(source.tokens.total_tokens),
+                source.sessions
+            );
+        }
+    }
+
+    if !report.by_model.is_empty() {
+        println!();
+        println!("By model");
+        for model in report.by_model.iter().take(10) {
+            println!(
+                "  {:<12} {:<18} {:>12} tokens",
+                model.source,
+                truncate_usage_label(&model.model, 18),
+                format_usage_number(model.tokens.total_tokens)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_source_filter(
+    source_filter: Option<&str>,
+    sources: &[(String, String)],
+) -> Result<Option<Vec<String>>> {
+    let Some(source) = source_filter else {
+        return Ok(None);
+    };
+    let lower = source.to_lowercase();
+    let resolved = sources
+        .iter()
+        .find(|(id, label)| id == &lower || label.to_lowercase() == lower)
+        .map(|(id, _)| id.clone())
+        .ok_or_else(|| anyhow::anyhow!("unknown source: {source}"))?;
+    Ok(Some(vec![resolved]))
+}
+
+fn parse_time_range(time_filter: Option<&str>) -> TimeRange {
+    match time_filter.map(|t| t.to_lowercase()) {
+        Some(ref t) if t == "today" => TimeRange::Today,
+        Some(ref t) if t == "7d" || t == "week" => TimeRange::Week,
+        Some(ref t) if t == "30d" || t == "month" => TimeRange::Month,
+        _ => TimeRange::All,
+    }
+}
+
+fn format_usage_number(value: i64) -> String {
+    let abs = value.abs();
+    if abs >= 1_000_000_000 {
+        return format_compact_decimal(value as f64 / 1_000_000_000.0, "B");
+    }
+    if abs >= 1_000_000 {
+        return format_compact_decimal(value as f64 / 1_000_000.0, "M");
+    }
+
+    let s = value.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+fn format_compact_decimal(value: f64, suffix: &str) -> String {
+    let formatted = format!("{value:.2}");
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.').to_string();
+    format!("{trimmed}{suffix}")
+}
+
+fn truncate_usage_label(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let suffix = "...";
+    let keep = max_chars.saturating_sub(suffix.len());
+    let mut out = value.chars().take(keep).collect::<String>();
+    out.push_str(suffix);
+    out
 }
 fn cmd_tui() -> Result<()> {
     use std::io;

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,37 @@ impl Role {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TokenSource {
+    Observed,
+    Derived,
+    Estimated,
+}
+
+impl TokenSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TokenSource::Observed => "observed",
+            TokenSource::Derived => "derived",
+            TokenSource::Estimated => "estimated",
+        }
+    }
+}
+
+impl std::str::FromStr for TokenSource {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "observed" => Ok(TokenSource::Observed),
+            "derived" => Ok(TokenSource::Derived),
+            "estimated" => Ok(TokenSource::Estimated),
+            _ => Err(()),
+        }
+    }
+}
+
 impl std::str::FromStr for Role {
     type Err = ();
 
@@ -45,6 +76,42 @@ pub struct Message {
     pub content: String,
     pub timestamp: Option<i64>,
     pub seq: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RawUsageEvent {
+    pub event_key: String,
+    pub event_seq: u32,
+    pub message_seq: Option<u32>,
+    pub timestamp: i64,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub token_source: TokenSource,
+    pub parser_version: u32,
+    pub source_path: Option<String>,
+    pub raw_usage_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageEventRecord {
+    pub session_id: String,
+    pub source: String,
+    pub source_id: String,
+    pub event_key: String,
+    pub timestamp: i64,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub token_source: String,
 }
 
 #[derive(Debug)]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,296 @@
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use anyhow::Result;
+use chrono::{Datelike, Local, TimeZone};
+use serde::Serialize;
+
+use crate::db::search::TimeRange;
+use crate::db::store::Store;
+use crate::types::UsageEventRecord;
+
+#[derive(Debug, Clone)]
+pub struct UsageFilters {
+    pub sources: Option<Vec<String>>,
+    pub time_range: TimeRange,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TokenTotals {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub total_tokens: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageSummary {
+    pub events: usize,
+    pub sessions: usize,
+    pub sources: usize,
+    pub models: usize,
+    pub token_source_events: BTreeMap<String, usize>,
+    pub tokens: TokenTotals,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceUsage {
+    pub source: String,
+    pub sessions: usize,
+    pub events: usize,
+    pub tokens: TokenTotals,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelUsage {
+    pub source: String,
+    pub provider: String,
+    pub model: String,
+    pub sessions: usize,
+    pub events: usize,
+    pub tokens: TokenTotals,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PeriodUsage {
+    pub period: String,
+    pub sessions: usize,
+    pub events: usize,
+    pub tokens: TokenTotals,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageReport {
+    pub summary: UsageSummary,
+    pub by_source: Vec<SourceUsage>,
+    pub by_model: Vec<ModelUsage>,
+    pub daily: Vec<PeriodUsage>,
+    pub weekly: Vec<PeriodUsage>,
+    pub monthly: Vec<PeriodUsage>,
+}
+
+#[derive(Default)]
+struct Accumulator {
+    tokens: TokenTotals,
+    sessions: BTreeSet<String>,
+    events: usize,
+}
+
+impl Accumulator {
+    fn add(&mut self, event: &UsageEventRecord) {
+        self.tokens.input_tokens += event.input_tokens.max(0);
+        self.tokens.output_tokens += event.output_tokens.max(0);
+        self.tokens.cache_read_tokens += event.cache_read_tokens.max(0);
+        self.tokens.cache_write_tokens += event.cache_write_tokens.max(0);
+        self.tokens.reasoning_tokens += event.reasoning_tokens.max(0);
+        self.tokens.total_tokens = self.tokens.input_tokens
+            + self.tokens.output_tokens
+            + self.tokens.cache_read_tokens
+            + self.tokens.cache_write_tokens
+            + self.tokens.reasoning_tokens;
+        self.sessions.insert(event.session_id.clone());
+        self.events += 1;
+    }
+}
+
+pub fn build_usage_report(store: &Store, filters: &UsageFilters) -> Result<UsageReport> {
+    let events = store.list_usage_events(filters.sources.as_deref(), filters.time_range)?;
+    Ok(aggregate_usage_events(&events))
+}
+
+pub fn aggregate_usage_events(events: &[UsageEventRecord]) -> UsageReport {
+    let events = dedupe_report_events(events);
+    let mut total = Accumulator::default();
+    let mut by_source: BTreeMap<String, Accumulator> = BTreeMap::new();
+    let mut by_model: BTreeMap<(String, String, String), Accumulator> = BTreeMap::new();
+    let mut daily: BTreeMap<String, Accumulator> = BTreeMap::new();
+    let mut weekly: BTreeMap<String, Accumulator> = BTreeMap::new();
+    let mut monthly: BTreeMap<String, Accumulator> = BTreeMap::new();
+    let mut token_source_events = BTreeMap::new();
+
+    for event in events {
+        total.add(event);
+        *token_source_events.entry(event.token_source.clone()).or_insert(0) += 1;
+
+        by_source.entry(event.source.clone()).or_default().add(event);
+        by_model
+            .entry((event.source.clone(), event.provider.clone(), event.model.clone()))
+            .or_default()
+            .add(event);
+
+        let (day, week, month) = period_keys(event.timestamp);
+        daily.entry(day).or_default().add(event);
+        weekly.entry(week).or_default().add(event);
+        monthly.entry(month).or_default().add(event);
+    }
+
+    let source_count = by_source.len();
+    let model_count = by_model.len();
+
+    let mut by_source = by_source
+        .into_iter()
+        .map(|(source, acc)| SourceUsage {
+            source,
+            sessions: acc.sessions.len(),
+            events: acc.events,
+            tokens: acc.tokens,
+        })
+        .collect::<Vec<_>>();
+    by_source.sort_by_key(|source| Reverse(source.tokens.total_tokens));
+
+    let mut by_model = by_model
+        .into_iter()
+        .map(|((source, provider, model), acc)| ModelUsage {
+            source,
+            provider,
+            model,
+            sessions: acc.sessions.len(),
+            events: acc.events,
+            tokens: acc.tokens,
+        })
+        .collect::<Vec<_>>();
+    by_model.sort_by_key(|model| Reverse(model.tokens.total_tokens));
+
+    UsageReport {
+        summary: UsageSummary {
+            events: total.events,
+            sessions: total.sessions.len(),
+            sources: source_count,
+            models: model_count,
+            token_source_events,
+            tokens: total.tokens,
+        },
+        by_source,
+        by_model,
+        daily: period_vec(daily),
+        weekly: period_vec(weekly),
+        monthly: period_vec(monthly),
+    }
+}
+
+fn dedupe_report_events(events: &[UsageEventRecord]) -> Vec<&UsageEventRecord> {
+    let mut codex_seen: HashSet<String> = HashSet::new();
+    let mut claude_seen: HashSet<String> = HashSet::new();
+    let mut deduped = Vec::with_capacity(events.len());
+
+    for event in events {
+        if event.source == "codex" {
+            let key = format!(
+                "codex:token_count:{}:{}:{}:{}:{}:{}:{}:{}",
+                event.timestamp,
+                event.provider,
+                event.model,
+                event.input_tokens,
+                event.output_tokens,
+                event.cache_read_tokens,
+                event.cache_write_tokens,
+                event.reasoning_tokens
+            );
+            if !codex_seen.insert(key) {
+                continue;
+            }
+        } else if event.source == "claude-code"
+            && event.event_key.starts_with("assistant:")
+            && !event.event_key.contains(":line:")
+            && !claude_seen.insert(event.event_key.clone())
+        {
+            continue;
+        }
+
+        deduped.push(event);
+    }
+
+    deduped
+}
+
+fn period_vec(map: BTreeMap<String, Accumulator>) -> Vec<PeriodUsage> {
+    map.into_iter()
+        .map(|(period, acc)| PeriodUsage {
+            period,
+            sessions: acc.sessions.len(),
+            events: acc.events,
+            tokens: acc.tokens,
+        })
+        .collect()
+}
+
+fn period_keys(timestamp_ms: i64) -> (String, String, String) {
+    let dt = Local
+        .timestamp_millis_opt(timestamp_ms)
+        .single()
+        .unwrap_or_else(|| Local.timestamp_millis_opt(0).single().expect("epoch is valid"));
+    let date = dt.date_naive();
+    let iso = date.iso_week();
+    (
+        date.format("%Y-%m-%d").to_string(),
+        format!("{}-W{:02}", iso.year(), iso.week()),
+        date.format("%Y-%m").to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(source: &str, session_id: &str, event_key: &str, timestamp: i64) -> UsageEventRecord {
+        UsageEventRecord {
+            session_id: session_id.to_string(),
+            source: source.to_string(),
+            source_id: session_id.to_string(),
+            event_key: event_key.to_string(),
+            timestamp,
+            model: "gpt-5.5".to_string(),
+            provider: "openai".to_string(),
+            input_tokens: 8,
+            output_tokens: 3,
+            cache_read_tokens: 2,
+            cache_write_tokens: 0,
+            reasoning_tokens: 1,
+            token_source: "derived".to_string(),
+        }
+    }
+
+    #[test]
+    fn aggregate_usage_dedupes_codex_token_count_across_sessions() {
+        let events = vec![
+            event("codex", "session-a", "token_count:1", 1_800_000_000_000),
+            event("codex", "session-b", "token_count:9", 1_800_000_000_000),
+        ];
+
+        let report = aggregate_usage_events(&events);
+
+        assert_eq!(report.summary.events, 1);
+        assert_eq!(report.summary.sessions, 1);
+        assert_eq!(report.summary.tokens.total_tokens, 14);
+    }
+
+    #[test]
+    fn aggregate_usage_keeps_codex_identical_deltas_at_distinct_timestamps() {
+        let events = vec![
+            event("codex", "session-a", "token_count:1", 1_800_000_000_000),
+            event("codex", "session-a", "token_count:2", 1_800_000_001_000),
+        ];
+
+        let report = aggregate_usage_events(&events);
+
+        assert_eq!(report.summary.events, 2);
+        assert_eq!(report.summary.tokens.total_tokens, 28);
+    }
+
+    #[test]
+    fn aggregate_usage_dedupes_claude_events_with_stable_message_ids() {
+        let mut first = event("claude-code", "session-a", "assistant:req-1:msg-1", 1);
+        first.provider = "anthropic".to_string();
+        first.model = "claude-sonnet".to_string();
+        first.token_source = "observed".to_string();
+        let mut duplicate = first.clone();
+        duplicate.session_id = "session-b".to_string();
+
+        let report = aggregate_usage_events(&[first, duplicate]);
+
+        assert_eq!(report.summary.events, 1);
+        assert_eq!(report.summary.tokens.total_tokens, 14);
+    }
+}

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -5,7 +5,8 @@ use recall::config::AppConfig;
 use recall::db::schema;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::Store;
-use recall::types::{Message, Role, Session};
+use recall::types::{Message, RawUsageEvent, Role, Session, TokenSource};
+use recall::usage::{UsageFilters, build_usage_report};
 
 fn setup() -> Store {
     schema::register_sqlite_vec();
@@ -36,8 +37,34 @@ fn make_message(session_id: &str, role: Role, content: &str, seq: u32) -> Messag
     }
 }
 
+fn make_usage_event(key: &str, timestamp: i64, model: &str) -> RawUsageEvent {
+    RawUsageEvent {
+        event_key: key.to_string(),
+        event_seq: 0,
+        message_seq: Some(1),
+        timestamp,
+        model: model.to_string(),
+        provider: "test-provider".to_string(),
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_tokens: 3,
+        cache_write_tokens: 2,
+        reasoning_tokens: 1,
+        token_source: TokenSource::Observed,
+        parser_version: 1,
+        source_path: Some("/tmp/source.jsonl".to_string()),
+        raw_usage_json: Some(r#"{"input_tokens":10}"#.to_string()),
+    }
+}
+
 fn no_filters() -> SearchFilters {
     SearchFilters { sources: None, time_range: TimeRange::All, directory: None }
+}
+
+#[test]
+fn schema_migration_sets_current_version() {
+    let store = setup();
+    assert_eq!(schema::schema_version(&store.conn).unwrap(), schema::current_schema_version());
 }
 
 #[test]
@@ -112,6 +139,58 @@ fn delete_session_cleans_embeddings() {
 
     let sessions = store.list_recent_sessions(10).unwrap();
     assert!(sessions.is_empty());
+}
+
+#[test]
+fn persist_session_writes_usage_events_and_report_aggregates() {
+    let store = setup();
+    let session = make_session("s1", "claude-code", "raw1", "Usage session");
+    let messages = vec![
+        make_message("s1", Role::User, "hello", 0),
+        make_message("s1", Role::Assistant, "hi", 1),
+    ];
+    let usage = vec![make_usage_event("evt-1", 1_800_000_000_000, "claude-sonnet")];
+
+    store.persist_session_with_usage(&session, &messages, &usage, Some(1)).unwrap();
+
+    let count: i64 =
+        store.conn.query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0)).unwrap();
+    assert_eq!(count, 1);
+    let state_count: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM usage_session_state", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(state_count, 1);
+
+    let report =
+        build_usage_report(&store, &UsageFilters { sources: None, time_range: TimeRange::All })
+            .unwrap();
+    assert_eq!(report.summary.events, 1);
+    assert_eq!(report.summary.sessions, 1);
+    assert_eq!(report.summary.tokens.total_tokens, 21);
+    assert_eq!(report.summary.token_source_events.get("observed"), Some(&1));
+    assert_eq!(report.by_source[0].source, "claude-code");
+    assert_eq!(report.by_model[0].model, "claude-sonnet");
+}
+
+#[test]
+fn delete_session_cascades_usage_events() {
+    let store = setup();
+    let session = make_session("s1", "codex", "raw1", "Usage session");
+    let messages = vec![make_message("s1", Role::User, "hello", 0)];
+    let usage = vec![make_usage_event("evt-1", 1_800_000_000_000, "gpt-5")];
+    store.persist_session_with_usage(&session, &messages, &usage, Some(1)).unwrap();
+
+    store.delete_session_data("codex", "raw1").unwrap();
+
+    let count: i64 =
+        store.conn.query_row("SELECT COUNT(*) FROM usage_events", [], |row| row.get(0)).unwrap();
+    assert_eq!(count, 0, "usage events must follow session lifecycle");
+    let state_count: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM usage_session_state", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(state_count, 0, "usage parser state must follow session lifecycle");
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- Add local usage event persistence and reporting for `recall usage`.
- Parse Codex and Claude Code token usage into session-attached usage events.
- Document source adapter usage support and credit tokscale.

### Why

- Gives Recall a local usage dashboard path without adding cloud sync or a separate usage adapter system.