### PR TITLE
[Feat] Publish sessions to Cloudflare Pages

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -1,0 +1,42 @@
+# Share Spec
+
+## Goal
+
+Let a user publish one Recall session to a browser-viewable URL. The current supported provider is Cloudflare Pages.
+
+## Flow
+
+1. The user runs `recall share init` once.
+2. Recall checks that `wrangler` exists, is logged in, and can access Cloudflare Pages.
+3. Recall asks for a Pages project name and a local publish directory.
+4. In the TUI session view, the user presses `s`.
+5. Recall writes one static HTML file to `<publish_dir>/<session_uuid>.html`.
+6. Recall deploys the publish directory with Wrangler.
+7. The TUI shows `https://<project_name>.pages.dev/<session_uuid>` for the user to copy.
+
+## Scope
+
+- Supported provider: Cloudflare Pages on `pages.dev`.
+- Published unit: one session, one static HTML page.
+- Re-publishing the same session UUID overwrites the same route.
+- Wrangler work during TUI publish is hidden unless it fails.
+
+## Page
+
+- Show readable user and assistant messages.
+- Collapse tool calls and tool results by default.
+- Do not show local filesystem paths.
+
+## Privacy
+
+- The published page is public to anyone with the URL.
+- Recall sets no-index headers and robots rules, but this is not access control.
+- Auth is not supported now; if needed later, it may use another Cloudflare tool such as Workers.
+- The user is responsible for choosing sessions that are safe to share.
+
+## Non-Goals
+
+- No share picker command.
+- No list, revoke, or update command.
+- No authentication or private access control.
+- No provider abstraction beyond what is needed for the current Cloudflare Pages path.

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,15 @@ pub struct AppConfig {
     /// `**/.claude-mem/**`, `**/scratch-*`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub excluded_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub share: Option<ShareConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShareConfig {
+    pub provider: String,
+    pub project_name: String,
+    pub publish_dir: String,
 }
 
 impl AppConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod embedding;
 pub mod export;
 pub mod import;
 pub mod semantic;
+pub mod share;
 pub mod skill_audit;
 pub mod tui;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -97,6 +99,22 @@ enum Commands {
         #[arg(long, help = "Parse and report without writing")]
         dry_run: bool,
     },
