### PR TITLE
[Feat] Add session preview rendering

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -484,13 +484,14 @@ fn cmd_session_share(
     let sources = adapters::source_labels();
     let session = resolve_session_ref(&store, &sources, id, source_filter, source_id)?;
     let messages = store.get_messages(&session.id)?;
+    let usage_events = store.list_usage_events_for_session(&session.id)?;
     let config = AppConfig::load_or_default();
-    let preview = recall::share::preview_session(&config, &session, &messages)?;
+    let preview = recall::share::preview_session(&config, &session, &messages, &usage_events)?;
     let url = if dry_run {
         preview.url.clone()
     } else {
         eprintln!("Sharing session {}...", session.id);
-        recall::share::publish_session(&config, &session, &messages)?
+        recall::share::publish_session(&config, &session, &messages, &usage_events)?
     };
 
     if copy_url {

--- a/src/share.rs
+++ b/src/share.rs
@@ -1,11 +1,13 @@
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, anyhow, bail};
+use serde_json::Value;
 
 use crate::config::{AppConfig, ShareConfig};
-use crate::types::{Message, Role, Session};
+use crate::types::{Message, Role, Session, SessionUsageEventRecord};
 use crate::utils;
 
 const PROVIDER_CLOUDFLARE_PAGES: &str = "cloudflare-pages";
@@ -26,6 +28,82 @@ pub struct SharePreview {
     pub url: String,
     pub html_bytes: usize,
 }
+
+const SESSION_PAGE_CSS: &str = r#"
+:root {
+  --page-bg: #F5F5F7;
+  --content-bg: #FFFFFF;
+  --text-primary: #1D1D1F;
+  --text-secondary: #86868B;
+  --user-block-bg: #FFF3D6;
+  --user-block-border: rgba(255, 149, 0, 0.22);
+  --user-block-accent: #FF9500;
+  --log-border: #E5E5EA;
+  --layout-width: 1040px;
+  --code-bg: #1E1E1E;
+  --code-text: #F5F5F7;
+  --border-radius: 12px;
+  --read-width: 700px;
+  --font-system: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  --font-mono: "SF Mono", Menlo, monospace;
+}
+*,*::before,*::after{box-sizing:border-box}
+body{margin:0;overflow-x:hidden;background:var(--page-bg);color:var(--text-primary);font:15px/1.65 var(--font-system);-webkit-font-smoothing:antialiased}
+.site-header{position:sticky;top:0;z-index:10;backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);background:rgba(255,255,255,.72);border-bottom:1px solid rgba(0,0,0,.05)}
+.site-header-inner{max-width:var(--layout-width);margin:0 auto;padding:22px 24px 18px}
+.site-header h1{margin:0 0 6px;font-size:22px;font-weight:600;line-height:1.3;letter-spacing:-.02em;color:var(--text-primary)}
+.meta{margin:0;color:var(--text-secondary);font-size:13px;line-height:1.5}
+.layout{display:flex;align-items:flex-start;justify-content:center;gap:36px;max-width:var(--layout-width);margin:0 auto;padding:28px 24px 64px}
+.page{flex:0 1 var(--read-width);min-width:0;padding:0;margin:0}
+.document{min-width:0;background:var(--content-bg);border-radius:var(--border-radius);padding:40px 36px 52px}
+.user-toc{flex:0 0 220px;position:sticky;top:88px;max-height:calc(100vh - 104px);overflow-y:auto;padding:4px 0 12px}
+.user-toc-title{margin:0 0 12px;font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-secondary)}
+.user-toc nav{display:flex;flex-direction:column;gap:2px}
+.user-toc a{display:block;padding:7px 10px;border-left:2px solid transparent;border-radius:0 8px 8px 0;color:var(--text-secondary);font-size:12px;line-height:1.45;text-decoration:none;transition:color .15s ease,background .15s ease,border-color .15s ease}
+.user-toc a:hover{color:var(--text-primary);background:rgba(0,0,0,.03);border-left-color:var(--user-block-accent)}
+.turn{margin:0}
+.turn.user{scroll-margin-top:96px}
+.role-label{display:block;margin:0 0 10px;font-size:12px;font-weight:500;letter-spacing:.02em;color:var(--text-secondary)}
+.turn.user .role-label{color:#B25000}
+.turn.assistant .role-label{color:#5856D6}
+.turn.user:not(:first-child){margin-top:48px;padding-top:36px;border-top:1px solid var(--log-border)}
+.turn.assistant{margin-top:24px}
+.turn.user+.turn.assistant{margin-top:20px}
+.user-block{min-width:0;max-width:100%;background:var(--user-block-bg);border-radius:var(--border-radius);padding:16px 20px;border:1px solid var(--user-block-border);box-shadow:inset 3px 0 0 var(--user-block-accent)}
+.assistant-body{min-width:0;max-width:100%;color:var(--text-primary);font-size:16px}
+.prose{min-width:0;max-width:100%;overflow-wrap:anywhere;word-break:break-word}
+.assistant-body .tool-run{margin:1.4em 0}
+.tool-group{margin:0;color:var(--text-secondary);font-size:13px;line-height:1.5}
+.tool-group>summary{cursor:pointer;list-style:none;color:var(--text-secondary);padding:2px 0}
+.tool-group>summary::-webkit-details-marker{display:none}
+.tool-group>summary::before{content:"▸ ";display:inline-block;transition:transform .15s ease}
+.tool-group[open]>summary::before{transform:rotate(90deg)}
+.tool-group-items{margin:8px 0 0;padding:0 0 0 8px}
+.prose p{margin:0 0 1.2em}
+.prose p:last-child{margin-bottom:0}
+.prose h2,.prose h3{margin:1.4em 0 .6em;font-weight:600;line-height:1.35;letter-spacing:-.02em;color:var(--text-primary)}
+.prose h2{font-size:19px}
+.prose h3{font-size:17px}
+.prose ul{margin:0 0 1.2em;padding-left:1.4em}
+.prose li{margin:0 0 .45em}
+.prose strong{font-weight:600}
+.prose code{font:13px/1.5 var(--font-mono);background:var(--user-block-bg);border-radius:4px;padding:2px 6px;color:var(--text-primary)}
+pre.code-block,pre.preformatted{margin:1.2em 0;padding:16px;border-radius:8px;font:13px/1.55 var(--font-mono);overflow-x:auto;white-space:pre;word-break:normal;max-width:100%}
+pre.code-block{background:var(--code-bg);color:var(--code-text)}
+pre.preformatted{background:rgba(0,0,0,.04);color:var(--text-primary)}
+.tool-run{margin:1.2em 0;padding:10px 0 10px 14px;border-left:3px solid var(--log-border)}
+.tool-run .tool-group{border-left:0;padding:0;margin:0}
+.tool-run .log,.tool-group-items .log{margin:0 0 6px;padding:0 0 0 10px;border-left:2px solid var(--log-border)}
+.tool-run .log:last-child,.tool-group-items .log:last-child{margin-bottom:0}
+.empty{margin:0;color:var(--text-secondary);font-size:15px;line-height:1.65}
+@media (max-width:960px){.layout{display:block;padding:28px 20px 64px}.user-toc{display:none}}
+.log{margin:1em 0;padding:0 0 0 14px;border-left:3px solid var(--log-border);color:var(--text-secondary);font-size:13px;line-height:1.5}
+.log summary{cursor:pointer;list-style:none;color:var(--text-secondary)}
+.log summary::-webkit-details-marker{display:none}
+.log summary::before{content:"▸ ";display:inline-block;transition:transform .15s ease}
+.log[open] summary::before{transform:rotate(90deg)}
+.log pre{margin:8px 0 0;padding:0;background:transparent;border:0;color:var(--text-secondary);font:13px/1.5 var(--font-mono);white-space:pre-wrap;word-break:break-word}
+"#;
 
 pub fn default_project_name() -> String {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
@@ -79,13 +157,93 @@ pub fn init_cloudflare_pages(
     config.save()
 }
 
+pub fn default_preview_dir() -> Result<PathBuf> {
+    let root = dirs::cache_dir()
+        .or_else(dirs::data_local_dir)
+        .or_else(dirs::data_dir)
+        .ok_or_else(|| anyhow!("cannot determine cache directory"))?;
+    Ok(root.join("recall").join("preview"))
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SessionDisplayMeta {
+    pub models: Vec<String>,
+    pub thinking_depths: Vec<String>,
+}
+
+pub fn collect_session_display_meta(
+    session: &Session,
+    usage_events: &[SessionUsageEventRecord],
+) -> SessionDisplayMeta {
+    let mut meta = SessionDisplayMeta::default();
+    enrich_display_meta_from_usage(&mut meta, usage_events);
+    if let Err(err) = enrich_display_meta_from_source(session, &mut meta) {
+        tracing::debug!("session display meta source enrichment skipped: {err}");
+    }
+    meta
+}
+
+pub fn write_preview_file(
+    session: &Session,
+    messages: &[Message],
+    usage_events: &[SessionUsageEventRecord],
+) -> Result<PathBuf> {
+    let preview_dir = default_preview_dir()?;
+    fs::create_dir_all(&preview_dir)
+        .with_context(|| format!("failed to create {}", preview_dir.display()))?;
+    let share_id = share_id_for_session(session);
+    let file_path = preview_dir.join(format!("{share_id}.html"));
+    let display_meta = collect_session_display_meta(session, usage_events);
+    let html = render_session_html(session, messages, &display_meta);
+    fs::write(&file_path, html)
+        .with_context(|| format!("failed to write {}", file_path.display()))?;
+    Ok(file_path)
+}
+
+pub fn open_path_in_browser(path: &Path) -> Result<()> {
+    let path_arg = path.as_os_str();
+    let status = if cfg!(target_os = "macos") {
+        Command::new("open").arg(path_arg).status()
+    } else if cfg!(target_os = "windows") {
+        Command::new("cmd").args(["/C", "start", "", &path.to_string_lossy()]).status()
+    } else {
+        Command::new("xdg-open").arg(path_arg).status()
+    }
+    .map_err(|e| anyhow!("failed to open browser for {}: {e}", path.display()))?;
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("failed to open browser for {}", path.display());
+    }
+}
+
+pub fn open_session_preview(
+    session: &Session,
+    messages: &[Message],
+    usage_events: &[SessionUsageEventRecord],
+) -> Result<PathBuf> {
+    let path = write_preview_file(session, messages, usage_events)?;
+    open_path_in_browser(&path)?;
+    Ok(path)
+}
+
+pub fn preview_session(
+    config: &AppConfig,
+    session: &Session,
+    messages: &[Message],
+    usage_events: &[SessionUsageEventRecord],
+) -> Result<SharePreview> {
+    let (preview, _) = build_publish_preview(config, session, messages, usage_events)?;
+    Ok(preview)
+}
+
 pub fn publish_session(
     config: &AppConfig,
     session: &Session,
     messages: &[Message],
+    usage_events: &[SessionUsageEventRecord],
 ) -> Result<String> {
-    let preview = preview_session(config, session, messages)?;
-    let html = render_session_html(session, messages);
+    let (preview, html) = build_publish_preview(config, session, messages, usage_events)?;
 
     init_publish_dir(&preview.publish_dir)?;
 
@@ -96,11 +254,12 @@ pub fn publish_session(
     Ok(preview.url)
 }
 
-pub fn preview_session(
+fn build_publish_preview(
     config: &AppConfig,
     session: &Session,
     messages: &[Message],
-) -> Result<SharePreview> {
+    usage_events: &[SessionUsageEventRecord],
+) -> Result<(SharePreview, String)> {
     let share = config
         .share
         .as_ref()
@@ -114,22 +273,26 @@ pub fn preview_session(
     let publish_dir = expand_path(&share.publish_dir);
 
     let share_id = share_id_for_session(session);
-    let html = render_session_html(session, messages);
+    let display_meta = collect_session_display_meta(session, usage_events);
+    let html = render_session_html(session, messages, &display_meta);
     if html.len() > MAX_PAGES_ASSET_BYTES {
         bail!("session page is larger than Cloudflare Pages' 25 MiB asset limit");
     }
 
     let file_path = publish_dir.join(format!("{share_id}.html"));
-    Ok(SharePreview {
-        provider: share.provider.clone(),
-        project_name: share.project_name.clone(),
-        project_domain: project_domain.clone(),
-        publish_dir,
-        file_path,
-        share_id: share_id.clone(),
-        url: format!("https://{project_domain}/{share_id}"),
-        html_bytes: html.len(),
-    })
+    Ok((
+        SharePreview {
+            provider: share.provider.clone(),
+            project_name: share.project_name.clone(),
+            project_domain: project_domain.clone(),
+            publish_dir,
+            file_path,
+            share_id: share_id.clone(),
+            url: format!("https://{project_domain}/{share_id}"),
+            html_bytes: html.len(),
+        },
+        html,
+    ))
 }
 
 fn configured_project_domain(share: &ShareConfig) -> Result<String> {
@@ -162,109 +325,524 @@ pub fn share_id_for_session(session: &Session) -> String {
     if trimmed.is_empty() { session.id.clone() } else { trimmed }
 }
 
-pub fn render_session_html(session: &Session, messages: &[Message]) -> String {
+pub fn render_session_html(
+    session: &Session,
+    messages: &[Message],
+    display_meta: &SessionDisplayMeta,
+) -> String {
     let title = session.custom_title.as_deref().unwrap_or(&session.title);
+    let display_title = display_title(title);
+    let blocks = prepare_render_blocks(messages);
+    let user_toc = collect_user_toc(&blocks);
     let mut out = String::new();
     out.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
     out.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
     out.push_str("<meta name=\"robots\" content=\"noindex,nofollow\">");
     out.push_str("<title>");
-    out.push_str(&escape_html(title));
+    out.push_str(&escape_html(&display_title));
     out.push_str("</title><style>");
-    out.push_str("body{margin:0;background:#f6f7f9;color:#17181c;font:15px/1.6 -apple-system,BlinkMacSystemFont,\"Segoe UI\",sans-serif}main{max-width:960px;margin:0 auto;padding:32px 20px 56px}header{border-bottom:1px solid #d8dce3;margin-bottom:24px;padding-bottom:18px}h1{font-size:26px;line-height:1.25;margin:0 0 12px}.meta{color:#687080;font-size:13px;display:flex;flex-wrap:wrap;gap:10px 18px}.msg{background:#fff;border:1px solid #dde1e8;border-radius:8px;margin:16px 0;overflow:hidden;box-shadow:0 1px 2px rgba(15,23,42,.04)}.role{font-size:12px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:10px 16px;border-bottom:1px solid #eef0f4;color:#596171;background:#fbfcfe}.user .role{color:#0f766e}.assistant .role{color:#6d28d9}.text{white-space:pre-wrap;word-break:break-word;padding:16px 18px;font-size:15px}.assistant .text{font-size:16px}.tool{border-top:1px solid #eef0f4;background:#fafbfc}.tool summary{cursor:pointer;padding:10px 16px;color:#687080;font-size:13px}.tool pre{white-space:pre-wrap;word-break:break-word;margin:0;padding:12px 16px 16px;color:#3f4654;background:#f3f5f8;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}.empty{color:#687080;background:#fff;border:1px solid #dde1e8;border-radius:8px;padding:16px}</style></head><body><main>");
-    out.push_str("<header><h1>");
-    out.push_str(&escape_html(title));
-    out.push_str("</h1><div class=\"meta\"><span>");
-    out.push_str(&escape_html(&session.source));
-    out.push_str("</span><span>");
+    out.push_str(SESSION_PAGE_CSS);
+    out.push_str("</style></head><body>");
+    out.push_str("<header class=\"site-header\"><div class=\"site-header-inner\"><h1>");
+    out.push_str(&escape_html(&display_title));
+    out.push_str("</h1><p class=\"meta\">");
+    out.push_str(&escape_html(&format_source_label(&session.source)));
+    out.push_str(" · ");
     out.push_str(&escape_html(&format_started_at(session.started_at)));
-    out.push_str("</span><span>");
+    out.push_str(" · ");
     out.push_str(&messages.len().to_string());
-    out.push_str(" messages</span>");
-    out.push_str("</div></header>");
-    if messages.is_empty() {
-        out.push_str("<div class=\"empty\">No messages in this session.</div>");
+    out.push_str(" messages");
+    append_header_display_meta(&mut out, display_meta);
+    out.push_str("</p></div></header>");
+    out.push_str("<div class=\"layout\"><div class=\"page\"><article class=\"document\">");
+    if blocks.is_empty() {
+        out.push_str("<p class=\"empty\">No messages in this session.</p>");
     } else {
-        for message in messages {
-            render_message_html(&mut out, message);
+        let mut user_index = 0usize;
+        for block in blocks {
+            if matches!(&block, RenderBlock::User(_)) {
+                user_index += 1;
+                render_block_html(&mut out, block, Some(user_index));
+            } else {
+                render_block_html(&mut out, block, None);
+            }
         }
     }
-    out.push_str("</main></body></html>");
+    out.push_str("</article></div>");
+    render_user_toc(&mut out, &user_toc);
+    out.push_str("</div></body></html>");
     out
 }
 
-fn render_message_html(out: &mut String, message: &Message) {
-    let role = match message.role {
-        Role::User => "User",
-        Role::Assistant => "Assistant",
-    };
-    let class = match message.role {
-        Role::User => "user",
-        Role::Assistant => "assistant",
-    };
-    out.push_str("<section class=\"msg ");
-    out.push_str(class);
-    out.push_str("\"><div class=\"role\">");
-    out.push_str(role);
-    out.push_str("</div>");
+enum RenderBlock {
+    User(String),
+    Assistant(Vec<AssistantSegment>),
+}
 
-    let mut text = String::new();
-    let mut rendered = false;
-    for line in message.content.lines() {
-        let sanitized = utils::sanitize_line(line);
-        if is_tool_line(&sanitized) {
-            if !text.trim().is_empty() {
-                render_text_segment(out, &text);
-            }
-            text.clear();
-            render_tool_segment(out, &sanitized);
-            rendered = true;
+enum AssistantSegment {
+    Text(String),
+    Tools(Vec<String>),
+}
+
+fn prepare_render_blocks(messages: &[Message]) -> Vec<RenderBlock> {
+    let mut blocks = Vec::new();
+    let mut pending_tools = Vec::new();
+
+    let attach_tools = |blocks: &mut Vec<RenderBlock>, pending: &mut Vec<String>| {
+        if pending.is_empty() {
+            return;
+        }
+        let tools = std::mem::take(pending);
+        if let Some(RenderBlock::Assistant(segments)) = blocks.last_mut() {
+            segments.push(AssistantSegment::Tools(tools));
         } else {
-            if !text.is_empty() {
-                text.push('\n');
+            blocks.push(RenderBlock::Assistant(vec![AssistantSegment::Tools(tools)]));
+        }
+    };
+
+    for message in messages {
+        match message.role {
+            Role::User => {
+                attach_tools(&mut blocks, &mut pending_tools);
+                blocks.push(RenderBlock::User(message.content.clone()));
             }
-            text.push_str(&sanitized);
+            Role::Assistant if is_tool_message(&message.content) => {
+                pending_tools.push(message.content.clone());
+            }
+            Role::Assistant => {
+                attach_tools(&mut blocks, &mut pending_tools);
+                if let Some(RenderBlock::Assistant(segments)) = blocks.last_mut() {
+                    segments.push(AssistantSegment::Text(message.content.clone()));
+                } else {
+                    blocks.push(RenderBlock::Assistant(vec![AssistantSegment::Text(
+                        message.content.clone(),
+                    )]));
+                }
+            }
         }
     }
-    if !text.trim().is_empty() {
-        render_text_segment(out, &text);
-        rendered = true;
-    }
-    if !rendered && !message.content.is_empty() {
-        let sanitized =
-            message.content.lines().map(utils::sanitize_line).collect::<Vec<_>>().join("\n");
-        render_text_segment(out, &sanitized);
-    }
-    out.push_str("</section>");
+    attach_tools(&mut blocks, &mut pending_tools);
+    blocks
 }
 
-fn render_text_segment(out: &mut String, text: &str) {
-    out.push_str("<div class=\"text\">");
-    out.push_str(&escape_html(text.trim()));
+fn collect_user_toc(blocks: &[RenderBlock]) -> Vec<(usize, String)> {
+    let mut entries = Vec::new();
+    let mut index = 0usize;
+    for block in blocks {
+        let RenderBlock::User(content) = block else {
+            continue;
+        };
+        index += 1;
+        entries.push((index, user_toc_label(content)));
+    }
+    entries
+}
+
+fn render_user_toc(out: &mut String, entries: &[(usize, String)]) {
+    if entries.is_empty() {
+        return;
+    }
+    out.push_str("<aside class=\"user-toc\"><p class=\"user-toc-title\">User messages</p><nav>");
+    for (index, label) in entries {
+        out.push_str("<a href=\"#user-");
+        out.push_str(&index.to_string());
+        out.push_str("\">");
+        out.push_str(&escape_html(&format!("{index}. {label}")));
+        out.push_str("</a>");
+    }
+    out.push_str("</nav></aside>");
+}
+
+fn render_block_html(out: &mut String, block: RenderBlock, user_index: Option<usize>) {
+    match block {
+        RenderBlock::User(content) => {
+            let index = user_index.unwrap_or(1);
+            out.push_str("<section class=\"turn user\" id=\"user-");
+            out.push_str(&index.to_string());
+            out.push_str("\"><span class=\"role-label\">User</span><div class=\"user-block\">");
+            render_content(out, &content);
+            out.push_str("</div></section>");
+        }
+        RenderBlock::Assistant(segments) => {
+            out.push_str(
+                "<section class=\"turn assistant\"><span class=\"role-label\">Assistant</span><div class=\"assistant-body\">",
+            );
+            for segment in segments {
+                match segment {
+                    AssistantSegment::Text(content) => render_content(out, &content),
+                    AssistantSegment::Tools(logs) => {
+                        out.push_str("<div class=\"tool-run\">");
+                        render_tool_group(out, &logs);
+                        out.push_str("</div>");
+                    }
+                }
+            }
+            out.push_str("</div></section>");
+        }
+    }
+}
+
+fn render_content(out: &mut String, text: &str) {
+    out.push_str("<div class=\"prose\">");
+    let mut prose = String::new();
+    let mut pending_logs = Vec::new();
+    let mut rendered = false;
+
+    let flush_logs = |out: &mut String, pending: &mut Vec<String>| {
+        if pending.is_empty() {
+            return;
+        }
+        render_tool_group(out, pending);
+        pending.clear();
+    };
+
+    for line in text.lines() {
+        let sanitized = utils::sanitize_line(line);
+        if is_log_line(&sanitized) {
+            if !prose.trim().is_empty() {
+                render_markdown_text(out, &prose);
+                prose.clear();
+            }
+            pending_logs.push(sanitized);
+            rendered = true;
+        } else {
+            flush_logs(out, &mut pending_logs);
+            if !prose.is_empty() {
+                prose.push('\n');
+            }
+            prose.push_str(&sanitized);
+        }
+    }
+    flush_logs(out, &mut pending_logs);
+    if !prose.trim().is_empty() {
+        render_markdown_text(out, &prose);
+        rendered = true;
+    }
+    if !rendered && !text.trim().is_empty() {
+        render_markdown_text(out, text);
+    }
     out.push_str("</div>");
 }
 
-fn render_tool_segment(out: &mut String, text: &str) {
-    out.push_str("<details class=\"tool\"><summary>");
-    out.push_str(&escape_html(&tool_summary(text)));
+fn render_markdown_text(out: &mut String, text: &str) {
+    for fragment in split_text_fragments(text.trim()) {
+        match fragment {
+            TextFragment::Prose(prose) => render_markdown_blocks(out, &prose),
+            TextFragment::Code(code) => render_code_block(out, &code),
+        }
+    }
+}
+
+fn render_markdown_blocks(out: &mut String, text: &str) {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut index = 0;
+    while index < lines.len() {
+        let line = lines[index].trim_end();
+        if line.trim().is_empty() {
+            index += 1;
+            continue;
+        }
+        if let Some(stripped) = line.strip_prefix("### ") {
+            out.push_str("<h3>");
+            render_inline_markup(out, stripped.trim());
+            out.push_str("</h3>");
+            index += 1;
+            continue;
+        }
+        if let Some(stripped) = line.strip_prefix("## ") {
+            out.push_str("<h2>");
+            render_inline_markup(out, stripped.trim());
+            out.push_str("</h2>");
+            index += 1;
+            continue;
+        }
+        if is_list_marker_line(line) {
+            out.push_str("<ul>");
+            while index < lines.len() && is_list_marker_line(lines[index]) {
+                out.push_str("<li>");
+                render_inline_markup(out, list_marker_text(lines[index]));
+                out.push_str("</li>");
+                index += 1;
+            }
+            out.push_str("</ul>");
+            continue;
+        }
+        let mut paragraph = String::new();
+        while index < lines.len() {
+            let current = lines[index].trim_end();
+            if current.trim().is_empty()
+                || current.starts_with("### ")
+                || current.starts_with("## ")
+                || is_list_marker_line(current)
+            {
+                break;
+            }
+            if is_preformatted_line(current) {
+                if !paragraph.is_empty() {
+                    out.push_str("<p>");
+                    render_inline_markup(out, paragraph.trim());
+                    out.push_str("</p>");
+                    paragraph.clear();
+                }
+                let start = index;
+                while index < lines.len() && is_preformatted_line(lines[index]) {
+                    index += 1;
+                }
+                render_preformatted_block(out, &lines[start..index]);
+                continue;
+            }
+            if !paragraph.is_empty() {
+                paragraph.push('\n');
+            }
+            paragraph.push_str(current);
+            index += 1;
+        }
+        if !paragraph.is_empty() {
+            out.push_str("<p>");
+            render_inline_markup(out, paragraph.trim());
+            out.push_str("</p>");
+        }
+    }
+}
+
+fn is_preformatted_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed
+        .chars()
+        .any(|ch| matches!(ch, '┌' | '┐' | '└' | '┘' | '├' | '┤' | '┬' | '┴' | '┼' | '│' | '─'))
+    {
+        return true;
+    }
+    if trimmed.starts_with('|') && trimmed.contains('|') {
+        return true;
+    }
+    trimmed.len() >= 16 && trimmed.chars().all(|ch| matches!(ch, '-' | '=' | '|' | ':' | ' ' | '+'))
+}
+
+fn render_preformatted_block(out: &mut String, lines: &[&str]) {
+    out.push_str("<pre class=\"preformatted\">");
+    for (index, line) in lines.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        out.push_str(&escape_html(line.trim_end()));
+    }
+    out.push_str("</pre>");
+}
+
+enum InlineToken {
+    Code(usize),
+    Bold(usize),
+}
+
+fn render_inline_markup(out: &mut String, text: &str) {
+    let mut rest = text;
+    while !rest.is_empty() {
+        let tick = rest.find('`');
+        let bold = rest.find("**");
+        let next = match (tick, bold) {
+            (Some(t), Some(b)) => {
+                if t < b {
+                    InlineToken::Code(t)
+                } else {
+                    InlineToken::Bold(b)
+                }
+            }
+            (Some(t), None) => InlineToken::Code(t),
+            (None, Some(b)) => InlineToken::Bold(b),
+            (None, None) => {
+                render_plain_text(out, rest);
+                break;
+            }
+        };
+        match next {
+            InlineToken::Code(pos) => {
+                render_plain_text(out, &rest[..pos]);
+                rest = &rest[pos + 1..];
+                if let Some(end) = rest.find('`') {
+                    let code = &rest[..end];
+                    if !code.is_empty() {
+                        out.push_str("<code>");
+                        out.push_str(&escape_html(code));
+                        out.push_str("</code>");
+                    }
+                    rest = &rest[end + 1..];
+                } else {
+                    out.push_str(&escape_html(&format!("`{rest}")));
+                    break;
+                }
+            }
+            InlineToken::Bold(pos) => {
+                render_plain_text(out, &rest[..pos]);
+                rest = &rest[pos + 2..];
+                if let Some(end) = rest.find("**") {
+                    out.push_str("<strong>");
+                    out.push_str(&escape_html(&rest[..end]));
+                    out.push_str("</strong>");
+                    rest = &rest[end + 2..];
+                } else {
+                    out.push_str("**");
+                    render_plain_text(out, rest);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn render_plain_text(out: &mut String, text: &str) {
+    for (index, line) in text.split('\n').enumerate() {
+        if index > 0 {
+            out.push_str("<br>");
+        }
+        out.push_str(&escape_html(line));
+    }
+}
+
+fn is_list_marker_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("* ") || trimmed.starts_with("- ")
+}
+
+fn list_marker_text(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    trimmed.strip_prefix("* ").or_else(|| trimmed.strip_prefix("- ")).unwrap_or(trimmed)
+}
+
+fn render_code_block(out: &mut String, text: &str) {
+    let code = strip_code_fence_language(text);
+    out.push_str("<pre class=\"code-block\">");
+    out.push_str(&escape_html(code.trim_end()));
+    out.push_str("</pre>");
+}
+
+fn render_tool_group(out: &mut String, logs: &[String]) {
+    if logs.is_empty() {
+        return;
+    }
+    if logs.len() == 1 {
+        render_log_segment(out, &logs[0]);
+        return;
+    }
+    out.push_str("<details class=\"tool-group\"><summary>");
+    out.push_str(&escape_html(&format!("{} tool executions", logs.len())));
+    out.push_str("</summary><div class=\"tool-group-items\">");
+    for log in logs {
+        render_log_segment(out, log);
+    }
+    out.push_str("</div></details>");
+}
+
+fn render_log_segment(out: &mut String, text: &str) {
+    out.push_str("<details class=\"log\"><summary>");
+    out.push_str(&escape_html(&log_summary(text)));
     out.push_str("</summary><pre>");
     out.push_str(&escape_html(text));
     out.push_str("</pre></details>");
 }
 
-fn is_tool_line(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    trimmed.starts_with("[tool:")
-        || trimmed.starts_with("[tool_result:")
-        || trimmed.starts_with("[tool_use:")
+enum TextFragment {
+    Prose(String),
+    Code(String),
 }
 
-fn tool_summary(line: &str) -> String {
-    let trimmed = line.trim_start();
+fn split_text_fragments(text: &str) -> Vec<TextFragment> {
+    let mut fragments = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find("```") {
+        if start > 0 {
+            let prose = rest[..start].trim();
+            if !prose.is_empty() {
+                fragments.push(TextFragment::Prose(prose.to_string()));
+            }
+        }
+        rest = &rest[start + 3..];
+        if let Some(end) = rest.find("```") {
+            fragments.push(TextFragment::Code(rest[..end].to_string()));
+            rest = &rest[end + 3..];
+        } else {
+            fragments.push(TextFragment::Code(rest.to_string()));
+            return fragments;
+        }
+    }
+    let prose = rest.trim();
+    if !prose.is_empty() {
+        fragments.push(TextFragment::Prose(prose.to_string()));
+    }
+    if fragments.is_empty() && !text.is_empty() {
+        fragments.push(TextFragment::Prose(text.to_string()));
+    }
+    fragments
+}
+
+fn strip_code_fence_language(text: &str) -> &str {
+    if text.starts_with('\n') {
+        return text.trim_start_matches('\n');
+    }
+    let Some(first_newline) = text.find('\n') else {
+        return if is_fence_language_tag(text.trim()) { "" } else { text };
+    };
+    let first_line = text[..first_newline].trim();
+    if is_fence_language_tag(first_line) { &text[first_newline + 1..] } else { text }
+}
+
+fn is_fence_language_tag(line: &str) -> bool {
+    !line.is_empty()
+        && line.len() <= 32
+        && line.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '+')
+}
+
+fn is_tool_message(content: &str) -> bool {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    is_agent_tool_line(trimmed.lines().next().unwrap_or(""))
+}
+
+fn is_log_line(line: &str) -> bool {
+    is_agent_tool_line(line) || is_xml_tag_line(line)
+}
+
+fn is_agent_tool_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.starts_with("[tool:")
+        || trimmed.starts_with("[tool_result:")
+        || trimmed.starts_with("[tool_use:")
+    {
+        return true;
+    }
+    if !trimmed.starts_with('[') {
+        return false;
+    }
+    let Some(end) = trimmed.find(']') else {
+        return false;
+    };
+    if end <= 1 {
+        return false;
+    }
+    let after = trimmed[end + 1..].trim_start();
+    after.is_empty() || after.starts_with('{') || after.starts_with("->")
+}
+
+fn is_xml_tag_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('<')
+        && trimmed.ends_with('>')
+        && trimmed.len() > 2
+        && !trimmed[1..trimmed.len() - 1].contains(' ')
+}
+
+fn log_summary(text: &str) -> String {
+    let trimmed = text.trim_start();
+    let first_line = trimmed.lines().next().unwrap_or(trimmed);
     for (prefix, label) in
         [("[tool:", "Tool call"), ("[tool_result:", "Tool result"), ("[tool_use:", "Tool use")]
     {
-        if let Some(name) = trimmed
+        if let Some(name) = first_line
             .strip_prefix(prefix)
             .and_then(|rest| rest.split(']').next())
             .filter(|name| !name.trim().is_empty())
@@ -272,7 +850,231 @@ fn tool_summary(line: &str) -> String {
             return format!("{label}: {name}");
         }
     }
-    "Tool event".to_string()
+    if let Some(name) = bracket_tool_name(first_line) {
+        if first_line[name.len() + 2..].trim_start().starts_with("->") {
+            return format!("{name} result");
+        }
+        return name.to_string();
+    }
+    if is_xml_tag_line(first_line) {
+        if first_line.contains("oai-mem-citation") {
+            return "Citation".to_string();
+        }
+        return "System log".to_string();
+    }
+    "Log".to_string()
+}
+
+fn bracket_tool_name(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+    let end = trimmed.find(']')?;
+    if end <= 1 {
+        return None;
+    }
+    Some(&trimmed[1..end])
+}
+
+fn append_header_display_meta(out: &mut String, display_meta: &SessionDisplayMeta) {
+    if !display_meta.models.is_empty() {
+        out.push_str(" · Model: ");
+        out.push_str(&escape_html(&display_meta.models.join(", ")));
+    }
+    if !display_meta.thinking_depths.is_empty() {
+        out.push_str(" · Thinking: ");
+        out.push_str(&escape_html(&display_meta.thinking_depths.join(", ")));
+    }
+}
+
+fn enrich_display_meta_from_usage(
+    meta: &mut SessionDisplayMeta,
+    usage_events: &[SessionUsageEventRecord],
+) {
+    for event in usage_events {
+        if event.model != "unknown" {
+            push_unique(&mut meta.models, &event.model);
+        }
+        if let Some(raw) = event.raw_usage_json.as_deref() {
+            enrich_display_meta_from_json_text(meta, raw);
+        }
+    }
+}
+
+fn enrich_display_meta_from_source(session: &Session, meta: &mut SessionDisplayMeta) -> Result<()> {
+    match session.source.as_str() {
+        "grok" => enrich_display_meta_from_grok(&session.source_id, meta)?,
+        "codex" => {
+            if let Some(path) = session.source_file_path.as_deref() {
+                enrich_display_meta_from_codex_rollout(Path::new(path), meta)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn enrich_display_meta_from_grok(source_id: &str, meta: &mut SessionDisplayMeta) -> Result<()> {
+    let Some(session_dir) = resolve_grok_session_dir(source_id) else {
+        return Ok(());
+    };
+    let summary_path = session_dir.join("summary.json");
+    if let Ok(content) = fs::read_to_string(&summary_path)
+        && let Ok(doc) = serde_json::from_str::<Value>(&content)
+        && let Some(model) = doc.get("current_model_id").and_then(Value::as_str)
+    {
+        push_unique(&mut meta.models, model);
+    }
+    let updates_path = session_dir.join("updates.jsonl");
+    if !updates_path.exists() {
+        return Ok(());
+    }
+    let file = fs::File::open(&updates_path)
+        .with_context(|| format!("failed to open {}", updates_path.display()))?;
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        if !line.contains("modelId")
+            && !line.contains("thinkingDepth")
+            && !line.contains("thinking_depth")
+            && !line.contains("reasoningEffort")
+            && !line.contains("reasoning_effort")
+        {
+            continue;
+        }
+        let Ok(doc) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let update = doc.pointer("/params/update").or_else(|| doc.get("update"));
+        if let Some(update) = update {
+            if let Some(model) = update.pointer("/_meta/modelId").and_then(Value::as_str) {
+                push_unique(&mut meta.models, model);
+            }
+            if let Some(depth) = update.pointer("/_meta/thinkingDepth").and_then(Value::as_str) {
+                push_unique(&mut meta.thinking_depths, depth);
+            }
+            if let Some(depth) = update.pointer("/_meta/thinking_depth").and_then(Value::as_str) {
+                push_unique(&mut meta.thinking_depths, depth);
+            }
+            if let Some(depth) = update.pointer("/_meta/reasoningEffort").and_then(Value::as_str) {
+                push_unique(&mut meta.thinking_depths, depth);
+            }
+            if let Some(depth) = update.pointer("/_meta/reasoning_effort").and_then(Value::as_str) {
+                push_unique(&mut meta.thinking_depths, depth);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn enrich_display_meta_from_codex_rollout(
+    path: &Path,
+    meta: &mut SessionDisplayMeta,
+) -> Result<()> {
+    let file =
+        fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        if !line.contains("turn_context") {
+            continue;
+        }
+        let Ok(doc) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if doc.get("type").and_then(Value::as_str) != Some("turn_context") {
+            continue;
+        }
+        let payload = doc.get("payload").unwrap_or(&doc);
+        if let Some(model) = payload.get("model").and_then(Value::as_str) {
+            push_unique(&mut meta.models, model);
+        }
+        for key in ["effort", "reasoning_effort", "thinking_depth", "thinkingDepth"] {
+            if let Some(depth) = payload.get(key).and_then(Value::as_str) {
+                push_unique(&mut meta.thinking_depths, depth);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn enrich_display_meta_from_json_text(meta: &mut SessionDisplayMeta, raw: &str) {
+    let Ok(doc) = serde_json::from_str::<Value>(raw) else {
+        return;
+    };
+    enrich_display_meta_from_json_value(meta, &doc);
+}
+
+fn enrich_display_meta_from_json_value(meta: &mut SessionDisplayMeta, doc: &Value) {
+    for key in ["model", "model_name", "model_id", "current_model_id"] {
+        if let Some(model) = doc.get(key).and_then(Value::as_str) {
+            push_unique(&mut meta.models, model);
+        }
+    }
+    for key in ["effort", "reasoning_effort", "thinking_depth", "thinkingDepth", "reasoningEffort"]
+    {
+        if let Some(depth) = doc.get(key).and_then(Value::as_str) {
+            push_unique(&mut meta.thinking_depths, depth);
+        }
+    }
+    if let Some(model_info) = doc.get("model_info") {
+        enrich_display_meta_from_json_value(meta, model_info);
+    }
+}
+
+fn resolve_grok_session_dir(source_id: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let sessions_dir = home.join(".grok").join("sessions");
+    let workspaces = fs::read_dir(sessions_dir).ok()?;
+    for workspace in workspaces.flatten() {
+        let session_dir = workspace.path().join(source_id);
+        if session_dir.join("summary.json").exists() {
+            return Some(session_dir);
+        }
+    }
+    None
+}
+
+fn push_unique(values: &mut Vec<String>, value: &str) {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || values.iter().any(|existing| existing == trimmed) {
+        return;
+    }
+    values.push(trimmed.to_string());
+}
+
+fn display_title(title: &str) -> String {
+    truncate_display_text(&strip_simple_markdown(title.lines().next().unwrap_or(title).trim()), 100)
+}
+
+fn user_toc_label(content: &str) -> String {
+    let line =
+        content.lines().map(str::trim).find(|line| !line.is_empty()).unwrap_or("User message");
+    let clean = strip_simple_markdown(line);
+    if clean.is_empty() { "User message".to_string() } else { truncate_display_text(&clean, 52) }
+}
+
+fn strip_simple_markdown(text: &str) -> String {
+    text.replace("**", "").replace('`', "")
+}
+
+fn truncate_display_text(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+fn format_source_label(source: &str) -> String {
+    let mut chars = source.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let mut out = String::new();
+    out.extend(first.to_uppercase());
+    out.extend(chars);
+    out
 }
 
 fn init_publish_dir(publish_dir: &Path) -> Result<()> {
@@ -447,6 +1249,10 @@ fn escape_html(input: &str) -> String {
 mod tests {
     use super::*;
 
+    fn render_html(session: &Session, messages: &[Message]) -> String {
+        render_session_html(session, messages, &SessionDisplayMeta::default())
+    }
+
     fn session(source_id: &str) -> Session {
         Session {
             id: "local-id".to_string(),
@@ -508,7 +1314,7 @@ mod tests {
 
     #[test]
     fn html_renderer_escapes_content() {
-        let html = render_session_html(
+        let html = render_html(
             &session("s1"),
             &[Message {
                 session_id: "local-id".to_string(),
@@ -524,13 +1330,13 @@ mod tests {
 
     #[test]
     fn html_renderer_omits_local_directory() {
-        let html = render_session_html(&session("s1"), &[]);
+        let html = render_html(&session("s1"), &[]);
         assert!(!html.contains("/tmp/project"));
     }
 
     #[test]
     fn html_renderer_collapses_tool_lines() {
-        let html = render_session_html(
+        let html = render_html(
             &session("s1"),
             &[Message {
                 session_id: "local-id".to_string(),
@@ -540,9 +1346,315 @@ mod tests {
                 seq: 0,
             }],
         );
-        assert!(html.contains("<div class=\"text\">I will inspect it.</div>"));
+        assert!(html.contains("<p>I will inspect it.</p>"));
+        assert!(html.contains("2 tool executions"));
         assert!(html.contains("<summary>Tool call: run_terminal_command_v2</summary>"));
         assert!(html.contains("<summary>Tool result: run_terminal_command_v2</summary>"));
-        assert!(html.contains("<div class=\"text\">The answer is here.</div>"));
+        assert!(html.contains("<p>The answer is here.</p>"));
+        assert!(html.contains("class=\"tool-group\""));
+    }
+
+    #[test]
+    fn html_renderer_uses_reading_layout_and_code_blocks() {
+        let html = render_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "Run this:\n```bash\nnpm test\n```".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("--read-width: 700px"));
+        assert!(html.contains("class=\"site-header\""));
+        assert!(html.contains("class=\"user-block\""));
+        assert!(html.contains("<pre class=\"code-block\">"));
+        assert!(html.contains("npm test"));
+    }
+
+    #[test]
+    fn html_renderer_preserves_unlabeled_code_fence_content() {
+        let html = render_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "Example:\n```\nhello\nworld\n```".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("hello"));
+        assert!(html.contains("world"));
+    }
+
+    #[test]
+    fn preview_writes_html_file() {
+        let dir =
+            std::env::temp_dir().join(format!("recall-preview-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let session = session("preview-test");
+        let messages = vec![Message {
+            session_id: "local-id".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: None,
+            seq: 0,
+        }];
+        let path = dir.join("preview.html");
+        let html = render_html(&session, &messages);
+        std::fs::write(&path, html).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("hello"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn html_renderer_collapses_citation_lines() {
+        let html = render_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::Assistant,
+                content:
+                    "Here is the answer.\n<oai-mem-citation>path/to/file</oai-mem-citation>\nDone."
+                        .to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("<summary>Citation</summary>"));
+        assert!(html.contains("<p>Here is the answer.</p>"));
+        assert!(html.contains("<p>Done.</p>"));
+    }
+
+    #[test]
+    fn html_renderer_batches_grok_tool_messages() {
+        let html = render_html(
+            &session("s1"),
+            &[
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "Answer incoming.".to_string(),
+                    timestamp: None,
+                    seq: 0,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "[Read] {\"path\":\"src/share.rs\"}".to_string(),
+                    timestamp: None,
+                    seq: 1,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "[Glob] {\"glob_pattern\":\"**/*\"}".to_string(),
+                    timestamp: None,
+                    seq: 2,
+                },
+            ],
+        );
+        assert!(html.contains("<p>Answer incoming.</p>"));
+        assert!(html.contains("class=\"tool-run\""));
+        assert!(html.contains("2 tool executions"));
+        assert!(html.contains("<summary>Read</summary>"));
+        assert!(html.contains("<summary>Glob</summary>"));
+        assert_eq!(html.matches("class=\"turn assistant\"").count(), 1);
+        assert!(html.contains("role-label\">Assistant"));
+        assert!(html.contains("assistant-body\"><div class=\"prose\"><p>Answer incoming.</p>"));
+    }
+
+    #[test]
+    fn html_renderer_groups_user_assistant_exchanges() {
+        let html = render_html(
+            &session("s1"),
+            &[
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::User,
+                    content: "First question".to_string(),
+                    timestamp: None,
+                    seq: 0,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "Working on it.".to_string(),
+                    timestamp: None,
+                    seq: 1,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "[Read] {\"path\":\"src/share.rs\"}".to_string(),
+                    timestamp: None,
+                    seq: 2,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "Here is the answer.".to_string(),
+                    timestamp: None,
+                    seq: 3,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::User,
+                    content: "Second question".to_string(),
+                    timestamp: None,
+                    seq: 4,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "Second answer.".to_string(),
+                    timestamp: None,
+                    seq: 5,
+                },
+            ],
+        );
+        assert_eq!(html.matches("class=\"turn user\"").count(), 2);
+        assert_eq!(html.matches("class=\"turn assistant\"").count(), 2);
+        assert!(html.contains("class=\"turn user\" id=\"user-1\""));
+        assert!(html.contains("turn assistant\"><span class=\"role-label\">Assistant</span>"));
+        assert!(html.contains("class=\"user-block\""));
+        let first_user = html.find("First question").unwrap();
+        let first_answer = html.find("Here is the answer.").unwrap();
+        let second_user = html.find("Second question").unwrap();
+        let tool_run = html.find("class=\"tool-run\"").unwrap();
+        assert!(first_user < tool_run);
+        assert!(tool_run < first_answer);
+        assert!(first_answer < second_user);
+    }
+
+    #[test]
+    fn html_renderer_renders_user_toc_and_highlight_anchors() {
+        let html = render_html(
+            &session("s1"),
+            &[
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::User,
+                    content: "First question".to_string(),
+                    timestamp: None,
+                    seq: 0,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::Assistant,
+                    content: "First answer.".to_string(),
+                    timestamp: None,
+                    seq: 1,
+                },
+                Message {
+                    session_id: "local-id".to_string(),
+                    role: Role::User,
+                    content: "Second question".to_string(),
+                    timestamp: None,
+                    seq: 2,
+                },
+            ],
+        );
+        assert!(html.contains("class=\"user-toc\""));
+        assert!(html.contains("href=\"#user-1\""));
+        assert!(html.contains("href=\"#user-2\""));
+        assert!(html.contains("id=\"user-1\""));
+        assert!(html.contains("id=\"user-2\""));
+        assert!(html.contains("--user-block-bg: #FFF3D6"));
+        assert!(html.contains("1. First question"));
+        assert!(html.contains("2. Second question"));
+    }
+
+    #[test]
+    fn collect_display_meta_from_usage_and_codex_rollout() {
+        let mut meta = SessionDisplayMeta::default();
+        enrich_display_meta_from_usage(
+            &mut meta,
+            &[SessionUsageEventRecord {
+                event_key: "e1".to_string(),
+                event_seq: 0,
+                message_seq: None,
+                timestamp: 0,
+                model: "gpt-5.5".to_string(),
+                provider: "openai".to_string(),
+                input_tokens: 1,
+                output_tokens: 1,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+                token_source: "observed".to_string(),
+                parser_version: 1,
+                source_path: None,
+                raw_usage_json: Some(r#"{"effort":"high"}"#.to_string()),
+            }],
+        );
+
+        let dir = std::env::temp_dir().join(format!("recall-share-meta-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let rollout = dir.join("rollout.jsonl");
+        fs::write(
+            &rollout,
+            r#"{"type":"turn_context","payload":{"model":"gpt-5-codex","effort":"medium"}}"#,
+        )
+        .unwrap();
+        enrich_display_meta_from_codex_rollout(&rollout, &mut meta).unwrap();
+        let _ = fs::remove_dir_all(dir);
+
+        assert_eq!(meta.models, vec!["gpt-5.5", "gpt-5-codex"]);
+        assert_eq!(meta.thinking_depths, vec!["high", "medium"]);
+    }
+
+    #[test]
+    fn html_renderer_shows_model_and_thinking_chips() {
+        let html = render_session_html(
+            &session("s1"),
+            &[],
+            &SessionDisplayMeta {
+                models: vec!["grok-composer-2.5-fast".to_string()],
+                thinking_depths: vec!["high".to_string()],
+            },
+        );
+        assert!(html.contains("<p class=\"meta\">"));
+        assert!(html.contains("0 messages · Model: grok-composer-2.5-fast · Thinking: high</p>"));
+    }
+
+    #[test]
+    fn html_renderer_wraps_box_drawing_tables_in_preformatted_block() {
+        let html = render_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "Author rejection cases:\n\n┌────────┬──────────────────────────┐\n│ Field  │ Reject when matched      │\n└────────┴──────────────────────────┘".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("preformatted"));
+        assert!(html.contains("┌────"));
+        assert!(!html.contains("<p>┌"));
+        assert!(html.contains("overflow-x:auto"));
+        assert!(html.contains("overflow-wrap:anywhere"));
+    }
+
+    #[test]
+    fn html_renderer_renders_markdown_and_keeps_inline_mentions() {
+        let html = render_html(
+            &session("s1"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "**Bold title**\n\n### Section\n\n* first item\n* second item\n\nMention `<oai-mem-citation>` in prose.".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+        );
+        assert!(html.contains("<strong>Bold title</strong>"));
+        assert!(html.contains("<h3>Section</h3>"));
+        assert!(html.contains("<li>first item</li>"));
+        assert!(!html.contains("<summary>Citation</summary>"));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1135,6 +1135,9 @@ impl App {
             KeyCode::Char('s') => {
                 self.share_current_session();
             }
+            KeyCode::Char('v') => {
+                self.preview_current_session();
+            }
             KeyCode::Char('/') => {
                 self.viewing_search_input = Some(String::new());
                 self.viewing_search_input_cursor = 0;
@@ -2339,6 +2342,28 @@ impl App {
         }
     }
 
+    fn preview_current_session(&mut self) {
+        let Some(result) = self.results.get(self.selected_index) else {
+            return;
+        };
+        let session = result.session.clone();
+        let messages = self.viewing_messages.clone();
+        let session_id = session.id.clone();
+        let usage_events = crate::db::store::Store::open()
+            .and_then(|store| store.list_usage_events_for_session(&session_id))
+            .unwrap_or_default();
+        match crate::share::open_session_preview(&session, &messages, &usage_events) {
+            Ok(path) => {
+                self.viewing_search_status = None;
+                self.status_message = Some(format!("Opened preview: {}", path.display()));
+            }
+            Err(error) => {
+                self.viewing_search_status = None;
+                self.status_message = Some(format!("Preview failed: {error}"));
+            }
+        }
+    }
+
     fn share_current_session(&mut self) {
         let Some(result) = self.results.get(self.selected_index) else {
             return;
@@ -2349,9 +2374,13 @@ impl App {
         let config = self.config.clone();
         let session = result.session.clone();
         let messages = self.viewing_messages.clone();
+        let session_id = session.id.clone();
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
-            let result = crate::share::publish_session(&config, &session, &messages)
+            let usage_events = crate::db::store::Store::open()
+                .and_then(|store| store.list_usage_events_for_session(&session_id))
+                .unwrap_or_default();
+            let result = crate::share::publish_session(&config, &session, &messages, &usage_events)
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);
         });


### PR DESCRIPTION
### What's changed?

- Added richer shared session HTML rendering with a reading layout, user navigation, grouped tool logs, markdown/code handling, and model/thinking metadata.
- Added local TUI session preview via `v` and passes usage metadata through CLI/TUI sharing paths.
- Kept Cloudflare Pages share previews on the configured project domain while validating generated asset size before deploy.

### Why

- Make shared session pages easier to read and let users preview the rendered HTML before publishing.