### PR TITLE
[Feat] Show TUI session summaries

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,8 +12,9 @@ use crate::embedding::EmbeddingProvider;
 use crate::skill_audit::{self, SkillAuditFilters, SkillAuditReport};
 use crate::types::{
     BackgroundJobStatus, MatchSource, Message, Role, SearchResult, SemanticProgress,
+    SessionUsageEventRecord,
 };
-use crate::usage::{self, UsageFilters, UsageReport};
+use crate::usage::{self, TokenTotals, UsageFilters, UsageReport};
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
 
@@ -53,6 +54,7 @@ mod tests {
             preview_selected_msg: 0,
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
+            viewing_session_summary: None,
             all_sources: vec![
                 source("claude", "Claude"),
                 source("cursor", "Cursor"),
@@ -133,6 +135,56 @@ mod tests {
             match_source: MatchSource::Fts,
             snippet: None,
         }
+    }
+
+    fn message(role: Role, timestamp: Option<i64>, seq: u32) -> Message {
+        Message {
+            session_id: "session1".to_string(),
+            role,
+            content: "hello".to_string(),
+            timestamp,
+            seq,
+        }
+    }
+
+    fn usage_event(input_tokens: i64, output_tokens: i64) -> SessionUsageEventRecord {
+        SessionUsageEventRecord {
+            event_key: "event1".to_string(),
+            event_seq: 0,
+            message_seq: None,
+            timestamp: 120_000,
+            model: "gpt".to_string(),
+            provider: "openai".to_string(),
+            input_tokens,
+            output_tokens,
+            cache_read_tokens: 3,
+            cache_write_tokens: 2,
+            reasoning_tokens: 1,
+            token_source: "derived".to_string(),
+        }
+    }
+
+    #[test]
+    fn viewing_session_summary_counts_messages_duration_and_tokens() {
+        let messages = vec![
+            message(Role::User, Some(0), 0),
+            message(Role::Assistant, Some(120_000), 1),
+            message(Role::User, None, 2),
+        ];
+        let usage_events = vec![usage_event(10, 5), usage_event(-1, 4)];
+
+        let summary = ViewingSessionSummary::from_session(&messages, None, &usage_events);
+
+        assert_eq!(summary.user_messages, 2);
+        assert_eq!(summary.total_messages, 3);
+        assert_eq!(summary.duration_minutes, Some(2));
+        assert_eq!(summary.usage_events, 2);
+        assert_eq!(summary.tokens.input_tokens, 10);
+        assert_eq!(summary.tokens.output_tokens, 9);
+        assert_eq!(summary.tokens.cache_read_tokens, 6);
+        assert_eq!(summary.tokens.cache_write_tokens, 4);
+        assert_eq!(summary.tokens.reasoning_tokens, 2);
+        assert_eq!(summary.tokens.total_tokens, 31);
     }
 
     #[test]
@@ -306,6 +358,53 @@ fn build_viewing_caches(msgs: &[Message]) -> Vec<Vec<SanitizedLine>> {
         .collect()
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ViewingSessionSummary {
+    pub user_messages: usize,
+    pub total_messages: usize,
+    pub duration_minutes: Option<u32>,
+    pub usage_events: usize,
+    pub tokens: TokenTotals,
+}
+
+impl ViewingSessionSummary {
+    fn from_session(
+        messages: &[Message],
+        duration_minutes: Option<u32>,
+        usage_events: &[SessionUsageEventRecord],
+    ) -> Self {
+        let mut tokens = TokenTotals::default();
+        for event in usage_events {
+            tokens.input_tokens += event.input_tokens.max(0);
+            tokens.output_tokens += event.output_tokens.max(0);
+            tokens.cache_read_tokens += event.cache_read_tokens.max(0);
+            tokens.cache_write_tokens += event.cache_write_tokens.max(0);
+            tokens.reasoning_tokens += event.reasoning_tokens.max(0);
+        }
+        tokens.total_tokens = tokens.input_tokens
+            + tokens.output_tokens
+            + tokens.cache_read_tokens
+            + tokens.cache_write_tokens
+            + tokens.reasoning_tokens;
+
+        Self {
+            user_messages: messages.iter().filter(|msg| msg.role == Role::User).count(),
+            total_messages: messages.len(),
+            duration_minutes: duration_minutes.or_else(|| message_span_minutes(messages)),
+            usage_events: usage_events.len(),
+            tokens,
+        }
+    }
+}
+
+fn message_span_minutes(messages: &[Message]) -> Option<u32> {
+    let mut timestamps = messages.iter().filter_map(|msg| msg.timestamp);
+    let first = timestamps.next()?;
+    let (min_ts, max_ts) =
+        timestamps.fold((first, first), |(min_ts, max_ts), ts| (min_ts.min(ts), max_ts.max(ts)));
+    Some(max_ts.saturating_sub(min_ts).div_euclid(60_000) as u32)
+}
+
 #[derive(PartialEq)]
 pub enum PanelFocus {
     SessionList,
@@ -369,6 +468,7 @@ pub struct App {
     pub preview_selected_msg: usize,
     pub viewing_messages: Vec<Message>,
     pub viewing_selected_msg: usize,
+    pub viewing_session_summary: Option<ViewingSessionSummary>,
     pub all_sources: Vec<(String, String)>,
     pub config: AppConfig,
     pub source_filter_selection: Vec<String>,
@@ -444,6 +544,7 @@ impl App {
             preview_selected_msg: 0,
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
+            viewing_session_summary: None,
             all_sources,
             config,
             source_filter_selection: Vec::new(),
@@ -881,6 +982,7 @@ impl App {
                 self.mode = AppMode::Search;
                 self.viewing_messages.clear();
                 self.viewing_selected_msg = 0;
+                self.viewing_session_summary = None;
                 self.viewing_search_query.clear();
                 self.viewing_search_status = None;
                 self.viewing_sanitized_lines.clear();
@@ -2064,6 +2166,13 @@ impl App {
         if let Some(result) = self.results.get(self.selected_index)
             && let Ok(msgs) = store.get_messages(&result.session.id)
         {
+            let usage_events =
+                store.list_usage_events_for_session(&result.session.id).unwrap_or_default();
+            self.viewing_session_summary = Some(ViewingSessionSummary::from_session(
+                &msgs,
+                result.session.duration_minutes,
+                &usage_events,
+            ));
             self.viewing_sanitized_lines = build_viewing_caches(&msgs);
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1248,6 +1248,12 @@ fn render_viewing(f: &mut Frame, app: &App) {
         .title(session_info)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
+    let content_area = block.inner(outer[0]);
+    f.render_widget(block, outer[0]);
+    let content = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
+        .split(content_area);
 
     let mut lines: Vec<Line> = Vec::new();
     let mut selected_line_start: usize = 0;
@@ -1289,10 +1295,11 @@ fn render_viewing(f: &mut Frame, app: &App) {
         lines.push(Line::from(""));
     }
 
-    let scroll = scroll_offset(selected_line_start, block.inner(outer[0]).height as usize);
+    let scroll = scroll_offset(selected_line_start, content[1].height as usize);
 
-    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: false }).scroll((scroll, 0));
-    f.render_widget(p, outer[0]);
+    render_viewing_summary(f, app, content[0]);
+    let p = Paragraph::new(lines).wrap(Wrap { trim: false }).scroll((scroll, 0));
+    f.render_widget(p, content[1]);
 
     let help_spans = vec![
         Span::styled(" ↑/↓", Style::default().fg(Color::Yellow)),
@@ -1349,6 +1356,76 @@ fn render_viewing(f: &mut Frame, app: &App) {
     }
 
     f.render_widget(Paragraph::new(status_line), outer[1]);
+}
+
+fn render_viewing_summary(f: &mut Frame, app: &App, area: Rect) {
+    let text = viewing_summary_text(app, area.width as usize);
+    let line = Line::from(Span::styled(text, Style::default().fg(Color::Green)));
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn viewing_summary_text(app: &App, width: usize) -> String {
+    let Some(summary) = app.viewing_session_summary.as_ref() else {
+        return fit_summary_text(vec![" tokens - | time - | user msgs -".to_string()], width);
+    };
+
+    let duration = format_duration_minutes(summary.duration_minutes);
+    let user_messages = format!("{}/{}", summary.user_messages, summary.total_messages);
+
+    if summary.usage_events == 0 {
+        return fit_summary_text(
+            vec![
+                format!(" tokens - | time {duration} | user msgs {user_messages}"),
+                format!(" tok - | {duration} | user {user_messages}"),
+            ],
+            width,
+        );
+    }
+
+    let tokens = &summary.tokens;
+    let total = format_compact(tokens.total_tokens);
+    let input = format_compact(tokens.input_tokens);
+    let output = format_compact(tokens.output_tokens);
+    let cache_read = format_compact(tokens.cache_read_tokens);
+    let cache_write = format_compact(tokens.cache_write_tokens);
+    let reasoning = format_compact(tokens.reasoning_tokens);
+
+    fit_summary_text(
+        vec![
+            format!(
+                " tokens {total} input {input} output {output} cache r/w {cache_read}/{cache_write} reasoning {reasoning} | time {duration} | user msgs {user_messages}"
+            ),
+            format!(
+                " tok {total} in {input} out {output} cache {cache_read}/{cache_write} reason {reasoning} | {duration} | user {user_messages}"
+            ),
+            format!(" tok {total} | time {duration} | user {user_messages}"),
+        ],
+        width,
+    )
+}
+
+fn fit_summary_text(variants: Vec<String>, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    for variant in &variants {
+        if UnicodeWidthStr::width(variant.as_str()) <= width {
+            return variant.clone();
+        }
+    }
+    truncate_label(variants.last().map(String::as_str).unwrap_or(""), width)
+}
+
+fn format_duration_minutes(minutes: Option<u32>) -> String {
+    let Some(minutes) = minutes else {
+        return "-".to_string();
+    };
+    if minutes < 60 {
+        return format!("{minutes}m");
+    }
+    let hours = minutes / 60;
+    let remaining = minutes % 60;
+    if remaining == 0 { format!("{hours}h") } else { format!("{hours}h{remaining}m") }
 }
 
 fn render_source_picker(f: &mut Frame, app: &App) {
@@ -1772,4 +1849,84 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         }
     };
     f.render_widget(Paragraph::new(line), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use crate::config::AppConfig;
+    use crate::db::store::Store;
+    use crate::tui::app::ViewingSessionSummary;
+    use crate::types::{Message, SearchResult, Session};
+
+    #[test]
+    fn render_viewing_shows_one_line_session_summary_below_title() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.mode = AppMode::Viewing;
+        app.results = vec![SearchResult {
+            session: Session {
+                id: "session1".to_string(),
+                source: "codex".to_string(),
+                source_id: "source1".to_string(),
+                title: "Test session".to_string(),
+                directory: Some("/tmp/repo".to_string()),
+                started_at: 0,
+                updated_at: Some(120_000),
+                message_count: 1,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: Some(2),
+            },
+            match_source: MatchSource::Fts,
+            snippet: None,
+        }];
+        app.viewing_messages = vec![Message {
+            session_id: "session1".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: Some(0),
+            seq: 0,
+        }];
+        app.viewing_sanitized_lines =
+            vec![vec![SanitizedLine { text: "hello".to_string(), lower: "hello".to_string() }]];
+        app.viewing_session_summary = Some(ViewingSessionSummary {
+            user_messages: 2,
+            total_messages: 3,
+            duration_minutes: Some(2),
+            usage_events: 2,
+            tokens: TokenTotals {
+                input_tokens: 10,
+                output_tokens: 9,
+                cache_read_tokens: 6,
+                cache_write_tokens: 4,
+                reasoning_tokens: 2,
+                total_tokens: 31,
+            },
+        });
+
+        let backend = TestBackend::new(100, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app)).unwrap();
+        let summary = buffer_row(terminal.backend().buffer(), 1, 100);
+
+        assert!(summary.contains(
+            "tokens 31 input 10 output 9 cache r/w 6/4 reasoning 2 | time 2m | user msgs 2/3"
+        ));
+        assert_eq!(terminal.backend().buffer()[(2, 1)].fg, Color::Green);
+    }
+
+    fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {
+        let mut row = String::new();
+        for x in 0..width {
+            row.push_str(buffer[(x, y)].symbol());
+        }
+        row
+    }
 }


### PR DESCRIPTION
### What's changed?
- Add a one-line session summary strip to the TUI session detail view with token totals, input/output/cache/reasoning breakdown, duration, and user message counts.
- Load per-session usage events when entering the detail view and clear the summary when leaving it.
- Render the summary in green and cover the aggregation/render path with focused tests.

### Why
- Makes high-signal session stats visible without mixing them into the message stream.

### Validation
- `make check`
- `codex review --commit HEAD`
