### PR TITLE
[Feat] Add project directory filter

### DIFF
--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -231,10 +231,19 @@ fn apply_filters(
         *param_idx += 1;
     }
     if let Some(ref dir) = filters.directory {
-        sql.push_str(&format!(" AND s.directory LIKE ?{}", *param_idx));
-        params.push(Box::new(format!("{dir}%")));
-        *param_idx += 1;
+        sql.push_str(&format!(
+            " AND (s.directory = ?{} OR s.directory LIKE ?{})",
+            *param_idx,
+            *param_idx + 1
+        ));
+        params.push(Box::new(dir.clone()));
+        params.push(Box::new(directory_child_pattern(dir)));
+        *param_idx += 2;
     }
+}
+
+fn directory_child_pattern(dir: &str) -> String {
+    if dir.ends_with('/') { format!("{dir}%") } else { format!("{dir}/%") }
 }
 
 fn rrf_merge(fts_hits: &[Hit], vec_hits: &[Hit], k: u32) -> Vec<(String, f64, MatchSource)> {

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -16,6 +16,13 @@ pub struct Store {
     pub conn: Connection,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectDirectory {
+    pub directory: String,
+    pub sessions: u64,
+    pub last_seen: i64,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct UsageSessionStateMeta {
     pub parser_version: u32,
@@ -637,6 +644,15 @@ impl Store {
         sources: Option<&[String]>,
         time_range: TimeRange,
     ) -> Result<SemanticProgress> {
+        self.semantic_progress_for_search_scope(sources, time_range, None)
+    }
+
+    pub fn semantic_progress_for_search_scope(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+        directory: Option<&str>,
+    ) -> Result<SemanticProgress> {
         let mut sql = String::from(
             "SELECT
                 COUNT(*),
@@ -650,7 +666,7 @@ impl Store {
         );
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         let mut param_idx = 1;
-        apply_scope_filters(&mut sql, &mut params, &mut param_idx, sources, time_range);
+        apply_scope_filters(&mut sql, &mut params, &mut param_idx, sources, time_range, directory);
         let param_refs: Vec<&dyn rusqlite::types::ToSql> =
             params.iter().map(|p| p.as_ref()).collect();
 
@@ -679,6 +695,7 @@ impl Store {
             &mut current_param_idx,
             sources,
             time_range,
+            directory,
         );
         current_sql.push_str(" ORDER BY COALESCE(s.updated_at, s.started_at) DESC LIMIT 1");
         let current_param_refs: Vec<&dyn rusqlite::types::ToSql> =
@@ -807,6 +824,15 @@ impl Store {
         sources: Option<&[String]>,
         time_range: TimeRange,
     ) -> Result<(u64, u64)> {
+        self.stats_for_search_scope(sources, time_range, None)
+    }
+
+    pub fn stats_for_search_scope(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+        directory: Option<&str>,
+    ) -> Result<(u64, u64)> {
         let mut session_sql = String::from("SELECT COUNT(*) FROM sessions s WHERE 1=1");
         let mut session_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         let mut session_param_idx = 1;
@@ -816,6 +842,7 @@ impl Store {
             &mut session_param_idx,
             sources,
             time_range,
+            directory,
         );
         let session_param_refs: Vec<&dyn rusqlite::types::ToSql> =
             session_params.iter().map(|p| p.as_ref()).collect();
@@ -836,6 +863,7 @@ impl Store {
             &mut message_param_idx,
             sources,
             time_range,
+            directory,
         );
         let message_param_refs: Vec<&dyn rusqlite::types::ToSql> =
             message_params.iter().map(|p| p.as_ref()).collect();
@@ -845,11 +873,30 @@ impl Store {
     }
 
     pub fn list_recent_sessions(&self, limit: usize) -> Result<Vec<Session>> {
-        let mut stmt = self.conn.prepare(
+        self.list_recent_sessions_for_search_scope(None, TimeRange::All, None, limit)
+    }
+
+    pub fn list_recent_sessions_for_search_scope(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+        directory: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<Session>> {
+        let mut sql = String::from(
             "SELECT id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint
-             FROM sessions ORDER BY started_at DESC LIMIT ?1",
-        )?;
-        let rows = stmt.query_map(rusqlite::params![limit as i64], |row| {
+             FROM sessions s
+             WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1;
+        apply_scope_filters(&mut sql, &mut params, &mut param_idx, sources, time_range, directory);
+        sql.push_str(&format!(" ORDER BY started_at DESC LIMIT ?{param_idx}"));
+        params.push(Box::new(limit as i64));
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
             Ok(Session {
                 id: row.get(0)?,
                 source: row.get(1)?,
@@ -868,6 +915,24 @@ impl Store {
         }
         Ok(sessions)
     }
+
+    pub fn list_project_directories(&self) -> Result<Vec<ProjectDirectory>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT directory, COUNT(*) AS sessions, MAX(COALESCE(updated_at, started_at)) AS last_seen
+             FROM sessions
+             WHERE directory IS NOT NULL AND directory != ''
+             GROUP BY directory
+             ORDER BY last_seen DESC, sessions DESC, directory ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ProjectDirectory {
+                directory: row.get(0)?,
+                sessions: row.get::<_, i64>(1)? as u64,
+                last_seen: row.get(2)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
 }
 
 fn apply_scope_filters(
@@ -876,6 +941,7 @@ fn apply_scope_filters(
     param_idx: &mut usize,
     sources: Option<&[String]>,
     time_range: TimeRange,
+    directory: Option<&str>,
 ) {
     if let Some(sources) = sources
         && !sources.is_empty()
@@ -894,4 +960,19 @@ fn apply_scope_filters(
         params.push(Box::new(min_ts));
         *param_idx += 1;
     }
+
+    if let Some(dir) = directory {
+        sql.push_str(&format!(
+            " AND (s.directory = ?{} OR s.directory LIKE ?{})",
+            *param_idx,
+            *param_idx + 1
+        ));
+        params.push(Box::new(dir.to_string()));
+        params.push(Box::new(directory_child_pattern(dir)));
+        *param_idx += 2;
+    }
+}
+
+fn directory_child_pattern(dir: &str) -> String {
+    if dir.ends_with('/') { format!("{dir}%") } else { format!("{dir}/%") }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,7 +7,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::adapters::{ResumeCommand, resume_command_for};
 use crate::config::AppConfig;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
-use crate::db::store::Store;
+use crate::db::store::{ProjectDirectory, Store};
 use crate::embedding::EmbeddingProvider;
 use crate::types::{
     BackgroundJobStatus, MatchSource, Message, Role, SearchResult, SemanticProgress,
@@ -53,6 +53,8 @@ mod tests {
             ],
             config: AppConfig::default(),
             source_filter_selection: Vec::new(),
+            project_directories: Vec::new(),
+            project_filter: None,
             time_filter: TimeRange::All,
             filter_focus: FilterFocus::Source,
             should_quit: false,
@@ -85,6 +87,13 @@ mod tests {
             source_picker_dirty: false,
             source_picker_typing: false,
             filters_editing_source: false,
+            project_picker_query: String::new(),
+            project_picker_cursor: 0,
+            project_picker_selected: 0,
+            project_picker_selection: None,
+            project_picker_dirty: false,
+            project_picker_typing: false,
+            filters_editing_project: false,
             usage_report: None,
             usage_year_report: None,
             usage_error: None,
@@ -102,6 +111,96 @@ mod tests {
         app.commit_source_picker_filter();
 
         assert_eq!(app.source_filter_selection, vec!["claude".to_string(), "cursor".to_string()]);
+    }
+
+    #[test]
+    fn project_picker_filters_by_path_tokens() {
+        let mut app = app_with_sources();
+        app.project_directories = vec![
+            ProjectDirectory {
+                directory: "/Users/x/git/samzong/Recall".to_string(),
+                sessions: 10,
+                last_seen: 2,
+            },
+            ProjectDirectory {
+                directory: "/Users/x/git/openclaw".to_string(),
+                sessions: 20,
+                last_seen: 1,
+            },
+        ];
+        app.project_picker_query = "sam recall".to_string();
+
+        let rows = app.project_picker_rows();
+
+        assert_eq!(rows.len(), 1);
+        assert!(matches!(rows[0], ProjectPickerRow::Project(0)));
+    }
+
+    #[test]
+    fn project_picker_space_toggles_pending_selection_without_committing() {
+        let mut app = app_with_sources();
+        app.project_directories = vec![ProjectDirectory {
+            directory: "/Users/x/git/samzong/Recall".to_string(),
+            sessions: 10,
+            last_seen: 2,
+        }];
+        app.project_picker_query = "recall".to_string();
+
+        app.toggle_project_picker_row();
+
+        assert_eq!(app.project_picker_selection, Some("/Users/x/git/samzong/Recall".to_string()));
+        assert!(app.project_picker_dirty);
+        assert_eq!(app.project_filter, None);
+    }
+
+    #[test]
+    fn source_picker_space_toggles_while_filtering() {
+        let mut app = app_with_sources();
+        app.source_picker_query = "cod".to_string();
+        app.source_picker_typing = true;
+
+        app.toggle_source_picker_row();
+        app.commit_source_picker_filter();
+
+        assert_eq!(app.source_filter_selection, vec!["codex".to_string()]);
+    }
+
+    #[test]
+    fn applying_project_picker_closes_filters_window() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let engine = SearchEngine::new(&store.conn);
+        let mut provider = None;
+        let mut app = app_with_sources();
+        app.mode = AppMode::Filters;
+        app.filters_editing_project = true;
+        app.project_picker_selection = Some("/Users/x/git/samzong/Recall".to_string());
+        app.project_picker_dirty = true;
+
+        app.apply_project_picker(&store, &engine, &mut provider);
+
+        assert!(matches!(app.mode, AppMode::Search));
+        assert!(!app.filters_editing_project);
+        assert_eq!(app.project_filter, Some("/Users/x/git/samzong/Recall".to_string()));
+    }
+
+    #[test]
+    fn applying_source_picker_closes_filters_window() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let engine = SearchEngine::new(&store.conn);
+        let mut provider = None;
+        let mut app = app_with_sources();
+        app.mode = AppMode::Filters;
+        app.filters_editing_source = true;
+        app.source_picker_selection = vec!["codex".to_string()];
+        app.source_picker_dirty = true;
+
+        app.apply_source_picker(&store, &engine, &mut provider);
+
+        assert!(matches!(app.mode, AppMode::Search));
+        assert!(!app.filters_editing_source);
+        assert_eq!(app.source_filter_selection, vec!["codex".to_string()]);
     }
 }
 
@@ -148,6 +247,7 @@ pub enum PanelFocus {
 #[derive(Clone, Copy, PartialEq)]
 pub enum FilterFocus {
     Source,
+    Project,
     Time,
     Sort,
 }
@@ -155,7 +255,8 @@ pub enum FilterFocus {
 impl FilterFocus {
     fn next(self) -> Self {
         match self {
-            Self::Source => Self::Time,
+            Self::Source => Self::Project,
+            Self::Project => Self::Time,
             Self::Time => Self::Sort,
             Self::Sort => Self::Source,
         }
@@ -164,7 +265,8 @@ impl FilterFocus {
     fn previous(self) -> Self {
         match self {
             Self::Source => Self::Sort,
-            Self::Time => Self::Source,
+            Self::Project => Self::Source,
+            Self::Time => Self::Project,
             Self::Sort => Self::Time,
         }
     }
@@ -176,20 +278,10 @@ pub enum SourcePickerRow {
     Source(usize),
 }
 
-fn source_digit_slot(key: char) -> Option<usize> {
-    match key {
-        '1'..='9' => Some(key as usize - '1' as usize),
-        '0' => Some(9),
-        _ => None,
-    }
-}
-
-fn source_digit_key(slot: usize) -> Option<char> {
-    match slot {
-        0..=8 => char::from_digit((slot + 1) as u32, 10),
-        9 => Some('0'),
-        _ => None,
-    }
+#[derive(Clone, Copy)]
+pub enum ProjectPickerRow {
+    All,
+    Project(usize),
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -244,6 +336,15 @@ pub struct App {
     pub source_picker_dirty: bool,
     pub source_picker_typing: bool,
     pub filters_editing_source: bool,
+    pub project_directories: Vec<ProjectDirectory>,
+    pub project_filter: Option<String>,
+    pub project_picker_query: String,
+    pub project_picker_cursor: usize,
+    pub project_picker_selected: usize,
+    pub project_picker_selection: Option<String>,
+    pub project_picker_dirty: bool,
+    pub project_picker_typing: bool,
+    pub filters_editing_project: bool,
     pub usage_report: Option<UsageReport>,
     pub usage_year_report: Option<UsageReport>,
     pub usage_error: Option<String>,
@@ -305,6 +406,15 @@ impl App {
             source_picker_dirty: false,
             source_picker_typing: false,
             filters_editing_source: false,
+            project_directories: store.list_project_directories().unwrap_or_default(),
+            project_filter: None,
+            project_picker_query: String::new(),
+            project_picker_cursor: 0,
+            project_picker_selected: 0,
+            project_picker_selection: None,
+            project_picker_dirty: false,
+            project_picker_typing: false,
+            filters_editing_project: false,
             usage_report: None,
             usage_year_report: None,
             usage_error: None,
@@ -383,6 +493,13 @@ impl App {
         }
     }
 
+    pub fn project_filter_label(&self) -> String {
+        self.project_filter
+            .as_deref()
+            .map(short_project_label)
+            .unwrap_or_else(|| "All projects".to_string())
+    }
+
     pub fn source_label_for<'a>(&'a self, source_id: &'a str) -> &'a str {
         self.all_sources
             .iter()
@@ -393,10 +510,16 @@ impl App {
 
     pub fn load_recent(&mut self, store: &Store) {
         let source_ids = self.source_filter_ids();
-        let recent = store.list_recent_sessions(200).unwrap_or_default();
+        let recent = store
+            .list_recent_sessions_for_search_scope(
+                source_ids.as_deref(),
+                self.time_filter,
+                self.project_filter.as_deref(),
+                200,
+            )
+            .unwrap_or_default();
         self.results = recent
             .into_iter()
-            .filter(|session| self.session_matches_filters(session, source_ids.as_deref()))
             .map(|session| SearchResult { session, match_source: MatchSource::Fts, snippet: None })
             .collect();
         self.selected_index = 0;
@@ -453,7 +576,12 @@ impl App {
             AppMode::Filters if self.filters_editing_source && self.source_picker_selected > 0 => {
                 self.source_picker_selected -= 1;
             }
-            AppMode::Filters if !self.filters_editing_source => {
+            AppMode::Filters
+                if self.filters_editing_project && self.project_picker_selected > 0 =>
+            {
+                self.project_picker_selected -= 1;
+            }
+            AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.previous();
             }
             _ => {}
@@ -487,7 +615,13 @@ impl App {
             {
                 self.source_picker_selected += 1;
             }
-            AppMode::Filters if !self.filters_editing_source => {
+            AppMode::Filters
+                if self.filters_editing_project
+                    && self.project_picker_selected + 1 < self.project_picker_rows().len() =>
+            {
+                self.project_picker_selected += 1;
+            }
+            AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.next();
             }
             _ => {}
@@ -852,6 +986,10 @@ impl App {
             self.handle_source_picker_key(key, store, engine, provider);
             return;
         }
+        if self.filters_editing_project {
+            self.handle_project_picker_key(key, store, engine, provider);
+            return;
+        }
 
         match key.code {
             KeyCode::Esc => {
@@ -904,6 +1042,9 @@ impl App {
             FilterFocus::Source => {
                 self.open_source_picker();
             }
+            FilterFocus::Project => {
+                self.open_project_picker(store);
+            }
             FilterFocus::Time => {
                 self.time_filter = match self.time_filter {
                     TimeRange::All => TimeRange::Today,
@@ -955,14 +1096,12 @@ impl App {
             KeyCode::Enter => {
                 self.apply_source_picker(store, engine, provider);
             }
-            KeyCode::Char(' ') if !self.source_picker_typing => {
+            KeyCode::Char(' ') => {
                 self.toggle_source_picker_row();
             }
             KeyCode::Char('/') if !self.source_picker_typing => {
                 self.source_picker_typing = true;
             }
-            KeyCode::Char(c)
-                if !self.source_picker_typing && self.toggle_source_picker_digit(c) => {}
             KeyCode::Up => self.handle_scroll_up(store),
             KeyCode::Down => self.handle_scroll_down(store),
             KeyCode::Backspace if self.source_picker_typing && self.source_picker_cursor > 0 => {
@@ -1015,11 +1154,13 @@ impl App {
     fn open_filters(&mut self) {
         self.mode = AppMode::Filters;
         self.filters_editing_source = false;
+        self.filters_editing_project = false;
     }
 
     fn open_source_picker(&mut self) {
         self.mode = AppMode::Filters;
         self.filters_editing_source = true;
+        self.filters_editing_project = false;
         self.source_picker_query.clear();
         self.source_picker_cursor = 0;
         self.source_picker_selected = 0;
@@ -1053,6 +1194,183 @@ impl App {
         self.source_picker_dirty = false;
     }
 
+    fn handle_project_picker_key(
+        &mut self,
+        key: KeyEvent,
+        store: &Store,
+        engine: &SearchEngine,
+        provider: &mut Option<EmbeddingProvider>,
+    ) {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('u') {
+            self.project_picker_query.clear();
+            self.project_picker_cursor = 0;
+            self.project_picker_selected = 0;
+            self.project_picker_typing = true;
+            return;
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('a') {
+            self.project_picker_selection = None;
+            self.project_picker_dirty = true;
+            return;
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                if self.project_picker_typing {
+                    self.project_picker_typing = false;
+                } else {
+                    self.close_project_picker();
+                }
+            }
+            KeyCode::Enter => {
+                self.apply_project_picker(store, engine, provider);
+            }
+            KeyCode::Char(' ') => {
+                self.toggle_project_picker_row();
+            }
+            KeyCode::Char('/') if !self.project_picker_typing => {
+                self.project_picker_typing = true;
+            }
+            KeyCode::Up => self.handle_scroll_up(store),
+            KeyCode::Down => self.handle_scroll_down(store),
+            KeyCode::Backspace if self.project_picker_typing && self.project_picker_cursor > 0 => {
+                let prev = self.project_picker_query[..self.project_picker_cursor]
+                    .char_indices()
+                    .last()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                self.project_picker_query.replace_range(prev..self.project_picker_cursor, "");
+                self.project_picker_cursor = prev;
+                self.project_picker_selected = 0;
+                self.clamp_project_picker_selected();
+            }
+            KeyCode::Left if self.project_picker_typing && self.project_picker_cursor > 0 => {
+                let prev = self.project_picker_query[..self.project_picker_cursor]
+                    .char_indices()
+                    .last()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                self.project_picker_cursor = prev;
+            }
+            KeyCode::Right
+                if self.project_picker_typing
+                    && self.project_picker_cursor < self.project_picker_query.len() =>
+            {
+                let next = self.project_picker_query[self.project_picker_cursor..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(i, _)| self.project_picker_cursor + i)
+                    .unwrap_or(self.project_picker_query.len());
+                self.project_picker_cursor = next;
+            }
+            KeyCode::Home if self.project_picker_typing => {
+                self.project_picker_cursor = 0;
+            }
+            KeyCode::End if self.project_picker_typing => {
+                self.project_picker_cursor = self.project_picker_query.len();
+            }
+            KeyCode::Char(c) => {
+                self.project_picker_typing = true;
+                self.project_picker_query.insert(self.project_picker_cursor, c);
+                self.project_picker_cursor += c.len_utf8();
+                self.project_picker_selected = 0;
+                self.clamp_project_picker_selected();
+            }
+            _ => {}
+        }
+    }
+
+    fn open_project_picker(&mut self, store: &Store) {
+        self.project_directories = store.list_project_directories().unwrap_or_default();
+        self.mode = AppMode::Filters;
+        self.filters_editing_source = false;
+        self.filters_editing_project = true;
+        self.project_picker_query.clear();
+        self.project_picker_cursor = 0;
+        self.project_picker_selected = 0;
+        self.project_picker_selection = self.project_filter.clone();
+        self.project_picker_dirty = false;
+        self.project_picker_typing = false;
+        if let Some(selected_project) = self.project_filter.as_ref() {
+            self.project_picker_selected = self
+                .project_picker_rows()
+                .iter()
+                .position(|row| match row {
+                    ProjectPickerRow::All => false,
+                    ProjectPickerRow::Project(index) => self
+                        .project_directories
+                        .get(*index)
+                        .map(|project| &project.directory == selected_project)
+                        .unwrap_or(false),
+                })
+                .unwrap_or(0);
+        }
+    }
+
+    fn close_project_picker(&mut self) {
+        self.filters_editing_project = false;
+        self.project_picker_query.clear();
+        self.project_picker_cursor = 0;
+        self.project_picker_selected = 0;
+        self.project_picker_selection = None;
+        self.project_picker_dirty = false;
+        self.project_picker_typing = false;
+    }
+
+    fn apply_project_picker(
+        &mut self,
+        store: &Store,
+        engine: &SearchEngine,
+        provider: &mut Option<EmbeddingProvider>,
+    ) {
+        self.commit_project_picker_filter();
+        self.close_project_picker();
+        self.mode = AppMode::Search;
+        self.refresh_after_filter_change(store, engine, provider);
+    }
+
+    fn commit_project_picker_filter(&mut self) {
+        if self.project_picker_dirty {
+            self.project_filter = self.project_picker_selection.clone();
+        } else if let Some(row) = self.project_picker_rows().get(self.project_picker_selected) {
+            match *row {
+                ProjectPickerRow::All => {
+                    self.project_filter = None;
+                }
+                ProjectPickerRow::Project(index) => {
+                    if let Some(project) = self.project_directories.get(index) {
+                        self.project_filter = Some(project.directory.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    fn toggle_project_picker_row(&mut self) {
+        let Some(row) = self.project_picker_rows().get(self.project_picker_selected).copied()
+        else {
+            return;
+        };
+
+        match row {
+            ProjectPickerRow::All => {
+                self.project_picker_selection = None;
+            }
+            ProjectPickerRow::Project(index) => {
+                let Some(project) = self.project_directories.get(index) else {
+                    return;
+                };
+                if self.project_picker_selection.as_deref() == Some(project.directory.as_str()) {
+                    self.project_picker_selection = None;
+                } else {
+                    self.project_picker_selection = Some(project.directory.clone());
+                }
+            }
+        }
+        self.project_picker_dirty = true;
+    }
+
     fn apply_source_picker(
         &mut self,
         store: &Store,
@@ -1068,6 +1386,7 @@ impl App {
         self.source_picker_selection.clear();
         self.source_picker_dirty = false;
         self.filters_editing_source = false;
+        self.mode = AppMode::Search;
         self.refresh_after_filter_change(store, engine, provider);
     }
 
@@ -1120,45 +1439,9 @@ impl App {
         self.source_picker_dirty = true;
     }
 
-    fn toggle_source_picker_digit(&mut self, key: char) -> bool {
-        let Some(slot) = source_digit_slot(key) else {
-            return false;
-        };
-        let Some(row_index) = self
-            .source_picker_rows()
-            .iter()
-            .enumerate()
-            .filter(|(_, row)| matches!(row, SourcePickerRow::Source(_)))
-            .nth(slot)
-            .map(|(index, _)| index)
-        else {
-            return false;
-        };
-
-        self.source_picker_selected = row_index;
-        self.toggle_source_picker_row();
-        true
-    }
-
-    pub fn source_picker_row_key(&self, row_index: usize) -> Option<char> {
-        let row = self.source_picker_rows().get(row_index).copied()?;
-        if !matches!(row, SourcePickerRow::Source(_)) {
-            return None;
-        }
-
-        let source_slot = self
-            .source_picker_rows()
-            .iter()
-            .take(row_index + 1)
-            .filter(|row| matches!(row, SourcePickerRow::Source(_)))
-            .count()
-            .saturating_sub(1);
-
-        source_digit_key(source_slot)
-    }
-
     fn clear_filters(&mut self) {
         self.source_filter_selection.clear();
+        self.project_filter = None;
         self.time_filter = TimeRange::All;
         self.sort_order = SortOrder::Relevance;
         self.filter_focus = FilterFocus::Source;
@@ -1303,7 +1586,7 @@ impl App {
         let filters = SearchFilters {
             sources: self.source_filter_ids(),
             time_range: self.time_filter,
-            directory: None,
+            directory: self.project_filter.clone(),
         };
 
         match engine.hybrid_search(query, embedding, &filters, 200, 3) {
@@ -1338,15 +1621,19 @@ impl App {
     }
 
     fn update_scope_metrics(&mut self, store: &Store) {
-        if let Ok((sessions, messages)) =
-            store.stats_for_scope(self.source_filter_ids().as_deref(), self.time_filter)
-        {
+        if let Ok((sessions, messages)) = store.stats_for_search_scope(
+            self.source_filter_ids().as_deref(),
+            self.time_filter,
+            self.project_filter.as_deref(),
+        ) {
             self.total_sessions = sessions;
             self.total_messages = messages;
         }
-        if let Ok(progress) =
-            store.semantic_progress_for_scope(self.source_filter_ids().as_deref(), self.time_filter)
-        {
+        if let Ok(progress) = store.semantic_progress_for_search_scope(
+            self.source_filter_ids().as_deref(),
+            self.time_filter,
+            self.project_filter.as_deref(),
+        ) {
             self.semantic_progress = progress;
         }
         if let Ok(status) = store.background_job_status("pipeline") {
@@ -1393,12 +1680,37 @@ impl App {
         rows
     }
 
+    pub fn project_picker_rows(&self) -> Vec<ProjectPickerRow> {
+        let query = self.project_picker_query.trim().to_lowercase();
+        let mut rows = Vec::new();
+        if query.is_empty() {
+            rows.push(ProjectPickerRow::All);
+        }
+
+        for (index, project) in self.project_directories.iter().enumerate() {
+            if query.is_empty() || project_matches_query(&project.directory, &query) {
+                rows.push(ProjectPickerRow::Project(index));
+            }
+        }
+
+        rows
+    }
+
     fn clamp_source_picker_selected(&mut self) {
         let row_count = self.source_picker_rows().len();
         if row_count == 0 {
             self.source_picker_selected = 0;
         } else if self.source_picker_selected >= row_count {
             self.source_picker_selected = row_count - 1;
+        }
+    }
+
+    fn clamp_project_picker_selected(&mut self) {
+        let row_count = self.project_picker_rows().len();
+        if row_count == 0 {
+            self.project_picker_selected = 0;
+        } else if self.project_picker_selected >= row_count {
+            self.project_picker_selected = row_count - 1;
         }
     }
 
@@ -1415,6 +1727,7 @@ impl App {
 
     fn reset_search_defaults(&mut self) {
         self.source_filter_selection.clear();
+        self.project_filter = None;
         self.time_filter = self.config.sync_window.to_time_range();
     }
 
@@ -1511,23 +1824,6 @@ impl App {
             self.load_recent(store);
         } else {
             self.do_search(store, engine, provider);
-        }
-    }
-
-    fn session_matches_filters(
-        &self,
-        session: &crate::types::Session,
-        sources: Option<&[String]>,
-    ) -> bool {
-        if let Some(sources) = sources
-            && !sources.iter().any(|source| source == &session.source)
-        {
-            return false;
-        }
-
-        match self.time_filter.millis_ago() {
-            Some(min_ts) => session.started_at >= min_ts,
-            None => true,
         }
     }
 
@@ -1711,4 +2007,18 @@ impl App {
             results.sort_by_key(|b| std::cmp::Reverse(b.session.started_at));
         }
     }
+}
+
+fn short_project_label(path: &str) -> String {
+    let parts: Vec<&str> = path.split('/').filter(|part| !part.is_empty()).collect();
+    match parts.len() {
+        0 => path.to_string(),
+        1 => parts[0].to_string(),
+        len => format!("{}/{}", parts[len - 2], parts[len - 1]),
+    }
+}
+
+fn project_matches_query(path: &str, query: &str) -> bool {
+    let path = path.to_lowercase();
+    query.split_whitespace().all(|part| path.contains(part))
 }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyEvent, MouseEvent, MouseEventKind};
+use crossterm::event::{self, Event, KeyEvent, KeyEventKind, MouseEvent, MouseEventKind};
 
 pub enum AppEvent {
     Key(KeyEvent),
@@ -13,7 +13,7 @@ pub enum AppEvent {
 pub fn poll_event(tick_rate: Duration) -> Result<AppEvent> {
     if event::poll(tick_rate)? {
         match event::read()? {
-            Event::Key(key) => return Ok(AppEvent::Key(key)),
+            Event::Key(key) if key.kind == KeyEventKind::Press => return Ok(AppEvent::Key(key)),
             Event::Mouse(MouseEvent { kind, .. }) => match kind {
                 MouseEventKind::ScrollUp => return Ok(AppEvent::ScrollUp),
                 MouseEventKind::ScrollDown => return Ok(AppEvent::ScrollDown),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,7 +10,8 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
 use crate::tui::app::{
-    App, AppMode, FilterFocus, PanelFocus, ResumeOrigin, SanitizedLine, SourcePickerRow,
+    App, AppMode, FilterFocus, PanelFocus, ProjectPickerRow, ResumeOrigin, SanitizedLine,
+    SourcePickerRow,
 };
 use crate::types::{MatchSource, Role};
 use crate::usage::{TokenTotals, UsageReport};
@@ -589,6 +590,18 @@ fn truncate_label(label: &str, max_chars: usize) -> String {
     format!("{}…", label.chars().take(max_chars - 1).collect::<String>())
 }
 
+fn truncate_start(label: &str, max_chars: usize) -> String {
+    let char_count = label.chars().count();
+    if char_count <= max_chars {
+        return label.to_string();
+    }
+    if max_chars <= 1 {
+        return "…".to_string();
+    }
+    let tail: String = label.chars().skip(char_count - max_chars + 1).collect();
+    format!("…{tail}")
+}
+
 fn format_count(value: usize) -> String {
     format_compact(value as i64)
 }
@@ -658,26 +671,32 @@ fn render_search_box(f: &mut Frame, app: &App, area: Rect) {
 
 fn render_filters(f: &mut Frame, app: &App, area: Rect) {
     let source_label = app.source_filter_label();
+    let project_label = truncate_label(&app.project_filter_label(), 20);
     let time_label = app.time_filter_label();
     let sort_label = app.sort_label();
 
     let line = Line::from(vec![
-        Span::styled("  Scope: Source ", Style::default().fg(Color::DarkGray)),
+        Span::styled(" S:", Style::default().fg(Color::DarkGray)),
         Span::styled(
             format!("[{source_label}]"),
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
         ),
-        Span::styled("  Time ", Style::default().fg(Color::DarkGray)),
+        Span::styled("  P:", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("[{project_label}]"),
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  T:", Style::default().fg(Color::DarkGray)),
         Span::styled(
             format!("[{time_label}]"),
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
         ),
-        Span::styled("  Sort ", Style::default().fg(Color::DarkGray)),
+        Span::styled("  Sort:", Style::default().fg(Color::DarkGray)),
         Span::styled(
             format!("[{sort_label}]"),
             Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
         ),
-        Span::styled("  (Ctrl+F)", Style::default().fg(Color::DarkGray)),
+        Span::styled("  Ctrl+F", Style::default().fg(Color::DarkGray)),
     ]);
 
     f.render_widget(Paragraph::new(line), area);
@@ -686,6 +705,8 @@ fn render_filters(f: &mut Frame, app: &App, area: Rect) {
 fn render_filter_picker(f: &mut Frame, app: &App) {
     if app.filters_editing_source {
         render_source_picker(f, app);
+    } else if app.filters_editing_project {
+        render_project_picker(f, app);
     } else {
         render_filter_overview(f, app);
     }
@@ -711,6 +732,12 @@ fn render_filter_overview(f: &mut Frame, app: &App) {
         &app.source_filter_label(),
         "Enter",
         app.filter_focus == FilterFocus::Source,
+    ));
+    lines.push(filter_overview_line(
+        "Project",
+        &app.project_filter_label(),
+        "Enter",
+        app.filter_focus == FilterFocus::Project,
     ));
     lines.push(filter_overview_line(
         "Time Range",
@@ -752,7 +779,10 @@ fn filter_overview_line(
     } else {
         Style::default().fg(Color::White)
     };
-    Line::from(Span::styled(format!(" {label:<12} {value:<22} {hint}"), style))
+    Line::from(Span::styled(
+        format!(" {label:<12} {:<22} {hint}", truncate_label(value, 22)),
+        style,
+    ))
 }
 
 fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
@@ -1068,7 +1098,7 @@ fn render_source_picker(f: &mut Frame, app: &App) {
             let text = match *row {
                 SourcePickerRow::All => {
                     let marker = if app.source_picker_selection.is_empty() { "(*)" } else { "( )" };
-                    format!(" {marker}      All enabled sources")
+                    format!(" {marker} All enabled sources")
                 }
                 SourcePickerRow::Source(index) => {
                     let Some((source_id, label)) = app.all_sources.get(index) else {
@@ -1076,10 +1106,7 @@ fn render_source_picker(f: &mut Frame, app: &App) {
                     };
                     let marker =
                         if app.source_is_selected_in_picker(source_id) { "[x]" } else { "[ ]" };
-                    match app.source_picker_row_key(row_index) {
-                        Some(key) => format!(" {marker} [{key}] {label} ({source_id})"),
-                        None => format!(" {marker}     {label} ({source_id})"),
-                    }
+                    format!(" {marker} {label} ({source_id})")
                 }
             };
             lines.push(Line::from(Span::styled(text, style)));
@@ -1088,12 +1115,10 @@ fn render_source_picker(f: &mut Frame, app: &App) {
 
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
-        Span::styled(" 1-9/0", Style::default().fg(Color::Yellow)),
-        Span::styled(" toggle  ", muted_style),
+        Span::styled(" Space", Style::default().fg(Color::Yellow)),
+        Span::styled(" select/clear  ", muted_style),
         Span::styled("/", Style::default().fg(Color::Yellow)),
         Span::styled(" filter  ", muted_style),
-        Span::styled("Space", Style::default().fg(Color::Yellow)),
-        Span::styled(" current  ", muted_style),
         Span::styled("Enter", Style::default().fg(Color::Yellow)),
         Span::styled(" apply  ", muted_style),
         Span::styled("Esc", Style::default().fg(Color::Yellow)),
@@ -1114,6 +1139,111 @@ fn render_source_picker(f: &mut Frame, app: &App) {
         let cursor_x = popup.x
             + 9
             + UnicodeWidthStr::width(&app.source_picker_query[..app.source_picker_cursor]) as u16;
+        f.set_cursor_position((cursor_x.min(popup.right().saturating_sub(2)), popup.y + 1));
+    }
+}
+
+fn render_project_picker(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let width = area.width.min(92);
+    let rows = app.project_picker_rows();
+    let desired_height = rows.len() as u16 + 7;
+    let height = desired_height.clamp(8, area.height.saturating_sub(2).max(8));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let popup = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .title(" Filters > Project ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let selected_style = Style::default().bg(Color::Cyan).fg(Color::Black);
+    let normal_style = Style::default().fg(Color::White);
+    let muted_style = Style::default().fg(Color::DarkGray);
+
+    let visible_rows = height.saturating_sub(7) as usize;
+    let start = if visible_rows == 0 || app.project_picker_selected < visible_rows {
+        0
+    } else {
+        app.project_picker_selected + 1 - visible_rows
+    };
+    let end = (start + visible_rows).min(rows.len());
+
+    let mut lines = Vec::new();
+    let filter_value = if app.project_picker_query.is_empty() && !app.project_picker_typing {
+        Span::styled("type to filter paths", muted_style)
+    } else {
+        Span::styled(app.project_picker_query.clone(), normal_style)
+    };
+    lines.push(Line::from(vec![
+        Span::styled(" Filter: ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        filter_value,
+    ]));
+    lines.push(Line::from(""));
+
+    if rows.is_empty() {
+        lines.push(Line::from(Span::styled(" No matching projects", muted_style)));
+    } else {
+        let path_width = width.saturating_sub(30) as usize;
+        for (offset, row) in rows[start..end].iter().enumerate() {
+            let row_index = start + offset;
+            let style = if row_index == app.project_picker_selected {
+                selected_style
+            } else {
+                normal_style
+            };
+
+            let text = match *row {
+                ProjectPickerRow::All => {
+                    let marker = if app.project_picker_selection.is_none() { "(*)" } else { "( )" };
+                    format!(" {marker} All projects")
+                }
+                ProjectPickerRow::Project(index) => {
+                    let Some(project) = app.project_directories.get(index) else {
+                        continue;
+                    };
+                    let marker = if app.project_picker_selection.as_deref()
+                        == Some(project.directory.as_str())
+                    {
+                        "(*)"
+                    } else {
+                        "( )"
+                    };
+                    let path = truncate_start(&project.directory, path_width);
+                    format!(" {marker} {path}  {}", project.sessions)
+                }
+            };
+            lines.push(Line::from(Span::styled(text, style)));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(" Space", Style::default().fg(Color::Yellow)),
+        Span::styled(" select/clear  ", muted_style),
+        Span::styled("/", Style::default().fg(Color::Yellow)),
+        Span::styled(" filter  ", muted_style),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" apply  ", muted_style),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" back", muted_style),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Ctrl+A", Style::default().fg(Color::Yellow)),
+        Span::styled(" all  ", muted_style),
+        Span::styled("Ctrl+U", Style::default().fg(Color::Yellow)),
+        Span::styled(" clear input", muted_style),
+    ]));
+
+    let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(Clear, popup);
+    f.render_widget(widget, popup);
+
+    if app.project_picker_typing {
+        let cursor_x = popup.x
+            + 9
+            + UnicodeWidthStr::width(&app.project_picker_query[..app.project_picker_cursor]) as u16;
         f.set_cursor_position((cursor_x.min(popup.right().saturating_sub(2)), popup.y + 1));
     }
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -321,6 +321,61 @@ fn search_with_source_filter() {
 }
 
 #[test]
+fn search_with_directory_filter_respects_project_boundary() {
+    let store = setup();
+    let mut exact = make_session("s1", "codex", "raw1", "Exact project");
+    exact.directory = Some("/tmp/project".to_string());
+    let mut child = make_session("s2", "opencode", "raw2", "Child project path");
+    child.directory = Some("/tmp/project/subdir".to_string());
+    let mut sibling = make_session("s3", "claude-code", "raw3", "Sibling prefix");
+    sibling.directory = Some("/tmp/project-sibling".to_string());
+    let mut missing = make_session("s4", "gemini-cli", "raw4", "Missing directory");
+    missing.directory = None;
+
+    for session in [&exact, &child, &sibling, &missing] {
+        store.insert_session(session).unwrap();
+    }
+    let messages = vec![
+        make_message("s1", Role::User, "fix the parser", 0),
+        make_message("s2", Role::User, "fix the parser", 0),
+        make_message("s3", Role::User, "fix the parser", 0),
+        make_message("s4", Role::User, "fix the parser", 0),
+    ];
+    store.insert_messages(&messages).unwrap();
+
+    let engine = SearchEngine::new(&store.conn);
+    let filters = SearchFilters {
+        sources: None,
+        time_range: TimeRange::All,
+        directory: Some("/tmp/project".to_string()),
+    };
+    let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
+    let mut ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
+    ids.sort();
+
+    assert_eq!(ids, vec!["s1".to_string(), "s2".to_string()]);
+}
+
+#[test]
+fn recent_sessions_with_directory_filter_respects_project_boundary() {
+    let store = setup();
+    let mut exact = make_session("s1", "codex", "raw1", "Exact project");
+    exact.directory = Some("/tmp/project".to_string());
+    let mut sibling = make_session("s2", "opencode", "raw2", "Sibling prefix");
+    sibling.directory = Some("/tmp/project-sibling".to_string());
+
+    store.insert_session(&exact).unwrap();
+    store.insert_session(&sibling).unwrap();
+
+    let sessions = store
+        .list_recent_sessions_for_search_scope(None, TimeRange::All, Some("/tmp/project"), 10)
+        .unwrap();
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "s1");
+}
+
+#[test]
 fn role_fromstr() {
     assert_eq!("user".parse::<Role>(), Ok(Role::User));
     assert_eq!("assistant".parse::<Role>(), Ok(Role::Assistant));


### PR DESCRIPTION
### What's changed?

- Add a Project filter to the TUI filters panel with searchable directory selection.
- Apply selected directories to search, recent sessions, scope stats, and semantic progress.
- Use exact-or-child directory matching and align source/project picker interactions around Space selection and Enter apply.

### Why

- Let users view conversations from multiple tools through a single project directory scope.