### PR TITLE
[Feat] add JSONL import

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,37 @@ recall search Q --project /path/to/repo
 recall usage         # usage dashboard
 recall usage --json  # usage report for scripts
 recall export --jsonl --source codex --project /path/to/repo --limit 20
+recall import recall-export.jsonl --dry-run  # preview an import
 recall info          # index stats and worker status
 ```
 
 ## Export
 
 `recall export --jsonl` writes one JSON object per indexed session. Each record
-includes `schema_version`, `record_type`, `session`, `messages`, and
-`usage_events`, and `events`. Optional fields are emitted as `null`; raw
-source-specific JSON is not part of the public export contract.
+includes `schema_version`, `record_type`, `session`, `messages`,
+`usage_events`, and `events`, covering everything Recall stores for a session.
+Optional fields are emitted as `null`. By default all sessions are exported;
+use `--limit N` to truncate. `--time` filters on `started_at`, so prefer a full
+export when moving data between machines.
+
+## Import
+
+`recall import <file>` (or `-` for stdin) loads sessions from an export file
+into the local index. How the file travels between machines is up to you.
+
+```bash
+# machine A
+recall export --jsonl > recall-a.jsonl
+# machine B
+recall import recall-a.jsonl
+```
+
+- Idempotent: a session whose `(source, source_id)` already exists locally is
+  skipped, so re-running an import is safe and local data always wins.
+- Imported sessions are searchable and appear in usage reports, but cannot be
+  resumed on this machine (the source tool's own files were not copied); the
+  TUI explains this if you try.
+- `--dry-run` parses and reports counts without writing anything.
 
 ## License
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -123,6 +123,8 @@ recall search "migration bug" --project /absolute/project/path
 recall search "migration bug" --project /absolute/project/path --source codex --time 30d
 recall export --jsonl --project /absolute/project/path --limit 0
 recall export --jsonl --project /absolute/project/path --source codex --time 30d --limit 100
+recall import recall-export.jsonl --dry-run
+recall import recall-export.jsonl
 recall usage --json
 ```
 
