### PR TITLE
fix(tui): clarify shortcut hints for search and detail views

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1346,10 +1346,8 @@ fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" resume  ", Style::default().fg(Color::DarkGray)),
         Span::styled("Ctrl+O", Style::default().fg(Color::Yellow)),
         Span::styled(" app  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" back  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("q", Style::default().fg(Color::Yellow)),
-        Span::styled(" quit", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc/q", Style::default().fg(Color::Yellow)),
+        Span::styled(" back", Style::default().fg(Color::DarkGray)),
     ];
 
     let status_line = if let Some(ref input) = app.viewing_search_input {
@@ -1970,9 +1968,11 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled(" settings  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("Esc", Style::default().fg(Color::Yellow)),
                     Span::styled(" clear  ", Style::default().fg(Color::DarkGray)),
-                    Span::styled("q", Style::default().fg(Color::Yellow)),
-                    Span::styled(" quit", Style::default().fg(Color::DarkGray)),
                 ];
+                if app.query.is_empty() {
+                    spans.push(Span::styled("q", Style::default().fg(Color::Yellow)));
+                    spans.push(Span::styled(" quit", Style::default().fg(Color::DarkGray)));
+                }
                 if let Some(span) = semantic_span.clone() {
                     spans.push(span);
                 }


### PR DESCRIPTION
Fixes #69.

- **Detail view:** both `Esc` and `q` return to Search (`handle_viewing_key`), so the footer now shows `Esc/q back` instead of the misleading `Esc back` + `q quit`.
- **Search view:** `q` only quits when the query is empty and focus is on the session list (`handle_search_key`). The `q quit` hint is now shown only in that state.

Key behavior is unchanged; this is a UI copy fix. `cargo test`, `fmt` and `clippy` all pass.