### PR TITLE
feat: opt-out sessions from indexing via excluded_paths globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1420,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "h2"
@@ -2671,6 +2694,7 @@ dependencies = [
  "crossterm",
  "dirs 5.0.1",
  "fs2",
+ "globset",
  "hf-hub",
  "ratatui",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 walkdir = "2"
+globset = "0.4"
 uuid = { version = "1", features = ["v4"] }
 ratatui = "0.29"
 crossterm = "0.28"

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -97,6 +97,10 @@ pub struct RawMessage {
 pub struct SyncScanStats {
     pub skipped_sessions: u32,
     pub filtered_sessions: u32,
+    /// Sessions dropped because their `directory` matched an
+    /// `excluded_paths` glob. Aggregated from per-adapter scans and
+    /// surfaced in the verbose sync summary.
+    pub excluded_sessions: u32,
 }
 
 pub struct SyncScanResult {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -97,10 +97,6 @@ pub struct RawMessage {
 pub struct SyncScanStats {
     pub skipped_sessions: u32,
     pub filtered_sessions: u32,
-    /// Sessions dropped because their `directory` matched an
-    /// `excluded_paths` glob. Aggregated from per-adapter scans and
-    /// surfaced in the verbose sync summary.
-    pub excluded_sessions: u32,
 }
 
 pub struct SyncScanResult {

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,11 @@ pub struct AppConfig {
     /// Glob patterns matched against each session's `directory` (cwd) field.
     /// Sessions whose cwd matches ANY glob are dropped at sync time — they
     /// never enter the FTS or vector index. Edit via the config file.
-    /// Examples: `**/.claude-mem/observer-sessions/**`, `**/tmp/scratch-*/**`.
+    ///
+    /// The pattern matches the cwd itself, so to exclude a directory use a
+    /// trailing-`**`-free pattern (a `dir/**` glob matches only its
+    /// children, not `dir`). Examples: `**/observer-sessions`,
+    /// `**/.claude-mem/**`, `**/scratch-*`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub excluded_paths: Vec<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::db::search::TimeRange;
@@ -61,6 +62,12 @@ pub struct AppConfig {
     legacy_enabled_sources: Vec<String>,
     #[serde(default)]
     pub sync_window: SyncWindow,
+    /// Glob patterns matched against each session's `directory` (cwd) field.
+    /// Sessions whose cwd matches ANY glob are dropped at sync time — they
+    /// never enter the FTS or vector index. Edit via the config file.
+    /// Examples: `**/.claude-mem/observer-sessions/**`, `**/tmp/scratch-*/**`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub excluded_paths: Vec<String>,
 }
 
 impl AppConfig {
@@ -103,6 +110,23 @@ impl AppConfig {
 
     pub fn is_source_enabled(&self, source_id: &str) -> bool {
         !self.disabled_sources.iter().any(|id| id == source_id)
+    }
+
+    /// Compile the `excluded_paths` globs into a single `GlobSet` matcher.
+    /// Returns `None` when no rules are configured. Errors propagate so an
+    /// invalid pattern fails loud — the user gets a startup error, not a
+    /// silent half-applied filter.
+    pub fn build_path_excluder(&self) -> Result<Option<GlobSet>> {
+        if self.excluded_paths.is_empty() {
+            return Ok(None);
+        }
+        let mut builder = GlobSetBuilder::new();
+        for pat in &self.excluded_paths {
+            let glob =
+                Glob::new(pat).with_context(|| format!("invalid excluded_paths glob: {pat}"))?;
+            builder.add(glob);
+        }
+        Ok(Some(builder.build()?))
     }
 }
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1392,10 +1392,8 @@ mod exclusion_tests {
 
         let paths = store.all_session_paths().unwrap();
         assert_eq!(paths.len(), 2);
-        let observer = paths
-            .iter()
-            .find(|(_, sid, _)| sid == "src-b")
-            .expect("observer session present");
+        let observer =
+            paths.iter().find(|(_, sid, _)| sid == "src-b").expect("observer session present");
         assert_eq!(observer.2.as_deref(), Some("/home/u/.claude-mem/observer-sessions/x"));
 
         // Simulate the pre-sync purge of the excluded row.

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -812,6 +812,22 @@ impl Store {
         Ok(SemanticProgress { current_session_title, ..progress })
     }
 
+    /// Every indexed session as `(source, source_id, directory)`. Lets the
+    /// pre-sync prune pass evaluate exclusion rules against rows already in
+    /// the DB — even ones the incremental scan would skip because their
+    /// file is unchanged.
+    pub fn all_session_paths(&self) -> Result<Vec<(String, String, Option<String>)>> {
+        let mut stmt = self.conn.prepare("SELECT source, source_id, directory FROM sessions")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub fn delete_session_data(&self, source: &str, source_id: &str) -> Result<()> {
         let session_ids: Vec<String> = {
             let mut stmt = self
@@ -1342,4 +1358,50 @@ fn apply_scope_filters(
 
 fn directory_child_pattern(dir: &str) -> String {
     if dir.ends_with('/') { format!("{dir}%") } else { format!("{dir}/%") }
+}
+
+#[cfg(test)]
+mod exclusion_tests {
+    use super::*;
+    use crate::types::Session;
+
+    fn sess(id: &str, dir: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            source: "claude-code".to_string(),
+            source_id: format!("src-{id}"),
+            title: "t".to_string(),
+            directory: Some(dir.to_string()),
+            started_at: 0,
+            updated_at: Some(1),
+            message_count: 0,
+            entrypoint: None,
+        }
+    }
+
+    /// all_session_paths must surface every indexed row's directory so the
+    /// pre-sync exclusion pass can purge matches that incremental sync would
+    /// otherwise skip. Regression for the codex P1: excluded content stayed
+    /// searchable for unchanged sessions.
+    #[test]
+    fn all_session_paths_round_trips_then_delete_clears() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        store.insert_session(&sess("a", "/home/u/proj")).unwrap();
+        store.insert_session(&sess("b", "/home/u/.claude-mem/observer-sessions/x")).unwrap();
+
+        let paths = store.all_session_paths().unwrap();
+        assert_eq!(paths.len(), 2);
+        let observer = paths
+            .iter()
+            .find(|(_, sid, _)| sid == "src-b")
+            .expect("observer session present");
+        assert_eq!(observer.2.as_deref(), Some("/home/u/.claude-mem/observer-sessions/x"));
+
+        // Simulate the pre-sync purge of the excluded row.
+        store.delete_session_data("claude-code", "src-b").unwrap();
+        let after = store.all_session_paths().unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].1, "src-a");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,17 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     // re-examined and its content would stay searchable.
     if let Some(matcher) = &path_excluder {
         for (source, source_id, directory) in store.all_session_paths()? {
+            // Honour the same source scope as the sync loop below: a
+            // `--source` filter or a disabled source must not have its rows
+            // mutated by a scoped/partial sync.
+            if let Some(sources) = &options.sources
+                && !sources.iter().any(|id| id == &source)
+            {
+                continue;
+            }
+            if !config.is_source_enabled(&source) {
+                continue;
+            }
             if directory.as_deref().is_some_and(|d| matcher.is_match(d)) {
                 store.delete_session_data(&source, &source_id)?;
                 excluded_out += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,9 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let mut config = AppConfig::load_or_default();
     config.normalize_sources(&labels);
     let since_ts = if options.usage_only { None } else { config.sync_window.to_since_cutoff() };
+    // Single matcher across all adapters. None when no rules configured —
+    // costs nothing at the loop check site.
+    let path_excluder = config.build_path_excluder()?;
 
     let mut new_sessions = 0u32;
     let mut updated_sessions = 0u32;
@@ -388,6 +391,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let mut total_messages = 0u32;
     let mut skipped = 0u32;
     let mut filtered_out = 0u32;
+    let mut excluded_out = 0u32;
 
     for adapter in &all {
         let source_id = adapter.id();
@@ -470,6 +474,19 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                     filtered_out += 1;
                     continue;
                 }
+            }
+
+            // Drop sessions whose cwd matches any excluded_paths glob.
+            // Sessions with no `directory` (e.g. observer-style sessions
+            // identified only by file path) can't be matched here; once a
+            // `source_file_path` field lands on RawSession, extend this
+            // arm to also test against it.
+            if let Some(matcher) = &path_excluder
+                && let Some(dir) = raw.directory.as_deref()
+                && matcher.is_match(dir)
+            {
+                excluded_out += 1;
+                continue;
             }
 
             let raw_source_id = raw.source_id.clone();
@@ -644,6 +661,9 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         }
         if filtered_out > 0 {
             print!(", {filtered_out} outside configured time scope");
+        }
+        if excluded_out > 0 {
+            print!(", {excluded_out} excluded by excluded_paths");
         }
         println!();
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,14 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 && let Some(dir) = raw.directory.as_deref()
                 && matcher.is_match(dir)
             {
+                // If the user added a rule after this session was already
+                // indexed, purge the stale rows so excluded content stops
+                // being searchable — otherwise it lingers until a full reset.
+                if existing_meta.remove(&raw.source_id).is_some() {
+                    store.delete_session_data(source_id, &raw.source_id)?;
+                    existing_usage_meta.remove(&raw.source_id);
+                    existing_event_meta.remove(&raw.source_id);
+                }
                 excluded_out += 1;
                 continue;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,11 +399,14 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     // sources it actually processes. This must happen regardless of the
     // incremental scan (which skips unchanged files) — otherwise a session
     // indexed before the rule was added would stay searchable.
-    let mut excluded_by_source: std::collections::HashMap<String, Vec<String>> = Default::default();
+    let mut excluded_by_source: std::collections::HashMap<
+        String,
+        std::collections::HashSet<String>,
+    > = Default::default();
     if let Some(matcher) = &path_excluder {
         for (source, source_id, directory) in store.all_session_paths()? {
             if directory.as_deref().is_some_and(|d| matcher.is_match(d)) {
-                excluded_by_source.entry(source).or_default().push(source_id);
+                excluded_by_source.entry(source).or_default().insert(source_id);
             }
         }
     }
@@ -505,11 +508,9 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
             // Drop sessions whose cwd matches any excluded_paths glob.
             // Sessions with no `directory` (e.g. observer-style sessions
             // identified only by file path) can't be matched here; once a
-            // `source_file_path` field lands on RawSession, extend this
-            // arm to also test against it.
-            // Decline to index a session whose cwd matches a rule. Existing
-            // indexed rows are already purged by the pre-sync pass above;
-            // this guards sessions appearing in this scan (new or changed).
+            // `source_file_path` field lands on RawSession, extend this arm too.
+            // Indexed rows are purged in the pre-sync pass above; this arm
+            // catches new/changed sessions from the current scan (e.g. --force).
             if let Some(matcher) = &path_excluder
                 && let Some(dir) = raw.directory.as_deref()
                 && matcher.is_match(dir)
@@ -518,7 +519,10 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                     store.delete_session_data(source_id, &raw.source_id)?;
                     existing_usage_meta.remove(&raw.source_id);
                     existing_event_meta.remove(&raw.source_id);
-                } else {
+                } else if !excluded_by_source
+                    .get(source_id)
+                    .is_some_and(|ids| ids.contains(&raw.source_id))
+                {
                     excluded_out += 1;
                 }
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,27 +393,17 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let mut filtered_out = 0u32;
     let mut excluded_out = 0u32;
 
-    // Pre-sync purge: drop any already-indexed session whose directory now
-    // matches an excluded_paths rule. This must run BEFORE the per-adapter
-    // scan because incremental sync skips unchanged sessions entirely — so
-    // a session indexed before the rule was added would otherwise never be
-    // re-examined and its content would stay searchable.
+    // Indexed sessions whose directory now matches an excluded_paths rule,
+    // grouped by source. We purge these per-source INSIDE the loop below,
+    // after the scope filters, so a scoped/usage-only sync only mutates the
+    // sources it actually processes. This must happen regardless of the
+    // incremental scan (which skips unchanged files) — otherwise a session
+    // indexed before the rule was added would stay searchable.
+    let mut excluded_by_source: std::collections::HashMap<String, Vec<String>> = Default::default();
     if let Some(matcher) = &path_excluder {
         for (source, source_id, directory) in store.all_session_paths()? {
-            // Honour the same source scope as the sync loop below: a
-            // `--source` filter or a disabled source must not have its rows
-            // mutated by a scoped/partial sync.
-            if let Some(sources) = &options.sources
-                && !sources.iter().any(|id| id == &source)
-            {
-                continue;
-            }
-            if !config.is_source_enabled(&source) {
-                continue;
-            }
             if directory.as_deref().is_some_and(|d| matcher.is_match(d)) {
-                store.delete_session_data(&source, &source_id)?;
-                excluded_out += 1;
+                excluded_by_source.entry(source).or_default().push(source_id);
             }
         }
     }
@@ -442,6 +432,17 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 println!("Skipping {label} (filtered)");
             }
             continue;
+        }
+
+        // Purge already-indexed rows for this in-scope source whose cwd now
+        // matches an excluded_paths rule (handles sessions the incremental
+        // scan would otherwise skip). Runs only for sources this sync
+        // actually processes — past all the scope filters above.
+        if let Some(ids) = excluded_by_source.get(source_id) {
+            for sid in ids {
+                store.delete_session_data(source_id, sid)?;
+                excluded_out += 1;
+            }
         }
 
         if options.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,6 +393,20 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let mut filtered_out = 0u32;
     let mut excluded_out = 0u32;
 
+    // Pre-sync purge: drop any already-indexed session whose directory now
+    // matches an excluded_paths rule. This must run BEFORE the per-adapter
+    // scan because incremental sync skips unchanged sessions entirely — so
+    // a session indexed before the rule was added would otherwise never be
+    // re-examined and its content would stay searchable.
+    if let Some(matcher) = &path_excluder {
+        for (source, source_id, directory) in store.all_session_paths()? {
+            if directory.as_deref().is_some_and(|d| matcher.is_match(d)) {
+                store.delete_session_data(&source, &source_id)?;
+                excluded_out += 1;
+            }
+        }
+    }
+
     for adapter in &all {
         let source_id = adapter.id();
         let label = adapter.label();
@@ -481,19 +495,20 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
             // identified only by file path) can't be matched here; once a
             // `source_file_path` field lands on RawSession, extend this
             // arm to also test against it.
+            // Decline to index a session whose cwd matches a rule. Existing
+            // indexed rows are already purged by the pre-sync pass above;
+            // this guards sessions appearing in this scan (new or changed).
             if let Some(matcher) = &path_excluder
                 && let Some(dir) = raw.directory.as_deref()
                 && matcher.is_match(dir)
             {
-                // If the user added a rule after this session was already
-                // indexed, purge the stale rows so excluded content stops
-                // being searchable — otherwise it lingers until a full reset.
                 if existing_meta.remove(&raw.source_id).is_some() {
                     store.delete_session_data(source_id, &raw.source_id)?;
                     existing_usage_meta.remove(&raw.source_id);
                     existing_event_meta.remove(&raw.source_id);
+                } else {
+                    excluded_out += 1;
                 }
-                excluded_out += 1;
                 continue;
             }
 


### PR DESCRIPTION
## Summary
Adds an `excluded_paths` glob list to the config so users can keep noisy
or sensitive sessions out of the search index (e.g. agent/observer
sessions, scratch dirs). Sessions whose `directory` (cwd) matches any
glob are dropped at sync time — they never enter FTS or the vector index.

## Behaviour
- **New/changed sessions** matching a rule are skipped during sync.
- **Already-indexed sessions** that newly match (rule added after they
  were indexed) are purged. Because incremental sync skips unchanged
  files, the purge is driven from the DB (`all_session_paths`) rather
  than the scan, so it works without `--force`.
- **Scope-safe**: the purge runs per-source *after* the `--source`,
  disabled-source, and usage-only eligibility filters, so a scoped or
  dashboard sync never mutates sources it isn't processing.
- Verbose sync reports `N excluded by excluded_paths`.

## Config
```json
{ "excluded_paths": ["**/observer-sessions", "**/.claude-mem/**", "**/scratch-*"] }
```
Patterns match the cwd itself — note a `dir/**` glob matches only
children, so to exclude a directory use a pattern without the trailing
`/**`.

## Notes
Invalid globs fail loud at startup (`build_path_excluder`), so a typo
surfaces immediately rather than silently disabling the filter. Empty
list = zero runtime cost.

## Verification
- `cargo build`, `cargo fmt -- --check`, `cargo test` — green
  (lib + integration); new `all_session_paths` round-trip test.
- Manual (throwaway DB, ~1000 sessions): with `**/observer-sessions`,
  a normal `recall sync` reported "excluded by excluded_paths" and the
  already-indexed observer rows dropped to 0; re-sync stayed "Up to date".

## Test plan
- [x] New matching session → not indexed
- [x] Rule added after indexing → existing rows purged on next sync (no --force)
- [x] `recall sync --source X` → other sources' excluded rows untouched
- [x] Invalid glob → clear startup error
