### PR TITLE
[Feat] Index session events

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ recall info          # index stats and worker status
 
 `recall export --jsonl` writes one JSON object per indexed session. Each record
 includes `schema_version`, `record_type`, `session`, `messages`, and
-`usage_events`. Optional fields are emitted as `null`; raw source-specific JSON
-is not part of the public export contract.
+`usage_events`, and `events`. Optional fields are emitted as `null`; raw
+source-specific JSON is not part of the public export contract.
 
 ## License
 

--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -55,6 +55,7 @@ impl SourceAdapter for AntigravityAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(cli_dir) = resolve_antigravity_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -7,16 +7,18 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
 
 pub struct ClaudeCodeAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 4;
+const EVENT_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for ClaudeCodeAdapter {
     fn id(&self) -> &str {
@@ -51,7 +53,7 @@ impl SourceAdapter for ClaudeCodeAdapter {
             let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
                 continue;
             };
-            if let Some(raw) = parse_claude_session_file(entry, mtime_ms, &session_index)? {
+            if let Some(raw) = parse_claude_session_file(entry, mtime_ms, &session_index, true)? {
                 sessions.push(raw);
             }
         }
@@ -63,11 +65,12 @@ impl SourceAdapter for ClaudeCodeAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(claude_dir) = resolve_claude_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
-        let result = scan_for_sync_impl(&claude_dir, store, since_ts)?;
+        let result = scan_for_sync_impl(&claude_dir, store, since_ts, include_events)?;
         Ok(Some(result))
     }
 }
@@ -92,6 +95,7 @@ fn scan_for_sync_impl(
     claude_dir: &Path,
     store: &Store,
     since_ts: Option<i64>,
+    include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let session_index = load_session_index(claude_dir);
     let mut entries = collect_project_entries(claude_dir, &session_index);
@@ -101,9 +105,14 @@ fn scan_for_sync_impl(
         store,
         "claude-code",
         since_ts,
-        file_scan::FileScanOptions { usage_parser_version: Some(USAGE_PARSER_VERSION) },
+        file_scan::FileScanOptions {
+            usage_parser_version: Some(USAGE_PARSER_VERSION),
+            event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+        },
         entries,
-        |entry, mtime_ms| parse_claude_session_file(entry, mtime_ms, &session_index),
+        |entry, mtime_ms| {
+            parse_claude_session_file(entry, mtime_ms, &session_index, include_events)
+        },
     )
 }
 