+    #[command(about = "Share session pages")]
+    Share {
+        #[command(subcommand)]
+        command: ShareCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum ShareCommands {
+    #[command(about = "Initialize Cloudflare Pages sharing")]
+    Init {
+        #[arg(long, help = "Cloudflare Pages project name")]
+        project_name: Option<String>,
+        #[arg(long, help = "Local directory used for generated share pages")]
+        publish_dir: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -133,6 +151,11 @@ fn main() -> Result<()> {
             cmd_export(source.as_deref(), time.as_deref(), project.as_deref(), limit)?
         }
         Some(Commands::Import { file, dry_run }) => cmd_import(&file, dry_run)?,
+        Some(Commands::Share { command }) => match command {
+            ShareCommands::Init { project_name, publish_dir } => {
+                cmd_share_init(project_name, publish_dir)?
+            }
+        },
         None => cmd_tui(None)?,
     }
 
@@ -1001,6 +1024,73 @@ fn cmd_import(file: &str, dry_run: bool) -> Result<()> {
     Ok(())
 }
 
+fn cmd_share_init(project_name: Option<String>, publish_dir: Option<PathBuf>) -> Result<()> {
+    let mut config = AppConfig::load_or_default();
+    let existing = config.share.clone();
+    if let Some(ref share) = existing {
+        println!("Share already initialized");
+        println!("  Provider     {}", share.provider);
+        println!("  Project      {}", share.project_name);
+        println!("  Publish dir  {}", share.publish_dir);
+        println!("  URL base     https://{}.pages.dev", share.project_name);
+        if !prompt_yes_no_default_yes("Reinitialize?")? {
+            return Ok(());
+        }
+    }
+
+    println!("Checking Wrangler and Cloudflare Pages...");
+    recall::share::preflight_cloudflare_pages()?;
+
+    let default_project = existing
+        .as_ref()
+        .map(|share| share.project_name.clone())
+        .unwrap_or_else(|| recall::share::default_project_name().to_string());
+    let project_name = match project_name {
+        Some(name) => name,
+        None => prompt_with_default("Cloudflare Pages project", &default_project)?,
+    };
+
+    let default_dir =
+        existing.as_ref().map(|share| share.publish_dir.clone()).unwrap_or_else(|| {
+            recall::share::default_publish_dir()
+                .map(|path| path.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "share-pages".to_string())
+        });
+    let publish_dir = match publish_dir {
+        Some(path) => recall::share::expand_path(&path.to_string_lossy()),
+        None => {
+            let input = prompt_with_default("Local share directory", &default_dir)?;
+            recall::share::expand_path(&input)
+        }
+    };
+
+    println!("Configuring Cloudflare Pages share target...");
+    recall::share::init_cloudflare_pages(&mut config, project_name.clone(), publish_dir.clone())?;
+    println!("Share initialized");
+    println!("  Project      {project_name}");
+    println!("  Publish dir  {}", publish_dir.display());
+    println!("  URL base     https://{project_name}.pages.dev");
+    Ok(())
+}
+
+fn prompt_with_default(label: &str, default: &str) -> Result<String> {
+    print!("{label} [{default}]: ");
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    let trimmed = input.trim();
+    if trimmed.is_empty() { Ok(default.to_string()) } else { Ok(trimmed.to_string()) }
+}
+
+fn prompt_yes_no_default_yes(label: &str) -> Result<bool> {
+    print!("{label} [Y/n]: ");
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    let trimmed = input.trim().to_lowercase();
+    Ok(trimmed.is_empty() || trimmed == "y" || trimmed == "yes")
+}
+
 fn format_usage_report_text(report: &usage::UsageReport) -> String {
     let mut out = String::new();
     writeln!(out, "Usage").unwrap();
@@ -1169,6 +1259,7 @@ fn cmd_tui(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Res
     let tick_rate = Duration::from_millis(50);
 
     loop {
+        app.poll_share_publish();
         terminal.draw(|f| ui::render(f, &app))?;
 
         match poll_event(tick_rate)? {
@@ -1290,8 +1381,9 @@ mod tests {
     use std::collections::HashSet;
 
     use super::{
-        BackfillPlan, Cli, Commands, ExistingSessionAction, decide_existing_session_action,
-        delete_excluded_sessions_for_source, raw_session_metadata_changed,
+        BackfillPlan, Cli, Commands, ExistingSessionAction, ShareCommands,
+        decide_existing_session_action, delete_excluded_sessions_for_source,
+        raw_session_metadata_changed,
     };
     use clap::{CommandFactory, Parser};
     use recall::adapters::{
@@ -1342,6 +1434,29 @@ mod tests {
     }
 
     #[test]
+    fn share_init_accepts_project_and_publish_dir() {
+        let cli = Cli::try_parse_from([
+            "recall",
+            "share",
+            "init",
+            "--project-name",
+            "recall-share",
+            "--publish-dir",
+            "/tmp/recall-share",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Share {
+                command: ShareCommands::Init { project_name, publish_dir },
+            }) => {
+                assert_eq!(project_name.as_deref(), Some("recall-share"));
+                assert_eq!(publish_dir.unwrap().to_string_lossy(), "/tmp/recall-share");
+            }
+            _ => panic!("expected share init command"),
+        }
+    }
+
+    #[test]
     fn top_level_help_describes_public_commands() {
         let mut command = Cli::command();
         let help = command.render_long_help().to_string();
@@ -1352,6 +1467,7 @@ mod tests {
         assert!(help.contains("usage   Show token usage reports"));
         assert!(help.contains("export  Export session records as JSON Lines"));
         assert!(help.contains("import  Import session records from JSON Lines"));
+        assert!(help.contains("share   Share session pages"));
     }
 
     #[test]

--- a/src/share.rs
+++ b/src/share.rs
@@ -1,0 +1,451 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::config::{AppConfig, ShareConfig};
+use crate::types::{Message, Role, Session};
+use crate::utils;
+
+const PROVIDER_CLOUDFLARE_PAGES: &str = "cloudflare-pages";
+const MAX_PAGES_ASSET_BYTES: usize = 25 * 1024 * 1024;
+const HEADERS: &str = "/*\n  X-Robots-Tag: noindex, nofollow\n  X-Frame-Options: DENY\n  X-Content-Type-Options: nosniff\n  Referrer-Policy: no-referrer\n";
+const ROBOTS: &str = "User-agent: *\nDisallow: /\n";
+
+pub fn default_project_name() -> &'static str {
+    "recall-share"
+}
+
+pub fn default_publish_dir() -> Result<PathBuf> {
+    if let Some(dir) = dirs::data_local_dir().or_else(dirs::data_dir) {
+        return Ok(dir.join("recall").join("share-pages"));
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
+    Ok(home.join(".local").join("share").join("recall").join("share-pages"))
+}
+
+pub fn expand_path(path: &str) -> PathBuf {
+    if path == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
+    }
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(path)
+}
+
+pub fn preflight_cloudflare_pages() -> Result<()> {
+    ensure_wrangler_available()?;
+    ensure_wrangler_login()?;
+    list_pages_projects()?;
+    Ok(())
+}
+
+pub fn init_cloudflare_pages(
+    config: &mut AppConfig,
+    project_name: String,
+    publish_dir: PathBuf,
+) -> Result<()> {
+    validate_project_name(&project_name)?;
+    ensure_wrangler_available()?;
+    ensure_wrangler_login()?;
+    ensure_pages_project(&project_name)?;
+    init_publish_dir(&publish_dir)?;
+    config.share = Some(ShareConfig {
+        provider: PROVIDER_CLOUDFLARE_PAGES.to_string(),
+        project_name,
+        publish_dir: publish_dir.to_string_lossy().to_string(),
+    });
+    config.save()
+}
+
+pub fn publish_session(
+    config: &AppConfig,
+    session: &Session,
+    messages: &[Message],
+) -> Result<String> {
+    let share = config
+        .share
+        .as_ref()
+        .ok_or_else(|| anyhow!("sharing is not initialized; run `recall share init` first"))?;
+    if share.provider != PROVIDER_CLOUDFLARE_PAGES {
+        bail!("unsupported share provider '{}'", share.provider);
+    }
+    validate_project_name(&share.project_name)?;
+
+    let publish_dir = expand_path(&share.publish_dir);
+    init_publish_dir(&publish_dir)?;
+
+    let share_id = share_id_for_session(session);
+    let html = render_session_html(session, messages);
+    if html.len() > MAX_PAGES_ASSET_BYTES {
+        bail!("session page is larger than Cloudflare Pages' 25 MiB asset limit");
+    }
+
+    let file_path = publish_dir.join(format!("{share_id}.html"));
+    fs::write(&file_path, html)
+        .with_context(|| format!("failed to write {}", file_path.display()))?;
+
+    deploy_pages(&publish_dir, &share.project_name)?;
+    Ok(format!("https://{}.pages.dev/{share_id}", share.project_name))
+}
+
+pub fn share_id_for_session(session: &Session) -> String {
+    let candidate =
+        if session.source_id.trim().is_empty() { &session.id } else { &session.source_id };
+    let mut out = String::with_capacity(candidate.len());
+    for c in candidate.chars() {
+        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() { session.id.clone() } else { trimmed }
+}
+
+pub fn render_session_html(session: &Session, messages: &[Message]) -> String {
+    let title = session.custom_title.as_deref().unwrap_or(&session.title);
+    let mut out = String::new();
+    out.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
+    out.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+    out.push_str("<meta name=\"robots\" content=\"noindex,nofollow\">");
+    out.push_str("<title>");
+    out.push_str(&escape_html(title));
+    out.push_str("</title><style>");
+    out.push_str("body{margin:0;background:#f6f7f9;color:#17181c;font:15px/1.6 -apple-system,BlinkMacSystemFont,\"Segoe UI\",sans-serif}main{max-width:960px;margin:0 auto;padding:32px 20px 56px}header{border-bottom:1px solid #d8dce3;margin-bottom:24px;padding-bottom:18px}h1{font-size:26px;line-height:1.25;margin:0 0 12px}.meta{color:#687080;font-size:13px;display:flex;flex-wrap:wrap;gap:10px 18px}.msg{background:#fff;border:1px solid #dde1e8;border-radius:8px;margin:16px 0;overflow:hidden;box-shadow:0 1px 2px rgba(15,23,42,.04)}.role{font-size:12px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:10px 16px;border-bottom:1px solid #eef0f4;color:#596171;background:#fbfcfe}.user .role{color:#0f766e}.assistant .role{color:#6d28d9}.text{white-space:pre-wrap;word-break:break-word;padding:16px 18px;font-size:15px}.assistant .text{font-size:16px}.tool{border-top:1px solid #eef0f4;background:#fafbfc}.tool summary{cursor:pointer;padding:10px 16px;color:#687080;font-size:13px}.tool pre{white-space:pre-wrap;word-break:break-word;margin:0;padding:12px 16px 16px;color:#3f4654;background:#f3f5f8;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}.empty{color:#687080;background:#fff;border:1px solid #dde1e8;border-radius:8px;padding:16px}</style></head><body><main>");
+    out.push_str("<header><h1>");
+    out.push_str(&escape_html(title));
+    out.push_str("</h1><div class=\"meta\"><span>");
+    out.push_str(&escape_html(&session.source));
+    out.push_str("</span><span>");
+    out.push_str(&escape_html(&format_started_at(session.started_at)));
+    out.push_str("</span><span>");
+    out.push_str(&messages.len().to_string());
+    out.push_str(" messages</span>");
+    out.push_str("</div></header>");
+    if messages.is_empty() {
+        out.push_str("<div class=\"empty\">No messages in this session.</div>");
+    } else {
+        for message in messages {
+            render_message_html(&mut out, message);
+        }
+    }
+    out.push_str("</main></body></html>");
+    out
+}
+
+fn render_message_html(out: &mut String, message: &Message) {
+    let role = match message.role {
+        Role::User => "User",
+        Role::Assistant => "Assistant",
+    };
+    let class = match message.role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+    };
+    out.push_str("<section class=\"msg ");
+    out.push_str(class);
+    out.push_str("\"><div class=\"role\">");
+    out.push_str(role);
+    out.push_str("</div>");
+
+    let mut text = String::new();
+    let mut rendered = false;
+    for line in message.content.lines() {
+        let sanitized = utils::sanitize_line(line);
+        if is_tool_line(&sanitized) {
+            if !text.trim().is_empty() {
+                render_text_segment(out, &text);
+            }
+            text.clear();
+            render_tool_segment(out, &sanitized);
+            rendered = true;
+        } else {
+            if !text.is_empty() {
+                text.push('\n');
+            }
+            text.push_str(&sanitized);
+        }
+    }
+    if !text.trim().is_empty() {
+        render_text_segment(out, &text);
+        rendered = true;
+    }
+    if !rendered && !message.content.is_empty() {
+        let sanitized =
+            message.content.lines().map(utils::sanitize_line).collect::<Vec<_>>().join("\n");
+        render_text_segment(out, &sanitized);
+    }
+    out.push_str("</section>");
+}
+
+fn render_text_segment(out: &mut String, text: &str) {
+    out.push_str("<div class=\"text\">");
+    out.push_str(&escape_html(text.trim()));
+    out.push_str("</div>");
+}
+
+fn render_tool_segment(out: &mut String, text: &str) {
+    out.push_str("<details class=\"tool\"><summary>");
+    out.push_str(&escape_html(&tool_summary(text)));
+    out.push_str("</summary><pre>");
+    out.push_str(&escape_html(text));
+    out.push_str("</pre></details>");
+}
+
+fn is_tool_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("[tool:")
+        || trimmed.starts_with("[tool_result:")
+        || trimmed.starts_with("[tool_use:")
+}
+
+fn tool_summary(line: &str) -> String {
+    let trimmed = line.trim_start();
+    for (prefix, label) in
+        [("[tool:", "Tool call"), ("[tool_result:", "Tool result"), ("[tool_use:", "Tool use")]
+    {
+        if let Some(name) = trimmed
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.split(']').next())
+            .filter(|name| !name.trim().is_empty())
+        {
+            return format!("{label}: {name}");
+        }
+    }
+    "Tool event".to_string()
+}
+
+fn init_publish_dir(publish_dir: &Path) -> Result<()> {
+    fs::create_dir_all(publish_dir)
+        .with_context(|| format!("failed to create {}", publish_dir.display()))?;
+    fs::write(publish_dir.join("_headers"), HEADERS)?;
+    fs::write(publish_dir.join("robots.txt"), ROBOTS)?;
+    Ok(())
+}
+
+fn ensure_wrangler_available() -> Result<()> {
+    let output = wrangler_command()?
+        .arg("--version")
+        .output()
+        .map_err(|e| anyhow!("wrangler is not available on PATH: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!("wrangler --version failed: {}", command_output_text(&output));
+    }
+}
+
+fn ensure_wrangler_login() -> Result<()> {
+    let output = wrangler_command()?
+        .arg("whoami")
+        .output()
+        .map_err(|e| anyhow!("failed to run wrangler whoami: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!("wrangler is not logged in: {}", command_output_text(&output));
+    }
+}
+
+fn ensure_pages_project(project_name: &str) -> Result<()> {
+    if json_has_project_name(&list_pages_projects()?, project_name) {
+        return Ok(());
+    }
+    let status = wrangler_command()?
+        .args(["pages", "project", "create", project_name, "--production-branch", "main"])
+        .status()
+        .map_err(|e| anyhow!("failed to run wrangler pages project create: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("failed to create Cloudflare Pages project '{project_name}'");
+    }
+}
+
+fn list_pages_projects() -> Result<serde_json::Value> {
+    let output = wrangler_command()?
+        .args(["pages", "project", "list", "--json"])
+        .output()
+        .map_err(|e| anyhow!("failed to run wrangler pages project list: {e}"))?;
+    if !output.status.success() {
+        bail!("failed to list Cloudflare Pages projects: {}", command_output_text(&output));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow!("failed to parse wrangler project list JSON: {e}"))
+}
+
+fn deploy_pages(publish_dir: &Path, project_name: &str) -> Result<()> {
+    let output = wrangler_command()?
+        .args(["pages", "deploy"])
+        .arg(publish_dir)
+        .args(["--project-name", project_name])
+        .output()
+        .map_err(|e| anyhow!("failed to run wrangler pages deploy: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!("wrangler pages deploy failed: {}", command_output_text(&output));
+    }
+}
+
+fn wrangler_command() -> Result<Command> {
+    let mut command = Command::new("wrangler");
+    command.current_dir(wrangler_work_dir()?);
+    Ok(command)
+}
+
+fn wrangler_work_dir() -> Result<PathBuf> {
+    let root = dirs::cache_dir()
+        .or_else(dirs::data_local_dir)
+        .or_else(dirs::data_dir)
+        .ok_or_else(|| anyhow!("cannot determine cache directory"))?;
+    let dir = root.join("recall").join("wrangler");
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    Ok(dir)
+}
+
+fn command_output_text(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() { "no output".to_string() } else { stdout }
+}
+
+fn json_has_project_name(value: &serde_json::Value, project_name: &str) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("name").and_then(|v| v.as_str()) == Some(project_name) {
+                return true;
+            }
+            map.values().any(|v| json_has_project_name(v, project_name))
+        }
+        serde_json::Value::Array(values) => {
+            values.iter().any(|v| json_has_project_name(v, project_name))
+        }
+        _ => false,
+    }
+}
+
+fn validate_project_name(project_name: &str) -> Result<()> {
+    let valid = !project_name.is_empty()
+        && project_name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && project_name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && project_name
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    if valid {
+        Ok(())
+    } else {
+        bail!("Cloudflare Pages project name must use lowercase letters, digits, and hyphens");
+    }
+}
+
+fn format_started_at(started_at: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(started_at)
+        .map(|dt| dt.with_timezone(&chrono::Local).format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "unknown time".to_string())
+}
+
+fn escape_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(source_id: &str) -> Session {
+        Session {
+            id: "local-id".to_string(),
+            source: "codex".to_string(),
+            source_id: source_id.to_string(),
+            title: "Fix <bug>".to_string(),
+            directory: Some("/tmp/project".to_string()),
+            started_at: 0,
+            updated_at: None,
+            message_count: 1,
+            entrypoint: None,
+            custom_title: None,
+            summary: None,
+            duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
+        }
+    }
+
+    #[test]
+    fn share_id_prefers_source_id() {
+        assert_eq!(
+            share_id_for_session(&session("019e6d8d-588b-7fd2-a326-c525469ed120")),
+            "019e6d8d-588b-7fd2-a326-c525469ed120"
+        );
+    }
+
+    #[test]
+    fn share_id_sanitizes_path_chars() {
+        assert_eq!(share_id_for_session(&session("foo/bar baz")), "foo-bar-baz");
+    }
+
+    #[test]
+    fn html_renderer_escapes_content() {
+        let html = render_session_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "<script>alert('x')</script>".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"));
+        assert!(!html.contains("<script>alert"));
+    }
+
+    #[test]
+    fn html_renderer_omits_local_directory() {
+        let html = render_session_html(&session("s1"), &[]);
+        assert!(!html.contains("/tmp/project"));
+    }
+
+    #[test]
+    fn html_renderer_collapses_tool_lines() {
+        let html = render_session_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::Assistant,
+                content: "I will inspect it.\n[tool:run_terminal_command_v2]\n[tool_result:run_terminal_command_v2] {\"output\":\"huge\"}\nThe answer is here.".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("<div class=\"text\">I will inspect it.</div>"));
+        assert!(html.contains("<summary>Tool call: run_terminal_command_v2</summary>"));
+        assert!(html.contains("<summary>Tool result: run_terminal_command_v2</summary>"));
+        assert!(html.contains("<div class=\"text\">The answer is here.</div>"));
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
 use std::time::Instant;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -28,6 +29,7 @@ pub enum AppMode {
     Search,
     Usage,
     Viewing,
+    ShareResult,
     ExportInput,
     Settings,
     Filters,
@@ -82,6 +84,8 @@ mod tests {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            share_popup: None,
+            share_publish_rx: None,
             exec_on_exit: None,
             viewing_search_query: String::new(),
             viewing_search_input: None,
@@ -420,6 +424,12 @@ pub struct PendingResume {
     pub origin: ResumeOrigin,
 }
 
+pub struct SharePopup {
+    pub url: Option<String>,
+    pub message: String,
+    pub is_error: bool,
+}
+
 pub struct SanitizedLine {
     pub text: String,
     pub lower: String,
@@ -572,6 +582,8 @@ pub struct App {
     pub semantic_last_refresh: Instant,
     pub settings_selected: usize,
     pub pending_resume: Option<PendingResume>,
+    pub share_popup: Option<SharePopup>,
+    pub share_publish_rx: Option<mpsc::Receiver<Result<String, String>>>,
     pub exec_on_exit: Option<(ResumeCommand, Option<String>)>,
     pub viewing_search_query: String,
     pub viewing_search_input: Option<String>,
@@ -648,6 +660,8 @@ impl App {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            share_popup: None,
+            share_publish_rx: None,
             exec_on_exit: None,
             viewing_search_query: String::new(),
             viewing_search_input: None,
@@ -806,10 +820,39 @@ impl App {
             AppMode::Search => self.handle_search_key(key, store, engine, provider),
             AppMode::Usage => self.handle_usage_key(key, store),
             AppMode::Viewing => self.handle_viewing_key(key),
+            AppMode::ShareResult => self.handle_share_result_key(key),
             AppMode::ExportInput => self.handle_export_key(key),
             AppMode::Settings => self.handle_settings_key(key, store, engine, provider),
             AppMode::Filters => self.handle_filters_key(key, store, engine, provider),
             AppMode::ConfirmResume => self.handle_confirm_resume_key(key),
+        }
+    }
+
+    pub fn poll_share_publish(&mut self) {
+        let Some(rx) = self.share_publish_rx.take() else {
+            return;
+        };
+        match rx.try_recv() {
+            Ok(result) => {
+                self.share_popup = Some(match result {
+                    Ok(url) => SharePopup {
+                        url: Some(url),
+                        message: "Session shared".to_string(),
+                        is_error: false,
+                    },
+                    Err(message) => SharePopup { url: None, message, is_error: true },
+                });
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                self.share_publish_rx = Some(rx);
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.share_popup = Some(SharePopup {
+                    url: None,
+                    message: "Share worker stopped before publishing finished".to_string(),
+                    is_error: true,
+                });
+            }
         }
     }
 
@@ -1069,6 +1112,7 @@ impl App {
                 self.viewing_search_status = None;
                 self.viewing_sanitized_lines.clear();
                 self.viewing_match_cache.clear();
+                self.share_popup = None;
             }
             KeyCode::Up | KeyCode::Char('k') if self.viewing_selected_msg > 0 => {
                 self.viewing_selected_msg -= 1;
@@ -1084,11 +1128,14 @@ impl App {
             KeyCode::End | KeyCode::Char('G') if !self.viewing_messages.is_empty() => {
                 self.viewing_selected_msg = self.viewing_messages.len() - 1;
             }
-            KeyCode::Char('c') => {
+            KeyCode::Char('c') | KeyCode::Char('C') => {
                 self.copy_current_message();
             }
             KeyCode::Char('e') => {
                 self.start_export();
+            }
+            KeyCode::Char('s') => {
+                self.share_current_session();
             }
             KeyCode::Char('/') => {
                 self.viewing_search_input = Some(String::new());
@@ -1100,6 +1147,27 @@ impl App {
             }
             KeyCode::Char('N') => {
                 self.jump_viewing_match(false);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_share_result_key(&mut self, key: KeyEvent) {
+        if self.share_publish_rx.is_some() {
+            return;
+        }
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+                self.share_popup = None;
+                self.mode = AppMode::Viewing;
+            }
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                if let Some(url) = self.share_popup.as_ref().and_then(|popup| popup.url.clone()) {
+                    self.copy_to_clipboard(&url);
+                    if let Some(popup) = self.share_popup.as_mut() {
+                        popup.message = "Copied share URL".to_string();
+                    }
+                }
             }
             _ => {}
         }
@@ -2277,6 +2345,31 @@ impl App {
         if let Some(text) = text {
             self.copy_to_clipboard(&text);
         }
+    }
+
+    fn share_current_session(&mut self) {
+        let Some(result) = self.results.get(self.selected_index) else {
+            return;
+        };
+        if self.share_publish_rx.is_some() {
+            return;
+        }
+        let config = self.config.clone();
+        let session = result.session.clone();
+        let messages = self.viewing_messages.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = crate::share::publish_session(&config, &session, &messages)
+                .map_err(|e| e.to_string());
+            let _ = tx.send(result);
+        });
+        self.share_publish_rx = Some(rx);
+        self.share_popup = Some(SharePopup {
+            url: None,
+            message: "Sharing session...".to_string(),
+            is_error: false,
+        });
+        self.mode = AppMode::ShareResult;
     }
 
     fn copy_to_clipboard(&mut self, text: &str) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -70,6 +70,10 @@ pub fn render(f: &mut Frame, app: &App) {
         AppMode::Search => render_search(f, app),
         AppMode::Usage => render_usage_dashboard(f, app),
         AppMode::Viewing => render_viewing(f, app),
+        AppMode::ShareResult => {
+            render_viewing(f, app);
+            render_share_result(f, app);
+        }
         AppMode::Filters => {
             render_search(f, app);
             render_filter_picker(f, app);
@@ -1312,6 +1316,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" copy  ", Style::default().fg(Color::DarkGray)),
         Span::styled("e", Style::default().fg(Color::Yellow)),
         Span::styled(" export  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("s", Style::default().fg(Color::Yellow)),
+        Span::styled(" share  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
         Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+O", Style::default().fg(Color::Yellow)),
@@ -1691,6 +1697,72 @@ fn render_settings(f: &mut Frame, app: &App) {
     f.render_widget(widget, popup);
 }
 
+fn render_share_result(f: &mut Frame, app: &App) {
+    let Some(popup) = app.share_popup.as_ref() else {
+        return;
+    };
+
+    let area = f.area();
+    let width = area.width.clamp(46, 88);
+    let height: u16 = if popup.url.is_some() { 9 } else { 8 };
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let rect = Rect::new(x, y, width, height);
+
+    let border = if popup.is_error { Color::Red } else { Color::Green };
+    let title = if popup.is_error { " Share failed " } else { " Session shared " };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border))
+        .style(Style::default().bg(Color::Black));
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            popup.message.clone(),
+            if popup.is_error {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+            },
+        )),
+    ];
+    if let Some(url) = popup.url.as_ref() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(url.clone(), Style::default().fg(Color::Cyan))));
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(" [C] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("copy URL   ", Style::default().fg(Color::White)),
+            Span::styled(
+                "[Enter/Esc] ",
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("close", Style::default().fg(Color::White)),
+        ]));
+    } else if popup.is_error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(
+                " [Enter/Esc] ",
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("close", Style::default().fg(Color::White)),
+        ]));
+    } else {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            " Publishing with Wrangler...",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(Clear, rect);
+    f.render_widget(widget, rect);
+}
+
 fn render_confirm_resume(f: &mut Frame, app: &App) {
     let Some(pending) = app.pending_resume.as_ref() else {
         return;
@@ -1859,7 +1931,7 @@ mod tests {
 
     use crate::config::AppConfig;
     use crate::db::store::Store;
-    use crate::tui::app::ViewingSessionSummary;
+    use crate::tui::app::{SharePopup, ViewingSessionSummary};
     use crate::types::{Message, SearchResult, Session};
 
     #[test]
@@ -1922,6 +1994,59 @@ mod tests {
             "tokens 31 input 10 output 9 cache r/w 6/4 reasoning 2 | time 2m | user msgs 2/3"
         ));
         assert_eq!(terminal.backend().buffer()[(2, 1)].fg, Color::Green);
+    }
+
+    #[test]
+    fn render_share_result_popup_shows_share_url() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.mode = AppMode::ShareResult;
+        app.results = vec![SearchResult {
+            session: Session {
+                id: "session1".to_string(),
+                source: "codex".to_string(),
+                source_id: "source1".to_string(),
+                title: "Test session".to_string(),
+                directory: None,
+                started_at: 0,
+                updated_at: None,
+                message_count: 1,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: None,
+                is_import: false,
+            },
+            match_source: MatchSource::Fts,
+            snippet: None,
+        }];
+        app.viewing_messages = vec![Message {
+            session_id: "session1".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: None,
+            seq: 0,
+        }];
+        app.viewing_sanitized_lines =
+            vec![vec![SanitizedLine { text: "hello".to_string(), lower: "hello".to_string() }]];
+        app.share_popup = Some(SharePopup {
+            url: Some("https://recall-share.pages.dev/source1".to_string()),
+            message: "Session shared".to_string(),
+            is_error: false,
+        });
+
+        let backend = TestBackend::new(100, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app)).unwrap();
+        let rendered = (0..18)
+            .map(|y| buffer_row(terminal.backend().buffer(), y, 100))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("https://recall-share.pages.dev/source1"));
     }
 
     fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {


### PR DESCRIPTION
### What's changed?

- Add `recall share init` for Cloudflare Pages configuration and Wrangler preflight.
- Add TUI session sharing with a copyable Pages URL.
- Render single-session HTML pages with collapsed tool events and no local path metadata.
- Document the share spec.

### Why

- Make a local Recall session easy to share with collaborators through a browser-viewable Pages URL.