### PR TITLE
[Feat] Open Codex sessions in app

### DIFF
--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -34,6 +34,10 @@ impl SourceAdapter for CodexAdapter {
         })
     }
 
+    fn app_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(open_url_command(codex_thread_url(source_id)))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }
@@ -69,6 +73,28 @@ impl SourceAdapter for CodexAdapter {
         let result = scan_for_sync_impl(&codex_dir, store, since_ts, include_events)?;
         Ok(Some(result))
     }
+}
+
+fn codex_thread_url(source_id: &str) -> String {
+    format!("codex://threads/{source_id}")
+}
+
+#[cfg(target_os = "macos")]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand { program: "open".to_string(), args: vec![url] }
+}
+
+#[cfg(target_os = "windows")]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand {
+        program: "cmd".to_string(),
+        args: vec!["/C".to_string(), "start".to_string(), String::new(), url],
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand { program: "xdg-open".to_string(), args: vec![url] }
 }
 
 fn resolve_codex_dir() -> anyhow::Result<Option<PathBuf>> {
@@ -844,6 +870,18 @@ mod tests {
     fn setup_store() -> Store {
         schema::register_sqlite_vec();
         Store::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn codex_app_command_opens_thread_deeplink() {
+        let command = CodexAdapter.app_command("019e6d8d-588b-7fd2-a326-c525469ed120").unwrap();
+
+        assert!(
+            command
+                .args
+                .iter()
+                .any(|arg| arg == "codex://threads/019e6d8d-588b-7fd2-a326-c525469ed120")
+        );
     }
 
     fn temp_codex_root(label: &str) -> PathBuf {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -33,6 +33,9 @@ pub trait SourceAdapter {
         Ok(None)
     }
     fn resume_command(&self, source_id: &str) -> Option<ResumeCommand>;
+    fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        None
+    }
 }
 
 pub struct RawSession {
@@ -142,6 +145,10 @@ pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
 
 pub fn resume_command_for(source: &str, source_id: &str) -> Option<ResumeCommand> {
     all_adapters().iter().find(|a| a.id() == source).and_then(|a| a.resume_command(source_id))
+}
+
+pub fn app_command_for(source: &str, source_id: &str) -> Option<ResumeCommand> {
+    all_adapters().iter().find(|a| a.id() == source).and_then(|a| a.app_command(source_id))
 }
 
 pub fn source_labels() -> Vec<(String, String)> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::adapters::{ResumeCommand, resume_command_for};
+use crate::adapters::{ResumeCommand, app_command_for, resume_command_for};
 use crate::config::AppConfig;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::{ProjectDirectory, Store};
@@ -100,6 +100,52 @@ mod tests {
             usage_time_filter: TimeRange::All,
             usage_refresh_requested_at: None,
         }
+    }
+
+    fn codex_search_result() -> SearchResult {
+        SearchResult {
+            session: crate::types::Session {
+                id: "session1".to_string(),
+                source: "codex".to_string(),
+                source_id: "019e6d8d-588b-7fd2-a326-c525469ed120".to_string(),
+                title: "Codex thread".to_string(),
+                directory: Some("/tmp/project".to_string()),
+                started_at: 0,
+                updated_at: None,
+                message_count: 1,
+                entrypoint: None,
+            },
+            match_source: MatchSource::Fts,
+            snippet: None,
+        }
+    }
+
+    #[test]
+    fn ctrl_o_from_search_confirms_codex_app_open() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let engine = SearchEngine::new(&store.conn);
+        let mut provider = None;
+        let mut app = app_with_sources();
+        app.results = vec![codex_search_result()];
+
+        app.handle_search_key(
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+            &store,
+            &engine,
+            &mut provider,
+        );
+
+        assert!(matches!(app.mode, AppMode::ConfirmResume));
+        let pending = app.pending_resume.as_ref().unwrap();
+        assert!(matches!(pending.action, PendingCommandAction::OpenApp));
+        assert!(
+            pending
+                .command
+                .args
+                .iter()
+                .any(|arg| arg == "codex://threads/019e6d8d-588b-7fd2-a326-c525469ed120")
+        );
     }
 
     #[test]
@@ -210,8 +256,15 @@ pub enum ResumeOrigin {
     Viewing,
 }
 
+#[derive(Clone, Copy)]
+pub enum PendingCommandAction {
+    Resume,
+    OpenApp,
+}
+
 pub struct PendingResume {
     pub command: ResumeCommand,
+    pub action: PendingCommandAction,
     pub source_label: String,
     pub session_title: String,
     pub cwd: Option<String>,
@@ -651,6 +704,11 @@ impl App {
             return;
         }
 
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
+            self.start_app_open_confirmation(ResumeOrigin::Search);
+            return;
+        }
+
         match key.code {
             KeyCode::Char('q')
                 if self.query.is_empty() && self.panel_focus == PanelFocus::SessionList =>
@@ -755,6 +813,10 @@ impl App {
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('r') {
             self.start_resume_confirmation(ResumeOrigin::Viewing);
+            return;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
+            self.start_app_open_confirmation(ResumeOrigin::Viewing);
             return;
         }
         match key.code {
@@ -915,16 +977,34 @@ impl App {
     }
 
     fn start_resume_confirmation(&mut self, origin: ResumeOrigin) {
+        self.start_command_confirmation(origin, PendingCommandAction::Resume);
+    }
+
+    fn start_app_open_confirmation(&mut self, origin: ResumeOrigin) {
+        self.start_command_confirmation(origin, PendingCommandAction::OpenApp);
+    }
+
+    fn start_command_confirmation(&mut self, origin: ResumeOrigin, action: PendingCommandAction) {
         let Some(result) = self.results.get(self.selected_index) else {
             return;
         };
         let session = &result.session;
-        let Some(command) = resume_command_for(&session.source, &session.source_id) else {
-            self.status_message = Some(format!("Resume not supported for {}", session.source));
+        let command = match action {
+            PendingCommandAction::Resume => resume_command_for(&session.source, &session.source_id),
+            PendingCommandAction::OpenApp => app_command_for(&session.source, &session.source_id),
+        };
+        let Some(command) = command else {
+            let action_label = match action {
+                PendingCommandAction::Resume => "Resume",
+                PendingCommandAction::OpenApp => "Open in app",
+            };
+            self.status_message =
+                Some(format!("{action_label} not supported for {}", session.source));
             return;
         };
         self.pending_resume = Some(PendingResume {
             command,
+            action,
             source_label: self.source_label_for(&session.source).to_string(),
             session_title: session.title.clone(),
             cwd: session.directory.clone(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,8 +10,8 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
 use crate::tui::app::{
-    App, AppMode, FilterFocus, PanelFocus, ProjectPickerRow, ResumeOrigin, SanitizedLine,
-    SourcePickerRow,
+    App, AppMode, FilterFocus, PanelFocus, PendingCommandAction, ProjectPickerRow, ResumeOrigin,
+    SanitizedLine, SourcePickerRow,
 };
 use crate::types::{MatchSource, Role};
 use crate::usage::{TokenTotals, UsageReport};
@@ -1006,6 +1006,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" export  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
         Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Ctrl+O", Style::default().fg(Color::Yellow)),
+        Span::styled(" app  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Esc", Style::default().fg(Color::Yellow)),
         Span::styled(" back  ", Style::default().fg(Color::DarkGray)),
         Span::styled("q", Style::default().fg(Color::Yellow)),
@@ -1323,8 +1325,17 @@ fn render_confirm_resume(f: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(height)) / 2;
     let popup = Rect::new(x, y, width, height);
 
+    let block_title = match pending.action {
+        PendingCommandAction::Resume => " Resume session ",
+        PendingCommandAction::OpenApp => " Open in app ",
+    };
+    let confirm_label = match pending.action {
+        PendingCommandAction::Resume => "confirm & exec     ",
+        PendingCommandAction::OpenApp => "confirm & open     ",
+    };
+
     let block = Block::default()
-        .title(" Resume session ")
+        .title(block_title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
         .style(Style::default().bg(Color::Black));
@@ -1369,7 +1380,7 @@ fn render_confirm_resume(f: &mut Frame, app: &App) {
         Line::from(""),
         Line::from(vec![
             Span::styled("  [Y] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-            Span::styled("confirm & exec     ", Style::default().fg(Color::White)),
+            Span::styled(confirm_label, Style::default().fg(Color::White)),
             Span::styled("[N] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
             Span::styled("cancel", Style::default().fg(Color::White)),
         ]),
@@ -1425,6 +1436,8 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled(" filter  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
                     Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("Ctrl+O", Style::default().fg(Color::Yellow)),
+                    Span::styled(" app  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Ctrl+S", Style::default().fg(Color::Yellow)),
                     Span::styled(" settings  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Esc", Style::default().fg(Color::Yellow)),


### PR DESCRIPTION
### What's changed?

- Add a Codex app opener command that targets `codex://threads/{id}`.
- Add `Ctrl+O` in TUI search and detail views to confirm and open supported Codex sessions in the app.
- Reuse the existing confirmation flow with app-specific copy.

### Why

- Lets users jump from Recall search results back into the original Codex App thread.