@@ -237,8 +246,9 @@ fn parse_claude_session_file(
     entry: FileScanEntry,
     mtime_ms: i64,
     session_index: &HashMap<String, SessionMeta>,
+    include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
-    let parsed = match parse_conversation_jsonl(&entry.stat_target, mtime_ms) {
+    let parsed = match parse_conversation_jsonl(&entry.stat_target, mtime_ms, include_events) {
         Ok(parsed) => parsed,
         Err(e) => {
             debug!("failed to parse {}: {e}", entry.stat_target.display());
@@ -258,7 +268,6 @@ fn parse_claude_session_file(
         .unwrap_or(0);
     let directory = meta.and_then(|m| m.cwd.clone()).or(entry.directory);
     let entrypoint = meta.and_then(|m| m.entrypoint.clone());
-
     Ok(Some(RawSession {
         source_id: entry.session_id,
         directory,
@@ -268,22 +277,27 @@ fn parse_claude_session_file(
         messages: parsed.messages,
         usage_events: parsed.usage_events,
         usage_parser_version: Some(USAGE_PARSER_VERSION),
+        events: parsed.events,
+        event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
     }))
 }
 
 struct ParsedConversation {
     messages: Vec<RawMessage>,
     usage_events: Vec<RawUsageEvent>,
+    events: Vec<RawSessionEvent>,
 }
 
 fn parse_conversation_jsonl(
     path: &Path,
     fallback_timestamp: i64,
+    include_events: bool,
 ) -> anyhow::Result<ParsedConversation> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
     let mut usage_events: Vec<RawUsageEvent> = Vec::new();
+    let mut events = Vec::new();
     let mut usage_index: HashMap<String, usize> = HashMap::new();
     let source_path = path.to_string_lossy().to_string();
 
@@ -319,6 +333,17 @@ fn parse_conversation_jsonl(
             .map(|dt| dt.timestamp_millis());
 
         let message_seq = if !text.is_empty() { Some(messages.len() as u32) } else { None };
+        if include_events {
+            collect_claude_content_events(
+                message.get("content"),
+                role.clone(),
+                timestamp,
+                &source_path,
+                line_index,
+                message_seq,
+                &mut events,
+            );
+        }
         if role == Role::Assistant
             && let Some(event) = extract_claude_usage_event(
                 &v,
@@ -342,7 +367,59 @@ fn parse_conversation_jsonl(
         }
     }
 
-    Ok(ParsedConversation { messages, usage_events })
+    Ok(ParsedConversation { messages, usage_events, events })
+}
+
+fn collect_claude_content_events(
+    content: Option<&Value>,
+    role: Role,
+    timestamp: Option<i64>,
+    source_path: &str,
+    line_index: usize,
+    message_seq: Option<u32>,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(Value::Array(arr)) = content else {
+        return;
+    };
+    for (item_index, item) in arr.iter().enumerate() {
+        match item.get("type").and_then(|t| t.as_str()) {
+            Some("tool_use") if role == Role::Assistant => {
+                let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
+                events_out.push(events::tool_call_event(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        message_seq,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name,
+                    item.get("input"),
+                ));
+            }
+            Some("tool_result") => {
+                let summary = item.get("content").map(|content| match content {
+                    Value::String(text) => text.to_string(),
+                    other => other.to_string(),
+                });
+                events_out.push(events::tool_result_event(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        message_seq,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    item.get("tool_use_id").and_then(|id| id.as_str()).map(String::from),
+                    summary,
+                ));
+            }
+            _ => {}
+        }
+    }
 }
 
 fn extract_claude_usage_event(
@@ -501,6 +578,61 @@ mod tests {
         path
     }
 
+    #[test]
+    fn parse_claude_session_file_extracts_structured_tool_events() {
+        let root = temp_claude_root("events");
+        let project = root.join("projects").join("-tmp-foo");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("tool-session.jsonl");
+        let assistant = serde_json::json!({
+            "type": "assistant",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tool-1", "name": "Read", "input": {"path": "src/main.rs"}}
+                ]
+            }
+        });
+        let user = serde_json::json!({
+            "type": "user",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tool-1", "content": "file body"}
+                ]
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{assistant}").unwrap();
+        writeln!(f, "{user}").unwrap();
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "tool-session".to_string(),
+            stat_target: path.clone(),
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let raw = parse_claude_session_file(entry, mtime, &HashMap::new(), true).unwrap().unwrap();
+
+        assert_eq!(raw.events.len(), 2);
+        assert_eq!(raw.events[0].kind, "file_read");
+        assert_eq!(raw.events[0].name.as_deref(), Some("Read"));
+        assert_eq!(raw.events[0].target.as_deref(), Some("src/main.rs"));
+        assert_eq!(raw.events[1].kind, "tool_result");
+
+        let entry = FileScanEntry {
+            session_id: "tool-session".to_string(),
+            stat_target: path,
+            directory: Some("/tmp/foo".to_string()),
+        };
+        let raw = parse_claude_session_file(entry, mtime, &HashMap::new(), false).unwrap().unwrap();
+
+        assert!(raw.events.is_empty());
+        assert_eq!(raw.event_parser_version, None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
     fn write_usage_jsonl(project_dir: &Path, session_id: &str) -> PathBuf {
         fs::create_dir_all(project_dir).unwrap();
         let path = project_dir.join(format!("{session_id}.jsonl"));
@@ -593,7 +725,7 @@ mod tests {
             directory: Some("/tmp/foo".to_string()),
         };
         let session_index = HashMap::new();
-        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+        let raw = parse_claude_session_file(entry, mtime, &session_index, true).unwrap().unwrap();
 
         assert_eq!(raw.source_id, "abc-123");
         assert_eq!(raw.updated_at, Some(mtime));
@@ -617,7 +749,7 @@ mod tests {
             directory: Some("/tmp/foo".to_string()),
         };
         let session_index = HashMap::new();
-        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+        let raw = parse_claude_session_file(entry, mtime, &session_index, true).unwrap().unwrap();
 
         assert_eq!(raw.usage_events.len(), 1);
         let event = &raw.usage_events[0];
@@ -646,7 +778,7 @@ mod tests {
             directory: Some("/tmp/foo".to_string()),
         };
         let session_index = HashMap::new();
-        let raw = parse_claude_session_file(entry, mtime, &session_index).unwrap().unwrap();
+        let raw = parse_claude_session_file(entry, mtime, &session_index, true).unwrap().unwrap();
 
         assert!(raw.messages.is_empty());
         assert_eq!(raw.started_at, 1_776_074_400_000);
@@ -684,7 +816,7 @@ mod tests {
             stat_target: path,
             directory: Some("/tmp/foo".to_string()),
         };
-        let raw = parse_claude_session_file(entry, mtime, &HashMap::new()).unwrap().unwrap();
+        let raw = parse_claude_session_file(entry, mtime, &HashMap::new(), true).unwrap().unwrap();
 
         assert_eq!(raw.usage_events.len(), 1);
         assert_eq!(raw.usage_events[0].model, "gpt-5.5");
@@ -733,8 +865,17 @@ mod tests {
                 Some(mtime),
             )
             .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "claude-code",
+                "sess-skip",
+                &[],
+                EVENT_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -753,7 +894,7 @@ mod tests {
             .insert_session(&make_existing_session("sess-stale", actual_mtime - 1_000, 1))
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "sess-stale");
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -770,7 +911,7 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "sess-fresh");
         assert_eq!(result.stats.skipped_sessions, 0);

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -45,6 +45,7 @@ impl SourceAdapter for ClineAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(tasks_dir) = resolve_tasks_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -6,16 +6,18 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
 
 pub struct CodexAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 4;
+const EVENT_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CodexAdapter {
     fn id(&self) -> &str {
@@ -48,7 +50,7 @@ impl SourceAdapter for CodexAdapter {
             let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
                 continue;
             };
-            if let Some(raw) = parse_codex_session_for_entry(entry, mtime_ms)? {
+            if let Some(raw) = parse_codex_session_for_entry(entry, mtime_ms, true)? {
                 sessions.push(raw);
             }
         }
@@ -59,11 +61,12 @@ impl SourceAdapter for CodexAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(codex_dir) = resolve_codex_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
-        let result = scan_for_sync_impl(&codex_dir, store, since_ts)?;
+        let result = scan_for_sync_impl(&codex_dir, store, since_ts, include_events)?;
         Ok(Some(result))
     }
 }
@@ -82,6 +85,7 @@ fn scan_for_sync_impl(
     codex_dir: &Path,
     store: &Store,
     since_ts: Option<i64>,
+    include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let sessions_dir = codex_dir.join("sessions");
     let archived_dir = codex_dir.join("archived_sessions");
@@ -90,9 +94,21 @@ fn scan_for_sync_impl(
         store,
         "codex",
         since_ts,
-        file_scan::FileScanOptions { usage_parser_version: Some(USAGE_PARSER_VERSION) },
+        file_scan::FileScanOptions {
+            usage_parser_version: Some(USAGE_PARSER_VERSION),
+            event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+        },
         entries,
-        parse_codex_session_for_entry,
+        |entry, mtime_ms| {
+            let Some(session) = parse_codex_session_for_entry(entry, mtime_ms, include_events)?
+            else {
+                return Ok(None);
+            };
+            if !include_events && session.messages.is_empty() && session.usage_events.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(session))
+        },
     )
 }
 
@@ -131,8 +147,9 @@ fn collect_codex_entries(base_dirs: &[&Path]) -> Vec<FileScanEntry> {
 fn parse_codex_session_for_entry(
     entry: FileScanEntry,
     mtime_ms: i64,
+    include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
-    let mut raw = match parse_codex_session(&entry.stat_target) {
+    let mut raw = match parse_codex_session_with_options(&entry.stat_target, include_events) {
         Ok(Some(raw)) => raw,
         Ok(None) => return Ok(None),
         Err(e) => {
@@ -156,7 +173,15 @@ fn extract_session_id_from_filename(stem: &str) -> Option<String> {
     uuid::Uuid::try_parse(tail).ok().map(|_| tail.to_string())
 }
 
+#[cfg(test)]
 fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
+    parse_codex_session_with_options(path, true)
+}
+
+fn parse_codex_session_with_options(
+    path: &Path,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let fallback_timestamp = file_scan::stat_mtime_ms(path).unwrap_or(0);
@@ -165,6 +190,7 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let mut meta_timestamp: Option<i64> = None;
     let mut messages = Vec::new();
     let mut usage_events = Vec::new();
+    let mut events = Vec::new();
     let mut current_model: Option<String> = None;
     let mut provider: Option<String> = None;
     let mut previous_totals: Option<CodexUsageTotals> = None;
@@ -337,6 +363,18 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
                     && payload.get("role").and_then(|r| r.as_str()) == Some("assistant")
                 {
                     let text = extract_content_array(payload.get("content"));
+                    let message_seq =
+                        if text.is_empty() { None } else { Some(messages.len() as u32) };
+                    if include_events {
+                        collect_codex_content_events(
+                            payload.get("content"),
+                            parse_timestamp(&v),
+                            &source_path,
+                            line_index,
+                            message_seq,
+                            &mut events,
+                        );
+                    }
                     if !text.is_empty() {
                         let ts = parse_timestamp(&v);
                         messages.push(RawMessage {
@@ -346,12 +384,21 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
                         });
                     }
                 }
+                if include_events && let Some(payload) = v.get("payload") {
+                    collect_codex_response_item_event(
+                        payload,
+                        parse_timestamp(&v),
+                        &source_path,
+                        line_index,
+                        &mut events,
+                    );
+                }
             }
             _ => {}
         }
     }
 
-    if messages.is_empty() && usage_events.is_empty() {
+    if messages.is_empty() && usage_events.is_empty() && events.is_empty() {
         return Ok(None);
     }
 
@@ -362,6 +409,7 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let started_at = meta_timestamp
         .or_else(|| messages.first().and_then(|m| m.timestamp))
         .or_else(|| usage_events.first().map(|event| event.timestamp))
+        .or_else(|| events.first().and_then(|event| event.timestamp))
         .unwrap_or(0);
 
     Ok(Some(RawSession {
@@ -371,12 +419,159 @@ fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
         updated_at: messages
             .last()
             .and_then(|m| m.timestamp)
-            .or_else(|| usage_events.last().map(|event| event.timestamp)),
+            .or_else(|| usage_events.last().map(|event| event.timestamp))
+            .or_else(|| events.last().and_then(|event| event.timestamp)),
         entrypoint: None,
         messages,
         usage_events,
         usage_parser_version: Some(USAGE_PARSER_VERSION),
+        events,
+        event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
     }))
+}
+
+fn collect_codex_response_item_event(
+    payload: &Value,
+    timestamp: Option<i64>,
+    source_path: &str,
+    line_index: usize,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(payload_type) = payload.get("type").and_then(|t| t.as_str()) else {
+        return;
+    };
+    let source_event_id = payload
+        .get("call_id")
+        .and_then(|id| id.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| line_index.to_string());
+
+    if payload_type.ends_with("_output") {
+        let mut event = events::tool_result_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: Some(source_path.to_string()),
+                source_event_id: Some(source_event_id),
+                message_seq: None,
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            payload.get("name").and_then(|name| name.as_str()).map(String::from),
+            codex_output_summary(payload),
+        );
+        event.status = payload.get("status").and_then(|status| status.as_str()).map(String::from);
+        events_out.push(event);
+        return;
+    }
+
+    if payload_type.ends_with("_call") {
+        let name = codex_call_name(payload_type, payload);
+        let mut event = match codex_call_args(payload) {
+            Some(Value::String(text)) => events::tool_call_event_from_text(
+                events::EventContext {
+                    event_seq: events_out.len() as u32,
+                    timestamp,
+                    source_path: Some(source_path.to_string()),
+                    source_event_id: Some(source_event_id.clone()),
+                    message_seq: None,
+                    parser_version: EVENT_PARSER_VERSION,
+                },
+                name,
+                Some(text),
+            ),
+            args => events::tool_call_event(
+                events::EventContext {
+                    event_seq: events_out.len() as u32,
+                    timestamp,
+                    source_path: Some(source_path.to_string()),
+                    source_event_id: Some(source_event_id),
+                    message_seq: None,
+                    parser_version: EVENT_PARSER_VERSION,
+                },
+                name,
+                args,
+            ),
+        };
+        event.status = payload.get("status").and_then(|status| status.as_str()).map(String::from);
+        events_out.push(event);
+    }
+}
+
+fn codex_call_name(payload_type: &str, payload: &Value) -> String {
+    payload.get("name").and_then(|name| name.as_str()).map(String::from).unwrap_or_else(|| {
+        match payload_type {
+            "function_call" | "custom_tool_call" => "tool".to_string(),
+            _ => payload_type.strip_suffix("_call").unwrap_or(payload_type).to_string(),
+        }
+    })
+}
+
+fn codex_call_args(payload: &Value) -> Option<&Value> {
+    payload
+        .get("arguments")
+        .or_else(|| payload.get("input"))
+        .or_else(|| payload.get("action"))
+        .or_else(|| payload.get("revised_prompt"))
+}
+
+fn codex_output_summary(payload: &Value) -> Option<String> {
+    ["output", "result", "content", "tools"]
+        .iter()
+        .find_map(|key| payload.get(*key))
+        .map(codex_value_summary)
+}
+
+fn codex_value_summary(value: &Value) -> String {
+    value.as_str().map(String::from).unwrap_or_else(|| value.to_string())
+}
+
+fn collect_codex_content_events(
+    content: Option<&Value>,
+    timestamp: Option<i64>,
+    source_path: &str,
+    line_index: usize,
+    message_seq: Option<u32>,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(Value::Array(arr)) = content else {
+        return;
+    };
+    for (item_index, item) in arr.iter().enumerate() {
+        match item.get("type").and_then(|t| t.as_str()) {
+            Some("function_call") => {
+                let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
+                let args = item.get("arguments").and_then(|a| a.as_str());
+                events_out.push(events::tool_call_event_from_text(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        message_seq,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name,
+                    args,
+                ));
+            }
+            Some("function_call_output") => {
+                let output = item.get("output").and_then(|o| o.as_str()).map(String::from);
+                events_out.push(events::tool_result_event(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        message_seq,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    None,
+                    output,
+                ));
+            }
+            _ => {}
+        }
+    }
 }
 
 fn extract_content_array(content: Option<&Value>) -> String {
@@ -687,6 +882,329 @@ mod tests {
         path
     }
 
+    fn write_codex_event_only_rollout(sessions_dir: &Path, session_uuid: &str) -> PathBuf {
+        fs::create_dir_all(sessions_dir).unwrap();
+        let filename = format!("rollout-2026-04-13T10-00-00-{session_uuid}.jsonl");
+        let path = sessions_dir.join(filename);
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": session_uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let web_search = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "web_search_call",
+                "status": "completed",
+                "call_id": "web_123",
+                "action": {
+                    "type": "search",
+                    "query": "rust sqlite json_extract"
+                }
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{web_search}").unwrap();
+        path
+    }
+
+    #[test]
+    fn parse_codex_session_extracts_structured_tool_events() {
+        let root = temp_codex_root("events");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2391";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let tool_call = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"cmd\":\"sed -n '1,220p' CLAUDE.md\",\"workdir\":\"/tmp/foo\",\"yield_time_ms\":1000}",
+                "call_id": "call_123"
+            }
+        });
+        let tool_result = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:02Z",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_123",
+                "output": "file body"
+            }
+        });
+        let custom_call = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:03Z",
+            "payload": {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_patch",
+                "name": "apply_patch",
+                "input": "*** Begin Patch\n*** End Patch"
+            }
+        });
+        let custom_result = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:04Z",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_patch",
+                "output": "{\"output\":\"Success\"}"
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{tool_call}").unwrap();
+        writeln!(f, "{tool_result}").unwrap();
+        writeln!(f, "{custom_call}").unwrap();
+        writeln!(f, "{custom_result}").unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.events.len(), 4);
+        assert_eq!(raw.events[0].kind, "command");
+        assert_eq!(raw.events[0].name.as_deref(), Some("exec_command"));
+        assert_eq!(raw.events[0].target.as_deref(), Some("sed -n '1,220p' CLAUDE.md"));
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("call_123"));
+        assert_eq!(raw.events[1].kind, "tool_result");
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("call_123"));
+        assert_eq!(raw.events[2].kind, "tool_call");
+        assert_eq!(raw.events[2].name.as_deref(), Some("apply_patch"));
+        assert_eq!(raw.events[2].status.as_deref(), Some("completed"));
+        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("call_patch"));
+        assert_eq!(raw.events[3].kind, "tool_result");
+        assert_eq!(raw.events[3].source_event_id.as_deref(), Some("call_patch"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_extracts_array_shell_command_target() {
+        let root = temp_codex_root("array-command-events");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2392";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let tool_call = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "arguments": "{\"command\":[\"bash\",\"-lc\",\"cd /tmp/foo && git status -sb\"]}",
+                "call_id": "call_shell"
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{tool_call}").unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.events[0].kind, "command");
+        assert_eq!(raw.events[0].target.as_deref(), Some("cd /tmp/foo && git status -sb"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_does_not_reference_missing_message_for_empty_tool_content() {
+        let root = temp_codex_root("empty-tool-content");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2393";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let tool_call = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "function_call",
+                        "name": "shell",
+                        "call_id": "call_empty"
+                    }
+                ]
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{tool_call}").unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert!(raw.messages.is_empty());
+        assert_eq!(raw.events[0].kind, "command");
+        assert_eq!(raw.events[0].message_seq, None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_without_events_ignores_event_only_lines() {
+        let root = temp_codex_root("no-events");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2394";
+        let path = write_codex_event_only_rollout(&sessions_dir, uuid);
+
+        assert!(parse_codex_session_with_options(&path, false).unwrap().is_none());
+
+        let raw = parse_codex_session_with_options(&path, true).unwrap().unwrap();
+        assert_eq!(raw.event_parser_version, Some(EVENT_PARSER_VERSION));
+        assert!(raw.events.iter().any(|event| event.kind == "search"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_extracts_non_function_response_item_events() {
+        let root = temp_codex_root("nonfunction-events");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2392";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo"
+            }
+        });
+        let web_search = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "type": "web_search_call",
+                "status": "completed",
+                "call_id": "web_123",
+                "action": {
+                    "type": "search",
+                    "query": "rust sqlite json_extract"
+                }
+            }
+        });
+        let tool_search = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:02Z",
+            "payload": {
+                "type": "tool_search_call",
+                "status": "completed",
+                "call_id": "tool_search_123",
+                "arguments": {
+                    "query": "serena initial_instructions",
+                    "limit": 5
+                }
+            }
+        });
+        let tool_search_output = serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:03Z",
+            "payload": {
+                "type": "tool_search_output",
+                "call_id": "tool_search_123",
+                "tools": [
+                    {"name": "mcp__serena__initial_instructions"}
+                ]
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{web_search}").unwrap();
+        writeln!(f, "{tool_search}").unwrap();
+        writeln!(f, "{tool_search_output}").unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.events.len(), 3);
+        assert_eq!(raw.events[0].kind, "search");
+        assert_eq!(raw.events[0].name.as_deref(), Some("web_search"));
+        assert_eq!(raw.events[0].target.as_deref(), Some("rust sqlite json_extract"));
+        assert_eq!(raw.events[0].status.as_deref(), Some("completed"));
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("web_123"));
+        assert_eq!(raw.events[1].kind, "search");
+        assert_eq!(raw.events[1].name.as_deref(), Some("tool_search"));
+        assert_eq!(raw.events[1].target.as_deref(), Some("serena initial_instructions"));
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("tool_search_123"));
+        assert_eq!(raw.events[2].kind, "tool_result");
+        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("tool_search_123"));
+        assert!(raw.events[2].summary.as_deref().unwrap_or("").contains("mcp__serena"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_ignores_metadata_only_rollout() {
+        let root = temp_codex_root("metadata-only");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2393";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {
+                "id": uuid,
+                "timestamp": "2026-04-13T10:00:00Z",
+                "cwd": "/tmp/foo",
+                "model": "gpt-5.5"
+            }
+        });
+        let turn = serde_json::json!({
+            "type": "turn_context",
+            "timestamp": "2026-04-13T10:00:01Z",
+            "payload": {
+                "cwd": "/tmp/foo",
+                "model": "gpt-5.5"
+            }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{turn}").unwrap();
+
+        assert!(parse_codex_session(&path).unwrap().is_none());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
     fn write_codex_usage_rollout(sessions_dir: &Path, session_uuid: &str) -> PathBuf {
         fs::create_dir_all(sessions_dir).unwrap();
         let filename = format!("rollout-2026-04-13T10-00-00-{session_uuid}.jsonl");
@@ -954,10 +1472,66 @@ mod tests {
                 Some(mtime),
             )
             .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "codex",
+                uuid,
+                &[],
+                EVENT_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn usage_only_scan_skips_unchanged_session_without_event_state() {
+        let root = temp_codex_root("usage-only-skip");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
+        let path = write_codex_rollout(&sessions_dir, uuid, "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "codex",
+                uuid,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn usage_only_scan_skips_event_only_session() {
+        let root = temp_codex_root("usage-only-event-only");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2381";
+        write_codex_event_only_rollout(&sessions_dir, uuid);
+        let store = setup_store();
+
+        let usage_result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        assert!(usage_result.sessions.is_empty());
+
+        let full_result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        assert_eq!(full_result.sessions.len(), 1);
+        assert!(full_result.sessions[0].messages.is_empty());
+        assert!(full_result.sessions[0].usage_events.is_empty());
+        assert!(full_result.sessions[0].events.iter().any(|event| event.kind == "search"));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -973,7 +1547,7 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -1000,7 +1574,7 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, good_uuid);
 
@@ -1016,7 +1590,7 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.stats.skipped_sessions, 0);

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -51,6 +51,7 @@ impl SourceAdapter for CopilotAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(sessions_dir) = resolve_copilot_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -51,6 +51,7 @@ impl SourceAdapter for CursorAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(projects_dir) = resolve_projects_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));

--- a/src/adapters/events.rs
+++ b/src/adapters/events.rs
@@ -1,0 +1,177 @@
+use serde_json::Value;
+
+use crate::types::RawSessionEvent;
+
+pub struct EventContext {
+    pub event_seq: u32,
+    pub timestamp: Option<i64>,
+    pub source_path: Option<String>,
+    pub source_event_id: Option<String>,
+    pub message_seq: Option<u32>,
+    pub parser_version: u32,
+}
+
+pub fn tool_call_event(
+    context: EventContext,
+    name: String,
+    args: Option<&Value>,
+) -> RawSessionEvent {
+    let target = args.and_then(target_from_value);
+    let kind = infer_tool_kind(&name, target.as_deref());
+    let summary = args.map(|value| match value {
+        Value::String(text) if text.trim().is_empty() => format!("[{name}]"),
+        Value::String(text) => format!("[{name}] {text}"),
+        other => format!("[{name}] {other}"),
+    });
+    RawSessionEvent {
+        event_seq: context.event_seq,
+        timestamp: context.timestamp,
+        kind: kind.to_string(),
+        actor: "assistant".to_string(),
+        name: Some(name),
+        status: None,
+        target,
+        message_seq: context.message_seq,
+        summary,
+        source_path: context.source_path,
+        source_event_id: context.source_event_id,
+        attrs_json: args.map(|value| value.to_string()),
+        parser_version: context.parser_version,
+    }
+}
+
+pub fn tool_call_event_from_text(
+    context: EventContext,
+    name: String,
+    args: Option<&str>,
+) -> RawSessionEvent {
+    let parsed = args.and_then(|text| serde_json::from_str::<Value>(text).ok());
+    let target =
+        parsed.as_ref().and_then(target_from_value).or_else(|| command_target(&name, args));
+    let kind = infer_tool_kind(&name, target.as_deref());
+    let summary = args.map(|text| {
+        if text.trim().is_empty() { format!("[{name}]") } else { format!("[{name}] {text}") }
+    });
+    RawSessionEvent {
+        event_seq: context.event_seq,
+        timestamp: context.timestamp,
+        kind: kind.to_string(),
+        actor: "assistant".to_string(),
+        name: Some(name),
+        status: None,
+        target,
+        message_seq: context.message_seq,
+        summary,
+        source_path: context.source_path,
+        source_event_id: context.source_event_id,
+        attrs_json: parsed.map(|value| value.to_string()),
+        parser_version: context.parser_version,
+    }
+}
+
+pub fn tool_result_event(
+    context: EventContext,
+    name: Option<String>,
+    summary: Option<String>,
+) -> RawSessionEvent {
+    RawSessionEvent {
+        event_seq: context.event_seq,
+        timestamp: context.timestamp,
+        kind: "tool_result".to_string(),
+        actor: "tool".to_string(),
+        name,
+        status: None,
+        target: None,
+        message_seq: context.message_seq,
+        summary,
+        source_path: context.source_path,
+        source_event_id: context.source_event_id,
+        attrs_json: None,
+        parser_version: context.parser_version,
+    }
+}
+
+pub fn target_from_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => non_empty(text),
+        Value::Array(values) => command_target_from_array(values),
+        Value::Object(map) => {
+            for key in [
+                "path",
+                "file_path",
+                "filePath",
+                "target",
+                "command",
+                "cmd",
+                "query",
+                "pattern",
+                "glob",
+                "glob_pattern",
+                "regex",
+                "url",
+            ] {
+                if let Some(text) = map.get(key).and_then(target_from_value) {
+                    return Some(text);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn command_target_from_array(values: &[Value]) -> Option<String> {
+    let parts: Option<Vec<&str>> = values.iter().map(|value| value.as_str()).collect();
+    let parts = parts?;
+    if parts.is_empty() {
+        return None;
+    }
+    if parts.len() >= 3
+        && matches!(parts[0], "bash" | "sh" | "zsh")
+        && matches!(parts[1], "-c" | "-lc")
+    {
+        return non_empty(parts[2]);
+    }
+    non_empty(&parts.join(" "))
+}
+
+fn command_target(name: &str, args: Option<&str>) -> Option<String> {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("bash") || lower.contains("shell") || lower.contains("exec") {
+        return args.and_then(non_empty);
+    }
+    None
+}
+
+fn infer_tool_kind(name: &str, target: Option<&str>) -> &'static str {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("bash") || lower.contains("shell") || lower.contains("exec") {
+        return "command";
+    }
+    if lower.contains("grep")
+        || lower.contains("search")
+        || lower.contains("glob")
+        || lower.contains("find")
+    {
+        return "search";
+    }
+    if target.is_some()
+        && (lower.contains("edit")
+            || lower.contains("write")
+            || lower.contains("patch")
+            || lower.contains("delete"))
+    {
+        return "file_write";
+    }
+    if target.is_some()
+        && (lower.contains("read") || lower.contains("open") || lower.contains("view"))
+    {
+        return "file_read";
+    }
+    "tool_call"
+}
+
+fn non_empty(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -10,6 +10,7 @@ use crate::db::store::Store;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FileScanOptions {
     pub usage_parser_version: Option<u32>,
+    pub event_parser_version: Option<u32>,
 }
 
 pub struct FileScanEntry {
@@ -56,6 +57,10 @@ where
         Some(_) => store.usage_state_meta_map(source_id)?,
         None => Default::default(),
     };
+    let event_state = match options.event_parser_version {
+        Some(_) => store.event_state_meta_map(source_id)?,
+        None => Default::default(),
+    };
     let mut sessions = Vec::new();
     let mut stats = SyncScanStats::default();
 
@@ -78,6 +83,11 @@ where
                 usage_state.get(&entry.session_id).copied(),
                 mtime_ms,
             )
+            && event_state_is_current(
+                options.event_parser_version,
+                event_state.get(&entry.session_id).copied(),
+                mtime_ms,
+            )
         {
             stats.skipped_sessions += 1;
             continue;
@@ -94,6 +104,20 @@ where
 fn usage_state_is_current(
     required_parser_version: Option<u32>,
     state: Option<crate::db::store::UsageSessionStateMeta>,
+    mtime_ms: i64,
+) -> bool {
+    let Some(required_parser_version) = required_parser_version else {
+        return true;
+    };
+    let Some(state) = state else {
+        return false;
+    };
+    state.parser_version >= required_parser_version && state.source_updated_at == Some(mtime_ms)
+}
+
+fn event_state_is_current(
+    required_parser_version: Option<u32>,
+    state: Option<crate::db::store::EventSessionStateMeta>,
     mtime_ms: i64,
 ) -> bool {
     let Some(required_parser_version) = required_parser_version else {
@@ -241,7 +265,7 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: Some(1) },
+            FileScanOptions { usage_parser_version: Some(1), event_parser_version: None },
             vec![entry],
             |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
         )
@@ -267,9 +291,61 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: Some(1) },
+            FileScanOptions { usage_parser_version: Some(1), event_parser_version: None },
             vec![entry],
             |_, _| panic!("current usage state should skip parsing"),
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn matching_mtime_reparses_until_event_state_is_current() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("event-backfill");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        store.insert_session(&make_session("s1", "sess-event", Some(mtime_ms), 1)).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "sess-event".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions { usage_parser_version: None, event_parser_version: Some(1) },
+            vec![entry],
+            |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        store
+            .persist_session_events_for_existing_session(
+                "test-source",
+                "sess-event",
+                &[],
+                1,
+                Some(mtime_ms),
+            )
+            .unwrap();
+        let entry = FileScanEntry {
+            session_id: "sess-event".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions { usage_parser_version: None, event_parser_version: Some(1) },
+            vec![entry],
+            |_, _| panic!("current event state should skip parsing"),
         )
         .unwrap();
         assert_eq!(result.sessions.len(), 0);

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -4,6 +4,7 @@ pub mod cline;
 pub mod codex;
 pub mod copilot;
 pub mod cursor;
+pub mod events;
 pub mod file_scan;
 pub mod gemini;
 pub mod kiro;
@@ -11,7 +12,7 @@ pub mod opencode;
 pub mod pi;
 
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub trait SourceAdapter {
     fn id(&self) -> &str;
@@ -27,6 +28,7 @@ pub trait SourceAdapter {
         &self,
         _store: &Store,
         _since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         Ok(None)
     }
@@ -42,6 +44,8 @@ pub struct RawSession {
     pub messages: Vec<RawMessage>,
     pub usage_events: Vec<RawUsageEvent>,
     pub usage_parser_version: Option<u32>,
+    pub events: Vec<RawSessionEvent>,
+    pub event_parser_version: Option<u32>,
 }
 
 impl RawSession {
@@ -62,12 +66,20 @@ impl RawSession {
             messages,
             usage_events: Vec::new(),
             usage_parser_version: None,
+            events: Vec::new(),
+            event_parser_version: None,
         }
     }
 
     pub fn with_usage(mut self, usage_events: Vec<RawUsageEvent>, parser_version: u32) -> Self {
         self.usage_events = usage_events;
         self.usage_parser_version = Some(parser_version);
+        self
+    }
+
+    pub fn with_events(mut self, events: Vec<RawSessionEvent>, parser_version: u32) -> Self {
+        self.events = events;
+        self.event_parser_version = Some(parser_version);
         self
     }
 }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -4,15 +4,17 @@ use rusqlite::{Connection, OpenFlags, params_from_iter};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::events;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SourceScanSummary, SyncScanResult,
     SyncScanStats,
 };
-use crate::db::store::{Store, UsageSessionStateMeta};
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::db::store::{EventSessionStateMeta, Store, UsageSessionStateMeta};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 const USAGE_PARSER_VERSION: u32 = 1;
+const EVENT_PARSER_VERSION: u32 = 2;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
     AND json_valid(p.data)
@@ -24,6 +26,11 @@ const PARSED_PART_FILTER_SQL: &str = "
             AND json_type(p.data, '$.input') IS NOT NULL)
         OR (json_extract(p.data, '$.type') = 'tool-result'
             AND json_type(p.data, '$.result') IS NOT NULL)
+        OR (json_extract(p.data, '$.type') = 'tool'
+            AND (json_type(p.data, '$.state.input') IS NOT NULL
+                OR json_type(p.data, '$.state.output') IS NOT NULL))
+        OR (json_extract(p.data, '$.type') = 'patch'
+            AND json_type(p.data, '$.files') = 'array')
     )
 ";
 
