### PR TITLE
[Feat] Add shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2728,7 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "dirs 5.0.1",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/samzong/Recall"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlite-vec = "0.1"
 hf-hub = { version = "0.5", features = ["ureq"] }

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ doc: ## Generate API documentation
 
 install: ## Install binary to ~/.cargo/bin
 	$(CARGO) install --path . --locked
+	@if [ -d "$(HOME)/.zsh/completions" ]; then \
+		"$(HOME)/.cargo/bin/recall" completions zsh > "$(HOME)/.zsh/completions/_recall"; \
+		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_recall$(RESET)\n'; \
+	fi
 
 uninstall: ## Remove installed binary
 	$(CARGO) uninstall recall

--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ brew install samzong/tap/recall
 make install # from a source checkout
 ```
 
+## Shell completion
+
+Generate a static completion script and load it from your shell `fpath`:
+
+```bash
+recall completions zsh > ~/.zsh/completions/_recall
+```
+
+Add to `~/.zshrc` (works alongside `gmc` and other tools):
+
+```bash
+fpath=(~/.zsh/completions ~/.grok/completions/zsh $fpath)
+autoload -Uz compinit && compinit
+```
+
+Other shells:
+
+```bash
+recall completions bash > ~/.bash_completion.d/recall
+recall completions fish > ~/.config/fish/completions/recall.fish
+```
+
 ## Support
 
 One index across every AI coding CLI. Sync once, search everywhere, resume right where you left off.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 
 use crate::session;
 
@@ -95,6 +96,11 @@ enum Commands {
         #[command(subcommand)]
         command: session::SessionCommands,
     },
+    #[command(about = "Generate shell completion script")]
+    Completions {
+        #[arg(help = "Target shell")]
+        shell: Shell,
+    },
 }
 
 #[derive(Subcommand)]
@@ -138,12 +144,13 @@ pub fn run() -> Result<()> {
             recall::export::run_cli(source.as_deref(), time.as_deref(), project.as_deref(), limit)?
         }
         Some(Commands::Import { file, dry_run }) => recall::import::run_cli(&file, dry_run)?,
-        Some(Commands::Share { command }) => match command {
-            ShareCommands::Init { project_name, publish_dir } => {
-                recall::share_init::run(project_name, publish_dir)?
-            }
-        },
+        Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
+            recall::share_init::run(project_name, publish_dir)?
+        }
         Some(Commands::Session { command }) => session::cmd_session(command)?,
+        Some(Commands::Completions { shell }) => {
+            generate(shell, &mut Cli::command(), "recall", &mut std::io::stdout());
+        }
         None => recall::tui::runner::run(None)?,
     }
 
@@ -152,7 +159,7 @@ pub fn run() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ShareCommands};
+    use super::{Cli, Commands, ShareCommands, Shell, generate};
     use clap::{CommandFactory, Parser};
     use recall::adapters::{
         adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
@@ -211,6 +218,21 @@ mod tests {
         assert!(compact_help.contains("import Import session records from JSON Lines"));
         assert!(compact_help.contains("share Share session pages"));
         assert!(compact_help.contains("session Operate on indexed sessions"));
+        assert!(compact_help.contains("completions Generate shell completion script"));
+    }
+
+    #[test]
+    fn completions_generates_zsh_script() {
+        assert!(matches!(
+            Cli::try_parse_from(["recall", "completions", "zsh"]).unwrap().command,
+            Some(Commands::Completions { shell: Shell::Zsh })
+        ));
+
+        let mut output = Vec::new();
+        generate(Shell::Zsh, &mut Cli::command(), "recall", &mut output);
+        let script = String::from_utf8(output).unwrap();
+        assert!(script.contains("#compdef recall"));
+        assert!(script.contains("search"));
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- Add `recall completions <shell>` using `clap_complete`.
- Install zsh completions during `make install` when `~/.zsh/completions` exists.
- Document static completion generation for zsh, bash, and fish.

### Why

- Let users generate shell completion scripts from the installed CLI without maintaining separate checked-in scripts.