@@ -141,7 +143,7 @@ Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `antigrav
 - `usage_events`
 - `events`
 
-The public export contract does not include raw source-specific JSON. Expect optional fields to be `null`.
+Since schema_version 3 the export is lossless against the Recall index: it also carries `session.source_file_path`, usage-event `parser_version` / `source_path` / `raw_usage_json`, and event `attrs_json` / `parser_version`. Expect optional fields to be `null`. `recall import` accepts schema_version 2 and 3 files and skips sessions that already exist locally by `(source, source_id)`.
 
 Important fields:
 
@@ -153,7 +155,7 @@ Important fields:
 - `messages[].role`: `user` or `assistant`.
 - `messages[].content`: the indexed message text.
 - `usage_events[]`: token usage when available.
-- `events[]`: tool/session events when available, without raw event attributes.
+- `events[]`: tool/session events when available, including `attrs_json` raw attributes.
 
 ## Avoid In Agent Tool Calls
 

--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -316,6 +316,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -833,6 +833,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -333,6 +333,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -1379,6 +1379,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -484,6 +484,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -53,6 +53,7 @@ where
     F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
 {
     let existing = store.session_meta_map(source_id)?;
+    let mut imported = store.imported_source_ids(source_id)?;
     let usage_state = match options.usage_parser_version {
         Some(_) => store.usage_state_meta_map(source_id)?,
         None => Default::default(),
@@ -69,17 +70,20 @@ where
             continue;
         };
 
-        if existing.contains_key(&entry.session_id)
-            && let Some(source_file_path) = entry.stat_target.to_str()
-        {
-            store.update_session_fields(
-                source_id,
-                &entry.session_id,
-                None,
-                None,
-                None,
-                Some(source_file_path),
-            )?;
+        if existing.contains_key(&entry.session_id) {
+            if let Some(source_file_path) = entry.stat_target.to_str() {
+                store.update_session_fields(
+                    source_id,
+                    &entry.session_id,
+                    None,
+                    None,
+                    None,
+                    Some(source_file_path),
+                )?;
+            }
+            if imported.remove(&entry.session_id) {
+                store.clear_import_marker(source_id, &entry.session_id)?;
+            }
         }
 
         if let Some(cutoff) = since_ts
@@ -182,6 +186,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 
@@ -265,6 +271,33 @@ mod tests {
         let paths = store.session_paths_for_source("test-source").unwrap();
         let stored = paths.iter().find(|path| path.source_id == "sess-skip").unwrap();
         assert_eq!(stored.source_file_path.as_deref(), path.to_str());
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn matching_mtime_skip_still_clears_import_marker() {
+        let store = setup_store();
+        let path = temp_file_with_mtime("import-clear");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        let mut session = make_session("s1", "sess-imported", Some(mtime_ms), 1);
+        session.is_import = true;
+        store.insert_session(&session).unwrap();
+
+        let entry = FileScanEntry {
+            session_id: "sess-imported".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+
+        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
+            panic!("parse should not be called for skipped entry")
+        })
+        .unwrap();
+
+        assert_eq!(result.stats.skipped_sessions, 1);
+        let sessions = store.list_recent_sessions(10).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(!sessions[0].is_import, "local raw backing must clear the import marker");
         let _ = fs::remove_file(&path);
     }
 

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -529,6 +529,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -714,6 +714,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -688,6 +688,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 
-const SCHEMA_VERSION: i64 = 7;
+const SCHEMA_VERSION: i64 = 8;
 
 #[allow(clippy::missing_transmute_annotations)]
 pub fn register_sqlite_vec() {
@@ -33,6 +33,9 @@ pub fn init(conn: &Connection) -> anyhow::Result<()> {
     }
     if version < 7 {
         migrate_v7(conn)?;
+    }
+    if version < 8 {
+        migrate_v8(conn)?;
     }
     Ok(())
 }
@@ -274,6 +277,15 @@ fn migrate_v7(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn migrate_v8(conn: &Connection) -> anyhow::Result<()> {
+    add_column_if_missing(
+        conn,
+        "ALTER TABLE sessions ADD COLUMN is_import INTEGER NOT NULL DEFAULT 0",
+    )?;
+    conn.execute_batch("PRAGMA user_version = 8;")?;
+    Ok(())
+}
+
 fn add_column_if_missing(conn: &Connection, stmt: &str) -> anyhow::Result<()> {
     if let Err(err) = conn.execute(stmt, []) {
         let msg = err.to_string();
@@ -340,6 +352,32 @@ mod tests {
         assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
         conn.prepare("SELECT source_file_path FROM sessions")
             .unwrap_or_else(|e| panic!("column source_file_path missing after migrate_v7: {e}"));
+    }
+
+    #[test]
+    fn migrate_v8_adds_is_import_to_existing_v7_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT NOT NULL, source_id TEXT NOT NULL,
+                title TEXT NOT NULL, directory TEXT, started_at INTEGER NOT NULL,
+                updated_at INTEGER, message_count INTEGER NOT NULL DEFAULT 0,
+                entrypoint TEXT, custom_title TEXT, summary TEXT,
+                duration_minutes INTEGER, source_file_path TEXT, UNIQUE(source, source_id)
+            );
+            INSERT INTO sessions (id, source, source_id, title, started_at)
+            VALUES ('s1', 'codex', 'c1', 'existing', 0);
+            PRAGMA user_version = 7;",
+        )
+        .unwrap();
+
+        init(&conn).unwrap();
+
+        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        let is_import: i64 = conn
+            .query_row("SELECT is_import FROM sessions WHERE id = 's1'", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(is_import, 0, "existing local sessions must default to is_import = 0");
     }
 
     #[test]

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use chrono::Utc;
@@ -12,7 +12,7 @@ use crate::types::{
 };
 use crate::utils::f32_slice_to_bytes;
 
-pub(crate) const SESSION_COLUMNS: &str = "id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes";
+pub(crate) const SESSION_COLUMNS: &str = "id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import";
 
 pub(crate) fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Session> {
     Ok(Session {
@@ -28,6 +28,8 @@ pub(crate) fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Sess
         custom_title: row.get(9)?,
         summary: row.get(10)?,
         duration_minutes: row.get::<_, Option<i64>>(11)?.map(|v| v as u32),
+        source_file_path: row.get(12)?,
+        is_import: row.get(13)?,
     })
 }
 
@@ -162,6 +164,22 @@ impl Store {
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
+    pub fn imported_source_ids(&self, source: &str) -> Result<HashSet<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT source_id FROM sessions WHERE source = ?1 AND is_import = 1")?;
+        let rows = stmt.query_map(rusqlite::params![source], |row| row.get(0))?;
+        rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
+    }
+
+    pub fn clear_import_marker(&self, source: &str, source_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET is_import = 0 WHERE source = ?1 AND source_id = ?2",
+            rusqlite::params![source, source_id],
+        )?;
+        Ok(())
+    }
+
     pub fn update_session_fields(
         &self,
         source: &str,
@@ -196,8 +214,8 @@ impl Store {
 
     pub fn insert_session(&self, session: &Session) -> Result<()> {
         self.conn.execute(
-            "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             rusqlite::params![
                 session.id,
                 session.source,
@@ -211,6 +229,8 @@ impl Store {
                 session.custom_title,
                 session.summary,
                 session.duration_minutes,
+                session.source_file_path,
+                session.is_import,
             ],
         )?;
         Ok(())
@@ -270,8 +290,8 @@ impl Store {
         let tx = self.conn.unchecked_transaction()?;
         {
             tx.execute(
-                "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 rusqlite::params![
                     session.id,
                     session.source,
@@ -285,6 +305,8 @@ impl Store {
                     session.custom_title,
                     session.summary,
                     session.duration_minutes,
+                    session.source_file_path,
+                    session.is_import,
                 ],
             )?;
 
@@ -1085,7 +1107,7 @@ impl Store {
         let mut stmt = self.conn.prepare(
             "SELECT event_key, event_seq, message_seq, timestamp, model, provider,
                     input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-                    reasoning_tokens, token_source
+                    reasoning_tokens, token_source, parser_version, source_path, raw_usage_json
              FROM usage_events
              WHERE session_id = ?1
              ORDER BY event_seq ASC, event_key ASC",
@@ -1104,6 +1126,9 @@ impl Store {
                 cache_write_tokens: row.get(9)?,
                 reasoning_tokens: row.get(10)?,
                 token_source: row.get(11)?,
+                parser_version: row.get(12)?,
+                source_path: row.get(13)?,
+                raw_usage_json: row.get(14)?,
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
@@ -1115,7 +1140,7 @@ impl Store {
     ) -> Result<Vec<SessionEventRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT event_seq, timestamp, kind, actor, name, status, target,
-                    message_seq, summary, source_path, source_event_id
+                    message_seq, summary, source_path, source_event_id, attrs_json, parser_version
              FROM session_events
              WHERE session_id = ?1
              ORDER BY event_seq ASC",
@@ -1133,6 +1158,8 @@ impl Store {
                 summary: row.get(8)?,
                 source_path: row.get(9)?,
                 source_event_id: row.get(10)?,
+                attrs_json: row.get(11)?,
+                parser_version: row.get(12)?,
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
@@ -1407,7 +1434,27 @@ mod exclusion_tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
+    }
+
+    #[test]
+    fn imported_source_ids_and_clear_import_marker_round_trip() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut imported = sess("a", None);
+        imported.is_import = true;
+        store.insert_session(&imported).unwrap();
+        store.insert_session(&sess("b", None)).unwrap();
+
+        let ids = store.imported_source_ids("claude-code").unwrap();
+        assert_eq!(ids, std::collections::HashSet::from(["src-a".to_string()]));
+
+        store.clear_import_marker("claude-code", "src-a").unwrap();
+        assert!(store.imported_source_ids("claude-code").unwrap().is_empty());
+        let sessions = store.list_recent_sessions(10).unwrap();
+        assert!(sessions.iter().all(|s| !s.is_import));
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -7,7 +7,7 @@ use crate::db::search::TimeRange;
 use crate::db::store::Store;
 use crate::types::{Message, Role, Session, SessionEventRecord, SessionUsageEventRecord};
 
-const SCHEMA_VERSION: u32 = 2;
+const SCHEMA_VERSION: u32 = 3;
 const RECORD_TYPE: &str = "session";
 
 pub struct ExportOptions {
@@ -41,6 +41,7 @@ struct ExportSession {
     custom_title: Option<String>,
     summary: Option<String>,
     duration_minutes: Option<u32>,
+    source_file_path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -65,6 +66,9 @@ struct ExportUsageEvent {
     cache_write_tokens: i64,
     reasoning_tokens: i64,
     token_source: String,
+    parser_version: u32,
+    source_path: Option<String>,
+    raw_usage_json: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -80,6 +84,8 @@ struct ExportEvent {
     summary: Option<String>,
     source_path: Option<String>,
     source_event_id: Option<String>,
+    attrs_json: Option<String>,
+    parser_version: u32,
 }
 
 pub fn write_jsonl<W: Write>(store: &Store, options: &ExportOptions, mut writer: W) -> Result<()> {
@@ -124,6 +130,7 @@ impl From<Session> for ExportSession {
             custom_title: session.custom_title,
             summary: session.summary,
             duration_minutes: session.duration_minutes,
+            source_file_path: session.source_file_path,
         }
     }
 }
@@ -153,6 +160,9 @@ impl From<SessionUsageEventRecord> for ExportUsageEvent {
             cache_write_tokens: event.cache_write_tokens,
             reasoning_tokens: event.reasoning_tokens,
             token_source: event.token_source,
+            parser_version: event.parser_version,
+            source_path: event.source_path,
+            raw_usage_json: event.raw_usage_json,
         }
     }
 }
@@ -171,6 +181,8 @@ impl From<SessionEventRecord> for ExportEvent {
             summary: event.summary,
             source_path: event.source_path,
             source_event_id: event.source_event_id,
+            attrs_json: event.attrs_json,
+            parser_version: event.parser_version,
         }
     }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,0 +1,558 @@
+use std::collections::HashSet;
+use std::io::BufRead;
+
+use anyhow::{Result, anyhow, bail};
+use serde::Deserialize;
+
+use crate::db::store::Store;
+use crate::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource};
+
+const RECORD_TYPE: &str = "session";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportSummary {
+    pub total: usize,
+    pub imported: usize,
+    pub skipped: usize,
+}
+
+#[derive(Deserialize)]
+struct ImportRecord {
+    schema_version: u32,
+    record_type: String,
+    session: ImportSession,
+    #[serde(default)]
+    messages: Vec<ImportMessage>,
+    #[serde(default)]
+    usage_events: Vec<ImportUsageEvent>,
+    #[serde(default)]
+    events: Vec<ImportEvent>,
+}
+
+#[derive(Deserialize)]
+struct ImportSession {
+    source: String,
+    source_id: String,
+    title: String,
+    #[serde(default)]
+    directory: Option<String>,
+    started_at: i64,
+    #[serde(default)]
+    updated_at: Option<i64>,
+    #[serde(default)]
+    entrypoint: Option<String>,
+    #[serde(default)]
+    custom_title: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    duration_minutes: Option<u32>,
+    #[serde(default)]
+    source_file_path: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ImportMessage {
+    seq: u32,
+    role: String,
+    #[serde(default)]
+    timestamp: Option<i64>,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ImportUsageEvent {
+    event_key: String,
+    event_seq: u32,
+    #[serde(default)]
+    message_seq: Option<u32>,
+    timestamp: i64,
+    model: String,
+    provider: String,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+    reasoning_tokens: i64,
+    token_source: String,
+    #[serde(default)]
+    parser_version: u32,
+    #[serde(default)]
+    source_path: Option<String>,
+    #[serde(default)]
+    raw_usage_json: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ImportEvent {
+    event_seq: u32,
+    #[serde(default)]
+    timestamp: Option<i64>,
+    kind: String,
+    actor: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    message_seq: Option<u32>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    source_path: Option<String>,
+    #[serde(default)]
+    source_event_id: Option<String>,
+    #[serde(default)]
+    attrs_json: Option<String>,
+    #[serde(default)]
+    parser_version: u32,
+}
+
+pub fn import_jsonl<R: BufRead>(store: &Store, dry_run: bool, reader: R) -> Result<ImportSummary> {
+    let mut summary = ImportSummary::default();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    for (idx, line) in reader.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = line.map_err(|e| anyhow!("line {line_no}: read failed: {e}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let record: ImportRecord = serde_json::from_str(&line)
+            .map_err(|e| anyhow!("line {line_no}: invalid record: {e}"))?;
+        if record.record_type != RECORD_TYPE {
+            bail!("line {line_no}: unsupported record_type '{}'", record.record_type);
+        }
+        if !matches!(record.schema_version, 2 | 3) {
+            bail!("line {line_no}: unsupported schema_version {}", record.schema_version);
+        }
+
+        summary.total += 1;
+
+        let key = (record.session.source.clone(), record.session.source_id.clone());
+        if seen.contains(&key)
+            || store.session_meta(&record.session.source, &record.session.source_id)?.is_some()
+        {
+            summary.skipped += 1;
+            continue;
+        }
+        seen.insert(key);
+        summary.imported += 1;
+        if dry_run {
+            continue;
+        }
+
+        persist_record(store, record, line_no)?;
+    }
+
+    Ok(summary)
+}
+
+fn persist_record(store: &Store, record: ImportRecord, line_no: usize) -> Result<()> {
+    let session_uuid = uuid::Uuid::new_v4().to_string();
+    let s = record.session;
+
+    let session = Session {
+        id: session_uuid.clone(),
+        source: s.source,
+        source_id: s.source_id,
+        title: s.title,
+        directory: s.directory,
+        started_at: s.started_at,
+        updated_at: s.updated_at,
+        message_count: record.messages.len() as u32,
+        entrypoint: s.entrypoint,
+        custom_title: s.custom_title,
+        summary: s.summary,
+        duration_minutes: s.duration_minutes,
+        source_file_path: s.source_file_path,
+        is_import: true,
+    };
+
+    let messages = record
+        .messages
+        .into_iter()
+        .map(|m| {
+            let role: Role = m
+                .role
+                .parse()
+                .map_err(|()| anyhow!("line {line_no}: invalid message role '{}'", m.role))?;
+            Ok(Message {
+                session_id: session_uuid.clone(),
+                role,
+                content: m.content,
+                timestamp: m.timestamp,
+                seq: m.seq,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let usage_events = record
+        .usage_events
+        .into_iter()
+        .map(|e| {
+            let token_source: TokenSource = e.token_source.parse().map_err(|()| {
+                anyhow!("line {line_no}: invalid token_source '{}'", e.token_source)
+            })?;
+            Ok(RawUsageEvent {
+                event_key: e.event_key,
+                event_seq: e.event_seq,
+                message_seq: e.message_seq,
+                timestamp: e.timestamp,
+                model: e.model,
+                provider: e.provider,
+                input_tokens: e.input_tokens,
+                output_tokens: e.output_tokens,
+                cache_read_tokens: e.cache_read_tokens,
+                cache_write_tokens: e.cache_write_tokens,
+                reasoning_tokens: e.reasoning_tokens,
+                token_source,
+                parser_version: e.parser_version,
+                source_path: e.source_path,
+                raw_usage_json: e.raw_usage_json,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let events: Vec<RawSessionEvent> = record
+        .events
+        .into_iter()
+        .map(|e| RawSessionEvent {
+            event_seq: e.event_seq,
+            timestamp: e.timestamp,
+            kind: e.kind,
+            actor: e.actor,
+            name: e.name,
+            status: e.status,
+            target: e.target,
+            message_seq: e.message_seq,
+            summary: e.summary,
+            source_path: e.source_path,
+            source_event_id: e.source_event_id,
+            attrs_json: e.attrs_json,
+            parser_version: e.parser_version,
+        })
+        .collect();
+
+    store.persist_session_with_usage_and_events(
+        &session,
+        &messages,
+        &usage_events,
+        None,
+        &events,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema;
+    use crate::db::search::TimeRange;
+    use crate::export::{ExportOptions, write_jsonl};
+
+    fn setup() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn full_session(source: &str, source_id: &str, title: &str) -> Session {
+        Session {
+            id: format!("local-{source_id}"),
+            source: source.to_string(),
+            source_id: source_id.to_string(),
+            title: title.to_string(),
+            directory: Some("/tmp/project".to_string()),
+            started_at: 1_000,
+            updated_at: Some(2_000),
+            message_count: 2,
+            entrypoint: Some("cli".to_string()),
+            custom_title: Some("Custom".to_string()),
+            summary: Some("A summary".to_string()),
+            duration_minutes: Some(7),
+            source_file_path: Some("/home/origin/.codex/sessions/a.jsonl".to_string()),
+            is_import: false,
+        }
+    }
+
+    fn full_messages(session_id: &str) -> Vec<Message> {
+        vec![
+            Message {
+                session_id: session_id.to_string(),
+                role: Role::User,
+                content: "zebraquery".to_string(),
+                timestamp: Some(1_000),
+                seq: 0,
+            },
+            Message {
+                session_id: session_id.to_string(),
+                role: Role::Assistant,
+                content: "assistant reply".to_string(),
+                timestamp: Some(1_500),
+                seq: 2,
+            },
+        ]
+    }
+
+    fn full_usage_event() -> RawUsageEvent {
+        RawUsageEvent {
+            event_key: "uk1".to_string(),
+            event_seq: 0,
+            message_seq: Some(2),
+            timestamp: 1_500,
+            model: "gpt-test".to_string(),
+            provider: "openai".to_string(),
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 3,
+            cache_write_tokens: 2,
+            reasoning_tokens: 1,
+            token_source: TokenSource::Observed,
+            parser_version: 4,
+            source_path: Some("/home/origin/raw.jsonl".to_string()),
+            raw_usage_json: Some("{\"input_tokens\":10}".to_string()),
+        }
+    }
+
+    fn full_event() -> RawSessionEvent {
+        RawSessionEvent {
+            event_seq: 0,
+            timestamp: Some(1_200),
+            kind: "tool".to_string(),
+            actor: "assistant".to_string(),
+            name: Some("Shell".to_string()),
+            status: Some("ok".to_string()),
+            target: Some("ls".to_string()),
+            message_seq: Some(0),
+            summary: Some("ran ls".to_string()),
+            source_path: Some("/home/origin/raw.jsonl".to_string()),
+            source_event_id: Some("ev-1".to_string()),
+            attrs_json: Some("{\"exit_code\":0}".to_string()),
+            parser_version: 5,
+        }
+    }
+
+    fn persist_full(store: &Store, source: &str, source_id: &str, title: &str) {
+        let session = full_session(source, source_id, title);
+        let messages = full_messages(&session.id);
+        store
+            .persist_session_with_usage_and_events(
+                &session,
+                &messages,
+                &[full_usage_event()],
+                Some(4),
+                &[full_event()],
+                Some(5),
+            )
+            .unwrap();
+    }
+
+    fn export_all(store: &Store) -> String {
+        let options =
+            ExportOptions { sources: None, time_range: TimeRange::All, project: None, limit: None };
+        let mut out = Vec::new();
+        write_jsonl(store, &options, &mut out).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    fn count(store: &Store, sql: &str) -> i64 {
+        store.conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn roundtrip_preserves_all_fields() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Roundtrip");
+        let exported = export_all(&a);
+
+        let b = setup();
+        let summary = import_jsonl(&b, false, exported.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 1, skipped: 0 });
+
+        let reexported = export_all(&b);
+        let mut orig: serde_json::Value = serde_json::from_str(exported.trim()).unwrap();
+        let mut copy: serde_json::Value = serde_json::from_str(reexported.trim()).unwrap();
+        orig["session"]["id"] = serde_json::Value::Null;
+        copy["session"]["id"] = serde_json::Value::Null;
+        assert_eq!(orig, copy, "export -> import -> export must be lossless");
+    }
+
+    #[test]
+    fn import_marks_is_import_and_writes_no_state_rows() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Marked");
+        let exported = export_all(&a);
+
+        let b = setup();
+        import_jsonl(&b, false, exported.as_bytes()).unwrap();
+
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions WHERE is_import = 1"), 1);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM usage_session_state"), 0);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM event_session_state"), 0);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM usage_events"), 1);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM session_events"), 1);
+    }
+
+    #[test]
+    fn import_is_idempotent() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Idem");
+        persist_full(&a, "grok", "src-2", "Idem2");
+        let exported = export_all(&a);
+
+        let b = setup();
+        let first = import_jsonl(&b, false, exported.as_bytes()).unwrap();
+        assert_eq!(first, ImportSummary { total: 2, imported: 2, skipped: 0 });
+
+        let second = import_jsonl(&b, false, exported.as_bytes()).unwrap();
+        assert_eq!(second, ImportSummary { total: 2, imported: 0, skipped: 2 });
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions"), 2);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM messages"), 4);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM usage_events"), 2);
+    }
+
+    #[test]
+    fn local_roundtrip_imports_nothing_and_keeps_local_rows() {
+        let store = setup();
+        persist_full(&store, "codex", "src-1", "Local");
+        let exported = export_all(&store);
+
+        let summary = import_jsonl(&store, false, exported.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 0, skipped: 1 });
+        assert_eq!(count(&store, "SELECT COUNT(*) FROM sessions"), 1);
+        assert_eq!(count(&store, "SELECT COUNT(*) FROM sessions WHERE is_import = 0"), 1);
+        assert_eq!(export_all(&store), exported, "local data must be untouched");
+    }
+
+    #[test]
+    fn skip_keeps_local_content_on_conflicting_import() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Remote version");
+        let exported = export_all(&a);
+
+        let b = setup();
+        persist_full(&b, "codex", "src-1", "Local version");
+        let summary = import_jsonl(&b, false, exported.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 0, skipped: 1 });
+
+        let title: String = b
+            .conn
+            .query_row(
+                "SELECT title FROM sessions WHERE source = 'codex' AND source_id = 'src-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(title, "Local version");
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Dry");
+        let exported = export_all(&a);
+
+        let b = setup();
+        let summary = import_jsonl(&b, true, exported.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 1, skipped: 0 });
+        for table in
+            ["sessions", "messages", "usage_events", "session_events", "session_embedding_state"]
+        {
+            assert_eq!(count(&b, &format!("SELECT COUNT(*) FROM {table}")), 0, "{table} dirty");
+        }
+    }
+
+    #[test]
+    fn duplicate_keys_in_one_file_count_once_in_dry_run_and_real_run() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Dup");
+        let line = export_all(&a);
+        let doubled = format!("{line}{line}");
+
+        let b = setup();
+        let dry = import_jsonl(&b, true, doubled.as_bytes()).unwrap();
+        let real = import_jsonl(&b, false, doubled.as_bytes()).unwrap();
+
+        let expected = ImportSummary { total: 2, imported: 1, skipped: 1 };
+        assert_eq!(dry, expected, "dry-run must predict exactly what a real import writes");
+        assert_eq!(real, expected);
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions"), 1);
+    }
+
+    #[test]
+    fn malformed_line_fails_with_line_number_keeping_prior_rows() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Good");
+        let mut exported = export_all(&a);
+        exported.push_str("not json\n");
+
+        let b = setup();
+        let err = import_jsonl(&b, false, exported.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("line 2"), "unexpected error: {err}");
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions"), 1);
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_version_and_record_type() {
+        let store = setup();
+        let bad_version = r#"{"schema_version":99,"record_type":"session","session":{"source":"codex","source_id":"x","title":"t","started_at":0}}"#;
+        let err = import_jsonl(&store, false, bad_version.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("schema_version"), "unexpected error: {err}");
+
+        let bad_type = r#"{"schema_version":3,"record_type":"snapshot","session":{"source":"codex","source_id":"x","title":"t","started_at":0}}"#;
+        let err = import_jsonl(&store, false, bad_type.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("record_type"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn accepts_schema_version_2_without_v3_fields() {
+        let store = setup();
+        let v2 = r#"{"schema_version":2,"record_type":"session","session":{"source":"codex","source_id":"v2-1","title":"V2","started_at":100},"messages":[{"seq":0,"role":"user","timestamp":100,"content":"hello v2"}],"usage_events":[{"event_key":"k","event_seq":0,"message_seq":null,"timestamp":100,"model":"m","provider":"p","input_tokens":1,"output_tokens":2,"cache_read_tokens":0,"cache_write_tokens":0,"reasoning_tokens":0,"token_source":"observed"}],"events":[{"event_seq":0,"timestamp":null,"kind":"tool","actor":"assistant"}]}"#;
+        let summary = import_jsonl(&store, false, v2.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 1, skipped: 0 });
+
+        let parser_version: i64 = store
+            .conn
+            .query_row("SELECT parser_version FROM usage_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(parser_version, 0, "missing v3 fields must default to 0");
+    }
+
+    #[test]
+    fn preserves_message_seq_and_fts() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Seq");
+        let exported = export_all(&a);
+
+        let b = setup();
+        import_jsonl(&b, false, exported.as_bytes()).unwrap();
+
+        let seqs: Vec<u32> = {
+            let mut stmt = b.conn.prepare("SELECT seq FROM messages ORDER BY seq").unwrap();
+            let rows = stmt.query_map([], |row| row.get(0)).unwrap();
+            rows.collect::<Result<Vec<_>, _>>().unwrap()
+        };
+        assert_eq!(seqs, vec![0, 2], "non-contiguous seq must be preserved");
+
+        let fts_hits =
+            count(&b, "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'zebraquery'");
+        assert_eq!(fts_hits, 1, "imported messages must be searchable via FTS");
+    }
+
+    #[test]
+    fn local_sync_refresh_clears_is_import() {
+        let a = setup();
+        persist_full(&a, "codex", "src-1", "Converge");
+        let exported = export_all(&a);
+
+        let b = setup();
+        import_jsonl(&b, false, exported.as_bytes()).unwrap();
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions WHERE is_import = 1"), 1);
+
+        persist_full(&b, "codex", "src-1", "Now local");
+        assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions WHERE is_import = 1"), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod embedding;
 pub mod export;
+pub mod import;
 pub mod semantic;
 pub mod skill_audit;
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,18 @@ enum Commands {
         time: Option<String>,
         #[arg(long, help = "Filter by project directory, including child paths")]
         project: Option<String>,
-        #[arg(long, default_value_t = 100, help = "Maximum sessions to export; 0 means all")]
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "Maximum sessions to export; 0 means all (default)"
+        )]
         limit: usize,
+    },
+    Import {
+        #[arg(help = "Input file path, or - for stdin")]
+        file: String,
+        #[arg(long, help = "Parse and report without writing")]
+        dry_run: bool,
     },
 }
 
@@ -119,6 +129,7 @@ fn main() -> Result<()> {
         Some(Commands::Export { jsonl, source, time, project, limit }) => {
             cmd_export(jsonl, source.as_deref(), time.as_deref(), project.as_deref(), limit)?
         }
+        Some(Commands::Import { file, dry_run }) => cmd_import(&file, dry_run)?,
         None => cmd_tui(None)?,
     }
 
@@ -479,6 +490,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         }
 
         let mut existing_meta = store.session_meta_map(source_id)?;
+        let mut imported_ids = store.imported_source_ids(source_id)?;
         let mut existing_usage_meta = store.usage_state_meta_map(source_id)?;
         let mut existing_event_meta = if options.usage_only && !options.backfill_events {
             Default::default()
@@ -515,7 +527,6 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 continue;
             }
 
-            let raw_source_file_path = raw.source_file_path.clone();
             let msg_count = raw.messages.len() as u32;
             let usage_backfill_needed = raw.usage_parser_version.is_some_and(|version| {
                 !usage_state_is_current(
@@ -535,6 +546,9 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
 
             match existing_meta.get(&raw_source_id) {
                 Some(&(old_updated_at, old_msg_count)) => {
+                    if imported_ids.remove(&raw_source_id) {
+                        store.clear_import_marker(source_id, &raw_source_id)?;
+                    }
                     let content_changed = old_msg_count != msg_count
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
                     match decide_existing_session_action(
@@ -642,6 +656,8 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 custom_title: raw.custom_title,
                 summary: raw.summary,
                 duration_minutes: raw.duration_minutes,
+                source_file_path: raw.source_file_path,
+                is_import: false,
             };
 
             let messages: Vec<Message> = raw
@@ -672,16 +688,6 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 &events,
                 event_parser_version,
             )?;
-            if let Some(source_file_path) = raw_source_file_path.as_deref() {
-                store.update_session_fields(
-                    source_id,
-                    &session.source_id,
-                    None,
-                    None,
-                    None,
-                    Some(source_file_path),
-                )?;
-            }
             existing_meta
                 .insert(session.source_id.clone(), (session.updated_at, session.message_count));
             if let Some(parser_version) = raw.usage_parser_version {
@@ -947,6 +953,25 @@ fn cmd_export(
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     recall::export::write_jsonl(&store, &options, &mut handle)
+}
+
+fn cmd_import(file: &str, dry_run: bool) -> Result<()> {
+    let store = Store::open()?;
+    let summary = if file == "-" {
+        let stdin = std::io::stdin();
+        recall::import::import_jsonl(&store, dry_run, stdin.lock())?
+    } else {
+        let f =
+            std::fs::File::open(file).map_err(|e| anyhow::anyhow!("cannot open {file}: {e}"))?;
+        recall::import::import_jsonl(&store, dry_run, std::io::BufReader::new(f))?
+    };
+
+    let suffix = if dry_run { " (dry-run, nothing written)" } else { "" };
+    println!(
+        "total {} | imported {} | skipped {}{suffix}",
+        summary.total, summary.imported, summary.skipped
+    );
+    Ok(())
 }
 
 fn format_usage_report_text(report: &usage::UsageReport) -> String {
@@ -1267,6 +1292,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         }
     }
 

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -496,6 +496,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         };
         let event = RawSessionEvent {
             event_seq: 0,
@@ -548,6 +550,8 @@ mod tests {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
         };
         let event = RawSessionEvent {
             event_seq: 0,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -131,6 +131,8 @@ mod tests {
                 custom_title: None,
                 summary: None,
                 duration_minutes: None,
+                source_file_path: None,
+                is_import: false,
             },
             match_source: MatchSource::Fts,
             snippet: None,
@@ -161,6 +163,9 @@ mod tests {
             cache_write_tokens: 2,
             reasoning_tokens: 1,
             token_source: "derived".to_string(),
+            parser_version: 1,
+            source_path: None,
+            raw_usage_json: None,
         }
     }
 
@@ -213,6 +218,38 @@ mod tests {
                 .iter()
                 .any(|arg| arg == "codex://threads/019e6d8d-588b-7fd2-a326-c525469ed120")
         );
+    }
+
+    #[test]
+    fn imported_session_suppresses_resume_and_app_open() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let engine = SearchEngine::new(&store.conn);
+        let mut provider = None;
+        let mut app = app_with_sources();
+        let mut result = codex_search_result();
+        result.session.is_import = true;
+        app.results = vec![result];
+
+        for key_char in ['r', 'o'] {
+            app.status_message = None;
+            app.handle_search_key(
+                KeyEvent::new(KeyCode::Char(key_char), KeyModifiers::CONTROL),
+                &store,
+                &engine,
+                &mut provider,
+            );
+
+            assert!(
+                !matches!(app.mode, AppMode::ConfirmResume),
+                "ctrl+{key_char} must not open confirmation for imported session"
+            );
+            assert!(app.pending_resume.is_none());
+            assert!(
+                app.status_message.as_deref().unwrap_or_default().contains("Imported"),
+                "status message must explain why nothing happened"
+            );
+        }
     }
 
     #[test]
@@ -1148,6 +1185,11 @@ impl App {
             return;
         };
         let session = &result.session;
+        if session.is_import {
+            self.status_message =
+                Some("Imported session: not resumable on this machine".to_string());
+            return;
+        }
         let command = match action {
             PendingCommandAction::Resume => resume_command_for(&session.source, &session.source_id),
             PendingCommandAction::OpenApp => app_command_for(&session.source, &session.source_id),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1883,6 +1883,8 @@ mod tests {
                 custom_title: None,
                 summary: None,
                 duration_minutes: Some(2),
+                source_file_path: None,
+                is_import: false,
             },
             match_source: MatchSource::Fts,
             snippet: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,6 +70,8 @@ pub struct Session {
     pub custom_title: Option<String>,
     pub summary: Option<String>,
     pub duration_minutes: Option<u32>,
+    pub source_file_path: Option<String>,
+    pub is_import: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -147,6 +149,8 @@ pub struct SessionEventRecord {
     pub summary: Option<String>,
     pub source_path: Option<String>,
     pub source_event_id: Option<String>,
+    pub attrs_json: Option<String>,
+    pub parser_version: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -163,6 +167,9 @@ pub struct SessionUsageEventRecord {
     pub cache_write_tokens: i64,
     pub reasoning_tokens: i64,
     pub token_source: String,
+    pub parser_version: u32,
+    pub source_path: Option<String>,
+    pub raw_usage_json: Option<String>,
 }
 
 #[derive(Debug)]

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -23,6 +23,8 @@ fn session(id: &str, source: &str, source_id: &str, title: &str) -> Session {
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
     }
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -28,6 +28,8 @@ fn make_session(id: &str, source: &str, source_id: &str, title: &str) -> Session
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
     }
 }
 
@@ -279,7 +281,7 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     let lines: Vec<_> = text.lines().collect();
     assert_eq!(lines.len(), 1);
     let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(value["schema_version"], 2);
+    assert_eq!(value["schema_version"], 3);
     assert_eq!(value["record_type"], "session");
     assert_eq!(value["session"]["source"], "codex");
     assert_eq!(value["session"]["source_id"], "raw1");
@@ -295,12 +297,15 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     assert_eq!(value["usage_events"][0]["message_seq"], 1);
     assert_eq!(value["usage_events"][0]["model"], "gpt-5");
     assert_eq!(value["usage_events"][0]["token_source"], "observed");
-    assert!(value["usage_events"][0].get("raw_usage_json").is_none());
+    assert_eq!(value["usage_events"][0]["parser_version"], 1);
+    assert_eq!(value["usage_events"][0]["source_path"], "/tmp/source.jsonl");
+    assert_eq!(value["usage_events"][0]["raw_usage_json"], r#"{"input_tokens":10}"#);
     assert_eq!(value["events"][0]["kind"], "file_read");
     assert_eq!(value["events"][0]["name"], "read_file");
     assert_eq!(value["events"][0]["target"], "src/main.rs");
     assert_eq!(value["events"][0]["message_seq"], 1);
-    assert!(value["events"][0].get("attrs_json").is_none());
+    assert_eq!(value["events"][0]["parser_version"], 1);
+    assert_eq!(value["events"][0]["attrs_json"], r#"{"path":"src/main.rs"}"#);
 }
 
 #[test]
@@ -575,6 +580,8 @@ fn sync_skips_unchanged_session() {
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
     };
     store.insert_session(&session).unwrap();
 
@@ -598,6 +605,8 @@ fn sync_detects_new_messages() {
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
     };
     store.insert_session(&session).unwrap();
     store.insert_messages(&[make_message("s1", Role::User, "hello", 0)]).unwrap();
@@ -633,6 +642,8 @@ fn sync_detects_updated_timestamp() {
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
     };
     store.insert_session(&session).unwrap();
 


### PR DESCRIPTION
### What's changed?

- Add `recall import` for JSONL records from files or stdin, including dry-run reporting, duplicate skipping, and schema v2/v3 input support.
- Upgrade JSONL export to schema v3 so session source paths plus usage/event parser metadata round-trip.
- Track imported sessions in the database, suppress resume/open for import-only rows, and clear the marker once local raw data is seen again.
- Cover migration, import/export round-trips, dry-run behavior, duplicate handling, FTS indexing, marker clearing, and TUI suppression with tests.

### Why

- This enables moving Recall session indexes between machines without treating imported-only rows as locally resumable sessions.
- This PR is deliberately above the usual size budget because the CLI, schema, import/export serialization, TUI safety behavior, and regression coverage are one cohesive feature.