@@ -61,7 +68,7 @@ impl SourceAdapter for OpenCodeAdapter {
             return Ok(vec![]);
         };
         let sessions = load_session_rows(&conn, None)?;
-        scan_session_messages(&conn, sessions)
+        scan_session_messages(&conn, sessions, true)
     }
 
     fn scan_summary(&self) -> anyhow::Result<Option<SourceScanSummary>> {
@@ -89,12 +96,13 @@ impl SourceAdapter for OpenCodeAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_opencode_db()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
 
-        Ok(Some(scan_for_sync_conn(&conn, store, since_ts, self.id())?))
+        Ok(Some(scan_for_sync_conn(&conn, store, since_ts, self.id(), include_events)?))
     }
 }
 
@@ -177,6 +185,7 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
 fn scan_session_messages(
     conn: &Connection,
     sessions: Vec<SessionRow>,
+    include_events: bool,
 ) -> anyhow::Result<Vec<RawSession>> {
     if sessions.is_empty() {
         return Ok(vec![]);
@@ -185,34 +194,190 @@ fn scan_session_messages(
     let session_ids: Vec<String> = sessions.iter().map(|session| session.id.clone()).collect();
     let mut session_messages: HashMap<String, Vec<RawMessage>> = HashMap::new();
     let mut session_usage_events: HashMap<String, Vec<RawUsageEvent>> = HashMap::new();
+    let mut session_events: HashMap<String, Vec<RawSessionEvent>> = HashMap::new();
 
     for chunk in session_ids.chunks(MAX_SQL_VARS_PER_BATCH) {
         load_message_chunk(conn, chunk, &mut session_messages)?;
         load_usage_chunk(conn, chunk, &mut session_usage_events)?;
+        if include_events {
+            load_event_chunk(conn, chunk, &mut session_events)?;
+        }
     }
 
     let mut raw_sessions = Vec::new();
     for session in sessions {
         let messages = session_messages.remove(&session.id).unwrap_or_default();
         let usage_events = session_usage_events.remove(&session.id).unwrap_or_default();
-        if messages.is_empty() && usage_events.is_empty() {
+        let events = session_events.remove(&session.id).unwrap_or_default();
+        if messages.is_empty() && usage_events.is_empty() && events.is_empty() {
             continue;
         }
 
-        raw_sessions.push(
-            RawSession::search_only(
-                session.id,
-                Some(session.directory),
-                session.time_created,
-                session.time_updated,
-                None,
-                messages,
-            )
-            .with_usage(usage_events, USAGE_PARSER_VERSION),
-        );
+        let raw = RawSession::search_only(
+            session.id,
+            Some(session.directory),
+            session.time_created,
+            session.time_updated,
+            None,
+            messages,
+        )
+        .with_usage(usage_events, USAGE_PARSER_VERSION);
+        raw_sessions.push(if include_events {
+            raw.with_events(events, EVENT_PARSER_VERSION)
+        } else {
+            raw
+        });
     }
 
     Ok(raw_sessions)
+}
+
+fn load_event_chunk(
+    conn: &Connection,
+    session_ids: &[String],
+    session_events: &mut HashMap<String, Vec<RawSessionEvent>>,
+) -> anyhow::Result<()> {
+    let placeholders = std::iter::repeat_n("?", session_ids.len()).collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "SELECT m.session_id, CAST(p.id AS TEXT), p.data, m.time_created
+         FROM message m
+         JOIN part p ON p.message_id = m.id
+         WHERE m.session_id IN ({placeholders})
+           AND json_valid(m.data)
+           AND json_valid(p.data)
+           AND json_extract(m.data, '$.role') = 'assistant'
+           AND json_extract(p.data, '$.type') IN ('tool-invocation', 'tool-result', 'tool', 'patch')
+         ORDER BY m.time_created, p.id"
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(session_ids.iter()), |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<i64>>(3)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (session_id, part_id, part_data, timestamp) = row?;
+        let events = session_events.entry(session_id).or_default();
+        let part_events = parse_part_events(&part_id, &part_data, timestamp, events.len() as u32);
+        events.extend(part_events);
+    }
+
+    Ok(())
+}
+
+fn parse_part_events(
+    part_id: &str,
+    part_data: &str,
+    timestamp: Option<i64>,
+    event_seq: u32,
+) -> Vec<RawSessionEvent> {
+    let Some(part) = serde_json::from_str::<Value>(part_data).ok() else {
+        return Vec::new();
+    };
+    match part.get("type").and_then(|t| t.as_str()) {
+        Some("tool-invocation") => {
+            let name = part.get("toolName").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
+            vec![events::tool_call_event(
+                events::EventContext {
+                    event_seq,
+                    timestamp,
+                    source_path: None,
+                    source_event_id: Some(part_id.to_string()),
+                    message_seq: None,
+                    parser_version: EVENT_PARSER_VERSION,
+                },
+                name,
+                part.get("input"),
+            )]
+        }
+        Some("tool-result") => {
+            let name = part.get("toolName").and_then(|n| n.as_str()).map(String::from);
+            let summary = part.get("result").map(|result| result.to_string());
+            vec![events::tool_result_event(
+                events::EventContext {
+                    event_seq,
+                    timestamp,
+                    source_path: None,
+                    source_event_id: Some(part_id.to_string()),
+                    message_seq: None,
+                    parser_version: EVENT_PARSER_VERSION,
+                },
+                name,
+                summary,
+            )]
+        }
+        Some("tool") => {
+            let name = opencode_tool_name(&part);
+            let Some(state) = part.get("state") else {
+                return Vec::new();
+            };
+            let status = state.get("status").and_then(|status| status.as_str()).map(String::from);
+            let mut part_events = Vec::new();
+
+            if let Some(input) = state.get("input") {
+                let mut event = events::tool_call_event(
+                    events::EventContext {
+                        event_seq,
+                        timestamp,
+                        source_path: None,
+                        source_event_id: Some(format!("{part_id}:input")),
+                        message_seq: None,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name.clone(),
+                    Some(input),
+                );
+                event.status = status.clone();
+                part_events.push(event);
+            }
+
+            if let Some(output) = state.get("output") {
+                let mut event = events::tool_result_event(
+                    events::EventContext {
+                        event_seq: event_seq + part_events.len() as u32,
+                        timestamp,
+                        source_path: None,
+                        source_event_id: Some(format!("{part_id}:output")),
+                        message_seq: None,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    Some(name),
+                    Some(display_json_value(output)),
+                );
+                event.status = status;
+                part_events.push(event);
+            }
+
+            part_events
+        }
+        Some("patch") => {
+            let files = patch_files(&part);
+            let target = files.first().cloned();
+            let summary =
+                if files.is_empty() { None } else { Some(format!("[patch] {}", files.join(", "))) };
+            vec![RawSessionEvent {
+                event_seq,
+                timestamp,
+                kind: "file_write".to_string(),
+                actor: "assistant".to_string(),
+                name: Some("patch".to_string()),
+                status: None,
+                target,
+                message_seq: None,
+                summary,
+                source_path: None,
+                source_event_id: Some(part_id.to_string()),
+                attrs_json: Some(part.to_string()),
+                parser_version: EVENT_PARSER_VERSION,
+            }]
+        }
+        _ => Vec::new(),
+    }
 }
 
 fn load_message_chunk(
@@ -409,7 +574,51 @@ fn parse_part_content(part_data: &str) -> Option<String> {
                 part.get("result").map(|result| format!("[{name}] {result}"))
             }
         }
+        "tool" => {
+            let name = opencode_tool_name(&part);
+            let state = part.get("state")?;
+            match (state.get("input"), state.get("output")) {
+                (Some(input), Some(output)) => Some(format!(
+                    "[{name}] input: {}\noutput: {}",
+                    display_json_value(input),
+                    display_json_value(output)
+                )),
+                (Some(input), None) => Some(format!("[{name}] {}", display_json_value(input))),
+                (None, Some(output)) => Some(format!("[{name}] {}", display_json_value(output))),
+                (None, None) => None,
+            }
+        }
+        "patch" => {
+            let files = patch_files(&part);
+            if files.is_empty() { None } else { Some(format!("[patch] {}", files.join(", "))) }
+        }
         _ => None,
+    }
+}
+
+fn opencode_tool_name(part: &Value) -> String {
+    part.get("tool")
+        .or_else(|| part.get("toolName"))
+        .and_then(|name| name.as_str())
+        .unwrap_or("tool")
+        .to_string()
+}
+
+fn patch_files(part: &Value) -> Vec<String> {
+    part.get("files")
+        .and_then(|files| files.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|file| file.as_str())
+        .filter(|file| !file.trim().is_empty())
+        .map(|file| file.trim().to_string())
+        .collect()
+}
+
+fn display_json_value(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -418,11 +627,14 @@ fn scan_for_sync_conn(
     store: &Store,
     since_ts: Option<i64>,
     source_id: &str,
+    include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
     let sessions = load_session_rows(conn, since_ts)?;
     let existing = store.session_meta_map(source_id)?;
     let usage_state = store.usage_state_meta_map(source_id)?;
+    let event_state =
+        if include_events { store.event_state_meta_map(source_id)? } else { Default::default() };
     let current_counts = load_message_counts(
         conn,
         &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
@@ -440,6 +652,11 @@ fn scan_for_sync_conn(
                     usage_state.get(&session.id).copied(),
                     session.time_updated,
                 )
+                && (!include_events
+                    || event_state_is_current(
+                        event_state.get(&session.id).copied(),
+                        session.time_updated,
+                    ))
             {
                 stats.skipped_sessions += 1;
                 continue;
@@ -448,7 +665,7 @@ fn scan_for_sync_conn(
         candidates.push(session);
     }
 
-    let sessions = scan_session_messages(conn, candidates)?;
+    let sessions = scan_session_messages(conn, candidates, include_events)?;
     Ok(SyncScanResult { sessions, stats })
 }
 
@@ -458,6 +675,15 @@ fn usage_state_is_current(
 ) -> bool {
     state.is_some_and(|state| {
         state.parser_version >= USAGE_PARSER_VERSION && state.source_updated_at == source_updated_at
+    })
+}
+
+fn event_state_is_current(
+    state: Option<EventSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    state.is_some_and(|state| {
+        state.parser_version >= EVENT_PARSER_VERSION && state.source_updated_at == source_updated_at
     })
 }
 
@@ -563,6 +789,18 @@ mod tests {
             .unwrap();
     }
 
+    fn mark_event_current(store: &Store, source_id: &str, updated_at: Option<i64>) {
+        store
+            .persist_session_events_for_existing_session(
+                "opencode",
+                source_id,
+                &[],
+                EVENT_PARSER_VERSION,
+                updated_at,
+            )
+            .unwrap();
+    }
+
     #[test]
     fn incremental_scan_skips_sessions_with_matching_updated_at_and_message_count() {
         let (path, conn) = setup_opencode_db();
@@ -571,8 +809,25 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
         mark_usage_current(&store, "s1", Some(200));
+        mark_event_current(&store, "s1", Some(200));
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        assert!(result.sessions.is_empty());
+        assert_eq!(result.stats.skipped_sessions, 1);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn usage_only_incremental_scan_skips_missing_event_state() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 200, 100, "hello");
+
+        let store = setup_store();
+        store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
+        mark_usage_current(&store, "s1", Some(200));
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", false).unwrap();
         assert!(result.sessions.is_empty());
         assert_eq!(result.stats.skipped_sessions, 1);
         drop(conn);
@@ -591,7 +846,7 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
         assert_eq!(result.stats.skipped_sessions, 0);
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "s1");
@@ -610,8 +865,9 @@ mod tests {
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
         store.insert_session(&make_session("local-s2", "s2", Some(150), 1)).unwrap();
         mark_usage_current(&store, "s2", Some(150));
+        mark_event_current(&store, "s2", Some(150));
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
         assert_eq!(result.stats.skipped_sessions, 1);
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "s1");
@@ -627,7 +883,7 @@ mod tests {
         insert_session_with_message(&conn, "new", 220, 200, "new");
 
         let store = setup_store();
-        let result = scan_for_sync_conn(&conn, &store, Some(200), "opencode").unwrap();
+        let result = scan_for_sync_conn(&conn, &store, Some(200), "opencode", true).unwrap();
 
         assert_eq!(result.stats.filtered_sessions, 1);
         assert_eq!(result.sessions.len(), 1);
@@ -686,7 +942,7 @@ mod tests {
         .unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode").unwrap();
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "good");
@@ -717,5 +973,157 @@ mod tests {
         let parsed = parse_part_content("{\"type\":\"text\",\"text\":\"  hello  \"}");
         assert_eq!(parsed.as_deref(), Some("  hello  "));
         assert_eq!(parse_part_content("{\"type\":\"text\",\"text\":\"   \"}"), None);
+    }
+
+    #[test]
+    fn parse_part_content_includes_current_tool_input_and_output() {
+        let parsed = parse_part_content(
+            r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"src/main.rs"},"output":"needle result"}}"#,
+        );
+
+        let content = parsed.unwrap();
+        assert!(content.contains("\"filePath\":\"src/main.rs\""));
+        assert!(content.contains("needle result"));
+    }
+
+    #[test]
+    fn scan_session_messages_extracts_structured_tool_events() {
+        let (path, conn) = setup_opencode_db();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('s1', 'Test', '/tmp/project', 100, 200)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('s1', '{\"role\":\"assistant\"}', 110)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![
+                message_id,
+                r#"{"type":"tool-invocation","toolName":"readFile","input":{"path":"src/main.rs"}}"#
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![
+                message_id,
+                r#"{"type":"tool-result","toolName":"readFile","result":"file body"}"#
+            ],
+        )
+        .unwrap();
+
+        let sessions = load_session_rows(&conn, None).unwrap();
+        let raw = scan_session_messages(&conn, sessions, true).unwrap();
+
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].events.len(), 2);
+        assert_eq!(raw[0].events[0].kind, "file_read");
+        assert_eq!(raw[0].events[0].name.as_deref(), Some("readFile"));
+        assert_eq!(raw[0].events[0].target.as_deref(), Some("src/main.rs"));
+        assert_eq!(raw[0].events[1].kind, "tool_result");
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scan_session_messages_extracts_current_tool_and_patch_events() {
+        let (path, conn) = setup_opencode_db();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('s1', 'Test', '/tmp/project', 100, 200)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('s1', '{\"role\":\"assistant\"}', 110)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![
+                message_id,
+                r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"src/main.rs"},"output":"file body"}}"#
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![
+                message_id,
+                r#"{"type":"patch","hash":"abc","files":["src/main.rs","README.md"]}"#
+            ],
+        )
+        .unwrap();
+
+        let sessions = load_session_rows(&conn, None).unwrap();
+        let raw = scan_session_messages(&conn, sessions, true).unwrap();
+
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].messages.len(), 2);
+        assert_eq!(raw[0].events.len(), 3);
+        assert_eq!(raw[0].events[0].kind, "file_read");
+        assert_eq!(raw[0].events[0].name.as_deref(), Some("read"));
+        assert_eq!(raw[0].events[0].status.as_deref(), Some("completed"));
+        assert_eq!(raw[0].events[0].target.as_deref(), Some("src/main.rs"));
+        assert_eq!(raw[0].events[1].kind, "tool_result");
+        assert_eq!(raw[0].events[1].name.as_deref(), Some("read"));
+        assert_eq!(raw[0].events[1].status.as_deref(), Some("completed"));
+        assert_eq!(raw[0].events[1].summary.as_deref(), Some("file body"));
+        assert_eq!(raw[0].events[2].kind, "file_write");
+        assert_eq!(raw[0].events[2].name.as_deref(), Some("patch"));
+        assert_eq!(raw[0].events[2].target.as_deref(), Some("src/main.rs"));
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scan_for_sync_omits_events_when_disabled() {
+        let (path, conn) = setup_opencode_db();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('s1', 'Test', '/tmp/project', 100, 200)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('s1', '{\"role\":\"assistant\"}', 110)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
+            rusqlite::params![
+                message_id,
+                r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"src/main.rs"},"output":"file body"}}"#
+            ],
+        )
+        .unwrap();
+        let store = setup_store();
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", false).unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].messages.len(), 1);
+        assert!(result.sessions[0].events.is_empty());
+        assert_eq!(result.sessions[0].event_parser_version, None);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -61,6 +61,7 @@ impl SourceAdapter for PiAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
+        _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let session_dirs = resolve_pi_session_dirs()?;
         if session_dirs.is_empty() {
@@ -178,7 +179,10 @@ fn scan_for_sync_impl(
         store,
         "pi",
         since_ts,
-        file_scan::FileScanOptions { usage_parser_version: Some(USAGE_PARSER_VERSION) },
+        file_scan::FileScanOptions {
+            usage_parser_version: Some(USAGE_PARSER_VERSION),
+            event_parser_version: None,
+        },
         entries,
         parse_pi_session_file,
     )
@@ -270,6 +274,8 @@ fn parse_pi_session_file(
         messages: parsed.messages,
         usage_events: parsed.usage_events,
         usage_parser_version: Some(USAGE_PARSER_VERSION),
+        events: Vec::new(),
+        event_parser_version: None,
     }))
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 5;
 
 #[allow(clippy::missing_transmute_annotations)]
 pub fn register_sqlite_vec() {
@@ -24,6 +24,9 @@ pub fn init(conn: &Connection) -> anyhow::Result<()> {
     }
     if version < 4 {
         migrate_v4(conn)?;
+    }
+    if version < 5 {
+        migrate_v5(conn)?;
     }
     Ok(())
 }
