### PR TITLE
[Feat] Add Skills tab to usage dashboard

### DIFF
--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -6,14 +6,17 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::events;
+use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::Role;
+use crate::types::{RawSessionEvent, Role};
 
 pub struct CopilotAdapter;
+
+const EVENT_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CopilotAdapter {
     fn id(&self) -> &str {
@@ -40,7 +43,7 @@ impl SourceAdapter for CopilotAdapter {
             let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
                 continue;
             };
-            if let Some(raw) = parse_copilot_session_for_entry(entry, mtime_ms)? {
+            if let Some(raw) = parse_copilot_session_for_entry(entry, mtime_ms, true)? {
                 sessions.push(raw);
             }
         }
@@ -51,12 +54,12 @@ impl SourceAdapter for CopilotAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
-        _include_events: bool,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(sessions_dir) = resolve_copilot_dir()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
-        let result = scan_for_sync_impl(&sessions_dir, store, since_ts)?;
+        let result = scan_for_sync_impl(&sessions_dir, store, since_ts, include_events)?;
         Ok(Some(result))
     }
 }
@@ -75,14 +78,19 @@ fn scan_for_sync_impl(
     sessions_dir: &Path,
     store: &Store,
     since_ts: Option<i64>,
+    include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_copilot_entries(sessions_dir);
-    file_scan::run_file_scan(
+    file_scan::run_file_scan_with_options(
         store,
         "copilot-cli",
         since_ts,
+        FileScanOptions {
+            usage_parser_version: None,
+            event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+        },
         entries,
-        parse_copilot_session_for_entry,
+        |entry, mtime_ms| parse_copilot_session_for_entry(entry, mtime_ms, include_events),
     )
 }
 
@@ -146,6 +154,7 @@ fn peek_copilot_session_id(events_path: &Path) -> Option<String> {
 fn parse_copilot_session_for_entry(
     entry: FileScanEntry,
     mtime_ms: i64,
+    include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
     let file = match fs::File::open(&entry.stat_target) {
         Ok(f) => f,
@@ -155,7 +164,13 @@ fn parse_copilot_session_for_entry(
         }
     };
     let lines = BufReader::new(file).lines();
-    let mut raw = match parse_copilot_events_from_lines(lines, &entry.session_id) {
+    let source_path = entry.stat_target.display().to_string();
+    let mut raw = match parse_copilot_events_from_lines(
+        lines,
+        &entry.session_id,
+        include_events,
+        Some(source_path),
+    ) {
         Ok(Some(raw)) => raw,
         Ok(None) => return Ok(None),
         Err(e) => {
@@ -175,12 +190,16 @@ pub fn parse_copilot_events(
     parse_copilot_events_from_lines(
         content.lines().map(|s| io::Result::Ok(s.to_string())),
         fallback_id,
+        true,
+        None,
     )
 }
 
 fn parse_copilot_events_from_lines<I>(
     lines: I,
     fallback_id: &str,
+    include_events: bool,
+    source_path: Option<String>,
 ) -> anyhow::Result<Option<RawSession>>
 where
     I: IntoIterator<Item = io::Result<String>>,
@@ -190,6 +209,7 @@ where
     let mut meta_started_at: Option<i64> = None;
     let mut tool_names: HashMap<String, String> = HashMap::new();
     let mut messages = Vec::new();
+    let mut session_events = Vec::new();
 
     for line in lines {
         let line = line?;
@@ -204,6 +224,7 @@ where
 
         let event_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
         let timestamp = parse_timestamp(&v);
+        let line_id = v.get("id").and_then(|id| id.as_str()).map(str::to_string);
 
         match event_type {
             "session.start" => {
@@ -241,6 +262,17 @@ where
                     (true, false) => tool_text,
                     (false, false) => format!("{prose}\n{tool_text}"),
                 };
+                let message_seq = messages.len() as u32;
+                if include_events {
+                    collect_tool_request_events(
+                        data.get("toolRequests"),
+                        timestamp,
+                        source_path.as_deref(),
+                        line_id.as_deref(),
+                        message_seq,
+                        &mut session_events,
+                    );
+                }
                 messages.push(RawMessage { role: Role::Assistant, content, timestamp });
             }
             "tool.execution_start" => {
@@ -263,6 +295,36 @@ where
                     .unwrap_or("")
                     .trim()
                     .to_string();
+                if include_events {
+                    let tool_name = data
+                        .get("toolCallId")
+                        .and_then(|s| s.as_str())
+                        .and_then(|id| tool_names.get(id).cloned())
+                        .or_else(|| {
+                            data.get("toolName").and_then(|s| s.as_str()).map(str::to_string)
+                        })
+                        .unwrap_or_else(|| "tool".to_string());
+                    let summary = if text.is_empty() { None } else { Some(text.clone()) };
+                    let mut event = events::tool_result_event(
+                        events::EventContext {
+                            event_seq: session_events.len() as u32,
+                            timestamp,
+                            source_path: source_path.clone(),
+                            source_event_id: line_id.clone().or_else(|| {
+                                data.get("toolCallId").and_then(|s| s.as_str()).map(str::to_string)
+                            }),
+                            message_seq: None,
+                            parser_version: EVENT_PARSER_VERSION,
+                        },
+                        Some(tool_name),
+                        summary,
+                    );
+                    if let Some(success) = data.get("success").and_then(|value| value.as_bool()) {
+                        event.status =
+                            Some(if success { "success".to_string() } else { "error".to_string() });
+                    }
+                    session_events.push(event);
+                }
                 if text.is_empty() {
                     continue;
                 }
@@ -281,7 +343,7 @@ where
         }
     }
 
-    if messages.is_empty() {
+    if messages.is_empty() && session_events.is_empty() {
         return Ok(None);
     }
 
@@ -290,7 +352,44 @@ where
         meta_started_at.or_else(|| messages.first().and_then(|m| m.timestamp)).unwrap_or(0);
     let updated_at = messages.last().and_then(|m| m.timestamp);
 
-    Ok(Some(RawSession::search_only(source_id, directory, started_at, updated_at, None, messages)))
+    let mut session =
+        RawSession::search_only(source_id, directory, started_at, updated_at, None, messages);
+    if include_events {
+        session = session.with_events(session_events, EVENT_PARSER_VERSION);
+    }
+    Ok(Some(session))
+}
+
+fn collect_tool_request_events(
+    tool_requests: Option<&Value>,
+    timestamp: Option<i64>,
+    source_path: Option<&str>,
+    source_event_id: Option<&str>,
+    message_seq: u32,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(requests) = tool_requests.and_then(|value| value.as_array()) else {
+        return;
+    };
+    for (index, request) in requests.iter().enumerate() {
+        let name =
+            request.get("name").and_then(|value| value.as_str()).unwrap_or("tool").to_string();
+        let call_id =
+            request.get("toolCallId").and_then(|value| value.as_str()).map(str::to_string);
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: source_path.map(str::to_string),
+                source_event_id: call_id
+                    .or_else(|| source_event_id.map(|id| format!("{id}:tool:{index}"))),
+                message_seq: Some(message_seq),
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name,
+            request.get("arguments"),
+        ));
+    }
 }
 
 fn extract_tool_requests(tool_requests: Option<&Value>) -> String {
@@ -437,6 +536,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_copilot_events_extracts_tool_events() {
+        let jsonl = r##"{"type":"session.start","data":{"sessionId":"sess-2","startTime":"2026-04-13T10:00:00Z","context":{"cwd":"/proj"}},"id":"e1","timestamp":"2026-04-13T10:00:00Z","parentId":null}
+{"type":"assistant.message","data":{"messageId":"m1","content":"Let me read the file.","toolRequests":[{"toolCallId":"tc1","name":"read_file","arguments":{"path":"/tmp/README.md"},"type":"function"}]},"id":"e2","timestamp":"2026-04-13T10:00:05Z","parentId":"e1"}
+{"type":"tool.execution_complete","data":{"toolCallId":"tc1","toolName":"read_file","success":true,"result":{"content":"short summary","detailedContent":"# My Project\nHello world."}},"id":"e4","timestamp":"2026-04-13T10:00:06Z","parentId":"e3"}"##;
+
+        let session = parse_copilot_events(jsonl, "fallback").unwrap().unwrap();
+        assert_eq!(session.events.len(), 2);
+        assert_eq!(session.events[0].kind, "file_read");
+        assert_eq!(session.events[0].name.as_deref(), Some("read_file"));
+        assert_eq!(session.events[0].target.as_deref(), Some("/tmp/README.md"));
+        assert_eq!(session.events[1].kind, "tool_result");
+        assert_eq!(session.events[1].status.as_deref(), Some("success"));
+        assert_eq!(session.event_parser_version, Some(EVENT_PARSER_VERSION));
+    }
+
+    #[test]
     fn scan_for_sync_skips_unchanged_session() {
         let root = temp_copilot_root("skip");
         let sessions_dir = root.join("session-state");
@@ -446,8 +561,17 @@ mod tests {
 
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "copilot-cli",
+                uuid,
+                &[],
+                EVENT_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -465,7 +589,7 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -483,7 +607,7 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.stats.skipped_sessions, 0);
@@ -508,7 +632,7 @@ mod tests {
         writeln!(f, "{user}").unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, dir_name);
 
@@ -530,7 +654,7 @@ mod tests {
         f.write_all(&[0xFF, 0xFE, 0xFD, 0xFC]).unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_impl(&sessions_dir, &store, None).unwrap();
+        let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, good_uuid);
 

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -9,15 +9,17 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::events;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::{Store, UsageSessionStateMeta};
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::db::store::{EventSessionStateMeta, Store, UsageSessionStateMeta};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
 
 pub struct CursorAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 2;
+const EVENT_PARSER_VERSION: u32 = 1;
 
 #[derive(Debug, Clone)]
 struct ComposerMeta {
@@ -31,6 +33,7 @@ struct ComposerMeta {
 struct ParsedComposerSession {
     messages: Vec<RawMessage>,
     usage_events: Vec<RawUsageEvent>,
+    events: Vec<RawSessionEvent>,
     started_at: i64,
     updated_at: Option<i64>,
     entrypoint: Option<String>,
@@ -55,14 +58,14 @@ impl SourceAdapter for CursorAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        scan_cursor_sessions(None)
+        scan_cursor_sessions(None, true)
     }
 
     fn scan_for_sync(
         &self,
         store: &Store,
         since_ts: Option<i64>,
-        _include_events: bool,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_global_db()? else {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
@@ -70,6 +73,8 @@ impl SourceAdapter for CursorAdapter {
 
         let existing = store.session_meta_map(self.id())?;
         let usage_state = store.usage_state_meta_map(self.id())?;
+        let event_state =
+            if include_events { store.event_state_meta_map(self.id())? } else { HashMap::new() };
         let global_mtime = global_db_mtime();
         let composer_ids = discover_composer_ids(&conn)?;
         let transcript_paths = collect_agent_transcript_paths();
@@ -89,13 +94,20 @@ impl SourceAdapter for CursorAdapter {
             let source_updated_at = updated_at.or(global_mtime);
             if let Some((old_updated_at, _)) = existing.get(&composer_id)
                 && *old_updated_at == source_updated_at
-                && usage_state_is_current(usage_state.get(&composer_id).copied(), source_updated_at)
+                && session_state_is_current(
+                    usage_state.get(&composer_id).copied(),
+                    event_state.get(&composer_id).copied(),
+                    source_updated_at,
+                    include_events,
+                )
             {
                 stats.skipped_sessions += 1;
                 continue;
             }
 
-            if let Some(raw) = build_raw_session(&conn, &composer_id, &meta, &transcript_paths)? {
+            if let Some(raw) =
+                build_raw_session(&conn, &composer_id, &meta, &transcript_paths, include_events)?
+            {
                 sessions.push(raw);
             }
         }
@@ -104,9 +116,12 @@ impl SourceAdapter for CursorAdapter {
     }
 }
 
-fn scan_cursor_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<RawSession>> {
+fn scan_cursor_sessions(
+    since_ts: Option<i64>,
+    include_events: bool,
+) -> anyhow::Result<Vec<RawSession>> {
     let Some(conn) = open_global_db()? else {
-        return scan_transcript_only_sessions(since_ts);
+        return scan_transcript_only_sessions(since_ts, include_events);
     };
 
     let transcript_paths = collect_agent_transcript_paths();
@@ -119,14 +134,19 @@ fn scan_cursor_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<RawSession>
                 continue;
             }
         }
-        if let Some(raw) = build_raw_session(&conn, &composer_id, &meta, &transcript_paths)? {
+        if let Some(raw) =
+            build_raw_session(&conn, &composer_id, &meta, &transcript_paths, include_events)?
+        {
             sessions.push(raw);
         }
     }
     Ok(sessions)
 }
 
-fn scan_transcript_only_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<RawSession>> {
+fn scan_transcript_only_sessions(
+    since_ts: Option<i64>,
+    include_events: bool,
+) -> anyhow::Result<Vec<RawSession>> {
     let Some(projects_dir) = resolve_projects_dir()? else {
         return Ok(vec![]);
     };
@@ -141,7 +161,7 @@ fn scan_transcript_only_sessions(since_ts: Option<i64>) -> anyhow::Result<Vec<Ra
         {
             continue;
         }
-        let mut raw = match parse_agent_transcript(&path)? {
+        let mut raw = match parse_agent_transcript(&path, include_events)? {
             Some(raw) => raw,
             None => continue,
         };
@@ -159,15 +179,23 @@ fn build_raw_session(
     composer_id: &str,
     meta: &ComposerMeta,
     transcript_paths: &HashMap<String, PathBuf>,
+    include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
-    let parsed = match parse_composer_session(conn, composer_id, meta)? {
-        Some(parsed) if !parsed.messages.is_empty() || !parsed.usage_events.is_empty() => parsed,
+    let parsed = match parse_composer_session(conn, composer_id, meta, include_events)? {
+        Some(parsed)
+            if !parsed.messages.is_empty()
+                || !parsed.usage_events.is_empty()
+                || !parsed.events.is_empty() =>
+        {
+            parsed
+        }
         _ => {
             let Some(path) = transcript_paths.get(composer_id) else {
                 return Ok(None);
             };
             let mtime_ms = stat_mtime_ms(path).unwrap_or(0);
-            let raw = parse_agent_transcript(path)?.filter(|raw| !raw.messages.is_empty());
+            let raw = parse_agent_transcript(path, include_events)?
+                .filter(|raw| !raw.messages.is_empty() || !raw.events.is_empty());
             let Some(mut raw) = raw else {
                 return Ok(None);
             };
@@ -180,23 +208,26 @@ fn build_raw_session(
         }
     };
 
-    Ok(Some(
-        RawSession::search_only(
-            composer_id.to_string(),
-            parsed.directory.or(meta.directory.clone()),
-            parsed.started_at,
-            parsed.updated_at,
-            parsed.entrypoint.or(meta.unified_mode.clone()),
-            parsed.messages,
-        )
-        .with_usage(parsed.usage_events, USAGE_PARSER_VERSION),
-    ))
+    let mut session = RawSession::search_only(
+        composer_id.to_string(),
+        parsed.directory.or(meta.directory.clone()),
+        parsed.started_at,
+        parsed.updated_at,
+        parsed.entrypoint.or(meta.unified_mode.clone()),
+        parsed.messages,
+    )
+    .with_usage(parsed.usage_events, USAGE_PARSER_VERSION);
+    if include_events {
+        session = session.with_events(parsed.events, EVENT_PARSER_VERSION);
+    }
+    Ok(Some(session))
 }
 
 fn parse_composer_session(
     conn: &Connection,
     composer_id: &str,
     meta: &ComposerMeta,
+    include_events: bool,
 ) -> anyhow::Result<Option<ParsedComposerSession>> {
     let Some(raw_json) = read_disk_kv(conn, &format!("composerData:{composer_id}")) else {
         return Ok(None);
@@ -219,6 +250,8 @@ fn parse_composer_session(
     let mut messages = Vec::new();
     let mut usage_events = Vec::new();
     let mut bubble_usage_events = Vec::new();
+    let mut session_events = Vec::new();
+    let source_path = format!("composer:{composer_id}");
 
     for (index, header) in headers.iter().enumerate() {
         let bubble_id = header.get("bubbleId").and_then(|value| value.as_str());
@@ -248,7 +281,22 @@ fn parse_composer_session(
                     .and_then(|value| json_i64(value.get("createdAt")))
             });
 
-        messages.push(RawMessage { role, content, timestamp });
+        messages.push(RawMessage { role: role.clone(), content, timestamp });
+
+        if include_events
+            && matches!(role, Role::Assistant)
+            && let Some(bubble) = bubble.as_ref()
+        {
+            let message_seq = (messages.len() - 1) as u32;
+            collect_bubble_tool_events(
+                bubble,
+                bubble_id.unwrap_or("unknown"),
+                &source_path,
+                timestamp,
+                message_seq,
+                &mut session_events,
+            );
+        }
 
         if let Some(bubble) = bubble.as_ref()
             && let Some(event) = extract_bubble_usage_event(
@@ -270,7 +318,7 @@ fn parse_composer_session(
         usage_events.push(event);
     }
 
-    if messages.is_empty() && usage_events.is_empty() {
+    if messages.is_empty() && usage_events.is_empty() && session_events.is_empty() {
         return Ok(None);
     }
 
@@ -286,6 +334,7 @@ fn parse_composer_session(
     Ok(Some(ParsedComposerSession {
         messages,
         usage_events,
+        events: session_events,
         started_at,
         updated_at,
         entrypoint: data
@@ -475,6 +524,96 @@ fn render_bubble_content(bubble: &Value, role: &Role) -> String {
     parts.join("\n")
 }
 
+fn collect_bubble_tool_events(
+    bubble: &Value,
+    bubble_id: &str,
+    source_path: &str,
+    timestamp: Option<i64>,
+    message_seq: u32,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(tool_data) = bubble.get("toolFormerData") else {
+        return;
+    };
+    let name = tool_data.get("name").and_then(|value| value.as_str()).unwrap_or("tool").to_string();
+    let source_event_id = Some(bubble_id.to_string());
+
+    if let Some(params) = tool_data.get("params") {
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: Some(source_path.to_string()),
+                source_event_id: source_event_id.clone(),
+                message_seq: Some(message_seq),
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name.clone(),
+            Some(params),
+        ));
+    } else if let Some(raw_args) = tool_data.get("rawArgs") {
+        match raw_args {
+            Value::String(text) => {
+                events_out.push(events::tool_call_event_from_text(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: source_event_id.clone(),
+                        message_seq: Some(message_seq),
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name.clone(),
+                    Some(text.as_str()),
+                ));
+            }
+            other => {
+                events_out.push(events::tool_call_event(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: source_event_id.clone(),
+                        message_seq: Some(message_seq),
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name.clone(),
+                    Some(other),
+                ));
+            }
+        }
+    } else {
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: Some(source_path.to_string()),
+                source_event_id: source_event_id.clone(),
+                message_seq: Some(message_seq),
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name.clone(),
+            None,
+        ));
+    }
+
+    if let Some(result) = tool_data.get("result") {
+        let summary = render_json_fragment(result).filter(|text| !text.is_empty());
+        events_out.push(events::tool_result_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: Some(source_path.to_string()),
+                source_event_id,
+                message_seq: Some(message_seq),
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            Some(name),
+            summary,
+        ));
+    }
+}
+
 fn render_legacy_bubble(value: &Value, role: &Role) -> String {
     if let Some(text) = non_empty_str(value.get("text")) {
         let normalized = if matches!(role, Role::User) {
@@ -638,12 +777,14 @@ fn bubble_role(header_type: Option<i64>) -> Option<Role> {
     }
 }
 
-fn parse_agent_transcript(path: &Path) -> anyhow::Result<Option<RawSession>> {
+fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<Option<RawSession>> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
+    let mut session_events = Vec::new();
+    let source_path = path.display().to_string();
 
-    for line in reader.lines() {
+    for (line_index, line) in reader.lines().enumerate() {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {
@@ -664,6 +805,16 @@ fn parse_agent_transcript(path: &Path) -> anyhow::Result<Option<RawSession>> {
             continue;
         };
         let is_user = matches!(role, Role::User);
+        if include_events && matches!(role, Role::Assistant) {
+            let message_seq = if messages.is_empty() { None } else { Some(messages.len() as u32) };
+            collect_transcript_content_events(
+                items,
+                &source_path,
+                line_index,
+                message_seq,
+                &mut session_events,
+            );
+        }
         let content = render_transcript_content_items(items, is_user);
         if content.is_empty() {
             continue;
@@ -671,18 +822,43 @@ fn parse_agent_transcript(path: &Path) -> anyhow::Result<Option<RawSession>> {
         messages.push(RawMessage { role, content, timestamp: None });
     }
 
-    if messages.is_empty() {
+    if messages.is_empty() && session_events.is_empty() {
         return Ok(None);
     }
 
-    Ok(Some(RawSession::search_only(
-        String::new(),
-        None,
-        0,
-        None,
-        Some("agent".to_string()),
-        messages,
-    )))
+    let mut session =
+        RawSession::search_only(String::new(), None, 0, None, Some("agent".to_string()), messages);
+    if include_events {
+        session = session.with_events(session_events, EVENT_PARSER_VERSION);
+    }
+    Ok(Some(session))
+}
+
+fn collect_transcript_content_events(
+    items: &[Value],
+    source_path: &str,
+    line_index: usize,
+    message_seq: Option<u32>,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    for (item_index, item) in items.iter().enumerate() {
+        if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+            continue;
+        }
+        let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp: None,
+                source_path: Some(source_path.to_string()),
+                source_event_id: Some(format!("{line_index}:{item_index}")),
+                message_seq,
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name,
+            item.get("input"),
+        ));
+    }
 }
 
 fn render_transcript_content_items(items: &[Value], is_user: bool) -> String {
@@ -810,6 +986,31 @@ fn usage_state_is_current(
         return false;
     };
     state.parser_version >= USAGE_PARSER_VERSION && state.source_updated_at == source_updated_at
+}
+
+fn event_state_is_current(
+    state: Option<EventSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    let Some(state) = state else {
+        return false;
+    };
+    state.parser_version >= EVENT_PARSER_VERSION && state.source_updated_at == source_updated_at
+}
+
+fn session_state_is_current(
+    usage_state: Option<UsageSessionStateMeta>,
+    event_state: Option<EventSessionStateMeta>,
+    source_updated_at: Option<i64>,
+    include_events: bool,
+) -> bool {
+    if !usage_state_is_current(usage_state, source_updated_at) {
+        return false;
+    }
+    if include_events && !event_state_is_current(event_state, source_updated_at) {
+        return false;
+    }
+    true
 }
 
 fn build_agent_cwd_map(db_path: Option<&Path>) -> HashMap<String, String> {
@@ -1035,7 +1236,7 @@ mod tests {
         let bubble_id = uuid::Uuid::new_v4().to_string();
         let conn = seed_global_db(&root, &composer_id, &bubble_id);
         let meta = load_composer_meta(&conn, &composer_id);
-        let parsed = parse_composer_session(&conn, &composer_id, &meta).unwrap().unwrap();
+        let parsed = parse_composer_session(&conn, &composer_id, &meta, false).unwrap().unwrap();
         assert_eq!(parsed.messages.len(), 1);
         assert_eq!(parsed.messages[0].content, "hello cursor");
         assert_eq!(parsed.usage_events.len(), 1);
@@ -1085,11 +1286,77 @@ mod tests {
         .unwrap();
 
         let meta = load_composer_meta(&conn, &composer_id);
-        let parsed = parse_composer_session(&conn, &composer_id, &meta).unwrap().unwrap();
+        let parsed = parse_composer_session(&conn, &composer_id, &meta, false).unwrap().unwrap();
         assert_eq!(parsed.usage_events.len(), 1);
         assert_eq!(parsed.usage_events[0].token_source, TokenSource::Observed);
         assert_eq!(parsed.usage_events[0].input_tokens, 12);
         assert_eq!(parsed.usage_events[0].output_tokens, 34);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn parse_composer_session_extracts_tool_events() {
+        let root = temp_root("tool-events");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let composer_data = serde_json::json!({
+            "composerId": composer_id,
+            "createdAt": 1_700_000_000_000_i64,
+            "lastUpdatedAt": 1_700_000_100_000_i64,
+            "unifiedMode": "chat",
+            "modelConfig": { "modelName": "claude-sonnet-4" },
+            "fullConversationHeadersOnly": [
+                { "bubbleId": bubble_id, "type": 2 },
+            ]
+        });
+        conn.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+            rusqlite::params![composer_data.to_string(), format!("composerData:{composer_id}"),],
+        )
+        .unwrap();
+        let bubble = serde_json::json!({
+            "type": 2,
+            "text": "",
+            "createdAt": 1_700_000_050_000_i64,
+            "toolFormerData": {
+                "name": "grep",
+                "rawArgs": "{\"pattern\":\"usage\"}",
+                "result": "{\"matches\":1}"
+            }
+        });
+        conn.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+            rusqlite::params![bubble.to_string(), format!("bubbleId:{composer_id}:{bubble_id}"),],
+        )
+        .unwrap();
+
+        let meta = load_composer_meta(&conn, &composer_id);
+        let parsed = parse_composer_session(&conn, &composer_id, &meta, true).unwrap().unwrap();
+        assert_eq!(parsed.events.len(), 2);
+        assert_eq!(parsed.events[0].kind, "search");
+        assert_eq!(parsed.events[0].name.as_deref(), Some("grep"));
+        assert_eq!(parsed.events[1].kind, "tool_result");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn parse_agent_transcript_extracts_tool_use_events() {
+        let root = temp_root("transcript-events");
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let jsonl_path = root.join(format!("{uuid}.jsonl"));
+        write_jsonl(
+            &jsonl_path,
+            &[
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nhello\n</user_query>"}]}}"#,
+                r#"{"role":"assistant","message":{"content":[{"type":"text","text":"searching"},{"type":"tool_use","name":"Glob","input":{"glob_pattern":"*.rs"}}]}}"#,
+            ],
+        );
+        let raw = parse_agent_transcript(&jsonl_path, true).unwrap().unwrap();
+        assert_eq!(raw.events.len(), 1);
+        assert_eq!(raw.events[0].kind, "search");
+        assert_eq!(raw.events[0].name.as_deref(), Some("Glob"));
+        assert_eq!(raw.event_parser_version, Some(EVENT_PARSER_VERSION));
         let _ = fs::remove_dir_all(root);
     }
 
@@ -1105,7 +1372,7 @@ mod tests {
                 r#"{"role":"assistant","message":{"content":[{"type":"text","text":"hi"},{"type":"tool_use","name":"Glob","input":{"glob_pattern":"*.rs"}}]}}"#,
             ],
         );
-        let raw = parse_agent_transcript(&jsonl_path).unwrap().unwrap();
+        let raw = parse_agent_transcript(&jsonl_path, true).unwrap().unwrap();
         assert_eq!(raw.messages.len(), 2);
         assert_eq!(raw.messages[0].content, "hello");
         assert!(raw.messages[1].content.contains("[tool_use:Glob]"));

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -154,3 +154,25 @@ pub fn app_command_for(source: &str, source_id: &str) -> Option<ResumeCommand> {
 pub fn source_labels() -> Vec<(String, String)> {
     all_adapters().iter().map(|a| (a.id().to_string(), a.label().to_string())).collect()
 }
+
+pub fn source_supports_event_backfill(source_id: &str) -> bool {
+    matches!(source_id, "codex" | "claude-code" | "cursor" | "copilot-cli" | "opencode")
+}
+
+pub fn adapter_supports_usage_dashboard(
+    adapter: &dyn SourceAdapter,
+    backfill_events: bool,
+) -> bool {
+    if adapter.usage_parser_version().is_some() {
+        return true;
+    }
+    backfill_events && source_supports_event_backfill(adapter.id())
+}
+
+pub fn dashboard_source_labels() -> Vec<(String, String)> {
+    all_adapters()
+        .iter()
+        .filter(|adapter| adapter_supports_usage_dashboard(adapter.as_ref(), true))
+        .map(|adapter| (adapter.id().to_string(), adapter.label().to_string()))
+        .collect()
+}

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -35,6 +35,16 @@ pub struct EventSessionStateMeta {
     pub source_updated_at: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+pub struct SkillAuditEventRow {
+    pub session_id: String,
+    pub source: String,
+    pub timestamp: Option<i64>,
+    pub name: Option<String>,
+    pub target: Option<String>,
+    pub attrs_json: Option<String>,
+}
+
 impl Store {
     pub fn open() -> Result<Self> {
         let data_dir = dirs::data_dir()
@@ -884,6 +894,98 @@ impl Store {
             })
         })?;
 
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn list_skill_audit_events(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+    ) -> Result<Vec<SkillAuditEventRow>> {
+        let mut sql = String::from(
+            "SELECT e.session_id, e.source,
+                    COALESCE(e.timestamp, s.updated_at, s.started_at) AS timestamp,
+                    e.name, e.target, e.attrs_json
+             FROM session_events e
+             JOIN sessions s ON s.id = e.session_id
+             WHERE (LOWER(e.name) IN ('skill', 'use_skill') OR e.target LIKE '%/skills/%/SKILL.md%'
+                    OR e.target LIKE '%/skills/%/references/%')",
+        );
+
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1;
+
+        if let Some(cutoff) = time_range.millis_ago() {
+            sql.push_str(&format!(
+                " AND COALESCE(e.timestamp, s.updated_at, s.started_at) >= ?{param_idx}"
+            ));
+            params.push(Box::new(cutoff));
+            param_idx += 1;
+        }
+
+        if let Some(source_ids) = sources
+            && !source_ids.is_empty()
+        {
+            sql.push_str(" AND e.source IN (");
+            for (i, source_id) in source_ids.iter().enumerate() {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&format!("?{param_idx}"));
+                params.push(Box::new(source_id.clone()));
+                param_idx += 1;
+            }
+            sql.push(')');
+        }
+
+        sql.push_str(
+            " ORDER BY COALESCE(e.timestamp, s.updated_at, s.started_at) ASC, e.session_id ASC, e.event_seq ASC",
+        );
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok(SkillAuditEventRow {
+                session_id: row.get(0)?,
+                source: row.get(1)?,
+                timestamp: row.get(2)?,
+                name: row.get(3)?,
+                target: row.get(4)?,
+                attrs_json: row.get(5)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn list_sessions_by_ids(&self, session_ids: &[String]) -> Result<Vec<Session>> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders =
+            std::iter::repeat_n("?", session_ids.len()).collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint
+             FROM sessions
+             WHERE id IN ({placeholders})
+             ORDER BY started_at DESC"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> =
+            session_ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+        let rows = stmt.query_map(params.as_slice(), |row| {
+            Ok(Session {
+                id: row.get(0)?,
+                source: row.get(1)?,
+                source_id: row.get(2)?,
+                title: row.get(3)?,
+                directory: row.get(4)?,
+                started_at: row.get(5)?,
+                updated_at: row.get(6)?,
+                message_count: row.get(7)?,
+                entrypoint: row.get(8)?,
+            })
+        })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod embedding;
 pub mod export;
 pub mod semantic;
+pub mod skill_audit;
 pub mod tui;
 pub mod types;
 pub mod usage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,14 @@ fn format_date_range(oldest: Option<i64>, newest: Option<i64>) -> String {
 fn cmd_sync(force: bool, verbose: bool, source_filter: Option<&str>) -> Result<()> {
     let labels = adapters::source_labels();
     let sources = resolve_source_filter(source_filter, &labels)?;
-    run_sync_job_inner(SyncRunOptions { force, verbose, emit: true, usage_only: false, sources })?;
+    run_sync_job_inner(SyncRunOptions {
+        force,
+        verbose,
+        emit: true,
+        usage_only: false,
+        backfill_events: false,
+        sources,
+    })?;
     semantic::ensure_background_worker(false)?;
     Ok(())
 }
@@ -328,6 +335,18 @@ fn run_usage_sync_job() -> Result<()> {
         verbose: false,
         emit: false,
         usage_only: true,
+        backfill_events: false,
+        sources: None,
+    })
+}
+
+fn run_dashboard_sync_job() -> Result<()> {
+    run_sync_job_inner(SyncRunOptions {
+        force: false,
+        verbose: false,
+        emit: false,
+        usage_only: true,
+        backfill_events: true,
         sources: None,
     })
 }
@@ -338,6 +357,7 @@ struct SyncRunOptions {
     verbose: bool,
     emit: bool,
     usage_only: bool,
+    backfill_events: bool,
     sources: Option<Vec<String>>,
 }
 
@@ -373,7 +393,12 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         let source_id = adapter.id();
         let label = adapter.label();
 
-        if options.usage_only && adapter.usage_parser_version().is_none() {
+        if options.usage_only
+            && !adapters::adapter_supports_usage_dashboard(
+                adapter.as_ref(),
+                options.backfill_events,
+            )
+        {
             continue;
         }
 
@@ -393,10 +418,11 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         if options.verbose {
             println!("Scanning {label}...");
         }
+        let include_events = !options.usage_only || options.backfill_events;
         let optimized = if options.force {
             None
         } else {
-            match adapter.scan_for_sync(&store, since_ts, !options.usage_only) {
+            match adapter.scan_for_sync(&store, since_ts, include_events) {
                 Ok(scan) => scan,
                 Err(e) => {
                     if options.emit {
@@ -431,7 +457,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
 
         let mut existing_meta = store.session_meta_map(source_id)?;
         let mut existing_usage_meta = store.usage_state_meta_map(source_id)?;
-        let mut existing_event_meta = if options.usage_only {
+        let mut existing_event_meta = if options.usage_only && !options.backfill_events {
             Default::default()
         } else {
             store.event_state_meta_map(source_id)?
@@ -455,7 +481,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                     raw.updated_at,
                 )
             });
-            let event_backfill_needed = !options.usage_only
+            let event_backfill_needed = (options.backfill_events || !options.usage_only)
                 && raw.event_parser_version.is_some_and(|version| {
                     !event_state_is_current(
                         version,
@@ -470,6 +496,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
                     match decide_existing_session_action(
                         options.usage_only,
+                        options.backfill_events,
                         options.force,
                         content_changed,
                         usage_backfill_needed,
@@ -567,10 +594,11 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 })
                 .collect();
 
-            let (events, event_parser_version) = if options.usage_only {
-                (Vec::new(), None)
-            } else {
+            let persist_events = !options.usage_only || options.backfill_events;
+            let (events, event_parser_version) = if persist_events {
                 (raw.events, raw.event_parser_version)
+            } else {
+                (Vec::new(), None)
             };
 
             store.persist_session_with_usage_and_events(
@@ -674,14 +702,20 @@ fn event_state_is_current(
 
 fn decide_existing_session_action(
     usage_only: bool,
+    backfill_events: bool,
     force: bool,
     content_changed: bool,
     usage_backfill_needed: bool,
     event_backfill_needed: bool,
 ) -> ExistingSessionAction {
     if usage_only {
-        return if usage_backfill_needed {
-            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: false })
+        let needs_usage = usage_backfill_needed;
+        let needs_events = backfill_events && event_backfill_needed;
+        return if needs_usage || needs_events {
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: needs_usage,
+                events: needs_events,
+            })
         } else {
             ExistingSessionAction::Skip
         };
@@ -966,8 +1000,11 @@ fn cmd_tui(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Res
     let usage_mode = usage_start.is_some();
     let store = Store::open()?;
     semantic::ensure_background_worker(true)?;
-    let sources =
-        if usage_start.is_some() { usage_source_labels() } else { adapters::source_labels() };
+    let sources = if usage_start.is_some() {
+        adapters::dashboard_source_labels()
+    } else {
+        adapters::source_labels()
+    };
 
     struct TerminalGuard;
     impl Drop for TerminalGuard {
@@ -1022,7 +1059,7 @@ fn cmd_tui(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Res
         if app.usage_refresh_is_due() {
             if usage_sync_pending {
                 usage_sync_pending = false;
-                match run_usage_sync_job() {
+                match run_dashboard_sync_job() {
                     Ok(()) => app.refresh_usage(&store),
                     Err(err) => app.fail_usage_refresh(err),
                 }
@@ -1086,23 +1123,54 @@ fn generate_title(messages: &[adapters::RawMessage]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{BackfillPlan, ExistingSessionAction, decide_existing_session_action};
+    use recall::adapters::{
+        adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
+    };
+
+    #[test]
+    fn dashboard_sync_skips_sources_without_usage_or_events() {
+        for adapter in all_adapters() {
+            let id = adapter.id();
+            if matches!(id, "cline" | "antigravity-cli" | "kiro-cli") {
+                assert!(
+                    !adapter_supports_usage_dashboard(adapter.as_ref(), true),
+                    "{id} should be skipped during dashboard sync"
+                );
+            }
+            if source_supports_event_backfill(id) {
+                assert!(adapter_supports_usage_dashboard(adapter.as_ref(), true));
+            }
+        }
+    }
 
     #[test]
     fn usage_only_never_refreshes_existing_session() {
         assert_eq!(
-            decide_existing_session_action(true, false, true, true, true),
+            decide_existing_session_action(true, false, false, true, true, true),
             ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: false })
         );
         assert_eq!(
-            decide_existing_session_action(true, false, true, false, true),
+            decide_existing_session_action(true, false, false, true, false, true),
             ExistingSessionAction::Skip
+        );
+    }
+
+    #[test]
+    fn usage_only_can_backfill_events_without_refresh() {
+        assert_eq!(
+            decide_existing_session_action(true, true, false, true, false, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: false, events: true })
+        );
+        assert_eq!(
+            decide_existing_session_action(true, true, false, true, true, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: true })
         );
     }
 
     #[test]
     fn full_sync_refreshes_changed_existing_session() {
         assert_eq!(
-            decide_existing_session_action(false, false, true, true, true),
+            decide_existing_session_action(false, false, false, true, true, true),
             ExistingSessionAction::RefreshSession
         );
     }
@@ -1110,11 +1178,11 @@ mod tests {
     #[test]
     fn full_sync_backfills_unchanged_existing_session_in_place() {
         assert_eq!(
-            decide_existing_session_action(false, false, false, true, true),
+            decide_existing_session_action(false, false, false, false, true, true),
             ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: true })
         );
         assert_eq!(
-            decide_existing_session_action(false, false, false, false, false),
+            decide_existing_session_action(false, false, false, false, false, false),
             ExistingSessionAction::Skip
         );
     }

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -1,0 +1,570 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::{Local, TimeZone};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::db::search::TimeRange;
+use crate::db::store::{SkillAuditEventRow, Store};
+
+pub const CORE_INVOCATION_THRESHOLD: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum SkillTier {
+    Core,
+    Occasional,
+    Dormant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub enum SkillSignal {
+    ReadSkillFile,
+    SkillTool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillAuditFilters {
+    pub sources: Option<Vec<String>>,
+    pub time_range: TimeRange,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillAuditSummary {
+    pub installed: usize,
+    pub core: usize,
+    pub occasional: usize,
+    pub dormant: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillUsageEntry {
+    pub id: String,
+    pub tier: SkillTier,
+    pub invocations: usize,
+    pub last_used: Option<i64>,
+    pub signals: Vec<SkillSignal>,
+    pub install_path: Option<String>,
+    pub session_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillAuditReport {
+    pub summary: SkillAuditSummary,
+    pub core: Vec<SkillUsageEntry>,
+    pub occasional: Vec<SkillUsageEntry>,
+    pub dormant: Vec<SkillUsageEntry>,
+    pub coverage_note: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstalledSkill {
+    pub id: String,
+    pub install_path: String,
+}
+
+#[derive(Default)]
+struct SkillAccumulator {
+    invocations: usize,
+    sessions: HashSet<String>,
+    last_used: Option<i64>,
+    signals: BTreeSet<SkillSignal>,
+}
+
+pub fn build_skill_audit_report(
+    store: &Store,
+    filters: &SkillAuditFilters,
+) -> Result<SkillAuditReport> {
+    let installed = scan_installed_skills();
+    let installed_ids: HashSet<String> = installed.iter().map(|skill| skill.id.clone()).collect();
+    let events = store.list_skill_audit_events(filters.sources.as_deref(), filters.time_range)?;
+    let mut usage: HashMap<String, SkillAccumulator> = HashMap::new();
+    for event in &events {
+        let Some((skill_id, signal)) = extract_skill_from_event(event, &installed_ids) else {
+            continue;
+        };
+        let entry = usage.entry(skill_id).or_default();
+        let first_in_session = entry.sessions.insert(event.session_id.clone());
+        if first_in_session {
+            entry.invocations += 1;
+        }
+        entry.signals.insert(signal);
+        if let Some(timestamp) = event.timestamp {
+            entry.last_used =
+                Some(entry.last_used.map_or(timestamp, |current| current.max(timestamp)));
+        }
+    }
+
+    let mut core = Vec::new();
+    let mut occasional = Vec::new();
+    let mut dormant = Vec::new();
+
+    for skill in installed {
+        let accumulator = usage.remove(&skill.id).unwrap_or_default();
+        let entry = build_entry(skill.id, skill.install_path, accumulator);
+        match entry.tier {
+            SkillTier::Core => core.push(entry),
+            SkillTier::Occasional => occasional.push(entry),
+            SkillTier::Dormant => dormant.push(entry),
+        }
+    }
+
+    sort_entries(&mut core);
+    sort_entries(&mut occasional);
+    dormant.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let summary = SkillAuditSummary {
+        installed: core.len() + occasional.len() + dormant.len(),
+        core: core.len(),
+        occasional: occasional.len(),
+        dormant: dormant.len(),
+    };
+
+    let coverage_note = if events.is_empty() {
+        Some(
+            "No skill activity in index. Run `recall sync --force` on codex/claude/cursor sources."
+                .to_string(),
+        )
+    } else {
+        None
+    };
+
+    Ok(SkillAuditReport { summary, core, occasional, dormant, coverage_note })
+}
+
+fn build_entry(id: String, install_path: String, accumulator: SkillAccumulator) -> SkillUsageEntry {
+    let tier = if accumulator.invocations >= CORE_INVOCATION_THRESHOLD {
+        SkillTier::Core
+    } else if accumulator.invocations > 0 {
+        SkillTier::Occasional
+    } else {
+        SkillTier::Dormant
+    };
+    let mut session_ids: Vec<String> = accumulator.sessions.into_iter().collect();
+    session_ids.sort();
+    SkillUsageEntry {
+        id,
+        tier,
+        invocations: accumulator.invocations,
+        last_used: accumulator.last_used,
+        signals: accumulator.signals.into_iter().collect(),
+        install_path: Some(install_path),
+        session_ids,
+    }
+}
+
+fn sort_entries(entries: &mut [SkillUsageEntry]) {
+    entries.sort_by(|left, right| {
+        right.invocations.cmp(&left.invocations).then_with(|| left.id.cmp(&right.id))
+    });
+}
+
+pub fn scan_installed_skills() -> Vec<InstalledSkill> {
+    let Some(home) = home_dir() else {
+        return Vec::new();
+    };
+    let mut by_id: HashMap<String, InstalledSkill> = HashMap::new();
+    for root in personal_skill_roots(&home) {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.join("SKILL.md").is_file() {
+                continue;
+            }
+            let Some(id) = path.file_name().and_then(|name| name.to_str()).map(str::to_string)
+            else {
+                continue;
+            };
+            by_id
+                .entry(id.clone())
+                .or_insert(InstalledSkill { id, install_path: shorten_home_path(&path) });
+        }
+    }
+    let mut skills: Vec<_> = by_id.into_values().collect();
+    skills.sort_by(|left, right| left.id.cmp(&right.id));
+    skills
+}
+
+fn personal_skill_roots(home: &Path) -> Vec<PathBuf> {
+    [home.join(".claude/skills"), home.join(".codex/skills"), home.join(".agents/skills")]
+        .into_iter()
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn shorten_home_path(path: &Path) -> String {
+    if let Some(home) = home_dir()
+        && let Ok(stripped) = path.strip_prefix(&home)
+    {
+        return format!("~/{}", stripped.display());
+    }
+    path.display().to_string()
+}
+
+fn extract_skill_from_event(
+    event: &SkillAuditEventRow,
+    installed_ids: &HashSet<String>,
+) -> Option<(String, SkillSignal)> {
+    if event.name.as_deref().is_some_and(is_skill_tool_name)
+        && let Some(raw) = skill_from_attrs(event.attrs_json.as_deref())
+    {
+        return Some((resolve_skill_id(&raw, installed_ids), SkillSignal::SkillTool));
+    }
+    if let Some(target) = event.target.as_deref()
+        && let Some(raw) = skill_id_from_path(target)
+    {
+        return Some((resolve_skill_id(&raw, installed_ids), SkillSignal::ReadSkillFile));
+    }
+    None
+}
+
+fn is_skill_tool_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("skill") || name.eq_ignore_ascii_case("use_skill")
+}
+
+fn skill_from_attrs(attrs_json: Option<&str>) -> Option<String> {
+    let attrs = attrs_json?;
+    let value: Value = serde_json::from_str(attrs).ok()?;
+    for key in ["skill", "name"] {
+        if let Some(skill) = value.get(key).and_then(|skill| skill.as_str()) {
+            return Some(skill.to_string());
+        }
+    }
+    None
+}
+
+fn skill_id_from_path(path: &str) -> Option<String> {
+    let marker = "/skills/";
+    let idx = path.find(marker)?;
+    let rest = &path[idx + marker.len()..];
+    let mut parts = rest.split('/');
+    let skill_id = trim_path_token(parts.next()?);
+    if skill_id.is_empty() {
+        return None;
+    }
+    let tail = parts.map(trim_path_token).collect::<Vec<_>>().join("/");
+    if tail.is_empty()
+        || tail.starts_with("SKILL.md")
+        || tail == "references"
+        || tail.starts_with("references/")
+    {
+        return Some(skill_id.to_string());
+    }
+    None
+}
+
+fn trim_path_token(token: &str) -> &str {
+    token.trim().trim_matches('"').trim_matches('\'')
+}
+
+fn resolve_skill_id(raw: &str, installed_ids: &HashSet<String>) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if installed_ids.contains(trimmed) {
+        return trimmed.to_string();
+    }
+    if let Some((base, _)) = trimmed.split_once(':')
+        && installed_ids.contains(base)
+    {
+        return base.to_string();
+    }
+    for installed in installed_ids {
+        if installed.eq_ignore_ascii_case(trimmed) {
+            return installed.clone();
+        }
+        if let Some((base, _)) = trimmed.split_once(':')
+            && installed.eq_ignore_ascii_case(base)
+        {
+            return installed.clone();
+        }
+    }
+    trimmed
+        .split(':')
+        .next()
+        .unwrap_or(trimmed)
+        .split_whitespace()
+        .next()
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+pub fn format_last_used(timestamp_ms: Option<i64>) -> String {
+    let Some(timestamp_ms) = timestamp_ms else {
+        return "never".to_string();
+    };
+    let Some(dt) = Local.timestamp_millis_opt(timestamp_ms).single() else {
+        return "unknown".to_string();
+    };
+    let now = Local::now();
+    let days = now.date_naive().signed_duration_since(dt.date_naive()).num_days();
+    match days {
+        0 => "today".to_string(),
+        1 => "1d ago".to_string(),
+        2..=6 => format!("{days}d ago"),
+        7..=29 => format!("{}w ago", days / 7),
+        _ => dt.format("%Y-%m-%d").to_string(),
+    }
+}
+
+pub fn format_signals(signals: &[SkillSignal]) -> &'static str {
+    let has_tool = signals.contains(&SkillSignal::SkillTool);
+    let has_read = signals.contains(&SkillSignal::ReadSkillFile);
+    match (has_tool, has_read) {
+        (true, true) => "both",
+        (true, false) => "invoke",
+        (false, true) => "read",
+        (false, false) => "-",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn installed(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|id| (*id).to_string()).collect()
+    }
+
+    #[test]
+    fn skill_id_from_path_reads_parent_skill_md() {
+        assert_eq!(
+            skill_id_from_path("/Users/x/.agents/skills/pre-ship/SKILL.md").as_deref(),
+            Some("pre-ship")
+        );
+    }
+
+    #[test]
+    fn skill_id_from_path_reads_reference_files() {
+        assert_eq!(
+            skill_id_from_path("/Users/x/.agents/skills/pre-ship/references/codex-style.md")
+                .as_deref(),
+            Some("pre-ship")
+        );
+    }
+
+    #[test]
+    fn resolve_skill_id_uses_installed_canonical_name() {
+        let installed = installed(&["commit", "pre-ship"]);
+        assert_eq!(resolve_skill_id("commit", &installed), "commit");
+        assert_eq!(resolve_skill_id("code-gate:source-align", &installed), "code-gate");
+    }
+
+    #[test]
+    fn extract_skill_from_skill_tool_attrs() {
+        let event = SkillAuditEventRow {
+            session_id: "s1".to_string(),
+            source: "codex".to_string(),
+            timestamp: Some(1),
+            name: Some("Skill".to_string()),
+            target: None,
+            attrs_json: Some(r#"{"skill":"commit"}"#.to_string()),
+        };
+        let (id, signal) = extract_skill_from_event(&event, &installed(&["commit"])).unwrap();
+        assert_eq!(id, "commit");
+        assert_eq!(signal, SkillSignal::SkillTool);
+    }
+
+    #[test]
+    fn tiering_uses_core_threshold() {
+        let accumulator =
+            SkillAccumulator { invocations: CORE_INVOCATION_THRESHOLD, ..Default::default() };
+        let entry =
+            build_entry("ship".to_string(), "~/.claude/skills/ship".to_string(), accumulator);
+        assert_eq!(entry.tier, SkillTier::Core);
+    }
+
+    #[test]
+    fn skill_id_from_path_reads_skill_md_in_shell_command() {
+        assert_eq!(
+            skill_id_from_path(r#"cat "/Users/x/.agents/skills/pre-ship/SKILL.md" && echo ok"#)
+                .as_deref(),
+            Some("pre-ship")
+        );
+    }
+
+    #[test]
+    fn extract_skill_from_opencode_native_skill_tool() {
+        let event = SkillAuditEventRow {
+            session_id: "s1".to_string(),
+            source: "opencode".to_string(),
+            timestamp: Some(1),
+            name: Some("skill".to_string()),
+            target: None,
+            attrs_json: Some(r#"{"name":"commit"}"#.to_string()),
+        };
+        let (id, signal) = extract_skill_from_event(&event, &installed(&["commit"])).unwrap();
+        assert_eq!(id, "commit");
+        assert_eq!(signal, SkillSignal::SkillTool);
+    }
+
+    #[test]
+    fn extract_skill_from_opencode_use_skill_plugin() {
+        let event = SkillAuditEventRow {
+            session_id: "s1".to_string(),
+            source: "opencode".to_string(),
+            timestamp: Some(1),
+            name: Some("use_skill".to_string()),
+            target: None,
+            attrs_json: Some(r#"{"skill":"pre-ship"}"#.to_string()),
+        };
+        let (id, signal) = extract_skill_from_event(&event, &installed(&["pre-ship"])).unwrap();
+        assert_eq!(id, "pre-ship");
+        assert_eq!(signal, SkillSignal::SkillTool);
+    }
+
+    #[test]
+    fn dedupe_counts_one_invocation_per_session() {
+        let mut usage: HashMap<String, SkillAccumulator> = HashMap::new();
+        let installed = installed(&["pre-ship"]);
+        let events = [
+            SkillAuditEventRow {
+                session_id: "s1".to_string(),
+                source: "codex".to_string(),
+                timestamp: Some(1),
+                name: Some("Skill".to_string()),
+                target: None,
+                attrs_json: Some(r#"{"skill":"pre-ship"}"#.to_string()),
+            },
+            SkillAuditEventRow {
+                session_id: "s1".to_string(),
+                source: "codex".to_string(),
+                timestamp: Some(2),
+                name: None,
+                target: Some("/Users/x/.agents/skills/pre-ship/references/a.md".to_string()),
+                attrs_json: None,
+            },
+            SkillAuditEventRow {
+                session_id: "s2".to_string(),
+                source: "codex".to_string(),
+                timestamp: Some(3),
+                name: Some("Skill".to_string()),
+                target: None,
+                attrs_json: Some(r#"{"skill":"pre-ship"}"#.to_string()),
+            },
+        ];
+        for event in &events {
+            let Some((skill_id, signal)) = extract_skill_from_event(event, &installed) else {
+                continue;
+            };
+            let entry = usage.entry(skill_id).or_default();
+            let first_in_session = entry.sessions.insert(event.session_id.clone());
+            if first_in_session {
+                entry.invocations += 1;
+            }
+            entry.signals.insert(signal);
+            if let Some(timestamp) = event.timestamp {
+                entry.last_used =
+                    Some(entry.last_used.map_or(timestamp, |current| current.max(timestamp)));
+            }
+        }
+        let accumulator = usage.remove("pre-ship").unwrap();
+        assert_eq!(accumulator.invocations, 2);
+        assert_eq!(accumulator.sessions.len(), 2);
+        assert_eq!(accumulator.signals.len(), 2);
+        assert_eq!(accumulator.last_used, Some(3));
+    }
+
+    #[test]
+    fn list_skill_audit_events_includes_command_wrapped_skill_md_reads() {
+        use crate::db::schema;
+        use crate::db::search::TimeRange;
+        use crate::db::store::Store;
+        use crate::types::{RawSessionEvent, Session};
+
+        schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let session = Session {
+            id: "session-1".to_string(),
+            source: "codex".to_string(),
+            source_id: "codex-1".to_string(),
+            title: "Codex session".to_string(),
+            directory: None,
+            started_at: now,
+            updated_at: Some(now),
+            message_count: 0,
+            entrypoint: None,
+        };
+        let event = RawSessionEvent {
+            event_seq: 0,
+            timestamp: Some(now),
+            kind: "command".to_string(),
+            actor: "assistant".to_string(),
+            name: Some("bash".to_string()),
+            status: None,
+            target: Some(
+                r#"cat "/Users/x/.agents/skills/pre-ship/SKILL.md" && echo ok"#.to_string(),
+            ),
+            message_seq: None,
+            summary: None,
+            source_path: None,
+            source_event_id: None,
+            attrs_json: None,
+            parser_version: 1,
+        };
+        store
+            .persist_session_with_usage_and_events(&session, &[], &[], None, &[event], Some(1))
+            .unwrap();
+
+        let events = store.list_skill_audit_events(None, TimeRange::All).unwrap();
+        assert_eq!(events.len(), 1);
+        let (id, signal) = extract_skill_from_event(&events[0], &installed(&["pre-ship"])).unwrap();
+        assert_eq!(id, "pre-ship");
+        assert_eq!(signal, SkillSignal::ReadSkillFile);
+    }
+
+    #[test]
+    fn list_skill_audit_events_uses_session_timestamp_when_event_timestamp_missing() {
+        use crate::db::schema;
+        use crate::db::search::TimeRange;
+        use crate::db::store::Store;
+        use crate::types::{RawSessionEvent, Session};
+
+        schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let now = chrono::Utc::now().timestamp_millis();
+        let session = Session {
+            id: "session-1".to_string(),
+            source: "cursor".to_string(),
+            source_id: "cursor-1".to_string(),
+            title: "Cursor session".to_string(),
+            directory: None,
+            started_at: now,
+            updated_at: Some(now),
+            message_count: 0,
+            entrypoint: None,
+        };
+        let event = RawSessionEvent {
+            event_seq: 0,
+            timestamp: None,
+            kind: "tool_call".to_string(),
+            actor: "assistant".to_string(),
+            name: Some("Skill".to_string()),
+            status: None,
+            target: None,
+            message_seq: None,
+            summary: None,
+            source_path: None,
+            source_event_id: None,
+            attrs_json: Some(r#"{"skill":"commit"}"#.to_string()),
+            parser_version: 1,
+        };
+        store
+            .persist_session_with_usage_and_events(&session, &[], &[], None, &[event], Some(1))
+            .unwrap();
+
+        assert_eq!(store.list_skill_audit_events(None, TimeRange::All).unwrap().len(), 1);
+        let ranged = store.list_skill_audit_events(None, TimeRange::Month).unwrap();
+        assert_eq!(ranged.len(), 1);
+        assert_eq!(ranged[0].timestamp, Some(now));
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,12 +9,19 @@ use crate::config::AppConfig;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::{ProjectDirectory, Store};
 use crate::embedding::EmbeddingProvider;
+use crate::skill_audit::{self, SkillAuditFilters, SkillAuditReport};
 use crate::types::{
     BackgroundJobStatus, MatchSource, Message, Role, SearchResult, SemanticProgress,
 };
 use crate::usage::{self, UsageFilters, UsageReport};
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageTab {
+    Tokens,
+    Skills,
+}
 
 pub enum AppMode {
     Search,
@@ -100,6 +107,10 @@ mod tests {
             usage_time_filter: TimeRange::All,
             usage_refresh_requested_at: None,
             usage_breakdown_scroll: 0,
+            usage_tab: UsageTab::Tokens,
+            skill_audit_report: None,
+            skill_audit_error: None,
+            skill_audit_selected: 0,
         }
     }
 
@@ -405,6 +416,10 @@ pub struct App {
     pub usage_time_filter: TimeRange,
     pub usage_refresh_requested_at: Option<Instant>,
     pub usage_breakdown_scroll: u16,
+    pub usage_tab: UsageTab,
+    pub skill_audit_report: Option<SkillAuditReport>,
+    pub skill_audit_error: Option<String>,
+    pub skill_audit_selected: usize,
 }
 
 impl App {
@@ -476,6 +491,10 @@ impl App {
             usage_time_filter: TimeRange::All,
             usage_refresh_requested_at: None,
             usage_breakdown_scroll: 0,
+            usage_tab: UsageTab::Tokens,
+            skill_audit_report: None,
+            skill_audit_error: None,
+            skill_audit_selected: 0,
         };
         app.reset_search_defaults();
         app.update_scope_metrics(store);
@@ -640,8 +659,15 @@ impl App {
             AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.previous();
             }
-            AppMode::Usage if self.usage_breakdown_scroll > 0 => {
+            AppMode::Usage
+                if self.usage_tab == UsageTab::Tokens && self.usage_breakdown_scroll > 0 =>
+            {
                 self.usage_breakdown_scroll -= 1;
+            }
+            AppMode::Usage
+                if self.usage_tab == UsageTab::Skills && self.skill_audit_selected > 0 =>
+            {
+                self.skill_audit_selected -= 1;
             }
             _ => {}
         }
@@ -683,8 +709,14 @@ impl App {
             AppMode::Filters if !self.filters_editing_source && !self.filters_editing_project => {
                 self.filter_focus = self.filter_focus.next();
             }
-            AppMode::Usage => {
+            AppMode::Usage if self.usage_tab == UsageTab::Tokens => {
                 self.usage_breakdown_scroll = self.usage_breakdown_scroll.saturating_add(1);
+            }
+            AppMode::Usage
+                if self.usage_tab == UsageTab::Skills
+                    && self.skill_audit_selected + 1 < self.skill_audit_entry_count() =>
+            {
+                self.skill_audit_selected += 1;
             }
             _ => {}
         }
@@ -793,10 +825,18 @@ impl App {
         }
     }
 
-    fn handle_usage_key(&mut self, key: KeyEvent, _store: &Store) {
+    fn handle_usage_key(&mut self, key: KeyEvent, store: &Store) {
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => {
                 self.should_quit = true;
+            }
+            KeyCode::Char('m') | KeyCode::Char('M') => {
+                self.usage_tab = match self.usage_tab {
+                    UsageTab::Tokens => UsageTab::Skills,
+                    UsageTab::Skills => UsageTab::Tokens,
+                };
+                self.usage_breakdown_scroll = 0;
+                self.skill_audit_selected = 0;
             }
             KeyCode::Char('t') | KeyCode::Char('T') => {
                 self.cycle_usage_time(false);
@@ -810,8 +850,11 @@ impl App {
                 self.reset_usage_dashboard();
                 self.request_usage_refresh();
             }
-            KeyCode::Up => self.handle_scroll_up(_store),
-            KeyCode::Down => self.handle_scroll_down(_store),
+            KeyCode::Enter if self.usage_tab == UsageTab::Skills => {
+                self.open_skill_sessions(store);
+            }
+            KeyCode::Up | KeyCode::Char('k') => self.handle_scroll_up(store),
+            KeyCode::Down | KeyCode::Char('j') => self.handle_scroll_down(store),
             _ => {}
         }
     }
@@ -1556,7 +1599,9 @@ impl App {
     pub fn refresh_usage(&mut self, store: &Store) {
         self.usage_refresh_requested_at = None;
         self.usage_error = None;
+        self.skill_audit_error = None;
         self.usage_breakdown_scroll = 0;
+        self.skill_audit_selected = 0;
         let sources = self.source_filter_ids();
         let current_filters =
             UsageFilters { sources: sources.clone(), time_range: self.usage_time_filter };
@@ -1582,6 +1627,20 @@ impl App {
                 }
             }
         }
+
+        let skill_filters = SkillAuditFilters {
+            sources: self.source_filter_ids(),
+            time_range: self.usage_time_filter,
+        };
+        match skill_audit::build_skill_audit_report(store, &skill_filters) {
+            Ok(report) => {
+                self.skill_audit_report = Some(report);
+            }
+            Err(err) => {
+                self.skill_audit_report = None;
+                self.skill_audit_error = Some(format!("Skill audit unavailable: {err}"));
+            }
+        }
     }
 
     pub fn request_usage_refresh(&mut self) {
@@ -1603,7 +1662,9 @@ impl App {
         self.usage_refresh_requested_at = None;
         self.usage_report = None;
         self.usage_year_report = None;
+        self.skill_audit_report = None;
         self.usage_error = Some(format!("Usage unavailable: {error}"));
+        self.skill_audit_error = Some(format!("Skill audit unavailable: {error}"));
     }
 
     pub fn try_search(
@@ -1827,6 +1888,66 @@ impl App {
         self.source_filter_selection.clear();
         self.usage_time_filter = TimeRange::All;
         self.usage_breakdown_scroll = 0;
+        self.skill_audit_selected = 0;
+    }
+
+    pub fn usage_tab_label(&self) -> &'static str {
+        match self.usage_tab {
+            UsageTab::Tokens => "tokens",
+            UsageTab::Skills => "skills",
+        }
+    }
+
+    pub fn skill_audit_entry_count(&self) -> usize {
+        let Some(report) = self.skill_audit_report.as_ref() else {
+            return 0;
+        };
+        report.core.len() + report.occasional.len() + report.dormant.len()
+    }
+
+    fn open_skill_sessions(&mut self, store: &Store) {
+        let Some(report) = self.skill_audit_report.as_ref() else {
+            return;
+        };
+        let entries: Vec<_> =
+            report.core.iter().chain(&report.occasional).chain(&report.dormant).collect();
+        let Some(entry) = entries.get(self.skill_audit_selected) else {
+            return;
+        };
+        let skill_id = entry.id.clone();
+        let session_ids = entry.session_ids.clone();
+        if session_ids.is_empty() {
+            self.status_message =
+                Some(format!("No indexed sessions for skill '{skill_id}' in this range"));
+            return;
+        }
+        match store.list_sessions_by_ids(&session_ids) {
+            Ok(sessions) if sessions.is_empty() => {
+                self.status_message =
+                    Some(format!("Sessions for '{skill_id}' are no longer in index"));
+            }
+            Ok(sessions) => {
+                let count = sessions.len();
+                self.results = sessions
+                    .into_iter()
+                    .map(|session| SearchResult {
+                        session,
+                        match_source: MatchSource::Fts,
+                        snippet: None,
+                    })
+                    .collect();
+                self.selected_index = 0;
+                self.panel_focus = PanelFocus::SessionList;
+                self.mode = AppMode::Search;
+                self.query = format!("skill:{skill_id}");
+                self.cursor_pos = self.query.len();
+                self.load_preview(store);
+                self.status_message = Some(format!("{count} sessions used skill '{skill_id}'"));
+            }
+            Err(err) => {
+                self.status_message = Some(format!("Failed to load sessions: {err}"));
+            }
+        }
     }
 
     fn cycle_usage_time(&mut self, reverse: bool) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -9,9 +9,10 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
+use crate::skill_audit::{SkillTier, SkillUsageEntry, format_last_used, format_signals};
 use crate::tui::app::{
     App, AppMode, FilterFocus, PanelFocus, PendingCommandAction, ProjectPickerRow, ResumeOrigin,
-    SanitizedLine, SourcePickerRow,
+    SanitizedLine, SourcePickerRow, UsageTab,
 };
 use crate::types::{MatchSource, Role};
 use crate::usage::{TokenTotals, UsageReport};
@@ -92,6 +93,13 @@ pub fn render(f: &mut Frame, app: &App) {
 }
 
 fn render_usage_dashboard(f: &mut Frame, app: &App) {
+    match app.usage_tab {
+        UsageTab::Tokens => render_tokens_dashboard(f, app),
+        UsageTab::Skills => render_skill_audit_dashboard(f, app),
+    }
+}
+
+fn render_tokens_dashboard(f: &mut Frame, app: &App) {
     let area = f.area();
     let outer = Layout::default()
         .direction(Direction::Vertical)
@@ -112,7 +120,7 @@ fn render_usage_dashboard(f: &mut Frame, app: &App) {
         .split(outer[2]);
     render_daily_token_chart(f, app, main[0]);
     render_usage_breakdown(f, app, main[1]);
-    render_usage_status(f, outer[3]);
+    render_usage_status(f, app, outer[3]);
 }
 
 fn render_usage_header(f: &mut Frame, app: &App, area: Rect) {
@@ -130,7 +138,7 @@ fn render_usage_header(f: &mut Frame, app: &App, area: Rect) {
         Span::styled(" source ", muted),
         Span::styled(format!("[{}]", app.source_filter_label()), chip),
         Span::styled(" metric ", muted),
-        Span::styled("[tokens]", chip),
+        Span::styled(format!("[{}]", app.usage_tab_label()), chip),
     ];
 
     let mut lines = vec![Line::from(control)];
@@ -453,19 +461,39 @@ fn build_usage_model_lines(
     lines
 }
 
-fn render_usage_status(f: &mut Frame, area: Rect) {
-    let line = Line::from(vec![
-        Span::styled("t", Style::default().fg(Color::Yellow)),
-        Span::styled(" time  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("s", Style::default().fg(Color::Yellow)),
-        Span::styled(" source  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("↑↓", Style::default().fg(Color::Yellow)),
-        Span::styled(" breakdown  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("r", Style::default().fg(Color::Yellow)),
-        Span::styled(" reset  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc/q", Style::default().fg(Color::Yellow)),
-        Span::styled(" quit", Style::default().fg(Color::DarkGray)),
-    ]);
+fn render_usage_status(f: &mut Frame, app: &App, area: Rect) {
+    let line = match app.usage_tab {
+        UsageTab::Tokens => Line::from(vec![
+            Span::styled("m", Style::default().fg(Color::Yellow)),
+            Span::styled(" tab  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("t", Style::default().fg(Color::Yellow)),
+            Span::styled(" time  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("s", Style::default().fg(Color::Yellow)),
+            Span::styled(" source  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+            Span::styled(" breakdown  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("r", Style::default().fg(Color::Yellow)),
+            Span::styled(" reset  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc/q", Style::default().fg(Color::Yellow)),
+            Span::styled(" quit", Style::default().fg(Color::DarkGray)),
+        ]),
+        UsageTab::Skills => Line::from(vec![
+            Span::styled("m", Style::default().fg(Color::Yellow)),
+            Span::styled(" tab  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("t", Style::default().fg(Color::Yellow)),
+            Span::styled(" time  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("s", Style::default().fg(Color::Yellow)),
+            Span::styled(" source  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("↑↓", Style::default().fg(Color::Yellow)),
+            Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" sessions  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("r", Style::default().fg(Color::Yellow)),
+            Span::styled(" reset  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc/q", Style::default().fg(Color::Yellow)),
+            Span::styled(" quit", Style::default().fg(Color::DarkGray)),
+        ]),
+    };
     f.render_widget(Paragraph::new(line), area);
 }
 
@@ -622,6 +650,235 @@ fn token_mix_lines(tokens: &TokenTotals, width: usize) -> Vec<Line<'static>> {
     .into_iter()
     .map(|(label, value, color)| usage_bar_line(label, value, max_value, width, color))
     .collect()
+}
+
+fn render_skill_audit_dashboard(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(6), Constraint::Min(8), Constraint::Length(1)])
+        .split(area);
+
+    render_skill_audit_header(f, app, outer[0]);
+    render_skill_audit_list(f, app, outer[1]);
+    render_usage_status(f, app, outer[2]);
+}
+
+fn render_skill_audit_header(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Recall Skill Audit ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+
+    let chip = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    let muted = Style::default().fg(Color::DarkGray);
+
+    let control = vec![
+        Span::styled(" range ", muted),
+        Span::styled(format!("[{}]", app.usage_time_label()), chip),
+        Span::styled(" source ", muted),
+        Span::styled(format!("[{}]", app.source_filter_label()), chip),
+        Span::styled(" tab ", muted),
+        Span::styled(format!("[{}]", app.usage_tab_label()), chip),
+    ];
+
+    let mut lines = vec![Line::from(control)];
+
+    if app.usage_is_loading() {
+        lines.push(Line::from(Span::styled(
+            " Loading skill audit...",
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )));
+    } else if let Some(error) = app.skill_audit_error.as_ref() {
+        lines.push(Line::from(Span::styled(error.clone(), Style::default().fg(Color::Red))));
+    } else if let Some(report) = app.skill_audit_report.as_ref() {
+        lines.push(Line::from(vec![
+            Span::styled(" installed ", muted),
+            Span::styled(
+                format_count(report.summary.installed),
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" core ", muted),
+            Span::styled(
+                format_count(report.summary.core),
+                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" occasional ", muted),
+            Span::styled(format_count(report.summary.occasional), Style::default().fg(Color::Cyan)),
+            Span::styled(" dormant ", muted),
+            Span::styled(
+                format_count(report.summary.dormant),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+        lines.push(Line::from(Span::styled(
+            " core ≥10 calls · occasional 1-9 · dormant installed but unused in range",
+            Style::default().fg(Color::DarkGray),
+        )));
+        if let Some(note) = report.coverage_note.as_ref() {
+            lines.push(Line::from(Span::styled(note.clone(), Style::default().fg(Color::Yellow))));
+        }
+    } else {
+        lines.push(Line::from(Span::styled("No skill audit loaded", muted)));
+    }
+
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_skill_audit_list(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Skills ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+
+    if app.usage_is_loading() {
+        f.render_widget(
+            Paragraph::new("Loading skill audit...")
+                .style(Style::default().fg(Color::Yellow))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let Some(report) = app.skill_audit_report.as_ref() else {
+        f.render_widget(
+            Paragraph::new("No skill audit data")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block),
+            area,
+        );
+        return;
+    };
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let inner_width = inner.width as usize;
+    let (lines, selected_line) =
+        build_skill_audit_lines(report, app.skill_audit_selected, inner_width);
+    let visible_height = inner.height as usize;
+    let max_scroll = lines.len().saturating_sub(visible_height);
+    let scroll = selected_line.saturating_sub(visible_height.saturating_sub(1)).min(max_scroll);
+    f.render_widget(Paragraph::new(lines).scroll((scroll as u16, 0)), inner);
+}
+
+fn build_skill_audit_lines(
+    report: &crate::skill_audit::SkillAuditReport,
+    selected: usize,
+    inner_width: usize,
+) -> (Vec<Line<'static>>, usize) {
+    let cols = skill_audit_columns(inner_width);
+    let mut lines = Vec::new();
+    let mut selected_line = 0usize;
+    let mut entry_index = 0usize;
+    let mut header_added = false;
+
+    let sections = [
+        ("CORE", SkillTier::Core, &report.core),
+        ("OCCASIONAL", SkillTier::Occasional, &report.occasional),
+        ("DORMANT", SkillTier::Dormant, &report.dormant),
+    ];
+
+    for (title, tier, entries) in sections {
+        if entries.is_empty() {
+            continue;
+        }
+        if !header_added {
+            lines.push(skill_audit_table_header(&cols));
+            lines.push(skill_audit_metrics_legend());
+            header_added = true;
+        }
+        lines.push(Line::from(Span::styled(
+            format!(" {title} ({})", entries.len()),
+            Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+        )));
+        for entry in entries {
+            if entry_index == selected {
+                selected_line = lines.len();
+            }
+            lines.push(skill_audit_entry_line(entry, tier, entry_index == selected, &cols));
+            entry_index += 1;
+        }
+        lines.push(Line::from(""));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " No personal skills found in ~/.claude/skills, ~/.codex/skills, or ~/.agents/skills",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    (lines, selected_line)
+}
+
+struct SkillAuditColumns {
+    skill: usize,
+    calls: usize,
+    last: usize,
+    via: usize,
+}
+
+fn skill_audit_columns(width: usize) -> SkillAuditColumns {
+    let calls = 5;
+    let last = 8;
+    let via = 6;
+    let gaps = 3;
+    let skill = width.saturating_sub(calls + last + via + gaps + 2).max(16);
+    SkillAuditColumns { skill, calls, last, via }
+}
+
+fn skill_audit_table_header(cols: &SkillAuditColumns) -> Line<'static> {
+    let style = Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    Line::from(vec![
+        Span::styled(format!("  {:<skill_w$}", "SKILL", skill_w = cols.skill), style),
+        Span::styled(format!(" {:>calls_w$}", "CALLS", calls_w = cols.calls), style),
+        Span::styled(format!(" {:>last_w$}", "LAST", last_w = cols.last), style),
+        Span::styled(format!(" {:>via_w$}", "VIA", via_w = cols.via), style),
+    ])
+}
+
+fn skill_audit_metrics_legend() -> Line<'static> {
+    Line::from(Span::styled(
+        "  CALLS session uses · LAST last use · VIA invoke/read/both",
+        Style::default().fg(Color::DarkGray),
+    ))
+}
+
+fn skill_audit_entry_line(
+    entry: &SkillUsageEntry,
+    tier: SkillTier,
+    selected: bool,
+    cols: &SkillAuditColumns,
+) -> Line<'static> {
+    let base = if selected {
+        Style::default().fg(Color::Black).bg(Color::Magenta).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    let muted = if selected {
+        Style::default().fg(Color::Black).bg(Color::Magenta)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let skill = truncate_label(&entry.id, cols.skill);
+    let (calls, last, via) = if tier == SkillTier::Dormant {
+        ("-".to_string(), "never".to_string(), "-".to_string())
+    } else {
+        (
+            format!("{}", entry.invocations),
+            format_last_used(entry.last_used),
+            format_signals(&entry.signals).to_string(),
+        )
+    };
+
+    Line::from(vec![
+        Span::styled(format!("  {:<skill_w$}", skill, skill_w = cols.skill), base),
+        Span::styled(format!(" {:>calls_w$}", calls, calls_w = cols.calls), base),
+        Span::styled(format!(" {:>last_w$}", last, last_w = cols.last), muted),
+        Span::styled(format!(" {:>via_w$}", via, via_w = cols.via), muted),
+    ])
 }
 
 fn truncate_label(label: &str, max_chars: usize) -> String {


### PR DESCRIPTION
### What's changed?

- Index structured session events from Cursor and Copilot CLI adapters
- Add `skill_audit` module with tiered skill usage reports and store event queries
- Backfill session events during usage dashboard sync without full session refresh
- Add a Skills sub-tab under `recall usage` with filters, tier table, and Enter-to-open sessions

### Why

- Usage dashboard previously showed token spend only; skill ROI was invisible even when session events were available
- Skills tab needs fresh event data on open, including event-only sources like Copilot CLI, without indexing unrelated adapters or inflating counts from reference reads

## Test plan

- [x] `make check`
- [ ] Open `recall usage`, press `m` to switch to Skills tab, verify installed skills appear with CALLS/LAST/VIA
- [ ] Press Enter on a skill with sessions and confirm matching sessions open in search view
- [ ] Filter by source/time and confirm counts update

## Considered and deferred

- Skills tab status bar does not surface Enter failures when a skill has no indexed sessions (UX-only)
- Usage-only event backfill on changed sessions may leave message_seq misaligned with stored messages; does not affect skill audit counts