### PR TITLE
feat(session): add agent handoff flow

### DIFF
--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+
+use crate::adapters::ResumeCommand;
+use crate::transcript;
+use crate::types::{Message, Session};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandoffTarget {
+    pub(crate) id: &'static str,
+    pub(crate) label: &'static str,
+}
+
+pub(crate) const TARGETS: [HandoffTarget; 4] = [
+    HandoffTarget { id: "codex", label: "Codex" },
+    HandoffTarget { id: "grok", label: "Grok" },
+    HandoffTarget { id: "claude-code", label: "Claude Code" },
+    HandoffTarget { id: "opencode", label: "OpenCode" },
+];
+
+pub fn build_prompt(session: &Session, messages: &[Message]) -> String {
+    format!(
+        "Use this Recall indexed session transcript as context for a new session. This is a handoff, not a native resume.\n\n{}",
+        transcript::render_plain(session, messages)
+    )
+}
+
+pub fn command_for_target(target: &HandoffTarget, prompt: String) -> ResumeCommand {
+    match target.id {
+        "codex" => ResumeCommand { program: "codex".to_string(), args: vec![prompt] },
+        "grok" => ResumeCommand { program: "grok".to_string(), args: vec![prompt] },
+        "claude-code" => ResumeCommand { program: "claude".to_string(), args: vec![prompt] },
+        "opencode" => ResumeCommand {
+            program: "opencode".to_string(),
+            args: vec!["run".to_string(), "-i".to_string(), prompt],
+        },
+        _ => unreachable!(),
+    }
+}
+
+pub fn target_for(target_id: &str) -> Result<&'static HandoffTarget> {
+    let id = target_id.to_ascii_lowercase();
+    TARGETS.iter().find(|target| target.id == id).ok_or_else(|| {
+        let supported = TARGETS.iter().map(|target| target.id).collect::<Vec<_>>().join(", ");
+        anyhow::anyhow!("unsupported handoff target: {target_id} (supported: {supported})")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Message, Role, Session};
+
+    fn session() -> Session {
+        Session {
+            id: "s1".to_string(),
+            source: "grok".to_string(),
+            source_id: "raw1".to_string(),
+            title: "Fix login bug".to_string(),
+            directory: Some("/tmp/project".to_string()),
+            started_at: 0,
+            updated_at: None,
+            message_count: 1,
+            entrypoint: None,
+            custom_title: None,
+            summary: None,
+            duration_minutes: None,
+            source_file_path: None,
+            is_import: true,
+        }
+    }
+
+    fn message() -> Message {
+        Message {
+            session_id: "s1".to_string(),
+            role: Role::User,
+            content: "continue this work".to_string(),
+            timestamp: None,
+            seq: 0,
+        }
+    }
+
+    #[test]
+    fn handoff_prompt_wraps_plain_transcript() {
+        let prompt = build_prompt(&session(), &[message()]);
+
+        assert!(prompt.contains("This is a handoff, not a native resume."));
+        assert!(prompt.contains("Session: Fix login bug"));
+        assert!(prompt.contains("## User [0]"));
+        assert!(prompt.contains("continue this work"));
+    }
+
+    #[test]
+    fn handoff_commands_cover_first_target_set() {
+        let cases = [
+            ("codex", "codex", vec!["prompt"]),
+            ("grok", "grok", vec!["prompt"]),
+            ("claude-code", "claude", vec!["prompt"]),
+            ("opencode", "opencode", vec!["run", "-i", "prompt"]),
+        ];
+
+        for (target_id, program, args) in cases {
+            let target = target_for(target_id).unwrap();
+            let command = command_for_target(target, "prompt".to_string());
+            assert_eq!(command.program, program);
+            assert_eq!(command.args, args);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod embedding;
 pub mod export;
+pub mod handoff;
 pub mod import;
 pub mod info;
 pub mod query;

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,6 +10,7 @@ use recall::config::AppConfig;
 use recall::db::search::{SearchEngine, SearchFilters, TimeRange};
 use recall::db::store::{SessionListSort, Store};
 use recall::export::ExportOptions;
+use recall::handoff;
 use recall::query::{parse_time_range, query_embedding, resolve_source_filter};
 use recall::semantic;
 use recall::session_action::{self, SessionAction};
@@ -119,6 +120,19 @@ pub(crate) enum SessionCommands {
         print_command: bool,
         #[arg(long, value_enum, default_value_t = SessionActionFormat::Text)]
         format: SessionActionFormat,
+    },
+    #[command(about = "Handoff one selected session to a new target agent session")]
+    Handoff {
+        #[arg(long, help = "Recall session id")]
+        id: Option<String>,
+        #[arg(long, help = "Source id or label")]
+        source: Option<String>,
+        #[arg(long, help = "Source-native session id")]
+        source_id: Option<String>,
+        #[arg(long, help = "Target agent id")]
+        to: String,
+        #[arg(long, help = "Print the handoff prompt instead of executing the target")]
+        print_prompt: bool,
     },
 }
 
@@ -260,6 +274,15 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
                 print_command,
                 format,
                 SessionAction::OpenApp,
+            )
+        }
+        SessionCommands::Handoff { id, source, source_id, to, print_prompt } => {
+            cmd_session_handoff(
+                id.as_deref(),
+                source.as_deref(),
+                source_id.as_deref(),
+                &to,
+                print_prompt,
             )
         }
     }
