### PR TITLE
[Feat] Cursor/Gemini usage indexing and usage breakdown UI

### DIFF
--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -9,19 +9,39 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::Store;
-use crate::types::Role;
+use crate::db::store::{Store, UsageSessionStateMeta};
+use crate::types::{RawUsageEvent, Role, TokenSource};
 
 pub struct CursorAdapter;
+
+const USAGE_PARSER_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+struct ComposerMeta {
+    name: Option<String>,
+    unified_mode: Option<String>,
+    directory: Option<String>,
+    created_at: Option<i64>,
+    last_updated_at: Option<i64>,
+}
+
+struct ParsedComposerSession {
+    messages: Vec<RawMessage>,
+    usage_events: Vec<RawUsageEvent>,
+    started_at: i64,
+    updated_at: Option<i64>,
+    entrypoint: Option<String>,
+    directory: Option<String>,
+}
 
 impl SourceAdapter for CursorAdapter {
     fn id(&self) -> &str {
         "cursor"
     }
+
     fn label(&self) -> &str {
         "CUR"
     }
@@ -30,21 +50,12 @@ impl SourceAdapter for CursorAdapter {
         None
     }
 
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let Some(projects_dir) = resolve_projects_dir()? else {
-            return Ok(vec![]);
-        };
-        let cwd_map = build_cwd_map(resolve_state_db_path().as_deref());
-        let mut sessions = Vec::new();
-        for entry in collect_cursor_entries(&projects_dir) {
-            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
-                continue;
-            };
-            if let Some(raw) = parse_cursor_session_for_entry(entry, mtime_ms, &cwd_map)? {
-                sessions.push(raw);
-            }
-        }
-        Ok(sessions)
+        scan_cursor_sessions(None)
     }
 
     fn scan_for_sync(
@@ -53,93 +64,580 @@ impl SourceAdapter for CursorAdapter {
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        let Some(projects_dir) = resolve_projects_dir()? else {
+        let Some(conn) = open_global_db()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
-        let cwd_map = build_cwd_map(resolve_state_db_path().as_deref());
-        let entries = collect_cursor_entries(&projects_dir);
-        let result =
-            file_scan::run_file_scan(store, "cursor", since_ts, entries, |entry, mtime_ms| {
-                parse_cursor_session_for_entry(entry, mtime_ms, &cwd_map)
-            })?;
-        Ok(Some(result))
+
+        let existing = store.session_meta_map(self.id())?;
+        let usage_state = store.usage_state_meta_map(self.id())?;
+        let global_mtime = global_db_mtime();
+        let composer_ids = discover_composer_ids(&conn)?;
+        let transcript_paths = collect_agent_transcript_paths();
+        let mut sessions = Vec::new();
+        let mut stats = SyncScanStats::default();
+
+        for composer_id in composer_ids {
+            let meta = load_composer_meta(&conn, &composer_id);
+            let updated_at = meta.last_updated_at.or(meta.created_at);
+            if let Some(cutoff) = since_ts
+                && updated_at.is_some_and(|ts| ts < cutoff)
+            {
+                stats.filtered_sessions += 1;
+                continue;
+            }
+
+            let source_updated_at = updated_at.or(global_mtime);
+            if let Some((old_updated_at, _)) = existing.get(&composer_id)
+                && *old_updated_at == source_updated_at
+                && usage_state_is_current(
+                    usage_state.get(&composer_id).copied(),
+                    source_updated_at,
+                )
+            {
+                stats.skipped_sessions += 1;
+                continue;
+            }
+
+            if let Some(raw) = build_raw_session(&conn, &composer_id, &meta, &transcript_paths)? {
+                sessions.push(raw);
+            }
+        }
+
+        Ok(Some(SyncScanResult { sessions, stats }))
     }
 }
 
-fn resolve_projects_dir() -> anyhow::Result<Option<PathBuf>> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    let dir = home.join(".cursor").join("projects");
-    if !dir.exists() {
-        debug!("~/.cursor/projects not found, skipping Cursor");
-        return Ok(None);
+fn scan_cursor_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<RawSession>> {
+    let Some(conn) = open_global_db()? else {
+        return scan_transcript_only_sessions(since_ts);
+    };
+
+    let transcript_paths = collect_agent_transcript_paths();
+    let mut sessions = Vec::new();
+    for composer_id in discover_composer_ids(&conn)? {
+        let meta = load_composer_meta(&conn, &composer_id);
+        if let Some(cutoff) = since_ts {
+            let updated_at = meta.last_updated_at.or(meta.created_at).unwrap_or(0);
+            if updated_at < cutoff {
+                continue;
+            }
+        }
+        if let Some(raw) = build_raw_session(&conn, &composer_id, &meta, &transcript_paths)? {
+            sessions.push(raw);
+        }
     }
-    Ok(Some(dir))
+    Ok(sessions)
 }
 
-fn resolve_state_db_path() -> Option<PathBuf> {
-    let db = dirs::config_dir()?.join("Cursor/User/globalStorage/state.vscdb");
-    if db.exists() { Some(db) } else { None }
-}
-
-fn collect_cursor_entries(projects_dir: &Path) -> Vec<FileScanEntry> {
-    let mut entries = Vec::new();
-    for walk_entry in WalkDir::new(projects_dir).into_iter().filter_map(|e| e.ok()) {
-        let path = walk_entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+fn scan_transcript_only_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<RawSession>> {
+    let Some(projects_dir) = resolve_projects_dir()? else {
+        return Ok(vec![]);
+    };
+    let cwd_map = build_agent_cwd_map(resolve_global_state_db_path().as_deref());
+    let mut sessions = Vec::new();
+    for (session_id, path) in collect_agent_transcript_paths_from_dir(&projects_dir) {
+        let Some(mtime_ms) = stat_mtime_ms(&path) else {
             continue;
         };
-        if uuid::Uuid::try_parse(stem).is_err() {
+        if let Some(cutoff) = since_ts
+            && mtime_ms < cutoff
+        {
             continue;
         }
-        let parent_name = path.parent().and_then(|p| p.file_name()).and_then(|n| n.to_str());
-        if parent_name != Some(stem) {
-            continue;
-        }
-        let grandparent_name = path
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str());
-        if grandparent_name != Some("agent-transcripts") {
-            continue;
-        }
-        entries.push(FileScanEntry {
-            session_id: stem.to_string(),
-            stat_target: path.to_path_buf(),
-            directory: None,
-        });
+        let mut raw = match parse_agent_transcript(&path)? {
+            Some(raw) => raw,
+            None => continue,
+        };
+        raw.source_id = session_id;
+        raw.directory = cwd_map.get(&raw.source_id).cloned();
+        raw.started_at = stat_birth_ms(&path).unwrap_or(mtime_ms);
+        raw.updated_at = Some(mtime_ms);
+        sessions.push(raw);
     }
-    entries
+    Ok(sessions)
 }
 
-fn parse_cursor_session_for_entry(
-    entry: FileScanEntry,
-    mtime_ms: i64,
-    cwd_map: &HashMap<String, String>,
+fn build_raw_session(
+    conn: &Connection,
+    composer_id: &str,
+    meta: &ComposerMeta,
+    transcript_paths: &HashMap<String, PathBuf>,
 ) -> anyhow::Result<Option<RawSession>> {
-    let path = &entry.stat_target;
-    let mut raw = match parse_cursor_session(path) {
-        Ok(Some(raw)) => raw,
-        Ok(None) => return Ok(None),
-        Err(e) => {
-            debug!("failed to parse cursor session {}: {e}", path.display());
+    let parsed = match parse_composer_session(conn, composer_id, meta)? {
+        Some(parsed) if !parsed.messages.is_empty() || !parsed.usage_events.is_empty() => parsed,
+        _ => {
+            let Some(path) = transcript_paths.get(composer_id) else {
+                return Ok(None);
+            };
+            let mtime_ms = stat_mtime_ms(path).unwrap_or(0);
+            let raw = parse_agent_transcript(path)?.filter(|raw| !raw.messages.is_empty());
+            let Some(mut raw) = raw else {
+                return Ok(None);
+            };
+            raw.source_id = composer_id.to_string();
+            raw.directory = meta.directory.clone().or(raw.directory);
+            raw.started_at = stat_birth_ms(path).unwrap_or(mtime_ms);
+            raw.updated_at = Some(mtime_ms);
+            raw.entrypoint = meta.unified_mode.clone().or(raw.entrypoint);
+            return Ok(Some(raw));
+        }
+    };
+
+    Ok(Some(
+        RawSession::search_only(
+            composer_id.to_string(),
+            parsed.directory.or(meta.directory.clone()),
+            parsed.started_at,
+            parsed.updated_at,
+            parsed.entrypoint.or(meta.unified_mode.clone()),
+            parsed.messages,
+        )
+        .with_usage(parsed.usage_events, USAGE_PARSER_VERSION),
+    ))
+}
+
+fn parse_composer_session(
+    conn: &Connection,
+    composer_id: &str,
+    meta: &ComposerMeta,
+) -> anyhow::Result<Option<ParsedComposerSession>> {
+    let Some(raw_json) = read_disk_kv(conn, &format!("composerData:{composer_id}")) else {
+        return Ok(None);
+    };
+    let data: Value = match serde_json::from_str(&raw_json) {
+        Ok(value) => value,
+        Err(err) => {
+            debug!("failed to parse composerData for {composer_id}: {err}");
             return Ok(None);
         }
     };
-    raw.directory = cwd_map.get(&entry.session_id).cloned();
-    raw.started_at = stat_birth_ms(path).unwrap_or(mtime_ms);
-    raw.updated_at = Some(mtime_ms);
-    raw.source_id = entry.session_id;
-    Ok(Some(raw))
+
+    let headers = data
+        .get("fullConversationHeadersOnly")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let conversation_map = data.get("conversationMap").and_then(|value| value.as_object());
+
+    let mut messages = Vec::new();
+    let mut usage_events = Vec::new();
+    let mut bubble_usage_events = Vec::new();
+
+    for (index, header) in headers.iter().enumerate() {
+        let bubble_id = header.get("bubbleId").and_then(|value| value.as_str());
+        let header_type = header.get("type").and_then(|value| value.as_i64());
+        let role = bubble_role(header_type);
+        let Some(role) = role else {
+            continue;
+        };
+
+        let bubble = bubble_id.and_then(|bubble_id| load_bubble(conn, composer_id, bubble_id));
+        let content = if let Some(bubble) = bubble.as_ref() {
+            render_bubble_content(bubble, &role)
+        } else if let (Some(bubble_id), Some(map)) = (bubble_id, conversation_map) {
+            map.get(bubble_id).map(|value| render_legacy_bubble(value, &role)).unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        if content.is_empty() {
+            continue;
+        }
+
+        let timestamp = bubble
+            .as_ref()
+            .and_then(|value| json_i64(value.get("createdAt")))
+            .or_else(|| {
+                conversation_map
+                    .and_then(|map| bubble_id.and_then(|id| map.get(id)))
+                    .and_then(|value| json_i64(value.get("createdAt")))
+            });
+
+        messages.push(RawMessage { role, content, timestamp });
+
+        if let Some(bubble) = bubble.as_ref()
+            && let Some(event) = extract_bubble_usage_event(
+                composer_id,
+                bubble_id.unwrap_or("unknown"),
+                index as u32,
+                timestamp.unwrap_or(0),
+                bubble,
+                &data,
+            )
+        {
+            bubble_usage_events.push(event);
+        }
+    }
+
+    if let Some(event) = extract_session_usage_event(composer_id, &data, meta) {
+        usage_events.push(event);
+    } else {
+        usage_events.extend(bubble_usage_events);
+    }
+
+    if messages.is_empty() && usage_events.is_empty() {
+        return Ok(None);
+    }
+
+    let started_at = json_i64(data.get("createdAt"))
+        .or(meta.created_at)
+        .or_else(|| messages.first().and_then(|msg| msg.timestamp))
+        .unwrap_or(0);
+    let updated_at = json_i64(data.get("lastUpdatedAt"))
+        .or(json_i64(data.get("conversationCheckpointLastUpdatedAt")))
+        .or(meta.last_updated_at)
+        .or_else(|| messages.last().and_then(|msg| msg.timestamp));
+
+    Ok(Some(ParsedComposerSession {
+        messages,
+        usage_events,
+        started_at,
+        updated_at,
+        entrypoint: data
+            .get("unifiedMode")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| meta.unified_mode.clone()),
+        directory: meta.directory.clone(),
+    }))
 }
 
-fn parse_cursor_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
+fn discover_composer_ids(conn: &Connection) -> anyhow::Result<BTreeSet<String>> {
+    let mut ids = BTreeSet::new();
+
+    if let Some(raw) = read_item_value(conn, "composer.composerHeaders")
+        && let Ok(value) = serde_json::from_str::<Value>(&raw)
+        && let Some(items) = value.get("allComposers").and_then(|value| value.as_array())
+    {
+        for item in items {
+            if let Some(id) = item.get("composerId").and_then(|value| value.as_str()) {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+
+    let mut stmt = conn.prepare("SELECT key FROM cursorDiskKV WHERE key LIKE 'composerData:%'")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let key = row?;
+        if let Some(id) = key.strip_prefix("composerData:") {
+            ids.insert(id.to_string());
+        }
+    }
+
+    if let Some(workspace_dir) = resolve_workspace_storage_dir() {
+        for entry in fs::read_dir(workspace_dir)? {
+            let entry = entry?;
+            let db_path = entry.path().join("state.vscdb");
+            if !db_path.exists() {
+                continue;
+            }
+            if let Ok(workspace_conn) = Connection::open_with_flags(
+                &db_path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+            ) && let Some(raw) = read_item_value(&workspace_conn, "composer.composerData")
+                && let Ok(value) = serde_json::from_str::<Value>(&raw)
+            {
+                collect_composer_ids_from_workspace_data(&value, &mut ids);
+            }
+        }
+    }
+
+    for (session_id, _) in collect_agent_transcript_paths() {
+        ids.insert(session_id);
+    }
+
+    Ok(ids)
+}
+
+fn collect_composer_ids_from_workspace_data(value: &Value, ids: &mut BTreeSet<String>) {
+    if let Some(items) = value.get("allComposers").and_then(|value| value.as_array()) {
+        for item in items {
+            if let Some(id) = item.get("composerId").and_then(|value| value.as_str()) {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+    for key in ["selectedComposerIds", "lastFocusedComposerIds"] {
+        if let Some(items) = value.get(key).and_then(|value| value.as_array()) {
+            for item in items {
+                if let Some(id) = item.as_str() {
+                    ids.insert(id.to_string());
+                }
+            }
+        }
+    }
+}
+
+fn load_composer_meta(conn: &Connection, composer_id: &str) -> ComposerMeta {
+    let mut meta = ComposerMeta {
+        name: None,
+        unified_mode: None,
+        directory: None,
+        created_at: None,
+        last_updated_at: None,
+    };
+
+    if let Some(raw) = read_item_value(conn, "composer.composerHeaders")
+        && let Ok(value) = serde_json::from_str::<Value>(&raw)
+        && let Some(items) = value.get("allComposers").and_then(|value| value.as_array())
+    {
+        for item in items {
+            if item.get("composerId").and_then(|value| value.as_str()) == Some(composer_id) {
+                meta.name = item.get("name").and_then(|value| value.as_str()).map(str::to_string);
+                meta.unified_mode =
+                    item.get("unifiedMode").and_then(|value| value.as_str()).map(str::to_string);
+                meta.created_at = json_i64(item.get("createdAt"));
+                meta.last_updated_at = json_i64(item.get("lastUpdatedAt"));
+                meta.directory = workspace_path_from_identifier(item.get("workspaceIdentifier"));
+                break;
+            }
+        }
+    }
+
+    if let Some(raw) = read_disk_kv(conn, &format!("composerData:{composer_id}"))
+        && let Ok(data) = serde_json::from_str::<Value>(&raw)
+    {
+        if meta.name.is_none() {
+            meta.name = data.get("name").and_then(|value| value.as_str()).map(str::to_string);
+        }
+        if meta.unified_mode.is_none() {
+            meta.unified_mode =
+                data.get("unifiedMode").and_then(|value| value.as_str()).map(str::to_string);
+        }
+        if meta.created_at.is_none() {
+            meta.created_at = json_i64(data.get("createdAt"));
+        }
+        if meta.last_updated_at.is_none() {
+            meta.last_updated_at = json_i64(data.get("lastUpdatedAt"))
+                .or(json_i64(data.get("conversationCheckpointLastUpdatedAt")));
+        }
+    }
+
+    if meta.directory.is_none()
+        && let Some(path) = build_agent_cwd_map(resolve_global_state_db_path().as_deref()).get(composer_id)
+    {
+        meta.directory = Some(path.clone());
+    }
+
+    meta
+}
+
+fn workspace_path_from_identifier(value: Option<&Value>) -> Option<String> {
+    let uri = value?.get("uri")?;
+    uri.get("fsPath")
+        .and_then(|value| value.as_str())
+        .filter(|path| !path.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn load_bubble(conn: &Connection, composer_id: &str, bubble_id: &str) -> Option<Value> {
+    let raw = read_disk_kv(conn, &format!("bubbleId:{composer_id}:{bubble_id}"))?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn render_bubble_content(bubble: &Value, role: &Role) -> String {
+    let mut parts = Vec::new();
+    if let Some(text) = non_empty_str(bubble.get("text").or_else(|| bubble.get("rawText"))) {
+        let normalized = if matches!(role, Role::User) {
+            strip_user_query_envelope(text).trim().to_string()
+        } else {
+            text.trim().to_string()
+        };
+        if !normalized.is_empty() {
+            parts.push(normalized);
+        }
+    }
+
+    if let Some(tool_data) = bubble.get("toolFormerData") {
+        let name = tool_data.get("name").and_then(|value| value.as_str()).unwrap_or("tool");
+        let args = tool_data
+            .get("rawArgs")
+            .or_else(|| tool_data.get("params"))
+            .and_then(render_json_fragment)
+            .unwrap_or_default();
+        if !args.is_empty() {
+            parts.push(format!("[tool:{name}] {args}"));
+        } else {
+            parts.push(format!("[tool:{name}]"));
+        }
+        if let Some(result) = tool_data.get("result").and_then(render_json_fragment).filter(|s| !s.is_empty())
+        {
+            parts.push(format!("[tool_result:{name}] {result}"));
+        }
+    }
+
+    if let Some(blocks) = bubble.get("codeBlocks").and_then(|value| value.as_array()) {
+        for block in blocks {
+            if let Some(content) = block.get("content").and_then(|value| value.as_str()) {
+                parts.push(format!("[code_block] {content}"));
+            }
+        }
+    }
+
+    parts.join("\n")
+}
+
+fn render_legacy_bubble(value: &Value, role: &Role) -> String {
+    if let Some(text) = non_empty_str(value.get("text")) {
+        let normalized = if matches!(role, Role::User) {
+            strip_user_query_envelope(text).trim().to_string()
+        } else {
+            text.trim().to_string()
+        };
+        if !normalized.is_empty() {
+            return normalized;
+        }
+    }
+    render_bubble_content(value, role)
+}
+
+fn extract_bubble_usage_event(
+    composer_id: &str,
+    bubble_id: &str,
+    event_seq: u32,
+    timestamp: i64,
+    bubble: &Value,
+    composer_data: &Value,
+) -> Option<RawUsageEvent> {
+    let token_count = bubble.get("tokenCount")?;
+    let input_tokens = token_count.get("inputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
+    let output_tokens = token_count.get("outputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
+    if input_tokens == 0 && output_tokens == 0 {
+        return None;
+    }
+
+    let model = model_from_composer(composer_data);
+    Some(RawUsageEvent {
+        event_key: format!("bubble:{bubble_id}"),
+        event_seq,
+        message_seq: Some(event_seq),
+        timestamp,
+        model: model.clone(),
+        provider: infer_cursor_provider(&model),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        token_source: TokenSource::Observed,
+        parser_version: USAGE_PARSER_VERSION,
+        source_path: Some(format!("composer:{composer_id}")),
+        raw_usage_json: Some(token_count.to_string()),
+    })
+}
+
+fn extract_session_usage_event(
+    composer_id: &str,
+    composer_data: &Value,
+    meta: &ComposerMeta,
+) -> Option<RawUsageEvent> {
+    let breakdown = composer_data.get("promptTokenBreakdown")?;
+    let total_used = json_i64(breakdown.get("totalUsedTokens")).unwrap_or(0).max(0);
+    if total_used == 0 {
+        let total_used = json_i64(composer_data.get("contextTokensUsed")).unwrap_or(0).max(0);
+        if total_used == 0 {
+            return None;
+        }
+        return Some(build_session_usage_event(
+            composer_id,
+            composer_data,
+            meta,
+            total_used,
+            0,
+            breakdown,
+        ));
+    }
+
+    let conversation_tokens = breakdown
+        .get("categories")
+        .and_then(|value| value.as_array())
+        .and_then(|categories| {
+            categories.iter().find(|category| {
+                category.get("id").and_then(|value| value.as_str()) == Some("conversation")
+            })
+        })
+        .and_then(|category| json_i64(category.get("estimatedTokens")))
+        .unwrap_or(0)
+        .max(0);
+    let input_tokens = total_used.saturating_sub(conversation_tokens);
+    Some(build_session_usage_event(
+        composer_id,
+        composer_data,
+        meta,
+        input_tokens,
+        conversation_tokens,
+        breakdown,
+    ))
+}
+
+fn build_session_usage_event(
+    composer_id: &str,
+    composer_data: &Value,
+    meta: &ComposerMeta,
+    input_tokens: i64,
+    output_tokens: i64,
+    breakdown: &Value,
+) -> RawUsageEvent {
+    let model = model_from_composer(composer_data);
+    let timestamp = meta
+        .last_updated_at
+        .or(meta.created_at)
+        .or_else(|| json_i64(composer_data.get("lastUpdatedAt")))
+        .unwrap_or(0);
+    RawUsageEvent {
+        event_key: "session:prompt-token-breakdown".to_string(),
+        event_seq: 0,
+        message_seq: None,
+        timestamp,
+        model: model.clone(),
+        provider: infer_cursor_provider(&model),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        token_source: TokenSource::Derived,
+        parser_version: USAGE_PARSER_VERSION,
+        source_path: Some(format!("composer:{composer_id}")),
+        raw_usage_json: Some(breakdown.to_string()),
+    }
+}
+
+fn model_from_composer(composer_data: &Value) -> String {
+    composer_data
+        .get("modelConfig")
+        .and_then(|value| value.get("modelName"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn infer_cursor_provider(model: &str) -> String {
+    let lower = model.to_lowercase();
+    if lower.starts_with("claude") {
+        "anthropic".to_string()
+    } else if lower.starts_with("gpt") || lower.starts_with("o1") || lower.starts_with("o3") {
+        "openai".to_string()
+    } else if lower.starts_with("gemini") {
+        "google".to_string()
+    } else if lower.contains("composer") || lower == "default" {
+        "cursor".to_string()
+    } else {
+        "cursor".to_string()
+    }
+}
+
+fn bubble_role(header_type: Option<i64>) -> Option<Role> {
+    match header_type {
+        Some(1) => Some(Role::User),
+        Some(2) => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn parse_agent_transcript(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
@@ -165,7 +663,7 @@ fn parse_cursor_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
             continue;
         };
         let is_user = matches!(role, Role::User);
-        let content = render_content_items(items, is_user);
+        let content = render_transcript_content_items(items, is_user);
         if content.is_empty() {
             continue;
         }
@@ -176,10 +674,17 @@ fn parse_cursor_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
         return Ok(None);
     }
 
-    Ok(Some(RawSession::search_only(String::new(), None, 0, None, None, messages)))
+    Ok(Some(RawSession::search_only(
+        String::new(),
+        None,
+        0,
+        None,
+        Some("agent".to_string()),
+        messages,
+    )))
 }
 
-fn render_content_items(items: &[Value], is_user: bool) -> String {
+fn render_transcript_content_items(items: &[Value], is_user: bool) -> String {
     let mut parts = Vec::new();
     for item in items {
         match item.get("type").and_then(|t| t.as_str()) {
@@ -219,27 +724,106 @@ fn strip_user_query_envelope(text: &str) -> &str {
     }
 }
 
-fn stat_birth_ms(path: &Path) -> Option<i64> {
-    let meta = fs::metadata(path).ok()?;
-    let created = meta.created().ok()?;
-    let duration = created.duration_since(UNIX_EPOCH).ok()?;
-    Some(duration.as_millis() as i64)
+fn collect_agent_transcript_paths() -> HashMap<String, PathBuf> {
+    let Some(projects_dir) = resolve_projects_dir().ok().flatten() else {
+        return HashMap::new();
+    };
+    collect_agent_transcript_paths_from_dir(&projects_dir)
+        .into_iter()
+        .collect()
 }
 
-fn build_cwd_map(db_path: Option<&Path>) -> HashMap<String, String> {
+fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<(String, PathBuf)> {
+    let mut entries = Vec::new();
+    for walk_entry in WalkDir::new(projects_dir).into_iter().filter_map(|e| e.ok()) {
+        let path = walk_entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if uuid::Uuid::try_parse(stem).is_err() {
+            continue;
+        }
+        let parent_name = path.parent().and_then(|p| p.file_name()).and_then(|n| n.to_str());
+        if parent_name != Some(stem) {
+            continue;
+        }
+        let grandparent_name = path
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str());
+        if grandparent_name != Some("agent-transcripts") {
+            continue;
+        }
+        entries.push((stem.to_string(), path.to_path_buf()));
+    }
+    entries
+}
+
+fn resolve_projects_dir() -> anyhow::Result<Option<PathBuf>> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let dir = home.join(".cursor").join("projects");
+    if !dir.exists() {
+        debug!("~/.cursor/projects not found, skipping Cursor");
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+fn resolve_global_state_db_path() -> Option<PathBuf> {
+    let db = dirs::config_dir()?.join("Cursor/User/globalStorage/state.vscdb");
+    if db.exists() { Some(db) } else { None }
+}
+
+fn resolve_workspace_storage_dir() -> Option<PathBuf> {
+    let dir = dirs::config_dir()?.join("Cursor/User/workspaceStorage");
+    if dir.exists() { Some(dir) } else { None }
+}
+
+fn open_global_db() -> anyhow::Result<Option<Connection>> {
+    let Some(path) = resolve_global_state_db_path() else {
+        debug!("Cursor global state DB not found, skipping composer sessions");
+        return Ok(None);
+    };
+    Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX)
+        .map(Some)
+        .map_err(Into::into)
+}
+
+fn global_db_mtime() -> Option<i64> {
+    resolve_global_state_db_path().and_then(|path| stat_mtime_ms(&path))
+}
+
+fn usage_state_is_current(
+    state: Option<UsageSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    let Some(state) = state else {
+        return false;
+    };
+    state.parser_version >= USAGE_PARSER_VERSION && state.source_updated_at == source_updated_at
+}
+
+fn build_agent_cwd_map(db_path: Option<&Path>) -> HashMap<String, String> {
     let Some(db_path) = db_path else {
         return HashMap::new();
     };
-    match read_cwd_map(db_path) {
+    match read_agent_cwd_map(db_path) {
         Ok(map) => map,
-        Err(e) => {
-            debug!("cursor cwd map unavailable from {}: {e}", db_path.display());
+        Err(err) => {
+            debug!("cursor cwd map unavailable from {}: {err}", db_path.display());
             HashMap::new()
         }
     }
 }
 
-fn read_cwd_map(db_path: &Path) -> anyhow::Result<HashMap<String, String>> {
+fn read_agent_cwd_map(db_path: &Path) -> anyhow::Result<HashMap<String, String>> {
     let conn = Connection::open_with_flags(
         db_path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -289,11 +873,52 @@ fn read_item_value(conn: &Connection, key: &str) -> Option<String> {
     .ok()
 }
 
+fn read_disk_kv(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row("SELECT value FROM cursorDiskKV WHERE key = ?1", [key], |row| {
+        row.get::<_, String>(0)
+    })
+    .ok()
+}
+
+fn stat_birth_ms(path: &Path) -> Option<i64> {
+    let meta = fs::metadata(path).ok()?;
+    let created = meta.created().ok()?;
+    let duration = created.duration_since(UNIX_EPOCH).ok()?;
+    Some(duration.as_millis() as i64)
+}
+
+fn stat_mtime_ms(path: &Path) -> Option<i64> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    Some(modified.duration_since(UNIX_EPOCH).ok()?.as_millis() as i64)
+}
+
+fn non_empty_str(value: Option<&Value>) -> Option<&str> {
+    value.and_then(|value| value.as_str()).filter(|value| !value.trim().is_empty())
+}
+
+fn render_json_fragment(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        _ => serde_json::to_string(value).ok(),
+    }
+}
+
+fn json_i64(value: Option<&Value>) -> Option<i64> {
+    value.and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().map(|value| value as i64))
+            .or_else(|| value.as_f64().map(|value| value as i64))
+    })
+}
 #[cfg(test)]
 mod tests {
     use std::io::Write;
 
+    use rusqlite::Connection;
+
     use super::*;
+    use crate::types::TokenSource;
 
     fn temp_root(label: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
@@ -315,6 +940,76 @@ mod tests {
         }
     }
 
+    fn seed_global_db(root: &Path, composer_id: &str, bubble_id: &str) -> Connection {
+        let db_path = root.join("state.vscdb");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+        )
+        .unwrap();
+
+        let headers = serde_json::json!({
+            "allComposers": [{
+                "composerId": composer_id,
+                "name": "Usage review",
+                "unifiedMode": "chat",
+                "createdAt": 1_700_000_000_000_i64,
+                "lastUpdatedAt": 1_700_000_100_000_i64,
+                "workspaceIdentifier": {
+                    "uri": { "fsPath": "/Users/x/project" }
+                }
+            }]
+        });
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+            ["composer.composerHeaders", &headers.to_string()],
+        )
+        .unwrap();
+
+        let composer_data = serde_json::json!({
+            "composerId": composer_id,
+            "createdAt": 1_700_000_000_000_i64,
+            "lastUpdatedAt": 1_700_000_100_000_i64,
+            "unifiedMode": "chat",
+            "modelConfig": { "modelName": "claude-sonnet-4" },
+            "promptTokenBreakdown": {
+                "totalUsedTokens": 1200,
+                "categories": [
+                    { "id": "conversation", "estimatedTokens": 300 }
+                ]
+            },
+            "fullConversationHeadersOnly": [
+                { "bubbleId": bubble_id, "type": 1 },
+            ]
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            [
+                format!("composerData:{composer_id}"),
+                composer_data.to_string(),
+            ],
+        )
+        .unwrap();
+
+        let bubble = serde_json::json!({
+            "type": 1,
+            "text": "<user_query>\nhello cursor\n</user_query>",
+            "createdAt": 1_700_000_000_000_i64,
+            "tokenCount": { "inputTokens": 0, "outputTokens": 0 }
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            [
+                format!("bubbleId:{composer_id}:{bubble_id}"),
+                bubble.to_string(),
+            ],
+        )
+        .unwrap();
+
+        conn
+    }
+
     #[test]
     fn strip_user_query_envelope_strips_wrapper() {
         let text = "<user_query>\nhello world\n</user_query>";
@@ -322,65 +1017,42 @@ mod tests {
     }
 
     #[test]
-    fn strip_user_query_envelope_keeps_text_without_wrapper() {
-        let text = "plain user input";
-        assert_eq!(strip_user_query_envelope(text), "plain user input");
+    fn render_bubble_content_includes_tool_former_data() {
+        let bubble = serde_json::json!({
+            "text": "",
+            "toolFormerData": {
+                "name": "grep",
+                "rawArgs": "{\"pattern\":\"usage\"}",
+                "result": "{\"matches\":1}"
+            }
+        });
+        let rendered = render_bubble_content(&bubble, &Role::Assistant);
+        assert!(rendered.contains("[tool:grep]"));
+        assert!(rendered.contains("usage"));
+        assert!(rendered.contains("[tool_result:grep]"));
     }
 
     #[test]
-    fn strip_user_query_envelope_ignores_partial_wrapper() {
-        let text = "<user_query>\nhalf only";
-        assert_eq!(strip_user_query_envelope(text), text);
+    fn parse_composer_session_extracts_messages_and_usage() {
+        let root = temp_root("composer");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let meta = load_composer_meta(&conn, &composer_id);
+        let parsed = parse_composer_session(&conn, &composer_id, &meta).unwrap().unwrap();
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].content, "hello cursor");
+        assert_eq!(parsed.usage_events.len(), 1);
+        assert_eq!(parsed.usage_events[0].token_source, TokenSource::Derived);
+        assert_eq!(parsed.directory.as_deref(), Some("/Users/x/project"));
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
-    fn render_content_items_strips_envelope_for_user_only() {
-        let items = vec![serde_json::json!({
-            "type": "text",
-            "text": "<user_query>\nfix the bug\n</user_query>"
-        })];
-        assert_eq!(render_content_items(&items, true), "fix the bug");
-        assert_eq!(render_content_items(&items, false), "<user_query>\nfix the bug\n</user_query>");
-    }
-
-    #[test]
-    fn render_content_items_leaves_xml_inside_assistant_text() {
-        let items = vec![serde_json::json!({
-            "type": "text",
-            "text": "saw a <tool> tag in code"
-        })];
-        assert_eq!(render_content_items(&items, false), "saw a <tool> tag in code");
-    }
-
-    #[test]
-    fn render_content_items_serializes_object_tool_input() {
-        let items = vec![serde_json::json!({
-            "type": "tool_use",
-            "name": "Glob",
-            "input": {"glob_pattern": "*.rs"}
-        })];
-        let rendered = render_content_items(&items, false);
-        assert!(rendered.starts_with("[tool_use:Glob] "));
-        assert!(rendered.contains("\"glob_pattern\""));
-        assert!(rendered.contains("*.rs"));
-    }
-
-    #[test]
-    fn render_content_items_passes_through_string_tool_input() {
-        let items = vec![serde_json::json!({
-            "type": "tool_use",
-            "name": "ApplyPatch",
-            "input": "*** Begin Patch\nsome diff\n*** End Patch"
-        })];
-        let rendered = render_content_items(&items, false);
-        assert_eq!(rendered, "[tool_use:ApplyPatch] *** Begin Patch\nsome diff\n*** End Patch");
-    }
-
-    #[test]
-    fn parse_cursor_session_happy_path() {
+    fn parse_agent_transcript_happy_path() {
         let root = temp_root("parse");
         let uuid = uuid::Uuid::new_v4().to_string();
-        let jsonl_path = root.join(&uuid).join(format!("{uuid}.jsonl"));
+        let jsonl_path = root.join(format!("{uuid}.jsonl"));
         write_jsonl(
             &jsonl_path,
             &[
@@ -388,109 +1060,17 @@ mod tests {
                 r#"{"role":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","name":"Glob","input":{"glob_pattern":"*.rs"}}]}}"#,
             ],
         );
-        let raw = parse_cursor_session(&jsonl_path).unwrap().unwrap();
+        let raw = parse_agent_transcript(&jsonl_path).unwrap().unwrap();
         assert_eq!(raw.messages.len(), 2);
-        assert!(matches!(raw.messages[0].role, Role::User));
         assert_eq!(raw.messages[0].content, "hello");
-        assert!(matches!(raw.messages[1].role, Role::Assistant));
-        assert!(raw.messages[1].content.contains("hi"));
         assert!(raw.messages[1].content.contains("[tool_use:Glob]"));
-        assert!(raw.messages[0].timestamp.is_none());
-
-        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
-    fn parse_cursor_session_skips_unknown_roles_and_malformed_lines() {
-        let root = temp_root("skip");
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let jsonl_path = root.join(&uuid).join(format!("{uuid}.jsonl"));
-        write_jsonl(
-            &jsonl_path,
-            &[
-                "not json",
-                r#"{"role":"system","message":{"content":[{"type":"text","text":"sys"}]}}"#,
-                r#"{"role":"user","message":{"content":[{"type":"text","text":"real"}]}}"#,
-            ],
-        );
-        let raw = parse_cursor_session(&jsonl_path).unwrap().unwrap();
-        assert_eq!(raw.messages.len(), 1);
-        assert_eq!(raw.messages[0].content, "real");
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn parse_cursor_session_returns_none_for_no_messages() {
-        let root = temp_root("empty");
-        let uuid = uuid::Uuid::new_v4().to_string();
-        let jsonl_path = root.join(&uuid).join(format!("{uuid}.jsonl"));
-        write_jsonl(&jsonl_path, &[""]);
-        let raw = parse_cursor_session(&jsonl_path).unwrap();
-        assert!(raw.is_none());
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn collect_cursor_entries_requires_agent_transcripts_parent() {
-        let root = temp_root("collect");
-        let projects = root.join("projects");
-        let uuid = uuid::Uuid::new_v4().to_string();
-
-        let good = projects.join("proj-a").join("agent-transcripts").join(&uuid);
-        write_jsonl(&good.join(format!("{uuid}.jsonl")), &["{}"]);
-
-        let bad = projects.join("proj-a").join("other-dir").join(&uuid);
-        write_jsonl(&bad.join(format!("{uuid}.jsonl")), &["{}"]);
-
-        let not_uuid_dir = projects.join("proj-a").join("agent-transcripts").join("notauuid");
-        write_jsonl(&not_uuid_dir.join("notauuid.jsonl"), &["{}"]);
-
-        let entries = collect_cursor_entries(&projects);
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].session_id, uuid);
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    fn seed_state_db(path: &Path, session_uuid: &str, fs_path: &str) {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap();
-        }
-        let conn = Connection::open(path).unwrap();
-        conn.execute("CREATE TABLE IF NOT EXISTS ItemTable (key TEXT PRIMARY KEY, value TEXT)", [])
-            .unwrap();
-
-        let membership = serde_json::json!({ session_uuid: "project-1" });
-        let projects = serde_json::json!([{
-            "id": "project-1",
-            "workspace": { "uri": { "fsPath": fs_path } }
-        }]);
-        conn.execute(
-            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
-            ["glass.localAgentProjectMembership.v1", &membership.to_string()],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
-            ["glass.localAgentProjects.v1", &projects.to_string()],
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn read_cwd_map_resolves_session_to_fspath() {
-        let root = temp_root("cwdmap");
-        let db_path = root.join("state.vscdb");
-        let session_uuid = uuid::Uuid::new_v4().to_string();
-        seed_state_db(&db_path, &session_uuid, "/Users/x/git/samzong/Recall");
-
-        let map = read_cwd_map(&db_path).unwrap();
-        assert_eq!(map.get(&session_uuid).map(String::as_str), Some("/Users/x/git/samzong/Recall"));
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn build_cwd_map_returns_empty_when_db_missing() {
-        let map = build_cwd_map(None);
-        assert!(map.is_empty());
+    fn infer_cursor_provider_maps_models() {
+        assert_eq!(infer_cursor_provider("claude-sonnet-4"), "anthropic");
+        assert_eq!(infer_cursor_provider("composer-2.5"), "cursor");
+        assert_eq!(infer_cursor_provider("gpt-4.1"), "openai");
     }
 }

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -17,7 +17,7 @@ use crate::types::{RawUsageEvent, Role, TokenSource};
 
 pub struct CursorAdapter;
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 #[derive(Debug, Clone)]
 struct ComposerMeta {
@@ -269,10 +269,10 @@ fn parse_composer_session(
         }
     }
 
-    if let Some(event) = extract_session_usage_event(composer_id, &data, meta) {
-        usage_events.push(event);
-    } else {
+    if !bubble_usage_events.is_empty() {
         usage_events.extend(bubble_usage_events);
+    } else if let Some(event) = extract_session_usage_event(composer_id, &data, meta) {
+        usage_events.push(event);
     }
 
     if messages.is_empty() && usage_events.is_empty() {
@@ -532,43 +532,54 @@ fn extract_session_usage_event(
     composer_data: &Value,
     meta: &ComposerMeta,
 ) -> Option<RawUsageEvent> {
-    let breakdown = composer_data.get("promptTokenBreakdown")?;
-    let total_used = json_i64(breakdown.get("totalUsedTokens")).unwrap_or(0).max(0);
-    if total_used == 0 {
-        let total_used = json_i64(composer_data.get("contextTokensUsed")).unwrap_or(0).max(0);
+    if let Some(breakdown) = composer_data.get("promptTokenBreakdown") {
+        let total_used = json_i64(breakdown.get("totalUsedTokens")).unwrap_or(0).max(0);
         if total_used == 0 {
             return None;
         }
+        let (input_tokens, cache_read_tokens) = map_context_breakdown(breakdown, total_used);
         return Some(build_session_usage_event(
             composer_id,
             composer_data,
             meta,
-            total_used,
-            0,
+            input_tokens,
+            cache_read_tokens,
             breakdown,
         ));
     }
 
-    let conversation_tokens = breakdown
-        .get("categories")
-        .and_then(|value| value.as_array())
-        .and_then(|categories| {
-            categories.iter().find(|category| {
-                category.get("id").and_then(|value| value.as_str()) == Some("conversation")
-            })
-        })
-        .and_then(|category| json_i64(category.get("estimatedTokens")))
-        .unwrap_or(0)
-        .max(0);
-    let input_tokens = total_used.saturating_sub(conversation_tokens);
+    let total_used = json_i64(composer_data.get("contextTokensUsed")).unwrap_or(0).max(0);
+    if total_used == 0 {
+        return None;
+    }
     Some(build_session_usage_event(
         composer_id,
         composer_data,
         meta,
-        input_tokens,
-        conversation_tokens,
-        breakdown,
+        total_used,
+        0,
+        &Value::Null,
     ))
+}
+
+fn map_context_breakdown(breakdown: &Value, total_used: i64) -> (i64, i64) {
+    let mut conversation_tokens = 0;
+    let mut prompt_tokens = 0;
+    if let Some(categories) = breakdown.get("categories").and_then(|value| value.as_array()) {
+        for category in categories {
+            let id = category.get("id").and_then(|value| value.as_str()).unwrap_or("");
+            let estimated = json_i64(category.get("estimatedTokens")).unwrap_or(0).max(0);
+            match id {
+                "conversation" | "summarized_conversation" => conversation_tokens += estimated,
+                _ => prompt_tokens += estimated,
+            }
+        }
+    }
+    let categorized = conversation_tokens + prompt_tokens;
+    if categorized < total_used {
+        prompt_tokens += total_used - categorized;
+    }
+    (prompt_tokens, conversation_tokens)
 }
 
 fn build_session_usage_event(
@@ -576,7 +587,7 @@ fn build_session_usage_event(
     composer_data: &Value,
     meta: &ComposerMeta,
     input_tokens: i64,
-    output_tokens: i64,
+    cache_read_tokens: i64,
     breakdown: &Value,
 ) -> RawUsageEvent {
     let model = model_from_composer(composer_data);
@@ -593,14 +604,18 @@ fn build_session_usage_event(
         model: model.clone(),
         provider: infer_cursor_provider(&model),
         input_tokens,
-        output_tokens,
-        cache_read_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens,
         cache_write_tokens: 0,
         reasoning_tokens: 0,
         token_source: TokenSource::Derived,
         parser_version: USAGE_PARSER_VERSION,
         source_path: Some(format!("composer:{composer_id}")),
-        raw_usage_json: Some(breakdown.to_string()),
+        raw_usage_json: if breakdown.is_null() {
+            None
+        } else {
+            Some(breakdown.to_string())
+        },
     }
 }
 
@@ -1044,7 +1059,62 @@ mod tests {
         assert_eq!(parsed.messages[0].content, "hello cursor");
         assert_eq!(parsed.usage_events.len(), 1);
         assert_eq!(parsed.usage_events[0].token_source, TokenSource::Derived);
+        assert_eq!(parsed.usage_events[0].input_tokens, 900);
+        assert_eq!(parsed.usage_events[0].cache_read_tokens, 300);
+        assert_eq!(parsed.usage_events[0].output_tokens, 0);
         assert_eq!(parsed.directory.as_deref(), Some("/Users/x/project"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn parse_composer_session_prefers_bubble_usage_over_context_breakdown() {
+        let root = temp_root("bubble-usage");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let composer_data = serde_json::json!({
+            "composerId": composer_id,
+            "createdAt": 1_700_000_000_000_i64,
+            "lastUpdatedAt": 1_700_000_100_000_i64,
+            "unifiedMode": "chat",
+            "modelConfig": { "modelName": "claude-sonnet-4" },
+            "promptTokenBreakdown": {
+                "totalUsedTokens": 1200,
+                "categories": [{ "id": "conversation", "estimatedTokens": 300 }]
+            },
+            "fullConversationHeadersOnly": [
+                { "bubbleId": bubble_id, "type": 2 },
+            ]
+        });
+        conn.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+            rusqlite::params![
+                composer_data.to_string(),
+                format!("composerData:{composer_id}"),
+            ],
+        )
+        .unwrap();
+        let bubble = serde_json::json!({
+            "type": 2,
+            "text": "assistant reply",
+            "createdAt": 1_700_000_050_000_i64,
+            "tokenCount": { "inputTokens": 12, "outputTokens": 34 }
+        });
+        conn.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+            rusqlite::params![
+                bubble.to_string(),
+                format!("bubbleId:{composer_id}:{bubble_id}"),
+            ],
+        )
+        .unwrap();
+
+        let meta = load_composer_meta(&conn, &composer_id);
+        let parsed = parse_composer_session(&conn, &composer_id, &meta).unwrap().unwrap();
+        assert_eq!(parsed.usage_events.len(), 1);
+        assert_eq!(parsed.usage_events[0].token_source, TokenSource::Observed);
+        assert_eq!(parsed.usage_events[0].input_tokens, 12);
+        assert_eq!(parsed.usage_events[0].output_tokens, 34);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -89,10 +89,7 @@ impl SourceAdapter for CursorAdapter {
             let source_updated_at = updated_at.or(global_mtime);
             if let Some((old_updated_at, _)) = existing.get(&composer_id)
                 && *old_updated_at == source_updated_at
-                && usage_state_is_current(
-                    usage_state.get(&composer_id).copied(),
-                    source_updated_at,
-                )
+                && usage_state_is_current(usage_state.get(&composer_id).copied(), source_updated_at)
             {
                 stats.skipped_sessions += 1;
                 continue;
@@ -244,10 +241,8 @@ fn parse_composer_session(
             continue;
         }
 
-        let timestamp = bubble
-            .as_ref()
-            .and_then(|value| json_i64(value.get("createdAt")))
-            .or_else(|| {
+        let timestamp =
+            bubble.as_ref().and_then(|value| json_i64(value.get("createdAt"))).or_else(|| {
                 conversation_map
                     .and_then(|map| bubble_id.and_then(|id| map.get(id)))
                     .and_then(|value| json_i64(value.get("createdAt")))
@@ -415,7 +410,8 @@ fn load_composer_meta(conn: &Connection, composer_id: &str) -> ComposerMeta {
     }
 
     if meta.directory.is_none()
-        && let Some(path) = build_agent_cwd_map(resolve_global_state_db_path().as_deref()).get(composer_id)
+        && let Some(path) =
+            build_agent_cwd_map(resolve_global_state_db_path().as_deref()).get(composer_id)
     {
         meta.directory = Some(path.clone());
     }
@@ -461,7 +457,8 @@ fn render_bubble_content(bubble: &Value, role: &Role) -> String {
         } else {
             parts.push(format!("[tool:{name}]"));
         }
-        if let Some(result) = tool_data.get("result").and_then(render_json_fragment).filter(|s| !s.is_empty())
+        if let Some(result) =
+            tool_data.get("result").and_then(render_json_fragment).filter(|s| !s.is_empty())
         {
             parts.push(format!("[tool_result:{name}] {result}"));
         }
@@ -501,8 +498,10 @@ fn extract_bubble_usage_event(
     composer_data: &Value,
 ) -> Option<RawUsageEvent> {
     let token_count = bubble.get("tokenCount")?;
-    let input_tokens = token_count.get("inputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
-    let output_tokens = token_count.get("outputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
+    let input_tokens =
+        token_count.get("inputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
+    let output_tokens =
+        token_count.get("outputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
     if input_tokens == 0 && output_tokens == 0 {
         return None;
     }
@@ -552,14 +551,7 @@ fn extract_session_usage_event(
     if total_used == 0 {
         return None;
     }
-    Some(build_session_usage_event(
-        composer_id,
-        composer_data,
-        meta,
-        total_used,
-        0,
-        &Value::Null,
-    ))
+    Some(build_session_usage_event(composer_id, composer_data, meta, total_used, 0, &Value::Null))
 }
 
 fn map_context_breakdown(breakdown: &Value, total_used: i64) -> (i64, i64) {
@@ -611,11 +603,7 @@ fn build_session_usage_event(
         token_source: TokenSource::Derived,
         parser_version: USAGE_PARSER_VERSION,
         source_path: Some(format!("composer:{composer_id}")),
-        raw_usage_json: if breakdown.is_null() {
-            None
-        } else {
-            Some(breakdown.to_string())
-        },
+        raw_usage_json: if breakdown.is_null() { None } else { Some(breakdown.to_string()) },
     }
 }
 
@@ -637,8 +625,6 @@ fn infer_cursor_provider(model: &str) -> String {
         "openai".to_string()
     } else if lower.starts_with("gemini") {
         "google".to_string()
-    } else if lower.contains("composer") || lower == "default" {
-        "cursor".to_string()
     } else {
         "cursor".to_string()
     }
@@ -743,9 +729,7 @@ fn collect_agent_transcript_paths() -> HashMap<String, PathBuf> {
     let Some(projects_dir) = resolve_projects_dir().ok().flatten() else {
         return HashMap::new();
     };
-    collect_agent_transcript_paths_from_dir(&projects_dir)
-        .into_iter()
-        .collect()
+    collect_agent_transcript_paths_from_dir(&projects_dir).into_iter().collect()
 }
 
 fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<(String, PathBuf)> {
@@ -806,9 +790,12 @@ fn open_global_db() -> anyhow::Result<Option<Connection>> {
         debug!("Cursor global state DB not found, skipping composer sessions");
         return Ok(None);
     };
-    Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX)
-        .map(Some)
-        .map_err(Into::into)
+    Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map(Some)
+    .map_err(Into::into)
 }
 
 fn global_db_mtime() -> Option<i64> {
@@ -1000,10 +987,7 @@ mod tests {
         });
         conn.execute(
             "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
-            [
-                format!("composerData:{composer_id}"),
-                composer_data.to_string(),
-            ],
+            [format!("composerData:{composer_id}"), composer_data.to_string()],
         )
         .unwrap();
 
@@ -1015,10 +999,7 @@ mod tests {
         });
         conn.execute(
             "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
-            [
-                format!("bubbleId:{composer_id}:{bubble_id}"),
-                bubble.to_string(),
-            ],
+            [format!("bubbleId:{composer_id}:{bubble_id}"), bubble.to_string()],
         )
         .unwrap();
 
@@ -1088,10 +1069,7 @@ mod tests {
         });
         conn.execute(
             "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
-            rusqlite::params![
-                composer_data.to_string(),
-                format!("composerData:{composer_id}"),
-            ],
+            rusqlite::params![composer_data.to_string(), format!("composerData:{composer_id}"),],
         )
         .unwrap();
         let bubble = serde_json::json!({
@@ -1102,10 +1080,7 @@ mod tests {
         });
         conn.execute(
             "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
-            rusqlite::params![
-                bubble.to_string(),
-                format!("bubbleId:{composer_id}:{bubble_id}"),
-            ],
+            rusqlite::params![bubble.to_string(), format!("bubbleId:{composer_id}:{bubble_id}"),],
         )
         .unwrap();
 

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -7,9 +7,11 @@ use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
-use crate::types::Role;
+use crate::types::{RawUsageEvent, Role, TokenSource};
 
 pub struct GeminiAdapter;
+
+const USAGE_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for GeminiAdapter {
     fn id(&self) -> &str {
@@ -24,6 +26,10 @@ impl SourceAdapter for GeminiAdapter {
             program: "gemini".to_string(),
             args: vec!["--resume".to_string(), source_id.to_string()],
         })
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
@@ -67,15 +73,19 @@ fn parse_gemini_session_file(path: &Path) -> anyhow::Result<Option<RawSession>> 
     let reader = BufReader::new(file);
     let doc: Value = serde_json::from_reader(reader)?;
     let fallback_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown");
-    parse_gemini_session_value(doc, fallback_id)
+    parse_gemini_session_value(doc, fallback_id, Some(path.display().to_string()))
 }
 
 pub fn parse_gemini_session(json: &str, fallback_id: &str) -> anyhow::Result<Option<RawSession>> {
     let doc: Value = serde_json::from_str(json)?;
-    parse_gemini_session_value(doc, fallback_id)
+    parse_gemini_session_value(doc, fallback_id, None)
 }
 
-fn parse_gemini_session_value(doc: Value, fallback_id: &str) -> anyhow::Result<Option<RawSession>> {
+fn parse_gemini_session_value(
+    doc: Value,
+    fallback_id: &str,
+    source_path: Option<String>,
+) -> anyhow::Result<Option<RawSession>> {
     let session_id =
         doc.get("sessionId").and_then(|s| s.as_str()).unwrap_or(fallback_id).to_string();
 
@@ -98,8 +108,9 @@ fn parse_gemini_session_value(doc: Value, fallback_id: &str) -> anyhow::Result<O
     };
 
     let mut messages = Vec::new();
+    let mut usage_events = Vec::new();
 
-    for msg in messages_arr {
+    for (index, msg) in messages_arr.iter().enumerate() {
         let msg_type = msg.get("type").and_then(|t| t.as_str()).unwrap_or("");
         let role = match msg_type {
             "user" => Role::User,
@@ -128,14 +139,90 @@ fn parse_gemini_session_value(doc: Value, fallback_id: &str) -> anyhow::Result<O
             (false, false) => format!("{prose}\n{tool_text}"),
         };
 
+        let message_seq = messages.len() as u32;
         messages.push(RawMessage { role, content, timestamp });
+
+        if msg_type == "gemini"
+            && let Some(event) = extract_gemini_usage_event(
+                msg,
+                index as u32,
+                message_seq,
+                timestamp.unwrap_or(started_at),
+                source_path.as_deref(),
+            )
+        {
+            usage_events.push(event);
+        }
     }
 
-    if messages.is_empty() {
+    if messages.is_empty() && usage_events.is_empty() {
         return Ok(None);
     }
 
-    Ok(Some(RawSession::search_only(session_id, None, started_at, updated_at, None, messages)))
+    let mut session = RawSession::search_only(session_id, None, started_at, updated_at, None, messages);
+    if !usage_events.is_empty() {
+        session = session.with_usage(usage_events, USAGE_PARSER_VERSION);
+    }
+    Ok(Some(session))
+}
+
+fn extract_gemini_usage_event(
+    msg: &Value,
+    event_seq: u32,
+    message_seq: u32,
+    timestamp: i64,
+    source_path: Option<&str>,
+) -> Option<RawUsageEvent> {
+    let tokens = msg.get("tokens")?;
+    let input_tokens = json_i64(tokens.get("input")).unwrap_or(0).max(0);
+    let output_tokens = json_i64(tokens.get("output")).unwrap_or(0).max(0);
+    let cache_read_tokens = json_i64(tokens.get("cached")).unwrap_or(0).max(0);
+    let reasoning_tokens = json_i64(tokens.get("thoughts")).unwrap_or(0).max(0);
+    if input_tokens == 0
+        && output_tokens == 0
+        && cache_read_tokens == 0
+        && reasoning_tokens == 0
+    {
+        return None;
+    }
+
+    let model = msg
+        .get("model")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string();
+    let event_key = msg
+        .get("id")
+        .map(|value| format!("message:{value}"))
+        .unwrap_or_else(|| format!("line:{event_seq}"));
+
+    Some(RawUsageEvent {
+        event_key,
+        event_seq,
+        message_seq: Some(message_seq),
+        timestamp,
+        model: model.clone(),
+        provider: "google".to_string(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens: 0,
+        reasoning_tokens,
+        token_source: TokenSource::Observed,
+        parser_version: USAGE_PARSER_VERSION,
+        source_path: source_path.map(str::to_string),
+        raw_usage_json: Some(tokens.to_string()),
+    })
+}
+
+fn json_i64(value: Option<&Value>) -> Option<i64> {
+    value.and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().map(|v| v as i64))
+            .or_else(|| value.as_f64().map(|v| v as i64))
+    })
 }
 
 fn extract_tool_calls(tool_calls: Option<&Value>) -> String {
@@ -174,4 +261,39 @@ fn extract_tool_result(result: Option<&Value>) -> String {
         }
     }
     parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_gemini_session_extracts_usage_events() {
+        let json = r#"{
+            "sessionId": "abc-123",
+            "startTime": "2025-11-13T13:48:00.000Z",
+            "messages": [
+                {"id": 0, "type": "user", "content": "hello", "timestamp": "2025-11-13T13:48:05.000Z"},
+                {
+                    "id": 1,
+                    "type": "gemini",
+                    "content": "hi there",
+                    "timestamp": "2025-11-13T13:48:10.000Z",
+                    "model": "gemini-2.5-pro",
+                    "tokens": { "input": 100, "output": 20, "cached": 30, "thoughts": 5 }
+                }
+            ]
+        }"#;
+
+        let session = parse_gemini_session(json, "fallback").unwrap().unwrap();
+        assert_eq!(session.usage_events.len(), 1);
+        let event = &session.usage_events[0];
+        assert_eq!(event.model, "gemini-2.5-pro");
+        assert_eq!(event.provider, "google");
+        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.output_tokens, 20);
+        assert_eq!(event.cache_read_tokens, 30);
+        assert_eq!(event.reasoning_tokens, 5);
+        assert_eq!(event.token_source, TokenSource::Observed);
+    }
 }

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -159,7 +159,8 @@ fn parse_gemini_session_value(
         return Ok(None);
     }
 
-    let mut session = RawSession::search_only(session_id, None, started_at, updated_at, None, messages);
+    let mut session =
+        RawSession::search_only(session_id, None, started_at, updated_at, None, messages);
     if !usage_events.is_empty() {
         session = session.with_usage(usage_events, USAGE_PARSER_VERSION);
     }
@@ -178,11 +179,7 @@ fn extract_gemini_usage_event(
     let output_tokens = json_i64(tokens.get("output")).unwrap_or(0).max(0);
     let cache_read_tokens = json_i64(tokens.get("cached")).unwrap_or(0).max(0);
     let reasoning_tokens = json_i64(tokens.get("thoughts")).unwrap_or(0).max(0);
-    if input_tokens == 0
-        && output_tokens == 0
-        && cache_read_tokens == 0
-        && reasoning_tokens == 0
-    {
+    if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
         return None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ enum Commands {
         force: bool,
         #[arg(short, long, help = "Show per-source scan progress and settings")]
         verbose: bool,
+        #[arg(long, help = "Sync only this source (id or label, e.g. cursor or CUR)")]
+        source: Option<String>,
     },
     #[command(hide = true, name = "__background-worker")]
     BackgroundWorker {
@@ -97,7 +99,9 @@ fn main() -> Result<()> {
 
     match cli.command {
         Some(Commands::Info) => cmd_info()?,
-        Some(Commands::Sync { force, verbose }) => cmd_sync(force, verbose)?,
+        Some(Commands::Sync { force, verbose, source }) => {
+            cmd_sync(force, verbose, source.as_deref())?
+        }
         Some(Commands::BackgroundWorker { sync_first }) => cmd_background_worker(sync_first)?,
         Some(Commands::BenchSemantic) => recall::bench::run_semantic()?,
         Some(Commands::BenchSearch { query }) => recall::bench::run_search(&query)?,
@@ -306,14 +310,22 @@ fn format_date_range(oldest: Option<i64>, newest: Option<i64>) -> String {
     format!("{oldest} -> {newest}")
 }
 
-fn cmd_sync(force: bool, verbose: bool) -> Result<()> {
-    run_sync_job(force, verbose)?;
+fn cmd_sync(force: bool, verbose: bool, source_filter: Option<&str>) -> Result<()> {
+    let labels = adapters::source_labels();
+    let sources = resolve_source_filter(source_filter, &labels)?;
+    run_sync_job_inner(SyncRunOptions {
+        force,
+        verbose,
+        emit: true,
+        usage_only: false,
+        sources,
+    })?;
     semantic::ensure_background_worker(false)?;
     Ok(())
 }
 
 fn run_sync_job(force: bool, verbose: bool) -> Result<()> {
-    run_sync_job_inner(SyncRunOptions { force, verbose, emit: true, usage_only: false })
+    cmd_sync(force, verbose, None)
 }
 
 fn run_usage_sync_job() -> Result<()> {
@@ -322,15 +334,17 @@ fn run_usage_sync_job() -> Result<()> {
         verbose: false,
         emit: false,
         usage_only: true,
+        sources: None,
     })
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct SyncRunOptions {
     force: bool,
     verbose: bool,
     emit: bool,
     usage_only: bool,
+    sources: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -366,6 +380,12 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         let label = adapter.label();
 
         if options.usage_only && adapter.usage_parser_version().is_none() {
+            continue;
+        }
+
+        if let Some(sources) = &options.sources
+            && !sources.iter().any(|id| id == source_id)
+        {
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,13 +313,7 @@ fn format_date_range(oldest: Option<i64>, newest: Option<i64>) -> String {
 fn cmd_sync(force: bool, verbose: bool, source_filter: Option<&str>) -> Result<()> {
     let labels = adapters::source_labels();
     let sources = resolve_source_filter(source_filter, &labels)?;
-    run_sync_job_inner(SyncRunOptions {
-        force,
-        verbose,
-        emit: true,
-        usage_only: false,
-        sources,
-    })?;
+    run_sync_job_inner(SyncRunOptions { force, verbose, emit: true, usage_only: false, sources })?;
     semantic::ensure_background_worker(false)?;
     Ok(())
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -99,6 +99,7 @@ mod tests {
             usage_error: None,
             usage_time_filter: TimeRange::All,
             usage_refresh_requested_at: None,
+            usage_breakdown_scroll: 0,
         }
     }
 
@@ -403,6 +404,7 @@ pub struct App {
     pub usage_error: Option<String>,
     pub usage_time_filter: TimeRange,
     pub usage_refresh_requested_at: Option<Instant>,
+    pub usage_breakdown_scroll: u16,
 }
 
 impl App {
@@ -473,6 +475,7 @@ impl App {
             usage_error: None,
             usage_time_filter: TimeRange::All,
             usage_refresh_requested_at: None,
+            usage_breakdown_scroll: 0,
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -637,6 +640,9 @@ impl App {
             AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.previous();
             }
+            AppMode::Usage if self.usage_breakdown_scroll > 0 => {
+                self.usage_breakdown_scroll -= 1;
+            }
             _ => {}
         }
     }
@@ -676,6 +682,9 @@ impl App {
             }
             AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.next();
+            }
+            AppMode::Usage => {
+                self.usage_breakdown_scroll = self.usage_breakdown_scroll.saturating_add(1);
             }
             _ => {}
         }
@@ -801,6 +810,8 @@ impl App {
                 self.reset_usage_dashboard();
                 self.request_usage_refresh();
             }
+            KeyCode::Up => self.handle_scroll_up(_store),
+            KeyCode::Down => self.handle_scroll_down(_store),
             _ => {}
         }
     }
@@ -1545,6 +1556,7 @@ impl App {
     pub fn refresh_usage(&mut self, store: &Store) {
         self.usage_refresh_requested_at = None;
         self.usage_error = None;
+        self.usage_breakdown_scroll = 0;
         let sources = self.source_filter_ids();
         let current_filters =
             UsageFilters { sources: sources.clone(), time_range: self.usage_time_filter };
@@ -1814,6 +1826,7 @@ impl App {
     fn reset_usage_dashboard(&mut self) {
         self.source_filter_selection.clear();
         self.usage_time_filter = TimeRange::All;
+        self.usage_breakdown_scroll = 0;
     }
 
     fn cycle_usage_time(&mut self, reverse: bool) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -378,22 +378,20 @@ fn render_usage_breakdown(f: &mut Frame, app: &App, area: Rect) {
         Paragraph::new(build_usage_source_lines(app, report, inner_width)),
         sections[0],
     );
-    f.render_widget(
-        Paragraph::new(build_usage_token_mix_lines(report, inner_width)),
-        sections[1],
-    );
+    f.render_widget(Paragraph::new(build_usage_token_mix_lines(report, inner_width)), sections[1]);
 
     let model_lines = build_usage_model_lines(app, report, inner_width);
     let visible_height = sections[2].height as usize;
     let max_scroll = model_lines.len().saturating_sub(visible_height);
     let scroll = app.usage_breakdown_scroll.min(max_scroll as u16) as usize;
-    f.render_widget(
-        Paragraph::new(model_lines).scroll((scroll as u16, 0)),
-        sections[2],
-    );
+    f.render_widget(Paragraph::new(model_lines).scroll((scroll as u16, 0)), sections[2]);
 }
 
-fn build_usage_source_lines(app: &App, report: &UsageReport, inner_width: usize) -> Vec<Line<'static>> {
+fn build_usage_source_lines(
+    app: &App,
+    report: &UsageReport,
+    inner_width: usize,
+) -> Vec<Line<'static>> {
     let source_max =
         report.by_source.iter().map(|source| source.tokens.total_tokens).max().unwrap_or(0);
     let mut lines = vec![Line::from(Span::styled(
@@ -427,7 +425,11 @@ fn build_usage_token_mix_lines(report: &UsageReport, inner_width: usize) -> Vec<
     lines
 }
 
-fn build_usage_model_lines(app: &App, report: &UsageReport, inner_width: usize) -> Vec<Line<'static>> {
+fn build_usage_model_lines(
+    app: &App,
+    report: &UsageReport,
+    inner_width: usize,
+) -> Vec<Line<'static>> {
     let model_max =
         report.by_model.iter().map(|model| model.tokens.total_tokens).max().unwrap_or(0);
     let mut lines = vec![Line::from(Span::styled(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -359,17 +359,49 @@ fn render_usage_breakdown(f: &mut Frame, app: &App, area: Rect) {
         return;
     };
 
-    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let inner_width = inner.width as usize;
+    let source_rows = report.by_source.len().max(1) as u16 + 2;
+    let token_mix_rows = 7;
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(source_rows),
+            Constraint::Length(token_mix_rows),
+            Constraint::Min(1),
+        ])
+        .split(inner);
+
+    f.render_widget(
+        Paragraph::new(build_usage_source_lines(app, report, inner_width)),
+        sections[0],
+    );
+    f.render_widget(
+        Paragraph::new(build_usage_token_mix_lines(report, inner_width)),
+        sections[1],
+    );
+
+    let model_lines = build_usage_model_lines(app, report, inner_width);
+    let visible_height = sections[2].height as usize;
+    let max_scroll = model_lines.len().saturating_sub(visible_height);
+    let scroll = app.usage_breakdown_scroll.min(max_scroll as u16) as usize;
+    f.render_widget(
+        Paragraph::new(model_lines).scroll((scroll as u16, 0)),
+        sections[2],
+    );
+}
+
+fn build_usage_source_lines(app: &App, report: &UsageReport, inner_width: usize) -> Vec<Line<'static>> {
     let source_max =
         report.by_source.iter().map(|source| source.tokens.total_tokens).max().unwrap_or(0);
-    let model_max =
-        report.by_model.iter().map(|model| model.tokens.total_tokens).max().unwrap_or(0);
     let mut lines = vec![Line::from(Span::styled(
-        " Sources",
+        format!(" Sources ({})", report.by_source.len()),
         Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
     ))];
 
-    for source in report.by_source.iter().take(5) {
+    for source in &report.by_source {
         lines.push(usage_bar_line(
             app.source_label_for(&source.source),
             source.tokens.total_tokens,
@@ -381,13 +413,29 @@ fn render_usage_breakdown(f: &mut Frame, app: &App, area: Rect) {
     if report.by_source.is_empty() {
         lines.push(Line::from(Span::styled("  -", Style::default().fg(Color::DarkGray))));
     }
-
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        " Models",
+    lines
+}
+
+fn build_usage_token_mix_lines(report: &UsageReport, inner_width: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        " Token Mix",
         Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
-    )));
-    for model in report.by_model.iter().take(6) {
+    ))];
+    lines.extend(token_mix_lines(&report.summary.tokens, inner_width));
+    lines.push(Line::from(""));
+    lines
+}
+
+fn build_usage_model_lines(app: &App, report: &UsageReport, inner_width: usize) -> Vec<Line<'static>> {
+    let model_max =
+        report.by_model.iter().map(|model| model.tokens.total_tokens).max().unwrap_or(0);
+    let mut lines = vec![Line::from(Span::styled(
+        format!(" Models ({})", report.by_model.len()),
+        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+    ))];
+
+    for model in &report.by_model {
         let label = format!("{}:{}", app.source_label_for(&model.source), model.model);
         lines.push(usage_bar_line(
             &label,
@@ -400,15 +448,7 @@ fn render_usage_breakdown(f: &mut Frame, app: &App, area: Rect) {
     if report.by_model.is_empty() {
         lines.push(Line::from(Span::styled("  -", Style::default().fg(Color::DarkGray))));
     }
-
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        " Token Mix",
-        Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
-    )));
-    lines.extend(token_mix_lines(&report.summary.tokens, inner_width));
-
-    f.render_widget(Paragraph::new(lines).block(block), area);
+    lines
 }
 
 fn render_usage_status(f: &mut Frame, area: Rect) {
@@ -417,6 +457,8 @@ fn render_usage_status(f: &mut Frame, area: Rect) {
         Span::styled(" time  ", Style::default().fg(Color::DarkGray)),
         Span::styled("s", Style::default().fg(Color::Yellow)),
         Span::styled(" source  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+        Span::styled(" breakdown  ", Style::default().fg(Color::DarkGray)),
         Span::styled("r", Style::default().fg(Color::Yellow)),
         Span::styled(" reset  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Esc/q", Style::default().fg(Color::Yellow)),


### PR DESCRIPTION
### What's changed?

- Index Cursor IDE composer sessions from `state.vscdb` for search and usage, with agent-transcript fallback
- Add `recall sync --source` to rebuild a single adapter
- Improve usage breakdown TUI: show all sources/models, Token Mix above Models, scrollable model list
- Index Gemini CLI per-message token usage from chat JSON logs
- Fix Cursor context breakdown mapping (no fake API output tokens; prefer bubble-level observed usage)
- Apply rustfmt/clippy fixes for `make check`

### Why

- Cursor and Gemini sessions were searchable but missing or inaccurate in usage reporting
- Usage breakdown previously capped sources/models and buried Token Mix below long model lists
- Context-window breakdown was being misread as API input/output token billing

## Test plan

- [x] `make check` (fmt, clippy, tests)
- [ ] `recall sync --force --source cursor` and `recall sync --force --source gemini-cli`
- [ ] `recall usage` — verify GEM/CUR sources, breakdown layout, model scrolling