### PR TITLE
[Fix] Restore Cursor agent project attribution

### DIFF
--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -40,6 +40,13 @@ struct ParsedComposerSession {
     directory: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct AgentTranscriptPath {
+    session_id: String,
+    path: PathBuf,
+    directory: Option<String>,
+}
+
 impl SourceAdapter for CursorAdapter {
     fn id(&self) -> &str {
         "cursor"
@@ -152,8 +159,9 @@ fn scan_transcript_only_sessions(
     };
     let cwd_map = build_agent_cwd_map(resolve_global_state_db_path().as_deref());
     let mut sessions = Vec::new();
-    for (session_id, path) in collect_agent_transcript_paths_from_dir(&projects_dir) {
-        let Some(mtime_ms) = stat_mtime_ms(&path) else {
+    for transcript in collect_agent_transcript_paths_from_dir(&projects_dir) {
+        let path = &transcript.path;
+        let Some(mtime_ms) = stat_mtime_ms(path) else {
             continue;
         };
         if let Some(cutoff) = since_ts
@@ -161,13 +169,14 @@ fn scan_transcript_only_sessions(
         {
             continue;
         }
-        let mut raw = match parse_agent_transcript(&path, include_events)? {
+        let mut raw = match parse_agent_transcript(path, include_events)? {
             Some(raw) => raw,
             None => continue,
         };
-        raw.source_id = session_id;
-        raw.directory = cwd_map.get(&raw.source_id).cloned();
-        raw.started_at = stat_birth_ms(&path).unwrap_or(mtime_ms);
+        raw.source_id = transcript.session_id;
+        raw.directory =
+            cwd_map.get(&raw.source_id).cloned().or(raw.directory).or(transcript.directory);
+        raw.started_at = stat_birth_ms(path).unwrap_or(mtime_ms);
         raw.updated_at = Some(mtime_ms);
         sessions.push(raw);
     }
@@ -178,7 +187,7 @@ fn build_raw_session(
     conn: &Connection,
     composer_id: &str,
     meta: &ComposerMeta,
-    transcript_paths: &HashMap<String, PathBuf>,
+    transcript_paths: &HashMap<String, AgentTranscriptPath>,
     include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
     let parsed = match parse_composer_session(conn, composer_id, meta, include_events)? {
@@ -190,9 +199,10 @@ fn build_raw_session(
             parsed
         }
         _ => {
-            let Some(path) = transcript_paths.get(composer_id) else {
+            let Some(transcript) = transcript_paths.get(composer_id) else {
                 return Ok(None);
             };
+            let path = &transcript.path;
             let mtime_ms = stat_mtime_ms(path).unwrap_or(0);
             let raw = parse_agent_transcript(path, include_events)?
                 .filter(|raw| !raw.messages.is_empty() || !raw.events.is_empty());
@@ -200,7 +210,8 @@ fn build_raw_session(
                 return Ok(None);
             };
             raw.source_id = composer_id.to_string();
-            raw.directory = meta.directory.clone().or(raw.directory);
+            raw.directory =
+                meta.directory.clone().or(raw.directory).or_else(|| transcript.directory.clone());
             raw.started_at = stat_birth_ms(path).unwrap_or(mtime_ms);
             raw.updated_at = Some(mtime_ms);
             raw.entrypoint = meta.unified_mode.clone().or(raw.entrypoint);
@@ -387,8 +398,8 @@ fn discover_composer_ids(conn: &Connection) -> anyhow::Result<BTreeSet<String>> 
         }
     }
 
-    for (session_id, _) in collect_agent_transcript_paths() {
-        ids.insert(session_id);
+    for transcript in collect_agent_transcript_paths().values() {
+        ids.insert(transcript.session_id.clone());
     }
 
     Ok(ids)
@@ -901,14 +912,17 @@ fn strip_user_query_envelope(text: &str) -> &str {
     }
 }
 
-fn collect_agent_transcript_paths() -> HashMap<String, PathBuf> {
+fn collect_agent_transcript_paths() -> HashMap<String, AgentTranscriptPath> {
     let Some(projects_dir) = resolve_projects_dir().ok().flatten() else {
         return HashMap::new();
     };
-    collect_agent_transcript_paths_from_dir(&projects_dir).into_iter().collect()
+    collect_agent_transcript_paths_from_dir(&projects_dir)
+        .into_iter()
+        .map(|transcript| (transcript.session_id.clone(), transcript))
+        .collect()
 }
 
-fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<(String, PathBuf)> {
+fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<AgentTranscriptPath> {
     let mut entries = Vec::new();
     for walk_entry in WalkDir::new(projects_dir).into_iter().filter_map(|e| e.ok()) {
         let path = walk_entry.path();
@@ -936,9 +950,58 @@ fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<(String, 
         if grandparent_name != Some("agent-transcripts") {
             continue;
         }
-        entries.push((stem.to_string(), path.to_path_buf()));
+        entries.push(AgentTranscriptPath {
+            session_id: stem.to_string(),
+            path: path.to_path_buf(),
+            directory: agent_transcript_directory_from_path(path),
+        });
     }
     entries
+}
+
+fn agent_transcript_directory_from_path(path: &Path) -> Option<String> {
+    let project_key = path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())?;
+    cursor_project_key_to_existing_path(project_key)
+}
+
+fn cursor_project_key_to_existing_path(key: &str) -> Option<String> {
+    let parts: Vec<&str> = key.split('-').filter(|part| !part.is_empty()).collect();
+    if parts.is_empty() {
+        return None;
+    }
+
+    let mut matches = Vec::new();
+    collect_cursor_project_key_matches(Path::new("/"), &parts, 0, &mut matches);
+    matches.sort();
+    matches.dedup();
+    if matches.len() == 1 { Some(matches.remove(0).to_string_lossy().to_string()) } else { None }
+}
+
+fn collect_cursor_project_key_matches(
+    current: &Path,
+    parts: &[&str],
+    index: usize,
+    matches: &mut Vec<PathBuf>,
+) {
+    if index == parts.len() {
+        if current.is_dir() {
+            matches.push(current.to_path_buf());
+        }
+        return;
+    }
+
+    for end in (index + 1..=parts.len()).rev() {
+        let component = parts[index..end].join("-");
+        let next = current.join(component);
+        if next.is_dir() {
+            collect_cursor_project_key_matches(&next, parts, end, matches);
+        }
+    }
 }
 
 fn resolve_projects_dir() -> anyhow::Result<Option<PathBuf>> {
@@ -1141,6 +1204,16 @@ mod tests {
         for l in lines {
             writeln!(f, "{l}").unwrap();
         }
+    }
+
+    fn cursor_project_key_for_test(path: &Path) -> String {
+        path.components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(part) => part.to_str(),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("-")
     }
 
     fn seed_global_db(root: &Path, composer_id: &str, bubble_id: &str) -> Connection {
@@ -1376,6 +1449,31 @@ mod tests {
         assert_eq!(raw.messages.len(), 2);
         assert_eq!(raw.messages[0].content, "hello");
         assert!(raw.messages[1].content.contains("[tool_use:Glob]"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn agent_transcript_directory_uses_project_folder_when_membership_is_missing() {
+        let root = temp_root("agent-directory");
+        let workspace = root.join("workspace-parent").join("repo-with-dash");
+        fs::create_dir_all(&workspace).unwrap();
+        let projects_dir = root.join(".cursor").join("projects");
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let project_key = cursor_project_key_for_test(&workspace);
+        let jsonl_path = projects_dir
+            .join(project_key)
+            .join("agent-transcripts")
+            .join(&uuid)
+            .join(format!("{uuid}.jsonl"));
+        write_jsonl(
+            &jsonl_path,
+            &[r#"{"role":"user","message":{"content":[{"type":"text","text":"hello"}]}}"#],
+        );
+
+        let entries = collect_agent_transcript_paths_from_dir(&projects_dir);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, uuid);
+        assert_eq!(entries[0].directory.as_deref(), Some(workspace.to_string_lossy().as_ref()));
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use anyhow::Result;
@@ -493,6 +493,11 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
         }
 
         let mut existing_meta = store.session_meta_map(source_id)?;
+        let mut existing_paths = store
+            .session_paths_for_source(source_id)?
+            .into_iter()
+            .map(|path| (path.source_id, (path.directory, path.source_file_path)))
+            .collect::<HashMap<_, _>>();
         let mut imported_ids = store.imported_source_ids(source_id)?;
         let mut existing_usage_meta = store.usage_state_meta_map(source_id)?;
         let mut existing_event_meta = if options.usage_only && !options.backfill_events {
@@ -521,6 +526,7 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
             {
                 if existing_meta.remove(&raw_source_id).is_some() {
                     store.delete_session_data(source_id, &raw_source_id)?;
+                    existing_paths.remove(&raw_source_id);
                     existing_usage_meta.remove(&raw_source_id);
                     existing_event_meta.remove(&raw_source_id);
                 }
@@ -552,7 +558,17 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                     if imported_ids.remove(&raw_source_id) {
                         store.clear_import_marker(source_id, &raw_source_id)?;
                     }
+                    let metadata_changed = existing_paths.get(&raw_source_id).is_some_and(
+                        |(old_directory, old_source_file_path)| {
+                            raw_session_metadata_changed(
+                                &raw,
+                                old_directory.as_deref(),
+                                old_source_file_path.as_deref(),
+                            )
+                        },
+                    );
                     let content_changed = old_msg_count != msg_count
+                        || metadata_changed
                         || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
                     match decide_existing_session_action(
                         options.usage_only,
@@ -693,6 +709,10 @@ fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
             )?;
             existing_meta
                 .insert(session.source_id.clone(), (session.updated_at, session.message_count));
+            existing_paths.insert(
+                session.source_id.clone(),
+                (session.directory.clone(), session.source_file_path.clone()),
+            );
             if let Some(parser_version) = raw.usage_parser_version {
                 existing_usage_meta.insert(
                     session.source_id.clone(),
@@ -822,6 +842,15 @@ fn decide_existing_session_action(
 
 fn cmd_background_worker(sync_first: bool) -> Result<()> {
     semantic::run_background_worker(sync_first, || run_sync_job(false, false))
+}
+
+fn raw_session_metadata_changed(
+    raw: &adapters::RawSession,
+    old_directory: Option<&str>,
+    old_source_file_path: Option<&str>,
+) -> bool {
+    raw.directory.as_deref().is_some_and(|directory| old_directory != Some(directory))
+        || raw.source_file_path.as_deref().is_some_and(|path| old_source_file_path != Some(path))
 }
 
 fn cmd_search(
@@ -1262,11 +1291,11 @@ mod tests {
 
     use super::{
         BackfillPlan, Cli, Commands, ExistingSessionAction, decide_existing_session_action,
-        delete_excluded_sessions_for_source,
+        delete_excluded_sessions_for_source, raw_session_metadata_changed,
     };
     use clap::{CommandFactory, Parser};
     use recall::adapters::{
-        adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
+        RawSession, adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
     };
     use recall::db::{schema, store::Store};
     use recall::types::Session;
@@ -1396,6 +1425,24 @@ mod tests {
             decide_existing_session_action(false, false, false, false, false, false),
             ExistingSessionAction::Skip
         );
+    }
+
+    #[test]
+    fn full_sync_treats_new_session_metadata_as_changed() {
+        let raw = RawSession::search_only(
+            "raw1",
+            Some("/Users/x/git/samzong/Recall".to_string()),
+            0,
+            Some(1),
+            None,
+            vec![],
+        );
+        assert!(raw_session_metadata_changed(&raw, None, None));
+        assert!(!raw_session_metadata_changed(&raw, Some("/Users/x/git/samzong/Recall"), None));
+
+        let mut raw_with_path = RawSession::search_only("raw1", None, 0, Some(1), None, vec![]);
+        raw_with_path.source_file_path = Some("/tmp/session.jsonl".to_string());
+        assert!(raw_session_metadata_changed(&raw_with_path, None, None));
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- Keep Cursor IDE and Cursor Agent sessions under the single `cursor` source while tracking agent transcript directory hints.
- Add fallback project attribution from `~/.cursor/projects/**/agent-transcripts` paths when Cursor membership metadata is missing.
- Refresh existing indexed sessions when newly discovered metadata changes from empty to populated.

### Why

- Cursor Agent transcript sessions were being indexed with `directory = NULL` when `glass.localAgentProjectMembership.v1` lacked a mapping, so project-scoped Recall searches missed them.