### PR TITLE
[Feat] Add usage dashboard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<()> {
         Some(Commands::Usage { json, source, time }) => {
             cmd_usage(json, source.as_deref(), time.as_deref())?
         }
-        None => cmd_tui()?,
+        None => cmd_tui(None)?,
     }
 
     Ok(())
@@ -633,10 +633,16 @@ fn cmd_search(query: &str, source_filter: Option<&str>, time_filter: Option<&str
 }
 
 fn cmd_usage(json: bool, source_filter: Option<&str>, time_filter: Option<&str>) -> Result<()> {
-    run_usage_sync_job()?;
+    let sources = usage_source_labels();
 
+    if !json {
+        let usage_source_filter = resolve_source_filter(source_filter, &sources)?;
+        let usage_time_filter = time_filter.map(|_| parse_time_range(time_filter));
+        return cmd_tui(Some((usage_source_filter, usage_time_filter)));
+    }
+
+    run_usage_sync_job()?;
     let store = Store::open()?;
-    let sources = adapters::source_labels();
     let filters = UsageFilters {
         sources: resolve_source_filter(source_filter, &sources)?,
         time_range: parse_time_range(time_filter),
@@ -709,6 +715,13 @@ fn resolve_source_filter(
     Ok(Some(vec![resolved]))
 }
 
+fn usage_source_labels() -> Vec<(String, String)> {
+    ["codex", "claude-code", "opencode"]
+        .into_iter()
+        .map(|source| (source.to_string(), source.to_string()))
+        .collect()
+}
+
 fn parse_time_range(time_filter: Option<&str>) -> TimeRange {
     match time_filter.map(|t| t.to_lowercase()) {
         Some(ref t) if t == "today" => TimeRange::Today,
@@ -754,7 +767,7 @@ fn truncate_usage_label(value: &str, max_chars: usize) -> String {
     out.push_str(suffix);
     out
 }
-fn cmd_tui() -> Result<()> {
+fn cmd_tui(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Result<()> {
     use std::io;
     use std::time::Duration;
 
@@ -765,13 +778,15 @@ fn cmd_tui() -> Result<()> {
     use ratatui::Terminal;
     use ratatui::backend::CrosstermBackend;
 
-    use recall::tui::app::App;
+    use recall::tui::app::{App, AppMode};
     use recall::tui::event::{AppEvent, poll_event};
     use recall::tui::ui;
 
+    let usage_mode = usage_start.is_some();
     let store = Store::open()?;
     semantic::ensure_background_worker(true)?;
-    let sources = adapters::source_labels();
+    let sources =
+        if usage_start.is_some() { usage_source_labels() } else { adapters::source_labels() };
 
     struct TerminalGuard;
     impl Drop for TerminalGuard {
@@ -796,6 +811,15 @@ fn cmd_tui() -> Result<()> {
     config.normalize_sources(&sources);
 
     let mut app = App::new(&store, sources, config);
+    if let Some((source_filter, time_filter)) = usage_start {
+        app.source_filter_selection = source_filter.unwrap_or_default();
+        if let Some(time_filter) = time_filter {
+            app.usage_time_filter = time_filter;
+        }
+        app.mode = AppMode::Usage;
+        app.request_usage_refresh();
+    }
+    let mut usage_sync_pending = usage_mode;
     let tick_rate = Duration::from_millis(50);
 
     loop {
@@ -808,6 +832,22 @@ fn cmd_tui() -> Result<()> {
             AppEvent::ScrollUp => app.handle_scroll_up(&store),
             AppEvent::ScrollDown => app.handle_scroll_down(&store),
             AppEvent::Tick => {}
+        }
+
+        if app.should_quit {
+            break;
+        }
+
+        if app.usage_refresh_is_due() {
+            if usage_sync_pending {
+                usage_sync_pending = false;
+                match run_usage_sync_job() {
+                    Ok(()) => app.refresh_usage(&store),
+                    Err(err) => app.fail_usage_refresh(err),
+                }
+            } else {
+                app.refresh_usage(&store);
+            }
         }
 
         app.try_search(&store, &engine, &mut provider);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,9 +12,13 @@ use crate::embedding::EmbeddingProvider;
 use crate::types::{
     BackgroundJobStatus, MatchSource, Message, Role, SearchResult, SemanticProgress,
 };
+use crate::usage::{self, UsageFilters, UsageReport};
+
+const USAGE_LOADING_MIN_MS: u128 = 75;
 
 pub enum AppMode {
     Search,
+    Usage,
     Viewing,
     ExportInput,
     Settings,
@@ -81,6 +85,11 @@ mod tests {
             source_picker_dirty: false,
             source_picker_typing: false,
             filters_editing_source: false,
+            usage_report: None,
+            usage_year_report: None,
+            usage_error: None,
+            usage_time_filter: TimeRange::All,
+            usage_refresh_requested_at: None,
         }
     }
 
@@ -235,6 +244,11 @@ pub struct App {
     pub source_picker_dirty: bool,
     pub source_picker_typing: bool,
     pub filters_editing_source: bool,
+    pub usage_report: Option<UsageReport>,
+    pub usage_year_report: Option<UsageReport>,
+    pub usage_error: Option<String>,
+    pub usage_time_filter: TimeRange,
+    pub usage_refresh_requested_at: Option<Instant>,
 }
 
 impl App {
@@ -291,6 +305,11 @@ impl App {
             source_picker_dirty: false,
             source_picker_typing: false,
             filters_editing_source: false,
+            usage_report: None,
+            usage_year_report: None,
+            usage_error: None,
+            usage_time_filter: TimeRange::All,
+            usage_refresh_requested_at: None,
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -348,6 +367,15 @@ impl App {
         }
     }
 
+    pub fn usage_time_label(&self) -> &'static str {
+        match self.usage_time_filter {
+            TimeRange::Today => "Today",
+            TimeRange::Week => "7d",
+            TimeRange::Month => "30d",
+            TimeRange::All => "All day",
+        }
+    }
+
     pub fn sort_label(&self) -> &'static str {
         match self.sort_order {
             SortOrder::Relevance => "Relevance",
@@ -392,6 +420,7 @@ impl App {
 
         match self.mode {
             AppMode::Search => self.handle_search_key(key, store, engine, provider),
+            AppMode::Usage => self.handle_usage_key(key, store),
             AppMode::Viewing => self.handle_viewing_key(key),
             AppMode::ExportInput => self.handle_export_key(key),
             AppMode::Settings => self.handle_settings_key(key, store, engine, provider),
@@ -558,6 +587,27 @@ impl App {
             }
             KeyCode::Tab => {
                 self.open_filters();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_usage_key(&mut self, key: KeyEvent, _store: &Store) {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.should_quit = true;
+            }
+            KeyCode::Char('t') | KeyCode::Char('T') => {
+                self.cycle_usage_time(false);
+                self.request_usage_refresh();
+            }
+            KeyCode::Char('s') | KeyCode::Char('S') => {
+                self.cycle_usage_source(false);
+                self.request_usage_refresh();
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.reset_usage_dashboard();
+                self.request_usage_refresh();
             }
             _ => {}
         }
@@ -1121,11 +1171,64 @@ impl App {
         provider: &mut Option<EmbeddingProvider>,
     ) {
         self.update_scope_metrics(store);
+        self.refresh_usage(store);
         if self.query.is_empty() {
             self.load_recent(store);
         } else {
             self.do_search(store, engine, provider);
         }
+    }
+
+    pub fn refresh_usage(&mut self, store: &Store) {
+        self.usage_refresh_requested_at = None;
+        self.usage_error = None;
+        let sources = self.source_filter_ids();
+        let current_filters =
+            UsageFilters { sources: sources.clone(), time_range: self.usage_time_filter };
+        match usage::build_usage_report(store, &current_filters) {
+            Ok(report) => {
+                self.usage_report = Some(report);
+            }
+            Err(err) => {
+                self.usage_report = None;
+                self.usage_error = Some(format!("Usage unavailable: {err}"));
+            }
+        }
+
+        let year_filters = UsageFilters { sources, time_range: TimeRange::All };
+        match usage::build_usage_report(store, &year_filters) {
+            Ok(report) => {
+                self.usage_year_report = Some(report);
+            }
+            Err(err) => {
+                self.usage_year_report = None;
+                if self.usage_error.is_none() {
+                    self.usage_error = Some(format!("Usage unavailable: {err}"));
+                }
+            }
+        }
+    }
+
+    pub fn request_usage_refresh(&mut self) {
+        self.usage_error = None;
+        self.usage_refresh_requested_at = Some(Instant::now());
+    }
+
+    pub fn usage_is_loading(&self) -> bool {
+        self.usage_refresh_requested_at.is_some()
+    }
+
+    pub fn usage_refresh_is_due(&self) -> bool {
+        self.usage_refresh_requested_at
+            .map(|requested_at| requested_at.elapsed().as_millis() >= USAGE_LOADING_MIN_MS)
+            .unwrap_or(false)
+    }
+
+    pub fn fail_usage_refresh(&mut self, error: impl std::fmt::Display) {
+        self.usage_refresh_requested_at = None;
+        self.usage_report = None;
+        self.usage_year_report = None;
+        self.usage_error = Some(format!("Usage unavailable: {error}"));
     }
 
     pub fn try_search(
@@ -1313,6 +1416,59 @@ impl App {
     fn reset_search_defaults(&mut self) {
         self.source_filter_selection.clear();
         self.time_filter = self.config.sync_window.to_time_range();
+    }
+
+    fn reset_usage_dashboard(&mut self) {
+        self.source_filter_selection.clear();
+        self.usage_time_filter = TimeRange::All;
+    }
+
+    fn cycle_usage_time(&mut self, reverse: bool) {
+        self.usage_time_filter = if reverse {
+            match self.usage_time_filter {
+                TimeRange::Today => TimeRange::All,
+                TimeRange::Week => TimeRange::Today,
+                TimeRange::Month => TimeRange::Week,
+                TimeRange::All => TimeRange::Month,
+            }
+        } else {
+            match self.usage_time_filter {
+                TimeRange::Today => TimeRange::Week,
+                TimeRange::Week => TimeRange::Month,
+                TimeRange::Month => TimeRange::All,
+                TimeRange::All => TimeRange::Today,
+            }
+        };
+    }
+
+    fn cycle_usage_source(&mut self, reverse: bool) {
+        let enabled: Vec<String> =
+            self.enabled_sources().into_iter().map(|(id, _)| id.clone()).collect();
+        if enabled.is_empty() {
+            self.source_filter_selection.clear();
+            return;
+        }
+
+        let current = self.normalized_source_selection(&self.source_filter_selection);
+        let next = if current.len() == 1 {
+            let current_index = enabled.iter().position(|id| id == &current[0]);
+            match (current_index, reverse) {
+                (Some(0), true) => None,
+                (Some(index), true) => enabled.get(index - 1).cloned(),
+                (Some(index), false) if index + 1 < enabled.len() => {
+                    enabled.get(index + 1).cloned()
+                }
+                (Some(_), false) => None,
+                (None, true) => enabled.last().cloned(),
+                (None, false) => enabled.first().cloned(),
+            }
+        } else if reverse {
+            enabled.last().cloned()
+        } else {
+            enabled.first().cloned()
+        };
+
+        self.source_filter_selection = next.into_iter().collect();
     }
 
     fn settings_row_count(&self) -> usize {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeMap;
+
+use chrono::{Datelike, Duration, Local, NaiveDate};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -5,10 +8,12 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
+use crate::db::search::TimeRange;
 use crate::tui::app::{
     App, AppMode, FilterFocus, PanelFocus, ResumeOrigin, SanitizedLine, SourcePickerRow,
 };
 use crate::types::{MatchSource, Role};
+use crate::usage::{TokenTotals, UsageReport};
 
 fn highlight_spans(text: &str, hay: &str, needle_lower: &str, base: Style) -> Vec<Span<'static>> {
     if needle_lower.is_empty() {
@@ -61,6 +66,7 @@ fn scroll_offset(selected_line_start: usize, inner_height: usize) -> u16 {
 pub fn render(f: &mut Frame, app: &App) {
     match app.mode {
         AppMode::Search => render_search(f, app),
+        AppMode::Usage => render_usage_dashboard(f, app),
         AppMode::Viewing => render_viewing(f, app),
         AppMode::Filters => {
             render_search(f, app);
@@ -81,6 +87,522 @@ pub fn render(f: &mut Frame, app: &App) {
             }
             render_confirm_resume(f, app);
         }
+    }
+}
+
+fn render_usage_dashboard(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Length(9),
+            Constraint::Min(9),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    render_usage_header(f, app, outer[0]);
+    render_vibe_coding_map(f, app, outer[1]);
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(64), Constraint::Percentage(36)])
+        .split(outer[2]);
+    render_daily_token_chart(f, app, main[0]);
+    render_usage_breakdown(f, app, main[1]);
+    render_usage_status(f, outer[3]);
+}
+
+fn render_usage_header(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Recall Usage Dashboard ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let chip = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let muted = Style::default().fg(Color::DarkGray);
+
+    let control = vec![
+        Span::styled(" range ", muted),
+        Span::styled(format!("[{}]", app.usage_time_label()), chip),
+        Span::styled(" source ", muted),
+        Span::styled(format!("[{}]", app.source_filter_label()), chip),
+        Span::styled(" metric ", muted),
+        Span::styled("[tokens]", chip),
+    ];
+
+    let mut lines = vec![Line::from(control)];
+
+    if app.usage_is_loading() {
+        lines.push(Line::from(Span::styled(
+            " Loading usage data...",
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+    } else if let Some(report) = app.usage_report.as_ref() {
+        let active_days = report
+            .daily
+            .iter()
+            .filter(|day| day.sessions > 0 || day.events > 0 || day.tokens.total_tokens > 0)
+            .count();
+        let top_source =
+            report.by_source.first().map(|source| source.source.as_str()).unwrap_or("-");
+        let top_model = report.by_model.first().map(|model| model.model.as_str()).unwrap_or("-");
+
+        lines.push(Line::from(vec![
+            Span::styled(" tokens ", muted),
+            Span::styled(
+                format_compact(report.summary.tokens.total_tokens),
+                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" sessions ", muted),
+            Span::styled(
+                format_count(report.summary.sessions),
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" events ", muted),
+            Span::styled(format_count(report.summary.events), Style::default().fg(Color::White)),
+            Span::styled(" active-days ", muted),
+            Span::styled(format_count(active_days), Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(" top-source ", muted),
+            Span::styled(
+                truncate_label(top_source, 18),
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" top-model ", muted),
+            Span::styled(truncate_label(top_model, 32), Style::default().fg(Color::White)),
+        ]));
+    } else if let Some(error) = app.usage_error.as_ref() {
+        lines.push(Line::from(Span::styled(error.clone(), Style::default().fg(Color::Red))));
+        lines.push(Line::from(""));
+    } else {
+        lines.push(Line::from(Span::styled("No usage data loaded", muted)));
+        lines.push(Line::from(""));
+    }
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_vibe_coding_map(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Vibe Coding Map (tokens) ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green));
+
+    if app.usage_is_loading() {
+        f.render_widget(
+            Paragraph::new("Loading usage data...")
+                .style(Style::default().fg(Color::Yellow))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let report = app.usage_year_report.as_ref().or(app.usage_report.as_ref());
+    let Some(report) = report else {
+        f.render_widget(
+            Paragraph::new("No usage events")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    };
+
+    let today = Local::now().date_naive();
+    let start = today.checked_sub_signed(Duration::days(364)).unwrap_or(today);
+    let grid_start = start
+        .checked_sub_signed(Duration::days(start.weekday().num_days_from_monday() as i64))
+        .unwrap_or(start);
+    let total_days = today.signed_duration_since(grid_start).num_days().max(0) as usize + 1;
+    let weeks = total_days.div_ceil(7);
+
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let map_width = inner_width.saturating_sub(5).max(1);
+    let visible_weeks = weeks.min(map_width);
+    let first_col = weeks.saturating_sub(visible_weeks);
+    let max_value = report.daily.iter().map(|day| day.tokens.total_tokens).max().unwrap_or(0);
+    let values = daily_token_map(report);
+
+    let mut lines = Vec::new();
+    for (row, label) in ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].iter().enumerate() {
+        let mut cells = String::new();
+        for (visible_col, col) in (first_col..weeks).enumerate() {
+            let cell_width = distributed_width(visible_col, visible_weeks, map_width);
+            let offset = (col * 7 + row) as i64;
+            let Some(date) = grid_start.checked_add_signed(Duration::days(offset)) else {
+                continue;
+            };
+            if date < start || date > today {
+                cells.push_str(&" ".repeat(cell_width));
+                continue;
+            }
+            let value = values.get(&date).copied().unwrap_or(0);
+            cells.push_str(&heatmap_cell(value, max_value).to_string().repeat(cell_width));
+        }
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {label} "), Style::default().fg(Color::DarkGray)),
+            Span::styled(cells, Style::default().fg(Color::Green)),
+        ]));
+    }
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_daily_token_chart(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Daily Token Usage ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    if app.usage_is_loading() {
+        f.render_widget(
+            Paragraph::new("Loading usage data...")
+                .style(Style::default().fg(Color::Yellow))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let Some(report) = app.usage_report.as_ref() else {
+        f.render_widget(
+            Paragraph::new("No token usage")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    };
+
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let label_width = 8usize;
+    let plot_width = inner_width.saturating_sub(label_width).max(1);
+    let points = daily_token_points(report, app.usage_time_filter, plot_width);
+    let max_tokens = points.iter().map(|(_, value)| *value).max().unwrap_or(0);
+    if points.is_empty() || max_tokens == 0 {
+        f.render_widget(
+            Paragraph::new("No token usage in this range")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let chart_height = area.height.saturating_sub(5).max(1) as usize;
+    let mut lines = Vec::new();
+    for row in (1..=chart_height).rev() {
+        let label = if row == chart_height {
+            format!("{:>7}", format_compact(max_tokens))
+        } else if row == 1 {
+            "      0".to_string()
+        } else {
+            "       ".to_string()
+        };
+        let mut bars = String::with_capacity(plot_width);
+        for (index, (_, value)) in points.iter().enumerate() {
+            let day_width = distributed_width(index, points.len(), plot_width);
+            if *value * chart_height as i64 >= max_tokens * row as i64 {
+                bars.push_str(&"█".repeat(day_width));
+            } else {
+                bars.push_str(&" ".repeat(day_width));
+            }
+        }
+        lines.push(Line::from(vec![
+            Span::styled(format!("{label} "), Style::default().fg(Color::DarkGray)),
+            Span::styled(bars, Style::default().fg(Color::Cyan)),
+        ]));
+    }
+
+    if let (Some((first, _)), Some((last, _))) = (points.first(), points.last()) {
+        lines.push(Line::from(vec![
+            Span::styled("        ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                endpoint_labels(first, last, plot_width),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_usage_breakdown(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Breakdown ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    if app.usage_is_loading() {
+        f.render_widget(
+            Paragraph::new("Loading usage data...")
+                .style(Style::default().fg(Color::Yellow))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let Some(report) = app.usage_report.as_ref() else {
+        f.render_widget(
+            Paragraph::new("No usage data")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    };
+
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let source_max =
+        report.by_source.iter().map(|source| source.tokens.total_tokens).max().unwrap_or(0);
+    let model_max =
+        report.by_model.iter().map(|model| model.tokens.total_tokens).max().unwrap_or(0);
+    let mut lines = vec![Line::from(Span::styled(
+        " Sources",
+        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+    ))];
+
+    for source in report.by_source.iter().take(5) {
+        lines.push(usage_bar_line(
+            app.source_label_for(&source.source),
+            source.tokens.total_tokens,
+            source_max,
+            inner_width,
+            Color::Cyan,
+        ));
+    }
+    if report.by_source.is_empty() {
+        lines.push(Line::from(Span::styled("  -", Style::default().fg(Color::DarkGray))));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        " Models",
+        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+    )));
+    for model in report.by_model.iter().take(6) {
+        let label = format!("{}:{}", app.source_label_for(&model.source), model.model);
+        lines.push(usage_bar_line(
+            &label,
+            model.tokens.total_tokens,
+            model_max,
+            inner_width,
+            Color::Green,
+        ));
+    }
+    if report.by_model.is_empty() {
+        lines.push(Line::from(Span::styled("  -", Style::default().fg(Color::DarkGray))));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        " Token Mix",
+        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+    )));
+    lines.extend(token_mix_lines(&report.summary.tokens, inner_width));
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_usage_status(f: &mut Frame, area: Rect) {
+    let line = Line::from(vec![
+        Span::styled("t", Style::default().fg(Color::Yellow)),
+        Span::styled(" time  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("s", Style::default().fg(Color::Yellow)),
+        Span::styled(" source  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("r", Style::default().fg(Color::Yellow)),
+        Span::styled(" reset  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc/q", Style::default().fg(Color::Yellow)),
+        Span::styled(" quit", Style::default().fg(Color::DarkGray)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn daily_token_map(report: &UsageReport) -> BTreeMap<NaiveDate, i64> {
+    let mut values = BTreeMap::new();
+    for day in &report.daily {
+        if let Ok(date) = NaiveDate::parse_from_str(&day.period, "%Y-%m-%d") {
+            values.insert(date, day.tokens.total_tokens);
+        }
+    }
+    values
+}
+
+fn daily_token_points(
+    report: &UsageReport,
+    time_range: TimeRange,
+    max_points: usize,
+) -> Vec<(String, i64)> {
+    if max_points == 0 {
+        return Vec::new();
+    }
+
+    let values: BTreeMap<NaiveDate, i64> = report
+        .daily
+        .iter()
+        .filter_map(|day| {
+            NaiveDate::parse_from_str(&day.period, "%Y-%m-%d")
+                .ok()
+                .map(|date| (date, day.tokens.total_tokens))
+        })
+        .collect();
+
+    match time_range {
+        TimeRange::Today | TimeRange::Week | TimeRange::Month => {
+            let days = match time_range {
+                TimeRange::Today => 1,
+                TimeRange::Week => 7,
+                TimeRange::Month => 30,
+                TimeRange::All => unreachable!(),
+            };
+            let today = Local::now().date_naive();
+            let start = today.checked_sub_signed(Duration::days(days - 1)).unwrap_or(today);
+            (0..days)
+                .filter_map(|offset| start.checked_add_signed(Duration::days(offset)))
+                .rev()
+                .take(max_points)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .map(|date| {
+                    let label = date.format("%m-%d").to_string();
+                    let value = values.get(&date).copied().unwrap_or(0);
+                    (label, value)
+                })
+                .collect()
+        }
+        TimeRange::All => values
+            .into_iter()
+            .rev()
+            .take(max_points)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .map(|(date, value)| (date.format("%m-%d").to_string(), value))
+            .collect(),
+    }
+}
+
+fn heatmap_cell(value: i64, max_value: i64) -> char {
+    if value <= 0 || max_value <= 0 {
+        return '·';
+    }
+    let ratio = value as f64 / max_value as f64;
+    if ratio < 0.25 {
+        '░'
+    } else if ratio < 0.5 {
+        '▒'
+    } else if ratio < 0.75 {
+        '▓'
+    } else {
+        '█'
+    }
+}
+
+fn distributed_width(index: usize, item_count: usize, total_width: usize) -> usize {
+    if item_count == 0 || total_width == 0 {
+        return 0;
+    }
+    let base = total_width / item_count;
+    let remainder = total_width % item_count;
+    base + usize::from(index < remainder)
+}
+
+fn endpoint_labels(first: &str, last: &str, width: usize) -> String {
+    let mut chars = vec![' '; width];
+    for (index, ch) in first.chars().take(width).enumerate() {
+        chars[index] = ch;
+    }
+    let last_len = last.chars().count().min(width);
+    let start = width.saturating_sub(last_len);
+    for (offset, ch) in last.chars().take(last_len).enumerate() {
+        chars[start + offset] = ch;
+    }
+    chars.into_iter().collect()
+}
+
+fn usage_bar_line(
+    label: &str,
+    value: i64,
+    max_value: i64,
+    width: usize,
+    color: Color,
+) -> Line<'static> {
+    let label_width = width.clamp(18, 24);
+    let value_text = format_compact(value);
+    let bar_width = width.saturating_sub(label_width + value_text.len() + 4).max(4);
+    let filled = if max_value > 0 {
+        ((value as f64 / max_value as f64) * bar_width as f64).round() as usize
+    } else {
+        0
+    }
+    .min(bar_width);
+    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(bar_width - filled));
+
+    Line::from(vec![
+        Span::styled(
+            format!(" {:<label_width$}", truncate_label(label, label_width)),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(bar, Style::default().fg(color)),
+        Span::styled(format!(" {value_text}"), Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+fn token_mix_lines(tokens: &TokenTotals, width: usize) -> Vec<Line<'static>> {
+    let max_value = [
+        tokens.input_tokens,
+        tokens.output_tokens,
+        tokens.cache_read_tokens,
+        tokens.cache_write_tokens,
+        tokens.reasoning_tokens,
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
+
+    [
+        ("input", tokens.input_tokens, Color::Cyan),
+        ("output", tokens.output_tokens, Color::Green),
+        ("cache read", tokens.cache_read_tokens, Color::Blue),
+        ("cache write", tokens.cache_write_tokens, Color::Magenta),
+        ("reasoning", tokens.reasoning_tokens, Color::Yellow),
+    ]
+    .into_iter()
+    .map(|(label, value, color)| usage_bar_line(label, value, max_value, width, color))
+    .collect()
+}
+
+fn truncate_label(label: &str, max_chars: usize) -> String {
+    if label.chars().count() <= max_chars {
+        return label.to_string();
+    }
+    if max_chars <= 1 {
+        return "…".to_string();
+    }
+    format!("{}…", label.chars().take(max_chars - 1).collect::<String>())
+}
+
+fn format_count(value: usize) -> String {
+    format_compact(value as i64)
+}
+
+fn format_compact(value: i64) -> String {
+    let abs = value.abs() as f64;
+    if abs >= 1_000_000_000.0 {
+        format!("{:.2}B", value as f64 / 1_000_000_000.0)
+    } else if abs >= 1_000_000.0 {
+        format!("{:.1}M", value as f64 / 1_000_000.0)
+    } else if abs >= 1_000.0 {
+        format!("{:.1}K", value as f64 / 1_000.0)
+    } else {
+        value.to_string()
     }
 }
 


### PR DESCRIPTION
### What's changed?

- Add a terminal-native usage dashboard for `recall usage`.
- Show token heatmap, daily token bars, and source/model/token breakdowns from local usage data.
- Restrict usage providers to `codex`, `claude-code`, and `opencode`, with loading states during refresh.

### Why

- Make local token usage analytics available directly in the TUI.