@@ -574,6 +597,33 @@ fn cmd_session_command(
     session_action::run(&command, session.directory.as_deref())
 }
 
+fn cmd_session_handoff(
+    id: Option<&str>,
+    source_filter: Option<&str>,
+    source_id: Option<&str>,
+    target: &str,
+    print_prompt: bool,
+) -> Result<()> {
+    let store = Store::open()?;
+    let sources = adapters::source_labels();
+    let session = resolve_session_ref(&store, &sources, id, source_filter, source_id)?;
+    let target = handoff::target_for(target)?;
+    let messages = store.get_messages(&session.id)?;
+    let prompt = handoff::build_prompt(&session, &messages);
+
+    if print_prompt {
+        print!("{prompt}");
+        return Ok(());
+    }
+
+    let command = handoff::command_for_target(target, prompt);
+    session_action::run(&command, handoff_working_directory(session.directory.as_deref()))
+}
+
+fn handoff_working_directory(directory: Option<&str>) -> Option<&str> {
+    directory.filter(|dir| std::path::Path::new(*dir).is_dir())
+}
+
 fn resolve_session_ref(
     store: &Store,
     sources: &[(String, String)],
@@ -874,4 +924,26 @@ fn open_url(url: &str) -> Result<()> {
         anyhow::bail!("{program} exited with status {status}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handoff_working_directory_keeps_existing_directory() {
+        let directory = std::env::temp_dir().to_string_lossy().into_owned();
+
+        assert_eq!(handoff_working_directory(Some(directory.as_str())), Some(directory.as_str()));
+    }
+
+    #[test]
+    fn handoff_working_directory_drops_missing_directory() {
+        let directory = std::env::temp_dir()
+            .join(format!("recall-missing-{}", uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(handoff_working_directory(Some(directory.as_str())), None);
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,6 +9,7 @@ use crate::adapters::ResumeCommand;
 use crate::config::AppConfig;
 use crate::db::search::{SearchFilters, TimeRange};
 use crate::db::store::{ProjectDirectory, Store};
+use crate::handoff;
 use crate::session_action;
 use crate::skill_audit::{self, SkillAuditFilters, SkillAuditReport};
 use crate::transcript;
@@ -18,8 +19,6 @@ use crate::types::{
     SessionUsageEventRecord,
 };
 use crate::usage::{self, TokenTotals, UsageFilters, UsageReport};
-
-pub use crate::session_action::SessionAction as PendingCommandAction;
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
 const SEARCH_DEBOUNCE_MS: u64 = 250;
@@ -38,7 +37,15 @@ pub enum AppMode {
     ExportInput,
     Settings,
     Filters,
+    HandoffTarget,
     ConfirmResume,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingCommandAction {
+    Resume,
+    OpenApp,
+    Handoff,
 }
 
 #[cfg(test)]
@@ -97,6 +104,7 @@ mod tests {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
             exec_on_exit: None,
@@ -268,6 +276,27 @@ mod tests {
                 "status message must explain why nothing happened"
             );
         }
+    }
+
+    #[test]
+    fn imported_session_can_handoff_from_detail_view() {
+        let mut app = app_with_sources();
+        let mut result = codex_search_result();
+        result.session.is_import = true;
+        app.results = vec![result];
+        app.viewing_messages = vec![message(Role::User, None, 0)];
+        app.mode = AppMode::Viewing;
+
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert!(matches!(app.mode, AppMode::HandoffTarget));
+
+        app.handle_handoff_target_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(matches!(app.mode, AppMode::ConfirmResume));
+        let pending = app.pending_resume.as_ref().unwrap();
+        assert_eq!(pending.action, PendingCommandAction::Handoff);
+        assert_eq!(pending.command.program, "codex");
+        assert!(pending.command.args[0].contains("This is a handoff, not a native resume."));
     }
 
     #[test]
@@ -732,6 +761,7 @@ pub struct App {
     pub semantic_last_refresh: Instant,
     pub settings_selected: usize,
     pub pending_resume: Option<PendingResume>,
+    pub handoff_target_selected: usize,
     pub share_popup: Option<SharePopup>,
     pub share_publish_rx: Option<mpsc::Receiver<Result<String, String>>>,
     pub exec_on_exit: Option<(ResumeCommand, Option<String>)>,
@@ -818,6 +848,7 @@ impl App {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
             exec_on_exit: None,
@@ -1009,6 +1040,7 @@ impl App {
             AppMode::ExportInput => self.handle_export_key(key),
             AppMode::Settings => self.handle_settings_key(key, store),
             AppMode::Filters => self.handle_filters_key(key, store),
+            AppMode::HandoffTarget => self.handle_handoff_target_key(key),
             AppMode::ConfirmResume => self.handle_confirm_resume_key(key),
         }
     }
@@ -1317,6 +1349,9 @@ impl App {
             KeyCode::Char('v') => {
                 self.preview_current_session();
             }
+            KeyCode::Char('h') => {
+                self.open_handoff_target_picker();
+            }
             KeyCode::Char('/') => {
                 self.viewing_search_input = Some(String::new());
                 self.viewing_search_input_cursor = 0;
@@ -1466,14 +1501,27 @@ impl App {
     }
 
     fn start_resume_confirmation(&mut self, origin: ResumeOrigin) {
-        self.start_command_confirmation(origin, PendingCommandAction::Resume);
+        self.start_source_command_confirmation(
+            origin,
+            session_action::SessionAction::Resume,
+            PendingCommandAction::Resume,
+        );
     }
 
     fn start_app_open_confirmation(&mut self, origin: ResumeOrigin) {
-        self.start_command_confirmation(origin, PendingCommandAction::OpenApp);
+        self.start_source_command_confirmation(
+            origin,
+            session_action::SessionAction::OpenApp,
+            PendingCommandAction::OpenApp,
+        );
     }
 
-    fn start_command_confirmation(&mut self, origin: ResumeOrigin, action: PendingCommandAction) {
+    fn start_source_command_confirmation(
+        &mut self,
+        origin: ResumeOrigin,
+        source_action: session_action::SessionAction,
+        action: PendingCommandAction,
+    ) {
         let Some(result) = self.results.get(self.selected_index) else {
             return;
         };
@@ -1484,10 +1532,10 @@ impl App {
             return;
         }
         let Some(command) =
-            session_action::command_for(action, &session.source, &session.source_id)
+            session_action::command_for(source_action, &session.source, &session.source_id)
         else {
             self.status_message =
-                Some(format!("{} not supported for {}", action.title(), session.source));
+                Some(format!("{} not supported for {}", source_action.title(), session.source));
             return;
         };
         self.pending_resume = Some(PendingResume {
@@ -1497,6 +1545,50 @@ impl App {
             session_title: session.title.clone(),
             cwd: session.directory.clone(),
             origin,
+        });
+        self.mode = AppMode::ConfirmResume;
+    }
+
+    fn open_handoff_target_picker(&mut self) {
+        self.handoff_target_selected = 0;
+        self.mode = AppMode::HandoffTarget;
+    }
+
+    fn handle_handoff_target_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = AppMode::Viewing;
+            }
+            KeyCode::Up | KeyCode::Char('k') if self.handoff_target_selected > 0 => {
+                self.handoff_target_selected -= 1;
+            }
+            KeyCode::Down | KeyCode::Char('j')
+                if self.handoff_target_selected + 1 < handoff::TARGETS.len() =>
+            {
+                self.handoff_target_selected += 1;
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                let target = &handoff::TARGETS[self.handoff_target_selected];
+                self.start_handoff_confirmation(target);
+            }
+            _ => {}
+        }
+    }
+
+    fn start_handoff_confirmation(&mut self, target: &handoff::HandoffTarget) {
+        let Some(result) = self.results.get(self.selected_index) else {
+            return;
+        };
+        let session = &result.session;
+        let prompt = handoff::build_prompt(session, &self.viewing_messages);
+        let command = handoff::command_for_target(target, prompt);
+        self.pending_resume = Some(PendingResume {
+            command,
+            action: PendingCommandAction::Handoff,
+            source_label: target.label.to_string(),
+            session_title: session.title.clone(),
+            cwd: session.directory.clone(),
+            origin: ResumeOrigin::Viewing,
         });
         self.mode = AppMode::ConfirmResume;
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -9,6 +9,7 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
+use crate::handoff;
 use crate::skill_audit::{SkillTier, SkillUsageEntry, format_last_used, format_signals};
 use crate::tui::app::{
     App, AppMode, FilterFocus, PanelFocus, PendingCommandAction, ProjectPickerRow, ResumeOrigin,
@@ -77,6 +78,10 @@ pub fn render(f: &mut Frame, app: &App) {
         AppMode::Filters => {
             render_search(f, app);
             render_filter_picker(f, app);
+        }
+        AppMode::HandoffTarget => {
+            render_viewing(f, app);
+            render_handoff_target_picker(f, app);
         }
         AppMode::ExportInput => {
             render_viewing(f, app);
@@ -1326,6 +1331,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" export  ", Style::default().fg(Color::DarkGray)),
         Span::styled("s", Style::default().fg(Color::Yellow)),
         Span::styled(" share  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("h", Style::default().fg(Color::Yellow)),
+        Span::styled(" handoff  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+R", Style::default().fg(Color::Yellow)),
         Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+O", Style::default().fg(Color::Yellow)),
@@ -1370,6 +1377,49 @@ fn render_viewing(f: &mut Frame, app: &App) {
     }
 
     f.render_widget(Paragraph::new(status_line), outer[1]);
+}
+
+fn render_handoff_target_picker(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let width = area.width.clamp(36, 56);
+    let height = (handoff::TARGETS.len() as u16 + 5).max(8);
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let rect = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .title(" Handoff target ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .style(Style::default().bg(Color::Black));
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(""));
+    for (index, target) in handoff::TARGETS.iter().enumerate() {
+        let selected = index == app.handoff_target_selected;
+        let marker = if selected { ">" } else { " " };
+        let style = if selected {
+            Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker} "), style),
+            Span::styled(target.label, style),
+            Span::styled(format!(" ({})", target.id), style),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(" [Enter] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled("select  ", Style::default().fg(Color::White)),
+        Span::styled("[Esc] ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled("cancel", Style::default().fg(Color::White)),
+    ]));
+
+    let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(Clear, rect);
+    f.render_widget(widget, rect);
 }
 
 fn render_viewing_summary(f: &mut Frame, app: &App, area: Rect) {
@@ -1786,10 +1836,12 @@ fn render_confirm_resume(f: &mut Frame, app: &App) {
     let block_title = match pending.action {
         PendingCommandAction::Resume => " Resume session ",
         PendingCommandAction::OpenApp => " Open in app ",
+        PendingCommandAction::Handoff => " Handoff session ",
     };
     let confirm_label = match pending.action {
         PendingCommandAction::Resume => "confirm & exec     ",
         PendingCommandAction::OpenApp => "confirm & open     ",
+        PendingCommandAction::Handoff => "confirm & handoff  ",
     };
 
     let block = Block::default()
@@ -1816,7 +1868,13 @@ fn render_confirm_resume(f: &mut Frame, app: &App) {
     let lines = vec![
         Line::from(""),
         Line::from(vec![
-            Span::styled(" Source:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                match pending.action {
+                    PendingCommandAction::Handoff => " Target:  ",
+                    _ => " Source:  ",
+                },
+                Style::default().fg(Color::DarkGray),
+            ),
             Span::styled(
                 pending.source_label.clone(),
                 Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
@@ -2055,6 +2113,59 @@ mod tests {
             .join("\n");
 
         assert!(rendered.contains("https://recall-share.pages.dev/source1"));
+    }
+
+    #[test]
+    fn render_handoff_target_picker_shows_targets() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.mode = AppMode::HandoffTarget;
+        app.handoff_target_selected = 3;
+        app.results = vec![SearchResult {
+            session: Session {
+                id: "session1".to_string(),
+                source: "codex".to_string(),
+                source_id: "source1".to_string(),
+                title: "Test session".to_string(),
+                directory: None,
+                started_at: 0,
+                updated_at: None,
+                message_count: 1,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: None,
+                is_import: true,
+            },
+            match_source: MatchSource::Fts,
+            snippet: None,
+        }];
+        app.viewing_messages = vec![Message {
+            session_id: "session1".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: None,
+            seq: 0,
+        }];
+        app.viewing_sanitized_lines =
+            vec![vec![SanitizedLine { text: "hello".to_string(), lower: "hello".to_string() }]];
+
+        let backend = TestBackend::new(90, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app)).unwrap();
+        let rendered = (0..18)
+            .map(|y| buffer_row(terminal.backend().buffer(), y, 90))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Handoff target"));
+        assert!(rendered.contains("Codex (codex)"));
+        assert!(rendered.contains("OpenCode (opencode)"));
+        assert!(rendered.contains("[Enter]"));
+        assert!(rendered.contains("select"));
     }
 
     fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {


### PR DESCRIPTION
### What's changed?

- Add `recall session handoff` for launching a new target-agent session from an indexed transcript.
- Add a TUI detail-view handoff picker and confirmation flow.
- Add prompt, target-command, imported-session, and picker-render coverage.

### Why

- Let Recall hand off indexed sessions to supported target agents without requiring native resume support.

### Verification

- `rtk proxy make check`
- `git diff --check HEAD~1..HEAD`
