### PR TITLE
docs(readme): add chinese readme with language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+**English** | [Chinese](./README.zh-CN.md)
+
 # Recall
 
 > Local-first search across every AI coding session on your machine.
 
-[![Recall TUI](docs/recall.png)](https://asciinema.org/a/909453)
+[![Recall](docs/recall.png)](https://asciinema.org/a/909453)
 
 Jump between Claude Code, Codex, and whatever comes next; Recall pulls those scattered local sessions into one searchable index, tracks usage when token metadata is available, and drops you back into the original CLI.
 
@@ -10,30 +12,25 @@ Jump between Claude Code, Codex, and whatever comes next; Recall pulls those sca
 
 ```bash
 brew install samzong/tap/recall
-# or
-make install # from a source checkout
 ```
 
-## Shell completion
-
-Generate a static completion script and load it from your shell `fpath`:
+## Usage
 
 ```bash
-recall completions zsh > ~/.zsh/completions/_recall
+recall sync          # incremental sync (safe to run anytime)
+recall               # launch TUI
+recall usage         # usage dashboard
+recall export > recall-export.jsonl # export all session
+recall import recall-export.jsonl --dry-run  # preview an import
+recall session list  # list sessions for agents/scripts
+recall session share --id <session-id> --format json  # publish one selected session
+recall info  # index stats and worker status
 ```
 
-Add to `~/.zshrc` (works alongside `gmc` and other tools):
+With Skill use **Recall** is the best way.
 
 ```bash
-fpath=(~/.zsh/completions ~/.grok/completions/zsh $fpath)
-autoload -Uz compinit && compinit
-```
-
-Other shells:
-
-```bash
-recall completions bash > ~/.bash_completion.d/recall
-recall completions fish > ~/.config/fish/completions/recall.fish
+recall skill install # auto detect agents and install skills
 ```
 
 ## Support
@@ -46,73 +43,23 @@ One index across every AI coding CLI. Sync once, search everywhere, resume right
 | OpenCode        |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Codex           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Pi              |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
-| Antigravity CLI |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
+| Antigravity |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
 | Gemini          |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Kiro            |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |       |
-| Copilot CLI     |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
+| Copilot     |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
 | Cursor          |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |   ✅   |
 | Cline           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |       |
 | Grok            |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |        |
 
-## Usage
+## Acknowledgements
 
-```bash
-recall sync          # incremental sync (safe to run anytime)
-recall sync --force  # reprocess every session (after changing embedding model)
-recall               # launch TUI
-recall search Q      # one-shot CLI search
-recall search Q --project /path/to/repo
-recall usage         # usage dashboard
-recall usage --json  # usage report for scripts
-recall export --source codex --project /path/to/repo --limit 20 > recall-export.jsonl
-recall import recall-export.jsonl --dry-run  # preview an import
-recall session list --source codex --limit 20  # list sessions for agents/scripts
-recall session show --id <session-id> --include metadata,messages --format json
-recall session export --id <session-id> --format jsonl
-recall session share --id <session-id> --format json  # publish one selected session
-recall session resume --id <session-id> --print-command
-recall info          # index stats and worker status
-```
-
-## Export
-
-`recall export` writes JSON Lines to stdout, with one JSON object per indexed
-session. Redirect stdout to save an export file:
-
-```bash
-recall export --source codex --project /path/to/repo > recall-export.jsonl
-```
-
-Each session includes `schema_version`, `record_type`, `session`, `messages`,
-`usage_events`, and `events`. It covers the portable session data Recall can
-import again; derived index state such as FTS rows, embeddings, and background
-job state is rebuilt locally. Optional fields are emitted as `null`. By default
-all sessions are exported; use `--limit N` to truncate. `--time` filters on
-`started_at`, so prefer a full export when moving data between machines.
-
-## Import
-
-`recall import <file>` (or `-` for stdin) loads sessions from an export file
-into the local index. How the file travels between machines is up to you.
-
-```bash
-# machine A
-recall export > recall-a.jsonl
-# machine B
-recall import recall-a.jsonl
-```
-
-- Idempotent: a session whose `(source, source_id)` already exists locally is
-  skipped, so re-running an import is safe and local data always wins.
-- Imported sessions are searchable and appear in usage reports, but cannot be
-  resumed on this machine (the source tool's own files were not copied); the
-  TUI explains this if you try.
-- `--dry-run` parses and reports counts without writing anything.
+- Thanks to [tokscale](https://github.com/junhoyeo/tokscale) for the usage dashboard reference and token accounting behavior.
+- Thanks to [Ratatui](https://github.com/ratatui/ratatui) and [Crossterm](https://github.com/crossterm-rs/crossterm) for the terminal UI foundation.
+- Thanks to [sqlite-vec](https://github.com/asg017/sqlite-vec) and SQLite FTS5 for keeping local text and vector search embedded.
+- Thanks to [Candle](https://github.com/huggingface/candle), Hugging Face, and [intfloat/multilingual-e5-small](https://huggingface.co/intfloat/multilingual-e5-small) for local semantic embeddings.
+- Thanks to [kitup](https://github.com/samzong/kitup) for the bundled agent skill installer.
+- Thanks to [LINUX DO](https://linux.do/) for the open-source sharing community.
 
 ## License
 
-[MIT](LICENSE)
-
-## Acknowledgements
-
-Thanks to [tokscale](https://github.com/junhoyeo/tokscale) for the usage dashboard reference and token accounting behavior.
+This project is licensed under the [MIT](LICENSE) License.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,65 @@
+[English](./README.md) | **中文**
+
+# Recall
+
+> 本地优先，搜索你机器上所有 AI 编程会话。
+
+[![Recall](docs/recall.png)](https://asciinema.org/a/909453)
+
+在 Claude Code、Codex 以及后续各种 CLI 之间跳转；Recall 将这些分散在本地的会话收进一个可搜索的索引，在可用时跟踪 token 用量，并把你送回原始 CLI。
+
+## 安装
+
+```bash
+brew install samzong/tap/recall
+```
+
+## 用法
+
+```bash
+recall sync          # 增量同步（随时可安全运行）
+recall               # 启动 TUI
+recall usage         # 用量面板
+recall export > recall-export.jsonl # 导出全部会话
+recall import recall-export.jsonl --dry-run  # 预览导入
+recall session list  # 为 agent/脚本列出会话
+recall session share --id <session-id> --format json  # 发布选中的一个会话
+recall info  # 索引统计与 worker 状态
+```
+
+配合 Skill 使用时，**Recall** 是最佳方式。
+
+```bash
+recall skill install # 自动检测 agent 并安装 skills
+```
+
+## 支持
+
+一个索引覆盖所有 AI 编程 CLI。同步一次，处处搜索，从上次停下的地方继续。
+
+| 适配器          | 发现 | 全量索引 | 增量同步 | 语义搜索 | 导出 | 恢复 | 用量 |
+| --------------- | :--: | :------: | :------: | :------: | :--: | :--: | :--: |
+| Claude Code     |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| OpenCode        |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| Codex           |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| Pi              |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| Antigravity     |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |      |
+| Gemini          |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| Kiro            |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |      |
+| Copilot         |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |      |
+| Cursor          |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |  ✅  |
+| Cline           |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |      |
+| Grok            |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |      |
+
+## 致谢
+
+- 感谢 [tokscale](https://github.com/junhoyeo/tokscale) 提供的用量面板参考与 token 统计行为。
+- 感谢 [Ratatui](https://github.com/ratatui/ratatui) 与 [Crossterm](https://github.com/crossterm-rs/crossterm) 提供的终端 UI 基础。
+- 感谢 [sqlite-vec](https://github.com/asg017/sqlite-vec) 与 SQLite FTS5，让本地文本与向量搜索保持嵌入式。
+- 感谢 [Candle](https://github.com/huggingface/candle)、Hugging Face 与 [intfloat/multilingual-e5-small](https://huggingface.co/intfloat/multilingual-e5-small) 提供的本地语义嵌入。
+- 感谢 [kitup](https://github.com/samzong/kitup) 提供的内置 agent skill 安装器。
+- 感谢 [LINUX DO](https://linux.do/) 开源分享社区。
+
+## 许可证
+
+本项目采用 [MIT](LICENSE) 许可证。


### PR DESCRIPTION
### What's changed?

- Add `README.zh-CN.md` with a full Chinese translation of the README
- Add a language switcher at the top of both README files

### Why

- Make Recall easier to discover and use for Chinese-speaking users without changing the default English README on GitHub