### PR TITLE
[fix] improve usage CLI filtering and display

### DIFF
--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use chrono::{Local, TimeZone};
 use rusqlite::Connection;
 
 use crate::types::{MatchSource, SearchResult, Session};
@@ -25,11 +26,18 @@ pub enum TimeRange {
 
 impl TimeRange {
     pub fn millis_ago(&self) -> Option<i64> {
-        let now = chrono::Utc::now().timestamp_millis();
+        self.cutoff_millis_at(Local::now())
+    }
+
+    fn cutoff_millis_at(&self, now: chrono::DateTime<Local>) -> Option<i64> {
         match self {
-            TimeRange::Today => Some(now - 24 * 3600 * 1000),
-            TimeRange::Week => Some(now - 7 * 24 * 3600 * 1000),
-            TimeRange::Month => Some(now - 30 * 24 * 3600 * 1000),
+            TimeRange::Today => now
+                .date_naive()
+                .and_hms_opt(0, 0, 0)
+                .and_then(|start| Local.from_local_datetime(&start).earliest())
+                .map(|start| start.timestamp_millis()),
+            TimeRange::Week => Some(now.timestamp_millis() - 7 * 24 * 3600 * 1000),
+            TimeRange::Month => Some(now.timestamp_millis() - 30 * 24 * 3600 * 1000),
             TimeRange::All => None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::info;
@@ -646,37 +648,49 @@ fn cmd_usage(json: bool, source_filter: Option<&str>, time_filter: Option<&str>)
         return Ok(());
     }
 
-    println!("Usage");
-    println!("  Total tokens  {}", format_usage_number(report.summary.tokens.total_tokens));
-    println!("  Sessions      {}", report.summary.sessions);
+    print!("{}", format_usage_report_text(&report));
+
+    Ok(())
+}
+
+fn format_usage_report_text(report: &usage::UsageReport) -> String {
+    let mut out = String::new();
+    writeln!(out, "Usage").unwrap();
+    writeln!(out, "  Total tokens  {}", format_usage_number(report.summary.tokens.total_tokens))
+        .unwrap();
+    writeln!(out, "  Sessions      {}", report.summary.sessions).unwrap();
 
     if !report.by_source.is_empty() {
-        println!();
-        println!("By source");
+        writeln!(out).unwrap();
+        writeln!(out, "By source").unwrap();
         for source in report.by_source.iter().take(10) {
-            println!(
+            writeln!(
+                out,
                 "  {:<14} {:>12} tokens  {:>4} sessions",
                 source.source,
                 format_usage_number(source.tokens.total_tokens),
                 source.sessions
-            );
+            )
+            .unwrap();
         }
     }
 
     if !report.by_model.is_empty() {
-        println!();
-        println!("By model");
+        writeln!(out).unwrap();
+        writeln!(out, "By model").unwrap();
         for model in report.by_model.iter().take(10) {
-            println!(
-                "  {:<12} {:<18} {:>12} tokens",
+            writeln!(
+                out,
+                "  {:<12} {:<24} {:>12} tokens",
                 model.source,
-                truncate_usage_label(&model.model, 18),
+                truncate_usage_label(&model.model, 24),
                 format_usage_number(model.tokens.total_tokens)
-            );
+            )
+            .unwrap();
         }
     }
 
-    Ok(())
+    out
 }
 
 fn resolve_source_filter(


### PR DESCRIPTION
## Summary

- Make `--time today` use the local calendar day boundary instead of a rolling 24-hour window.
- Keep the text `recall usage` output focused on summary, By source, and By model.
- Widen the By model column so names like `gpt-5.3-codex-spark` are not truncated.

## Validation

- `make check`