@@ -190,6 +193,60 @@ fn migrate_v4(conn: &Connection) -> anyhow::Result<()> {
         conn.execute_batch("ALTER TABLE usage_events DROP COLUMN cost_source;")?;
     }
     conn.execute_batch("PRAGMA user_version = 4;")?;
+    Ok(())
+}
+
+fn migrate_v5(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS session_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            source TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            event_seq INTEGER NOT NULL,
+            timestamp INTEGER,
+            kind TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            name TEXT,
+            status TEXT,
+            target TEXT,
+            message_seq INTEGER,
+            summary TEXT,
+            source_path TEXT,
+            source_event_id TEXT,
+            attrs_json TEXT,
+            parser_version INTEGER NOT NULL DEFAULT 1,
+            created_at INTEGER NOT NULL,
+            UNIQUE(session_id, event_seq)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_session_events_session
+            ON session_events(session_id, event_seq);
+        CREATE INDEX IF NOT EXISTS idx_session_events_kind_time
+            ON session_events(kind, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_session_events_source_time
+            ON session_events(source, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_session_events_target
+            ON session_events(target);
+
+        CREATE TABLE IF NOT EXISTS event_session_state (
+            session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+            source TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            parser_version INTEGER NOT NULL,
+            source_updated_at INTEGER,
+            event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+            synced_at INTEGER NOT NULL,
+            UNIQUE(source, source_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_event_session_state_source
+            ON event_session_state(source, source_id);
+
+        PRAGMA user_version = 5;
+        ",
+    )?;
     Ok(())
 }
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -7,8 +7,8 @@ use rusqlite::OptionalExtension;
 
 use crate::db::search::TimeRange;
 use crate::types::{
-    BackgroundJobStatus, Message, RawUsageEvent, Role, SemanticProgress, SemanticSessionJob,
-    Session, SessionUsageEventRecord, UsageEventRecord,
+    BackgroundJobStatus, Message, RawSessionEvent, RawUsageEvent, Role, SemanticProgress,
+    SemanticSessionJob, Session, SessionEventRecord, SessionUsageEventRecord, UsageEventRecord,
 };
 use crate::utils::f32_slice_to_bytes;
 
@@ -25,6 +25,12 @@ pub struct ProjectDirectory {
 
 #[derive(Debug, Clone, Copy)]
 pub struct UsageSessionStateMeta {
+    pub parser_version: u32,
+    pub source_updated_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EventSessionStateMeta {
     pub parser_version: u32,
     pub source_updated_at: Option<i64>,
 }
@@ -99,6 +105,27 @@ impl Store {
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
+    pub fn event_state_meta_map(
+        &self,
+        source: &str,
+    ) -> Result<HashMap<String, EventSessionStateMeta>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source_id, parser_version, source_updated_at
+             FROM event_session_state
+             WHERE source = ?1",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![source], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                EventSessionStateMeta {
+                    parser_version: row.get(1)?,
+                    source_updated_at: row.get(2)?,
+                },
+            ))
+        })?;
+        rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
+    }
+
     pub fn insert_session(&self, session: &Session) -> Result<()> {
         self.conn.execute(
             "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint)
@@ -149,6 +176,25 @@ impl Store {
         messages: &[Message],
         usage_events: &[RawUsageEvent],
         usage_parser_version: Option<u32>,
+    ) -> Result<()> {
+        self.persist_session_with_usage_and_events(
+            session,
+            messages,
+            usage_events,
+            usage_parser_version,
+            &[],
+            None,
+        )
+    }
+
+    pub fn persist_session_with_usage_and_events(
+        &self,
+        session: &Session,
+        messages: &[Message],
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: Option<u32>,
+        session_events: &[RawSessionEvent],
+        event_parser_version: Option<u32>,
     ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         {
@@ -267,6 +313,16 @@ impl Store {
                     ],
                 )?;
             }
+
+            replace_session_events(
+                &tx,
+                &session.id,
+                &session.source,
+                &session.source_id,
+                session_events,
+                event_parser_version,
+                session.updated_at,
+            )?;
 
             let units_total: i64 = tx.query_row(
                 "SELECT COUNT(*) FROM messages
@@ -394,6 +450,43 @@ impl Store {
                     usage_events.len() as u32,
                     Utc::now().timestamp_millis(),
                 ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(true)
+    }
+
+    pub fn persist_session_events_for_existing_session(
+        &self,
+        source: &str,
+        source_id: &str,
+        session_events: &[RawSessionEvent],
+        event_parser_version: u32,
+        source_updated_at: Option<i64>,
+    ) -> Result<bool> {
+        let session_id = self
+            .conn
+            .query_row(
+                "SELECT id FROM sessions WHERE source = ?1 AND source_id = ?2",
+                rusqlite::params![source, source_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+
+        let Some(session_id) = session_id else {
+            return Ok(false);
+        };
+
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            replace_session_events(
+                &tx,
+                &session_id,
+                source,
+                source_id,
+                session_events,
+                Some(event_parser_version),
+                source_updated_at,
             )?;
         }
         tx.commit()?;
@@ -846,6 +939,35 @@ impl Store {
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
+    pub fn list_session_events_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<SessionEventRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT event_seq, timestamp, kind, actor, name, status, target,
+                    message_seq, summary, source_path, source_event_id
+             FROM session_events
+             WHERE session_id = ?1
+             ORDER BY event_seq ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![session_id], |row| {
+            Ok(SessionEventRecord {
+                event_seq: row.get(0)?,
+                timestamp: row.get(1)?,
+                kind: row.get(2)?,
+                actor: row.get(3)?,
+                name: row.get(4)?,
+                status: row.get(5)?,
+                target: row.get(6)?,
+                message_seq: row.get(7)?,
+                summary: row.get(8)?,
+                source_path: row.get(9)?,
+                source_event_id: row.get(10)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub fn stats(&self) -> Result<(u64, u64)> {
         self.stats_for_scope(None, TimeRange::All)
     }
@@ -1003,6 +1125,79 @@ impl Store {
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
+}
+
+fn replace_session_events(
+    tx: &rusqlite::Transaction<'_>,
+    session_id: &str,
+    source: &str,
+    source_id: &str,
+    session_events: &[RawSessionEvent],
+    event_parser_version: Option<u32>,
+    source_updated_at: Option<i64>,
+) -> Result<()> {
+    tx.execute("DELETE FROM session_events WHERE session_id = ?1", rusqlite::params![session_id])?;
+
+    let created_at = Utc::now().timestamp_millis();
+    let mut stmt = tx.prepare(
+        "INSERT INTO session_events (
+            session_id, source, source_id, event_seq, timestamp,
+            kind, actor, name, status, target, message_seq, summary,
+            source_path, source_event_id, attrs_json, parser_version, created_at
+         )
+         VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+            ?12, ?13, ?14, ?15, ?16, ?17
+         )",
+    )?;
+    for event in session_events {
+        stmt.execute(rusqlite::params![
+            session_id,
+            source,
+            source_id,
+            event.event_seq,
+            event.timestamp,
+            event.kind,
+            event.actor,
+            event.name,
+            event.status,
+            event.target,
+            event.message_seq,
+            event.summary,
+            event.source_path,
+            event.source_event_id,
+            event.attrs_json,
+            event.parser_version,
+            created_at,
+        ])?;
+    }
+
+    if let Some(parser_version) = event_parser_version {
+        tx.execute(
+            "INSERT INTO event_session_state (
+                session_id, source, source_id, parser_version,
+                source_updated_at, event_count, synced_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(source, source_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                parser_version = excluded.parser_version,
+                source_updated_at = excluded.source_updated_at,
+                event_count = excluded.event_count,
+                synced_at = excluded.synced_at",
+            rusqlite::params![
+                session_id,
+                source,
+                source_id,
+                parser_version,
+                source_updated_at,
+                session_events.len() as u32,
+                Utc::now().timestamp_millis(),
+            ],
+        )?;
+    }
+
+    Ok(())
 }
 
 fn apply_scope_filters(

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 
 use crate::db::search::TimeRange;
 use crate::db::store::Store;
-use crate::types::{Message, Role, Session, SessionUsageEventRecord};
+use crate::types::{Message, Role, Session, SessionEventRecord, SessionUsageEventRecord};
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const RECORD_TYPE: &str = "session";
 
 pub struct ExportOptions {
@@ -24,6 +24,7 @@ struct ExportSessionRecord {
     session: ExportSession,
     messages: Vec<ExportMessage>,
     usage_events: Vec<ExportUsageEvent>,
+    events: Vec<ExportEvent>,
 }
 
 #[derive(Serialize)]
@@ -63,6 +64,21 @@ struct ExportUsageEvent {
     token_source: String,
 }
 
+#[derive(Serialize)]
+struct ExportEvent {
+    event_seq: u32,
+    timestamp: Option<i64>,
+    kind: String,
+    actor: String,
+    name: Option<String>,
+    status: Option<String>,
+    target: Option<String>,
+    message_seq: Option<u32>,
+    summary: Option<String>,
+    source_path: Option<String>,
+    source_event_id: Option<String>,
+}
+
 pub fn write_jsonl<W: Write>(store: &Store, options: &ExportOptions, mut writer: W) -> Result<()> {
     let sessions = store.list_export_sessions(
         options.sources.as_deref(),
@@ -74,12 +90,14 @@ pub fn write_jsonl<W: Write>(store: &Store, options: &ExportOptions, mut writer:
     for session in sessions {
         let messages = store.get_messages(&session.id)?;
         let usage_events = store.list_usage_events_for_session(&session.id)?;
+        let events = store.list_session_events_for_session(&session.id)?;
         let record = ExportSessionRecord {
             schema_version: SCHEMA_VERSION,
             record_type: RECORD_TYPE,
             session: session.into(),
             messages: messages.into_iter().map(Into::into).collect(),
             usage_events: usage_events.into_iter().map(Into::into).collect(),
+            events: events.into_iter().map(Into::into).collect(),
         };
         serde_json::to_writer(&mut writer, &record)?;
         writer.write_all(b"\n")?;
@@ -129,6 +147,24 @@ impl From<SessionUsageEventRecord> for ExportUsageEvent {
             cache_write_tokens: event.cache_write_tokens,
             reasoning_tokens: event.reasoning_tokens,
             token_source: event.token_source,
+        }
+    }
+}
+
+impl From<SessionEventRecord> for ExportEvent {
+    fn from(event: SessionEventRecord) -> Self {
+        Self {
+            event_seq: event.event_seq,
+            timestamp: event.timestamp,
+            kind: event.kind,
+            actor: event.actor,
+            name: event.name,
+            status: event.status,
+            target: event.target,
+            message_seq: event.message_seq,
+            summary: event.summary,
+            source_path: event.source_path,
+            source_event_id: event.source_event_id,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use recall::adapters;
 use recall::config::AppConfig;
 use recall::db;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
-use recall::db::store::{Store, UsageSessionStateMeta};
+use recall::db::store::{EventSessionStateMeta, Store, UsageSessionStateMeta};
 use recall::embedding::EmbeddingProvider;
 use recall::export::ExportOptions;
 use recall::semantic;
@@ -333,6 +333,19 @@ struct SyncRunOptions {
     usage_only: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BackfillPlan {
+    usage: bool,
+    events: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExistingSessionAction {
+    Skip,
+    BackfillOnly(BackfillPlan),
+    RefreshSession,
+}
+
 fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let store = Store::open()?;
     let all = adapters::all_adapters();
@@ -369,7 +382,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         let optimized = if options.force {
             None
         } else {
-            match adapter.scan_for_sync(&store, since_ts) {
+            match adapter.scan_for_sync(&store, since_ts, !options.usage_only) {
                 Ok(scan) => scan,
                 Err(e) => {
                     if options.emit {
@@ -404,6 +417,11 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
 
         let mut existing_meta = store.session_meta_map(source_id)?;
         let mut existing_usage_meta = store.usage_state_meta_map(source_id)?;
+        let mut existing_event_meta = if options.usage_only {
+            Default::default()
+        } else {
+            store.event_state_meta_map(source_id)?
+        };
 
         for raw in raw_sessions {
             if let Some(cutoff) = since_ts {
@@ -414,45 +432,88 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 }
             }
 
+            let raw_source_id = raw.source_id.clone();
             let msg_count = raw.messages.len() as u32;
             let usage_backfill_needed = raw.usage_parser_version.is_some_and(|version| {
                 !usage_state_is_current(
                     version,
-                    existing_usage_meta.get(&raw.source_id).copied(),
+                    existing_usage_meta.get(&raw_source_id).copied(),
                     raw.updated_at,
                 )
             });
+            let event_backfill_needed = !options.usage_only
+                && raw.event_parser_version.is_some_and(|version| {
+                    !event_state_is_current(
+                        version,
+                        existing_event_meta.get(&raw_source_id).copied(),
+                        raw.updated_at,
+                    )
+                });
 
-            match existing_meta.get(&raw.source_id) {
+            match existing_meta.get(&raw_source_id) {
                 Some(&(old_updated_at, old_msg_count)) => {
                     let content_changed = old_msg_count != msg_count
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
-                    if !content_changed && usage_backfill_needed && !options.force {
-                        if let Some(parser_version) = raw.usage_parser_version
-                            && store.persist_usage_events_for_existing_session(
-                                source_id,
-                                &raw.source_id,
-                                &raw.usage_events,
-                                parser_version,
-                                raw.updated_at,
-                            )?
-                        {
-                            existing_usage_meta.insert(
-                                raw.source_id.clone(),
-                                UsageSessionStateMeta {
-                                    parser_version,
-                                    source_updated_at: raw.updated_at,
-                                },
-                            );
-                            reprocessed_sessions += 1;
+                    match decide_existing_session_action(
+                        options.usage_only,
+                        options.force,
+                        content_changed,
+                        usage_backfill_needed,
+                        event_backfill_needed,
+                    ) {
+                        ExistingSessionAction::Skip => {
+                            skipped += 1;
+                            continue;
                         }
-                        continue;
+                        ExistingSessionAction::BackfillOnly(plan) => {
+                            let mut reprocessed = false;
+                            if plan.usage
+                                && let Some(parser_version) = raw.usage_parser_version
+                                && store.persist_usage_events_for_existing_session(
+                                    source_id,
+                                    &raw_source_id,
+                                    &raw.usage_events,
+                                    parser_version,
+                                    raw.updated_at,
+                                )?
+                            {
+                                existing_usage_meta.insert(
+                                    raw.source_id.clone(),
+                                    UsageSessionStateMeta {
+                                        parser_version,
+                                        source_updated_at: raw.updated_at,
+                                    },
+                                );
+                                reprocessed = true;
+                            }
+                            if plan.events
+                                && let Some(parser_version) = raw.event_parser_version
+                                && store.persist_session_events_for_existing_session(
+                                    source_id,
+                                    &raw_source_id,
+                                    &raw.events,
+                                    parser_version,
+                                    raw.updated_at,
+                                )?
+                            {
+                                existing_event_meta.insert(
+                                    raw.source_id.clone(),
+                                    EventSessionStateMeta {
+                                        parser_version,
+                                        source_updated_at: raw.updated_at,
+                                    },
+                                );
+                                reprocessed = true;
+                            }
+                            if reprocessed {
+                                reprocessed_sessions += 1;
+                            }
+                            continue;
+                        }
+                        ExistingSessionAction::RefreshSession => {}
                     }
-                    if !content_changed && !options.force {
-                        skipped += 1;
-                        continue;
-                    }
-                    store.delete_session_data(source_id, &raw.source_id)?;
+                    store.delete_session_data(source_id, &raw_source_id)?;
+                    existing_event_meta.remove(&raw_source_id);
                     if content_changed {
                         updated_sessions += 1;
                     } else {
@@ -492,11 +553,19 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 })
                 .collect();
 
-            store.persist_session_with_usage(
+            let (events, event_parser_version) = if options.usage_only {
+                (Vec::new(), None)
+            } else {
+                (raw.events, raw.event_parser_version)
+            };
+
+            store.persist_session_with_usage_and_events(
                 &session,
                 &messages,
                 &raw.usage_events,
                 raw.usage_parser_version,
+                &events,
+                event_parser_version,
             )?;
             existing_meta
                 .insert(session.source_id.clone(), (session.updated_at, session.message_count));
@@ -504,6 +573,12 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 existing_usage_meta.insert(
                     session.source_id.clone(),
                     UsageSessionStateMeta { parser_version, source_updated_at: session.updated_at },
+                );
+            }
+            if let Some(parser_version) = event_parser_version {
+                existing_event_meta.insert(
+                    session.source_id.clone(),
+                    EventSessionStateMeta { parser_version, source_updated_at: session.updated_at },
                 );
             }
             total_messages += msg_count;
@@ -570,6 +645,46 @@ fn usage_state_is_current(
         state.parser_version >= required_parser_version
             && state.source_updated_at == source_updated_at
     })
+}
+
+fn event_state_is_current(
+    required_parser_version: u32,
+    state: Option<EventSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    state.is_some_and(|state| {
+        state.parser_version >= required_parser_version
+            && state.source_updated_at == source_updated_at
+    })
+}
+
+fn decide_existing_session_action(
+    usage_only: bool,
+    force: bool,
+    content_changed: bool,
+    usage_backfill_needed: bool,
+    event_backfill_needed: bool,
+) -> ExistingSessionAction {
+    if usage_only {
+        return if usage_backfill_needed {
+            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: false })
+        } else {
+            ExistingSessionAction::Skip
+        };
+    }
+
+    if !content_changed && !force {
+        return if usage_backfill_needed || event_backfill_needed {
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: usage_backfill_needed,
+                events: event_backfill_needed,
+            })
+        } else {
+            ExistingSessionAction::Skip
+        };
+    }
+
+    ExistingSessionAction::RefreshSession
 }
 
 fn cmd_background_worker(sync_first: bool) -> Result<()> {
@@ -952,4 +1067,41 @@ fn generate_title(messages: &[adapters::RawMessage]) -> String {
     let user_contents: Vec<&str> =
         messages.iter().filter(|m| m.role == Role::User).map(|m| m.content.as_str()).collect();
     utils::title_from_user_messages(&user_contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackfillPlan, ExistingSessionAction, decide_existing_session_action};
+
+    #[test]
+    fn usage_only_never_refreshes_existing_session() {
+        assert_eq!(
+            decide_existing_session_action(true, false, true, true, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: false })
+        );
+        assert_eq!(
+            decide_existing_session_action(true, false, true, false, true),
+            ExistingSessionAction::Skip
+        );
+    }
+
+    #[test]
+    fn full_sync_refreshes_changed_existing_session() {
+        assert_eq!(
+            decide_existing_session_action(false, false, true, true, true),
+            ExistingSessionAction::RefreshSession
+        );
+    }
+
+    #[test]
+    fn full_sync_backfills_unchanged_existing_session_in_place() {
+        assert_eq!(
+            decide_existing_session_action(false, false, false, true, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: true })
+        );
+        assert_eq!(
+            decide_existing_session_action(false, false, false, false, false),
+            ExistingSessionAction::Skip
+        );
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,6 +98,23 @@ pub struct RawUsageEvent {
 }
 
 #[derive(Debug, Clone)]
+pub struct RawSessionEvent {
+    pub event_seq: u32,
+    pub timestamp: Option<i64>,
+    pub kind: String,
+    pub actor: String,
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub target: Option<String>,
+    pub message_seq: Option<u32>,
+    pub summary: Option<String>,
+    pub source_path: Option<String>,
+    pub source_event_id: Option<String>,
+    pub attrs_json: Option<String>,
+    pub parser_version: u32,
+}
+
+#[derive(Debug, Clone)]
 pub struct UsageEventRecord {
     pub session_id: String,
     pub source: String,
@@ -112,6 +129,21 @@ pub struct UsageEventRecord {
     pub cache_write_tokens: i64,
     pub reasoning_tokens: i64,
     pub token_source: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionEventRecord {
+    pub event_seq: u32,
+    pub timestamp: Option<i64>,
+    pub kind: String,
+    pub actor: String,
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub target: Option<String>,
+    pub message_seq: Option<u32>,
+    pub summary: Option<String>,
+    pub source_path: Option<String>,
+    pub source_event_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -6,7 +6,7 @@ use recall::db::schema;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::Store;
 use recall::export::{ExportOptions, write_jsonl};
-use recall::types::{Message, RawUsageEvent, Role, Session, TokenSource};
+use recall::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource};
 use recall::usage::{UsageFilters, build_usage_report};
 
 fn setup() -> Store {
@@ -55,6 +55,24 @@ fn make_usage_event(key: &str, timestamp: i64, model: &str) -> RawUsageEvent {
         parser_version: 1,
         source_path: Some("/tmp/source.jsonl".to_string()),
         raw_usage_json: Some(r#"{"input_tokens":10}"#.to_string()),
+    }
+}
+
+fn make_session_event(kind: &str, name: Option<&str>, target: Option<&str>) -> RawSessionEvent {
+    RawSessionEvent {
+        event_seq: 0,
+        timestamp: Some(1_800_000_001_000),
+        kind: kind.to_string(),
+        actor: "assistant".to_string(),
+        name: name.map(String::from),
+        status: None,
+        target: target.map(String::from),
+        message_seq: Some(1),
+        summary: Some("event summary".to_string()),
+        source_path: Some("/tmp/source.jsonl".to_string()),
+        source_event_id: Some("42".to_string()),
+        attrs_json: Some(r#"{"path":"src/main.rs"}"#.to_string()),
+        parser_version: 1,
     }
 }
 
@@ -195,6 +213,33 @@ fn delete_session_cascades_usage_events() {
 }
 
 #[test]
+fn persist_session_writes_session_events_and_state() {
+    let store = setup();
+    let session = make_session("s1", "codex", "raw1", "Event session");
+    let messages = vec![make_message("s1", Role::Assistant, "[read_file] src/main.rs", 0)];
+    let events = vec![make_session_event("file_read", Some("read_file"), Some("src/main.rs"))];
+
+    store
+        .persist_session_with_usage_and_events(&session, &messages, &[], None, &events, Some(1))
+        .unwrap();
+
+    let count: i64 =
+        store.conn.query_row("SELECT COUNT(*) FROM session_events", [], |row| row.get(0)).unwrap();
+    assert_eq!(count, 1);
+    let state_count: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM event_session_state", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(state_count, 1);
+
+    let loaded = store.list_session_events_for_session("s1").unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].kind, "file_read");
+    assert_eq!(loaded[0].name.as_deref(), Some("read_file"));
+    assert_eq!(loaded[0].target.as_deref(), Some("src/main.rs"));
+}
+
+#[test]
 fn export_jsonl_emits_session_messages_and_usage_events() {
     let store = setup();
     let mut session = make_session("s1", "codex", "raw1", "Export session");
@@ -207,7 +252,17 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
         make_message("s1", Role::Assistant, "hi", 1),
     ];
     let usage = vec![make_usage_event("evt-1", 1_800_000_001_000, "gpt-5")];
-    store.persist_session_with_usage(&session, &messages, &usage, Some(1)).unwrap();
+    let events = vec![make_session_event("file_read", Some("read_file"), Some("src/main.rs"))];
+    store
+        .persist_session_with_usage_and_events(
+            &session,
+            &messages,
+            &usage,
+            Some(1),
+            &events,
+            Some(1),
+        )
+        .unwrap();
 
     let options =
         ExportOptions { sources: None, time_range: TimeRange::All, project: None, limit: Some(10) };
@@ -218,7 +273,7 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     let lines: Vec<_> = text.lines().collect();
     assert_eq!(lines.len(), 1);
     let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["schema_version"], 2);
     assert_eq!(value["record_type"], "session");
     assert_eq!(value["session"]["source"], "codex");
     assert_eq!(value["session"]["source_id"], "raw1");
@@ -232,6 +287,11 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     assert_eq!(value["usage_events"][0]["model"], "gpt-5");
     assert_eq!(value["usage_events"][0]["token_source"], "observed");
     assert!(value["usage_events"][0].get("raw_usage_json").is_none());
+    assert_eq!(value["events"][0]["kind"], "file_read");
+    assert_eq!(value["events"][0]["name"], "read_file");
+    assert_eq!(value["events"][0]["target"], "src/main.rs");
+    assert_eq!(value["events"][0]["message_seq"], 1);
+    assert!(value["events"][0].get("attrs_json").is_none());
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- Add normalized session event extraction for Codex, Claude Code, and OpenCode tool calls/results.
- Add SQLite schema v5 event tables plus event backfill state and sync handling.
- Include session events in JSONL exports and regression coverage.
- Size note: this exceeds the normal PR size budget because parser, storage, sync, export, and tests must land together for a coherent event index.

### Why

- Recall needs a first-class event timeline alongside messages and usage events so exports and analysis can inspect tool activity without depending on source-specific raw JSON.
