### PR TITLE
[Feat] Add machine-readable session export

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,19 @@ recall sync          # incremental sync (safe to run anytime)
 recall sync --force  # reprocess every session (after changing embedding model)
 recall               # launch TUI
 recall search Q      # one-shot CLI search
+recall search Q --project /path/to/repo
 recall usage         # usage dashboard
 recall usage --json  # usage report for scripts
+recall export --jsonl --source codex --project /path/to/repo --limit 20
 recall info          # index stats and worker status
 ```
+
+## Export
+
+`recall export --jsonl` writes one JSON object per indexed session. Each record
+includes `schema_version`, `record_type`, `session`, `messages`, and
+`usage_events`. Optional fields are emitted as `null`; raw source-specific JSON
+is not part of the public export contract.
 
 ## License
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -8,7 +8,7 @@ use rusqlite::OptionalExtension;
 use crate::db::search::TimeRange;
 use crate::types::{
     BackgroundJobStatus, Message, RawUsageEvent, Role, SemanticProgress, SemanticSessionJob,
-    Session, UsageEventRecord,
+    Session, SessionUsageEventRecord, UsageEventRecord,
 };
 use crate::utils::f32_slice_to_bytes;
 
@@ -815,6 +815,37 @@ impl Store {
         Ok(messages)
     }
 
+    pub fn list_usage_events_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<SessionUsageEventRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT event_key, event_seq, message_seq, timestamp, model, provider,
+                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                    reasoning_tokens, token_source
+             FROM usage_events
+             WHERE session_id = ?1
+             ORDER BY event_seq ASC, event_key ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![session_id], |row| {
+            Ok(SessionUsageEventRecord {
+                event_key: row.get(0)?,
+                event_seq: row.get(1)?,
+                message_seq: row.get(2)?,
+                timestamp: row.get(3)?,
+                model: row.get(4)?,
+                provider: row.get(5)?,
+                input_tokens: row.get(6)?,
+                output_tokens: row.get(7)?,
+                cache_read_tokens: row.get(8)?,
+                cache_write_tokens: row.get(9)?,
+                reasoning_tokens: row.get(10)?,
+                token_source: row.get(11)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub fn stats(&self) -> Result<(u64, u64)> {
         self.stats_for_scope(None, TimeRange::All)
     }
@@ -914,6 +945,45 @@ impl Store {
             sessions.push(row?);
         }
         Ok(sessions)
+    }
+
+    pub fn list_export_sessions(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+        directory: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<Session>> {
+        let mut sql = String::from(
+            "SELECT id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint
+             FROM sessions s
+             WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1;
+        apply_scope_filters(&mut sql, &mut params, &mut param_idx, sources, time_range, directory);
+        sql.push_str(" ORDER BY started_at DESC, source ASC, source_id ASC");
+        if let Some(limit) = limit {
+            sql.push_str(&format!(" LIMIT ?{param_idx}"));
+            params.push(Box::new(limit as i64));
+        }
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok(Session {
+                id: row.get(0)?,
+                source: row.get(1)?,
+                source_id: row.get(2)?,
+                title: row.get(3)?,
+                directory: row.get(4)?,
+                started_at: row.get(5)?,
+                updated_at: row.get(6)?,
+                message_count: row.get(7)?,
+                entrypoint: row.get(8)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     pub fn list_project_directories(&self) -> Result<Vec<ProjectDirectory>> {

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,134 @@
+use std::io::Write;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::db::search::TimeRange;
+use crate::db::store::Store;
+use crate::types::{Message, Role, Session, SessionUsageEventRecord};
+
+const SCHEMA_VERSION: u32 = 1;
+const RECORD_TYPE: &str = "session";
+
+pub struct ExportOptions {
+    pub sources: Option<Vec<String>>,
+    pub time_range: TimeRange,
+    pub project: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ExportSessionRecord {
+    schema_version: u32,
+    record_type: &'static str,
+    session: ExportSession,
+    messages: Vec<ExportMessage>,
+    usage_events: Vec<ExportUsageEvent>,
+}
+
+#[derive(Serialize)]
+struct ExportSession {
+    id: String,
+    source: String,
+    source_id: String,
+    title: String,
+    directory: Option<String>,
+    started_at: i64,
+    updated_at: Option<i64>,
+    message_count: u32,
+    entrypoint: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ExportMessage {
+    seq: u32,
+    role: &'static str,
+    timestamp: Option<i64>,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ExportUsageEvent {
+    event_key: String,
+    event_seq: u32,
+    message_seq: Option<u32>,
+    timestamp: i64,
+    model: String,
+    provider: String,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+    reasoning_tokens: i64,
+    token_source: String,
+}
+
+pub fn write_jsonl<W: Write>(store: &Store, options: &ExportOptions, mut writer: W) -> Result<()> {
+    let sessions = store.list_export_sessions(
+        options.sources.as_deref(),
+        options.time_range,
+        options.project.as_deref(),
+        options.limit,
+    )?;
+
+    for session in sessions {
+        let messages = store.get_messages(&session.id)?;
+        let usage_events = store.list_usage_events_for_session(&session.id)?;
+        let record = ExportSessionRecord {
+            schema_version: SCHEMA_VERSION,
+            record_type: RECORD_TYPE,
+            session: session.into(),
+            messages: messages.into_iter().map(Into::into).collect(),
+            usage_events: usage_events.into_iter().map(Into::into).collect(),
+        };
+        serde_json::to_writer(&mut writer, &record)?;
+        writer.write_all(b"\n")?;
+    }
+
+    Ok(())
+}
+
+impl From<Session> for ExportSession {
+    fn from(session: Session) -> Self {
+        Self {
+            id: session.id,
+            source: session.source,
+            source_id: session.source_id,
+            title: session.title,
+            directory: session.directory,
+            started_at: session.started_at,
+            updated_at: session.updated_at,
+            message_count: session.message_count,
+            entrypoint: session.entrypoint,
+        }
+    }
+}
+
+impl From<Message> for ExportMessage {
+    fn from(message: Message) -> Self {
+        let role = match message.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+        };
+        Self { seq: message.seq, role, timestamp: message.timestamp, content: message.content }
+    }
+}
+
+impl From<SessionUsageEventRecord> for ExportUsageEvent {
+    fn from(event: SessionUsageEventRecord) -> Self {
+        Self {
+            event_key: event.event_key,
+            event_seq: event.event_seq,
+            message_seq: event.message_seq,
+            timestamp: event.timestamp,
+            model: event.model,
+            provider: event.provider,
+            input_tokens: event.input_tokens,
+            output_tokens: event.output_tokens,
+            cache_read_tokens: event.cache_read_tokens,
+            cache_write_tokens: event.cache_write_tokens,
+            reasoning_tokens: event.reasoning_tokens,
+            token_source: event.token_source,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bench;
 pub mod config;
 pub mod db;
 pub mod embedding;
+pub mod export;
 pub mod semantic;
 pub mod tui;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use recall::db;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::{Store, UsageSessionStateMeta};
 use recall::embedding::EmbeddingProvider;
+use recall::export::ExportOptions;
 use recall::semantic;
 use recall::types::{self, Message, Role, Session};
 use recall::usage::{self, UsageFilters};
@@ -57,6 +58,8 @@ enum Commands {
         source: Option<String>,
         #[arg(long)]
         time: Option<String>,
+        #[arg(long, help = "Filter by project directory, including child paths")]
+        project: Option<String>,
     },
     Usage {
         #[arg(long, help = "Output usage report as JSON")]
@@ -65,6 +68,18 @@ enum Commands {
         source: Option<String>,
         #[arg(long)]
         time: Option<String>,
+    },
+    Export {
+        #[arg(long, help = "Output session records as JSON Lines")]
+        jsonl: bool,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long)]
+        time: Option<String>,
+        #[arg(long, help = "Filter by project directory, including child paths")]
+        project: Option<String>,
+        #[arg(long, default_value_t = 100, help = "Maximum sessions to export; 0 means all")]
+        limit: usize,
     },
 }
 
@@ -90,11 +105,14 @@ fn main() -> Result<()> {
             recall::bench::run_eval(dataset.as_deref(), verbose)?
         }
         Some(Commands::BenchDumpSessions) => recall::bench::dump_sessions()?,
-        Some(Commands::Search { query, source, time }) => {
-            cmd_search(&query, source.as_deref(), time.as_deref())?
+        Some(Commands::Search { query, source, time, project }) => {
+            cmd_search(&query, source.as_deref(), time.as_deref(), project.as_deref())?
         }
         Some(Commands::Usage { json, source, time }) => {
             cmd_usage(json, source.as_deref(), time.as_deref())?
+        }
+        Some(Commands::Export { jsonl, source, time, project, limit }) => {
+            cmd_export(jsonl, source.as_deref(), time.as_deref(), project.as_deref(), limit)?
         }
         None => cmd_tui(None)?,
     }
@@ -558,7 +576,12 @@ fn cmd_background_worker(sync_first: bool) -> Result<()> {
     semantic::run_background_worker(sync_first, || run_sync_job(false, false))
 }
 
-fn cmd_search(query: &str, source_filter: Option<&str>, time_filter: Option<&str>) -> Result<()> {
+fn cmd_search(
+    query: &str,
+    source_filter: Option<&str>,
+    time_filter: Option<&str>,
+    project_filter: Option<&str>,
+) -> Result<()> {
     let store = Store::open()?;
     let engine = SearchEngine::new(&store.conn);
     let sources = adapters::source_labels();
@@ -597,7 +620,11 @@ fn cmd_search(query: &str, source_filter: Option<&str>, time_filter: Option<&str
         _ => TimeRange::All,
     };
 
-    let filters = SearchFilters { sources: resolved_source, time_range, directory: None };
+    let filters = SearchFilters {
+        sources: resolved_source,
+        time_range,
+        directory: project_filter.map(String::from),
+    };
 
     let results = engine.hybrid_search(query, query_embedding.as_deref(), &filters, 20, 3)?;
 
@@ -657,6 +684,30 @@ fn cmd_usage(json: bool, source_filter: Option<&str>, time_filter: Option<&str>)
     print!("{}", format_usage_report_text(&report));
 
     Ok(())
+}
+
+fn cmd_export(
+    jsonl: bool,
+    source_filter: Option<&str>,
+    time_filter: Option<&str>,
+    project_filter: Option<&str>,
+    limit: usize,
+) -> Result<()> {
+    if !jsonl {
+        anyhow::bail!("export requires --jsonl");
+    }
+
+    let store = Store::open()?;
+    let sources = adapters::source_labels();
+    let options = ExportOptions {
+        sources: resolve_source_filter(source_filter, &sources)?,
+        time_range: parse_time_range(time_filter),
+        project: project_filter.map(String::from),
+        limit: if limit == 0 { None } else { Some(limit) },
+    };
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    recall::export::write_jsonl(&store, &options, &mut handle)
 }
 
 fn format_usage_report_text(report: &usage::UsageReport) -> String {

--- a/src/types.rs
+++ b/src/types.rs
@@ -114,6 +114,22 @@ pub struct UsageEventRecord {
     pub token_source: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct SessionUsageEventRecord {
+    pub event_key: String,
+    pub event_seq: u32,
+    pub message_seq: Option<u32>,
+    pub timestamp: i64,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub token_source: String,
+}
+
 #[derive(Debug)]
 pub enum MatchSource {
     Fts,

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -5,6 +5,7 @@ use recall::config::AppConfig;
 use recall::db::schema;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::Store;
+use recall::export::{ExportOptions, write_jsonl};
 use recall::types::{Message, RawUsageEvent, Role, Session, TokenSource};
 use recall::usage::{UsageFilters, build_usage_report};
 
@@ -191,6 +192,89 @@ fn delete_session_cascades_usage_events() {
         .query_row("SELECT COUNT(*) FROM usage_session_state", [], |row| row.get(0))
         .unwrap();
     assert_eq!(state_count, 0, "usage parser state must follow session lifecycle");
+}
+
+#[test]
+fn export_jsonl_emits_session_messages_and_usage_events() {
+    let store = setup();
+    let mut session = make_session("s1", "codex", "raw1", "Export session");
+    session.started_at = 1_800_000_000_000;
+    session.updated_at = Some(1_800_000_001_000);
+    session.message_count = 2;
+    session.entrypoint = Some("codex resume raw1".to_string());
+    let messages = vec![
+        make_message("s1", Role::User, "hello", 0),
+        make_message("s1", Role::Assistant, "hi", 1),
+    ];
+    let usage = vec![make_usage_event("evt-1", 1_800_000_001_000, "gpt-5")];
+    store.persist_session_with_usage(&session, &messages, &usage, Some(1)).unwrap();
+
+    let options =
+        ExportOptions { sources: None, time_range: TimeRange::All, project: None, limit: Some(10) };
+    let mut out = Vec::new();
+    write_jsonl(&store, &options, &mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+    let lines: Vec<_> = text.lines().collect();
+    assert_eq!(lines.len(), 1);
+    let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["record_type"], "session");
+    assert_eq!(value["session"]["source"], "codex");
+    assert_eq!(value["session"]["source_id"], "raw1");
+    assert_eq!(value["session"]["directory"], "/tmp/test");
+    assert_eq!(value["messages"][0]["seq"], 0);
+    assert_eq!(value["messages"][0]["role"], "user");
+    assert_eq!(value["messages"][1]["seq"], 1);
+    assert_eq!(value["messages"][1]["role"], "assistant");
+    assert_eq!(value["usage_events"][0]["event_key"], "evt-1");
+    assert_eq!(value["usage_events"][0]["message_seq"], 1);
+    assert_eq!(value["usage_events"][0]["model"], "gpt-5");
+    assert_eq!(value["usage_events"][0]["token_source"], "observed");
+    assert!(value["usage_events"][0].get("raw_usage_json").is_none());
+}
+
+#[test]
+fn export_jsonl_applies_source_time_project_and_limit_filters() {
+    let store = setup();
+    let now = chrono::Utc::now().timestamp_millis();
+
+    let mut newest = make_session("s-newest", "codex", "raw-newest", "Newest Codex");
+    newest.started_at = now;
+    newest.directory = Some("/tmp/project".to_string());
+    let mut recent = make_session("s-recent", "codex", "raw-recent", "Recent Codex");
+    recent.started_at = now - 1_000;
+    recent.directory = Some("/tmp/project/subdir".to_string());
+    let mut old = make_session("s-old", "codex", "raw-old", "Old Codex");
+    old.started_at = now - 40 * 24 * 60 * 60 * 1_000;
+    old.directory = Some("/tmp/project".to_string());
+    let mut sibling = make_session("s-sibling", "codex", "raw-sibling", "Sibling Project");
+    sibling.started_at = now + 2_000;
+    sibling.directory = Some("/tmp/project-sibling".to_string());
+    let mut other_source = make_session("s-other", "claude-code", "raw-other", "Other Source");
+    other_source.started_at = now + 1_000;
+    other_source.directory = Some("/tmp/project".to_string());
+
+    for session in [&newest, &recent, &old, &sibling, &other_source] {
+        store.insert_session(session).unwrap();
+        store.insert_messages(&[make_message(&session.id, Role::User, &session.title, 0)]).unwrap();
+    }
+
+    let options = ExportOptions {
+        sources: Some(vec!["codex".to_string()]),
+        time_range: TimeRange::Month,
+        project: Some("/tmp/project".to_string()),
+        limit: Some(1),
+    };
+    let mut out = Vec::new();
+    write_jsonl(&store, &options, &mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+    let lines: Vec<_> = text.lines().collect();
+    assert_eq!(lines.len(), 1);
+    let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(value["session"]["id"], "s-newest");
+    assert_eq!(value["session"]["source"], "codex");
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- Add `recall export --jsonl` to emit session-level JSONL records with session metadata, messages, and usage events.
- Add `--project` filtering to `recall search` and `recall export`, reusing existing directory boundary semantics.
- Document the export command and add regression coverage for JSON shape plus source/time/project/limit filters.

### Why

- Recall needs a stable machine-readable session export so downstream tools do not need to parse source-specific raw session stores.

Closes #26