### PR TITLE
feat(tui): add scroll anchoring, mouse selection, and scrollbars

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Position, Rect};
 
 use crate::adapters::ResumeCommand;
 use crate::config::AppConfig;
@@ -15,7 +16,12 @@ use crate::repo_identity::RepoIdentityCache;
 use crate::session_action;
 use crate::skill_audit::{self, SkillAuditFilters, SkillAuditReport};
 use crate::transcript;
+use crate::tui::layout::{
+    MessagePane, SearchLayout, ViewingLayout, search_layout, vertical_scrollbar_position,
+    viewing_layout,
+};
 use crate::tui::search_worker::{SearchPhase, SearchRequest, SearchResponse, SearchWorker};
+use crate::tui::text_layout::wrap_visual_rows;
 use crate::types::{
     BackgroundJobStatus, MatchSource, Message, Role, SearchResult, SemanticProgress,
     SessionUsageEventRecord,
@@ -60,16 +66,20 @@ mod tests {
 
     fn app_with_sources() -> App {
         App {
+            terminal_area: Rect::new(0, 0, 80, 24),
             mode: AppMode::Search,
             panel_focus: PanelFocus::SessionList,
             query: String::new(),
             cursor_pos: 0,
             results: Vec::new(),
             selected_index: 0,
+            result_scroll_offset: 0,
             preview_messages: Vec::new(),
             preview_selected_msg: 0,
+            preview_scroll_offset: 0,
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
+            viewing_scroll_offset: 0,
             viewing_session_summary: None,
             all_sources: vec![
                 source("claude", "Claude"),
@@ -211,6 +221,99 @@ mod tests {
             source_path: None,
             raw_usage_json: None,
         }
+    }
+
+    fn numbered_results(count: usize) -> Vec<SearchResult> {
+        (0..count)
+            .map(|n| {
+                let mut result = codex_search_result();
+                result.session.id = format!("session{n}");
+                result.session.title = format!("Session {n}");
+                result
+            })
+            .collect()
+    }
+
+    #[test]
+    fn list_up_keeps_viewport_while_selection_remains_visible() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.set_terminal_size(80, 12);
+        app.results = numbered_results(6);
+        app.selected_index = 5;
+        app.result_scroll_offset = 1;
+
+        let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+        app.handle_key(up, &store);
+        assert_eq!(app.selected_index, 4);
+        assert_eq!(app.result_list_start(5), 1);
+
+        for _ in 0..3 {
+            app.handle_key(up, &store);
+        }
+        assert_eq!(app.selected_index, 1);
+        assert_eq!(app.result_list_start(5), 1);
+
+        app.handle_key(up, &store);
+        assert_eq!(app.selected_index, 0);
+        assert_eq!(app.result_list_start(5), 0);
+    }
+
+    #[test]
+    fn mouse_click_selects_visible_session_row() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.set_terminal_size(22, 12);
+        app.results = numbered_results(6);
+
+        app.handle_mouse_down(2, 6, &store);
+
+        assert!(app.panel_focus == PanelFocus::SessionList);
+        assert_eq!(app.selected_index, 1);
+    }
+
+    #[test]
+    fn mouse_click_selects_preview_message() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.set_terminal_size(80, 12);
+        app.results = numbered_results(1);
+        app.preview_messages =
+            vec![message(Role::User, None, 0), message(Role::Assistant, None, 1)];
+
+        app.handle_mouse_down(40, 8, &store);
+
+        assert!(app.panel_focus == PanelFocus::Preview);
+        assert_eq!(app.preview_selected_msg, 1);
+    }
+
+    #[test]
+    fn viewing_selection_anchors_scroll_offset() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.set_terminal_size(80, 10);
+        app.mode = AppMode::Viewing;
+        app.viewing_messages = (0..5).map(|n| message(Role::User, None, n)).collect();
+        app.viewing_sanitized_lines = build_viewing_caches(&app.viewing_messages);
+
+        let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+        let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+
+        app.handle_key(down, &store);
+        assert_eq!((app.viewing_selected_msg, app.viewing_scroll_offset), (1, 0));
+
+        app.handle_key(down, &store);
+        assert_eq!((app.viewing_selected_msg, app.viewing_scroll_offset), (2, 2));
+
+        app.handle_key(down, &store);
+        assert_eq!((app.viewing_selected_msg, app.viewing_scroll_offset), (3, 5));
+
+        app.handle_key(up, &store);
+        assert_eq!((app.viewing_selected_msg, app.viewing_scroll_offset), (2, 5));
     }
 
     #[test]
@@ -711,6 +814,12 @@ pub enum PanelFocus {
     Preview,
 }
 
+#[derive(Clone, Copy)]
+enum SearchMouseTarget {
+    SessionList(Option<usize>),
+    Preview,
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum FilterFocus {
     Source,
@@ -758,16 +867,20 @@ pub enum SortOrder {
 }
 
 pub struct App {
+    terminal_area: Rect,
     pub mode: AppMode,
     pub panel_focus: PanelFocus,
     pub query: String,
     pub cursor_pos: usize,
     pub results: Vec<SearchResult>,
     pub selected_index: usize,
+    pub result_scroll_offset: usize,
     pub preview_messages: Vec<Message>,
     pub preview_selected_msg: usize,
+    pub preview_scroll_offset: usize,
     pub viewing_messages: Vec<Message>,
     pub viewing_selected_msg: usize,
+    pub viewing_scroll_offset: usize,
     pub viewing_session_summary: Option<ViewingSessionSummary>,
     pub all_sources: Vec<(String, String)>,
     pub config: AppConfig,
@@ -848,16 +961,20 @@ impl App {
         let repo_filter = default_repo_filter(&config);
 
         let mut app = Self {
+            terminal_area: Rect::new(0, 0, 80, 24),
             mode: AppMode::Search,
             panel_focus: PanelFocus::SessionList,
             query: String::new(),
             cursor_pos: 0,
             results: Vec::new(),
             selected_index: 0,
+            result_scroll_offset: 0,
             preview_messages: Vec::new(),
             preview_selected_msg: 0,
+            preview_scroll_offset: 0,
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
+            viewing_scroll_offset: 0,
             viewing_session_summary: None,
             all_sources,
             config,
@@ -1063,6 +1180,7 @@ impl App {
             .map(|session| SearchResult { session, match_source: MatchSource::Fts, snippet: None })
             .collect();
         self.selected_index = 0;
+        self.result_scroll_offset = 0;
         self.panel_focus = PanelFocus::SessionList;
         self.search_pending = false;
         self.search_in_flight = false;
@@ -1080,7 +1198,13 @@ impl App {
         match self.mode {
             AppMode::Search => self.handle_search_key(key, store),
             AppMode::Usage => self.handle_usage_key(key, store),
-            AppMode::Viewing => self.handle_viewing_key(key),
+            AppMode::Viewing => {
+                let before = self.viewing_selected_msg;
+                self.handle_viewing_key(key);
+                if matches!(self.mode, AppMode::Viewing) && self.viewing_selected_msg != before {
+                    self.anchor_viewing_scroll();
+                }
+            }
             AppMode::ShareResult => self.handle_share_result_key(key),
             AppMode::ExportInput => self.handle_export_key(key),
             AppMode::Settings => self.handle_settings_key(key, store),
@@ -1088,6 +1212,10 @@ impl App {
             AppMode::HandoffTarget => self.handle_handoff_target_key(key),
             AppMode::ConfirmResume => self.handle_confirm_resume_key(key),
         }
+    }
+
+    pub fn set_terminal_size(&mut self, width: u16, height: u16) {
+        self.terminal_area = Rect::new(0, 0, width, height);
     }
 
     pub fn poll_share_publish(&mut self) {
@@ -1121,20 +1249,12 @@ impl App {
     pub fn handle_scroll_up(&mut self, store: &Store) {
         match self.mode {
             AppMode::Search => match self.panel_focus {
-                PanelFocus::SessionList => {
-                    if !self.results.is_empty() && self.selected_index > 0 {
-                        self.selected_index -= 1;
-                        self.load_preview(store);
-                    }
-                }
-                PanelFocus::Preview => {
-                    if self.preview_selected_msg > 0 {
-                        self.preview_selected_msg -= 1;
-                    }
-                }
+                PanelFocus::SessionList => self.scroll_result_list_up(store),
+                PanelFocus::Preview => self.move_preview_selection(true),
             },
             AppMode::Viewing if self.viewing_selected_msg > 0 => {
                 self.viewing_selected_msg -= 1;
+                self.anchor_viewing_scroll();
             }
             AppMode::Settings if self.settings_selected > 0 => {
                 self.settings_selected -= 1;
@@ -1167,20 +1287,12 @@ impl App {
     pub fn handle_scroll_down(&mut self, store: &Store) {
         match self.mode {
             AppMode::Search => match self.panel_focus {
-                PanelFocus::SessionList => {
-                    if self.selected_index + 1 < self.results.len() {
-                        self.selected_index += 1;
-                        self.load_preview(store);
-                    }
-                }
-                PanelFocus::Preview => {
-                    if self.preview_selected_msg + 1 < self.preview_messages.len() {
-                        self.preview_selected_msg += 1;
-                    }
-                }
+                PanelFocus::SessionList => self.scroll_result_list_down(store),
+                PanelFocus::Preview => self.move_preview_selection(false),
             },
             AppMode::Viewing if self.viewing_selected_msg + 1 < self.viewing_messages.len() => {
                 self.viewing_selected_msg += 1;
+                self.anchor_viewing_scroll();
             }
             AppMode::Settings if self.settings_selected + 1 < self.settings_row_count() => {
                 self.settings_selected += 1;
@@ -1211,6 +1323,324 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    fn scroll_result_list_up(&mut self, store: &Store) {
+        if self.results.is_empty() || self.selected_index == 0 {
+            return;
+        }
+
+        let visible_rows = search_layout(self.terminal_area).list_inner().height as usize;
+        let start = self.result_list_start(visible_rows);
+        self.selected_index -= 1;
+        if visible_rows > 0 && self.selected_index < start {
+            self.result_scroll_offset = self.selected_index;
+        } else {
+            self.result_scroll_offset = start;
+        }
+        self.load_preview(store);
+    }
+
+    fn scroll_result_list_down(&mut self, store: &Store) {
+        if self.selected_index + 1 >= self.results.len() {
+            return;
+        }
+
+        let visible_rows = search_layout(self.terminal_area).list_inner().height as usize;
+        let start = self.result_list_start(visible_rows);
+        self.selected_index += 1;
+        if visible_rows > 0 && self.selected_index >= start + visible_rows {
+            self.result_scroll_offset = self.selected_index + 1 - visible_rows;
+        } else {
+            self.result_scroll_offset = start;
+        }
+        self.load_preview(store);
+    }
+
+    pub fn result_list_start(&self, visible_rows: usize) -> usize {
+        if visible_rows == 0 || self.results.is_empty() {
+            return 0;
+        }
+
+        let selected_index = self.selected_index.min(self.results.len().saturating_sub(1));
+        let max_start = self.results.len().saturating_sub(visible_rows);
+        let start = self.result_scroll_offset.min(max_start);
+        if selected_index < start {
+            selected_index
+        } else if selected_index >= start + visible_rows {
+            selected_index + 1 - visible_rows
+        } else {
+            start
+        }
+    }
+
+    fn move_preview_selection(&mut self, up: bool) {
+        let can_move = if up {
+            self.preview_selected_msg > 0
+        } else {
+            self.preview_selected_msg + 1 < self.preview_messages.len()
+        };
+        if !can_move {
+            return;
+        }
+
+        let inner = search_layout(self.terminal_area).preview_inner();
+        let pane = self.preview_pane(inner.width as usize);
+        let viewport = inner.height as usize;
+        self.preview_scroll_offset =
+            pane.scroll_start(self.preview_scroll_offset, self.preview_selected_msg, viewport);
+        if up {
+            self.preview_selected_msg -= 1;
+        } else {
+            self.preview_selected_msg += 1;
+        }
+        self.preview_scroll_offset =
+            pane.scroll_start(self.preview_scroll_offset, self.preview_selected_msg, viewport);
+    }
+
+    fn anchor_viewing_scroll(&mut self) {
+        let messages = viewing_layout(self.terminal_area).messages;
+        let pane = self.viewing_pane(messages.width as usize);
+        self.viewing_scroll_offset = pane.scroll_start(
+            self.viewing_scroll_offset,
+            self.viewing_selected_msg,
+            messages.height as usize,
+        );
+    }
+
+    pub fn preview_pane(&self, inner_width: usize) -> MessagePane {
+        let mut rows = Vec::with_capacity(self.preview_messages.len());
+        let mut focus = Vec::with_capacity(self.preview_messages.len());
+        for msg in &self.preview_messages {
+            let text: String = msg.content.chars().take(300).collect();
+            let body: usize = text
+                .lines()
+                .take(6)
+                .map(|line| {
+                    let line = crate::utils::sanitize_line(line);
+                    wrap_visual_rows(&format!("  {line}"), inner_width).len()
+                })
+                .sum();
+            rows.push(body + 2);
+            focus.push(1 + usize::from(text.lines().next().is_some()));
+        }
+        MessagePane::new(rows, focus)
+    }
+
+    pub fn viewing_pane(&self, inner_width: usize) -> MessagePane {
+        let mut rows = Vec::with_capacity(self.viewing_messages.len());
+        let mut focus = Vec::with_capacity(self.viewing_messages.len());
+        for index in 0..self.viewing_messages.len() {
+            let lines = self.viewing_sanitized_lines.get(index);
+            let body: usize = lines
+                .map(|lines| {
+                    lines.iter().map(|line| wrap_visual_rows(&line.text, inner_width).len()).sum()
+                })
+                .unwrap_or(0);
+            rows.push(body + 2);
+            focus.push(1 + usize::from(lines.is_some_and(|lines| !lines.is_empty())));
+        }
+        MessagePane::new(rows, focus)
+    }
+
+    fn preview_message_at_row(&self, row: u16, layout: &SearchLayout) -> Option<(usize, usize)> {
+        let inner = layout.preview_inner();
+        if row < inner.y || row >= inner.bottom() {
+            return None;
+        }
+
+        let pane = self.preview_pane(inner.width as usize);
+        let start = pane.scroll_start(
+            self.preview_scroll_offset,
+            self.preview_selected_msg,
+            inner.height as usize,
+        );
+        pane.index_at(start + usize::from(row - inner.y)).map(|index| (index, start))
+    }
+
+    fn viewing_message_at_row(&self, row: u16, layout: &ViewingLayout) -> Option<(usize, usize)> {
+        let messages = layout.messages;
+        if row < messages.y || row >= messages.bottom() {
+            return None;
+        }
+
+        let pane = self.viewing_pane(messages.width as usize);
+        let start = pane.scroll_start(
+            self.viewing_scroll_offset,
+            self.viewing_selected_msg,
+            messages.height as usize,
+        );
+        pane.index_at(start + usize::from(row - messages.y)).map(|index| (index, start))
+    }
+
+    pub fn handle_mouse_down(&mut self, column: u16, row: u16, store: &Store) {
+        if matches!(self.mode, AppMode::Viewing) {
+            let layout = viewing_layout(self.terminal_area);
+            if self.handle_viewing_scrollbar_down(column, row, &layout) {
+                return;
+            }
+            if let Some((index, start)) = self.viewing_message_at_row(row, &layout) {
+                self.viewing_selected_msg = index;
+                self.viewing_scroll_offset = start;
+            }
+            return;
+        }
+
+        if !matches!(self.mode, AppMode::Search) {
+            return;
+        }
+
+        let layout = search_layout(self.terminal_area);
+        if self.handle_search_scrollbar_down(column, row, &layout, store) {
+            return;
+        }
+
+        match self.search_mouse_target(column, row, &layout) {
+            Some(SearchMouseTarget::SessionList(index)) => {
+                self.panel_focus = PanelFocus::SessionList;
+                if let Some(index) = index {
+                    self.result_scroll_offset =
+                        self.result_list_start(layout.list_inner().height as usize);
+                    self.selected_index = index;
+                    self.load_preview(store);
+                }
+            }
+            Some(SearchMouseTarget::Preview) if !self.preview_messages.is_empty() => {
+                self.panel_focus = PanelFocus::Preview;
+                if let Some((index, start)) = self.preview_message_at_row(row, &layout) {
+                    self.preview_selected_msg = index;
+                    self.preview_scroll_offset = start;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_search_scrollbar_down(
+        &mut self,
+        column: u16,
+        row: u16,
+        layout: &SearchLayout,
+        store: &Store,
+    ) -> bool {
+        let list_viewport = layout.list_inner().height as usize;
+        if let Some(position) =
+            vertical_scrollbar_position(column, row, layout.list, self.results.len(), list_viewport)
+        {
+            self.panel_focus = PanelFocus::SessionList;
+            self.result_scroll_offset = position;
+            self.selected_index = position.min(self.results.len().saturating_sub(1));
+            self.load_preview(store);
+            return true;
+        }
+
+        if self.preview_messages.is_empty() {
+            return false;
+        }
+
+        let inner = layout.preview_inner();
+        let pane = self.preview_pane(inner.width as usize);
+        if let Some(position) = vertical_scrollbar_position(
+            column,
+            row,
+            layout.preview,
+            pane.total_rows(),
+            inner.height as usize,
+        ) {
+            self.panel_focus = PanelFocus::Preview;
+            self.preview_scroll_offset = position;
+            if let Some(index) = pane.index_at(position) {
+                self.preview_selected_msg = index;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    fn handle_viewing_scrollbar_down(
+        &mut self,
+        column: u16,
+        row: u16,
+        layout: &ViewingLayout,
+    ) -> bool {
+        let messages = layout.messages;
+        let pane = self.viewing_pane(messages.width as usize);
+        if let Some(position) = vertical_scrollbar_position(
+            column,
+            row,
+            layout.scrollbar_area(),
+            pane.total_rows(),
+            messages.height as usize,
+        ) {
+            self.viewing_scroll_offset = position;
+            if let Some(index) = pane.index_at(position) {
+                self.viewing_selected_msg = index;
+            }
+            return true;
+        }
+
+        false
+    }
+
+    pub fn handle_mouse_scroll_up(&mut self, column: u16, row: u16, store: &Store) {
+        self.handle_mouse_scroll(column, row, true, store);
+    }
+
+    pub fn handle_mouse_scroll_down(&mut self, column: u16, row: u16, store: &Store) {
+        self.handle_mouse_scroll(column, row, false, store);
+    }
+
+    fn handle_mouse_scroll(&mut self, column: u16, row: u16, up: bool, store: &Store) {
+        if matches!(self.mode, AppMode::Search) {
+            let layout = search_layout(self.terminal_area);
+            match self.search_mouse_target(column, row, &layout) {
+                Some(SearchMouseTarget::SessionList(_)) => {
+                    self.panel_focus = PanelFocus::SessionList;
+                    if up {
+                        self.scroll_result_list_up(store);
+                    } else {
+                        self.scroll_result_list_down(store);
+                    }
+                    return;
+                }
+                Some(SearchMouseTarget::Preview) if !self.preview_messages.is_empty() => {
+                    self.panel_focus = PanelFocus::Preview;
+                    self.move_preview_selection(up);
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        if up { self.handle_scroll_up(store) } else { self.handle_scroll_down(store) }
+    }
+
+    fn search_mouse_target(
+        &self,
+        column: u16,
+        row: u16,
+        layout: &SearchLayout,
+    ) -> Option<SearchMouseTarget> {
+        let pos = Position { x: column, y: row };
+        if layout.list.contains(pos) {
+            let inner = layout.list_inner();
+            if !inner.contains(pos) {
+                return Some(SearchMouseTarget::SessionList(None));
+            }
+
+            let start = self.result_list_start(inner.height as usize);
+            let index = start + usize::from(row - inner.y);
+            return Some(SearchMouseTarget::SessionList(
+                (index < self.results.len()).then_some(index),
+            ));
+        }
+
+        if layout.preview.contains(pos) {
+            return Some(SearchMouseTarget::Preview);
+        }
+
+        None
     }
 
     fn handle_search_key(&mut self, key: KeyEvent, store: &Store) {
@@ -1290,6 +1720,7 @@ impl App {
                 } else if !self.preview_messages.is_empty() {
                     self.panel_focus = PanelFocus::Preview;
                     self.preview_selected_msg = 0;
+                    self.preview_scroll_offset = 0;
                 }
             }
             KeyCode::Up => {
@@ -1361,6 +1792,7 @@ impl App {
                 self.mode = AppMode::Search;
                 self.viewing_messages.clear();
                 self.viewing_selected_msg = 0;
+                self.viewing_scroll_offset = 0;
                 self.viewing_session_summary = None;
                 self.viewing_search_query.clear();
                 self.viewing_search_status = None;
@@ -2296,6 +2728,7 @@ impl App {
                 self.apply_sort(&mut results);
                 self.results = results;
                 self.selected_index = 0;
+                self.result_scroll_offset = 0;
                 self.panel_focus = PanelFocus::SessionList;
                 self.load_preview(store);
 
@@ -2550,6 +2983,7 @@ impl App {
                     })
                     .collect();
                 self.selected_index = 0;
+                self.result_scroll_offset = 0;
                 self.panel_focus = PanelFocus::SessionList;
                 self.mode = AppMode::Search;
                 self.query = format!("skill:{skill_id}");
@@ -2653,6 +3087,7 @@ impl App {
 
     fn load_preview(&mut self, store: &Store) {
         self.preview_selected_msg = 0;
+        self.preview_scroll_offset = 0;
         if let Some(result) = self.results.get(self.selected_index) {
             match store.get_messages(&result.session.id) {
                 Ok(msgs) => {
@@ -2681,6 +3116,7 @@ impl App {
             self.viewing_sanitized_lines = build_viewing_caches(&msgs);
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;
+            self.viewing_scroll_offset = 0;
             self.viewing_search_query.clear();
             self.viewing_search_input = None;
             self.viewing_search_input_cursor = 0;

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,12 +1,15 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyEvent, KeyEventKind, MouseEvent, MouseEventKind};
+use crossterm::event::{
+    self, Event, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
+};
 
 pub enum AppEvent {
     Key(KeyEvent),
-    ScrollUp,
-    ScrollDown,
+    MouseDown { column: u16, row: u16 },
+    ScrollUp { column: u16, row: u16 },
+    ScrollDown { column: u16, row: u16 },
     Tick,
 }
 
@@ -14,9 +17,13 @@ pub fn poll_event(tick_rate: Duration) -> Result<AppEvent> {
     if event::poll(tick_rate)? {
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => return Ok(AppEvent::Key(key)),
-            Event::Mouse(MouseEvent { kind, .. }) => match kind {
-                MouseEventKind::ScrollUp => return Ok(AppEvent::ScrollUp),
-                MouseEventKind::ScrollDown => return Ok(AppEvent::ScrollDown),
+            Event::Mouse(MouseEvent { kind, column, row, .. }) => match kind {
+                MouseEventKind::Down(MouseButton::Left)
+                | MouseEventKind::Drag(MouseButton::Left) => {
+                    return Ok(AppEvent::MouseDown { column, row });
+                }
+                MouseEventKind::ScrollUp => return Ok(AppEvent::ScrollUp { column, row }),
+                MouseEventKind::ScrollDown => return Ok(AppEvent::ScrollDown { column, row }),
                 _ => {}
             },
             _ => {}

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -1,0 +1,222 @@
+use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
+
+pub struct SearchLayout {
+    pub search_box: Rect,
+    pub filters: Rect,
+    pub list: Rect,
+    pub preview: Rect,
+    pub status: Rect,
+}
+
+impl SearchLayout {
+    pub fn list_inner(&self) -> Rect {
+        self.list.inner(Margin { horizontal: 1, vertical: 1 })
+    }
+
+    pub fn preview_inner(&self) -> Rect {
+        self.preview.inner(Margin { horizontal: 1, vertical: 1 })
+    }
+}
+
+pub fn search_layout(area: Rect) -> SearchLayout {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(5),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(outer[2]);
+
+    SearchLayout {
+        search_box: outer[0],
+        filters: outer[1],
+        list: main[0],
+        preview: main[1],
+        status: outer[3],
+    }
+}
+
+pub struct ViewingLayout {
+    pub content: Rect,
+    pub summary: Rect,
+    pub messages: Rect,
+    pub help: Rect,
+}
+
+impl ViewingLayout {
+    pub fn scrollbar_area(&self) -> Rect {
+        Rect::new(
+            self.content.x,
+            self.messages.y.saturating_sub(1),
+            self.content.width,
+            self.messages.height.saturating_add(2),
+        )
+    }
+}
+
+pub fn viewing_layout(area: Rect) -> ViewingLayout {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(1)])
+        .split(area);
+
+    let inner = outer[0].inner(Margin { horizontal: 1, vertical: 1 });
+    let content = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
+        .split(inner);
+
+    ViewingLayout { content: outer[0], summary: content[0], messages: content[1], help: outer[1] }
+}
+
+pub struct MessagePane {
+    rows: Vec<usize>,
+    focus: Vec<usize>,
+}
+
+impl MessagePane {
+    pub fn new(rows: Vec<usize>, focus: Vec<usize>) -> Self {
+        debug_assert_eq!(rows.len(), focus.len());
+        Self { rows, focus }
+    }
+
+    pub fn total_rows(&self) -> usize {
+        self.rows.iter().sum()
+    }
+
+    pub fn start_of(&self, index: usize) -> usize {
+        self.rows.iter().take(index).sum()
+    }
+
+    pub fn index_at(&self, row: usize) -> Option<usize> {
+        let mut end = 0usize;
+        for (index, count) in self.rows.iter().enumerate() {
+            end += count;
+            if row < end {
+                return Some(index);
+            }
+        }
+        None
+    }
+
+    pub fn scroll_start(&self, offset: usize, selected: usize, viewport_rows: usize) -> usize {
+        if viewport_rows == 0 || self.rows.is_empty() {
+            return 0;
+        }
+
+        let max_start = self.total_rows().saturating_sub(viewport_rows);
+        let start = offset.min(max_start);
+        let selected = selected.min(self.rows.len() - 1);
+        let selected_start = self.start_of(selected);
+        let focus_end = selected_start + self.focus[selected].min(viewport_rows);
+
+        if selected_start < start {
+            selected_start.min(max_start)
+        } else if focus_end > start + viewport_rows {
+            (focus_end - viewport_rows).min(max_start)
+        } else {
+            start
+        }
+    }
+}
+
+pub fn vertical_scrollbar_position(
+    column: u16,
+    row: u16,
+    area: Rect,
+    content_len: usize,
+    viewport_len: usize,
+) -> Option<usize> {
+    if viewport_len == 0 || content_len <= viewport_len {
+        return None;
+    }
+
+    let track = area.inner(Margin { horizontal: 0, vertical: 1 });
+    if track.width == 0 || track.height == 0 {
+        return None;
+    }
+
+    let bar_column = track.x + track.width - 1;
+    if column != bar_column || row < track.y || row >= track.bottom() {
+        return None;
+    }
+
+    let max_position = content_len - viewport_len;
+    let rel = usize::from(row - track.y);
+    match usize::from(track.height - 1) {
+        0 => Some(0),
+        denom => Some((rel * max_position + denom / 2) / denom),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pane() -> MessagePane {
+        MessagePane::new(vec![3, 3, 3, 3, 3], vec![2, 2, 2, 2, 2])
+    }
+
+    #[test]
+    fn scroll_start_keeps_viewport_while_selection_visible() {
+        let pane = pane();
+        assert_eq!(pane.scroll_start(2, 1, 6), 2);
+        assert_eq!(pane.scroll_start(2, 2, 6), 2);
+    }
+
+    #[test]
+    fn scroll_start_follows_selection_above_viewport() {
+        let pane = pane();
+        assert_eq!(pane.scroll_start(6, 1, 6), 3);
+        assert_eq!(pane.scroll_start(6, 0, 6), 0);
+    }
+
+    #[test]
+    fn scroll_start_follows_selection_focus_below_viewport() {
+        let pane = pane();
+        assert_eq!(pane.scroll_start(0, 2, 6), 2);
+        assert_eq!(pane.scroll_start(0, 4, 6), 8);
+    }
+
+    #[test]
+    fn scroll_start_clamps_stale_offset() {
+        let pane = pane();
+        assert_eq!(pane.scroll_start(100, 4, 6), 9);
+    }
+
+    #[test]
+    fn index_at_maps_rows_to_messages() {
+        let pane = pane();
+        assert_eq!(pane.index_at(0), Some(0));
+        assert_eq!(pane.index_at(2), Some(0));
+        assert_eq!(pane.index_at(3), Some(1));
+        assert_eq!(pane.index_at(14), Some(4));
+        assert_eq!(pane.index_at(15), None);
+    }
+
+    #[test]
+    fn search_layout_partitions_main_area() {
+        for width in 20u16..=200 {
+            let layout = search_layout(Rect::new(0, 0, width, 24));
+            assert_eq!(layout.list.width + layout.preview.width, width);
+            assert_eq!(layout.preview.x, layout.list.x + layout.list.width);
+        }
+    }
+
+    #[test]
+    fn scrollbar_position_maps_track_ends() {
+        let area = Rect::new(0, 4, 20, 10);
+        let bar = area.x + area.width - 1;
+        assert_eq!(vertical_scrollbar_position(bar, 5, area, 100, 8), Some(0));
+        assert_eq!(vertical_scrollbar_position(bar, 12, area, 100, 8), Some(92));
+        assert_eq!(vertical_scrollbar_position(bar - 1, 5, area, 100, 8), None);
+        assert_eq!(vertical_scrollbar_position(bar, 5, area, 8, 8), None);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,7 @@
 pub mod app;
 pub mod event;
+pub mod layout;
 pub mod runner;
 pub mod search_worker;
+pub mod text_layout;
 pub mod ui;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -72,12 +72,15 @@ pub fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Res
         }
         terminal.draw(|f| ui::render(f, &app))?;
 
+        let size = terminal.size()?;
+        app.set_terminal_size(size.width, size.height);
         match poll_event(tick_rate)? {
-            AppEvent::Key(key) => {
-                app.handle_key(key, &store);
+            AppEvent::Key(key) => app.handle_key(key, &store),
+            AppEvent::MouseDown { column, row } => app.handle_mouse_down(column, row, &store),
+            AppEvent::ScrollUp { column, row } => app.handle_mouse_scroll_up(column, row, &store),
+            AppEvent::ScrollDown { column, row } => {
+                app.handle_mouse_scroll_down(column, row, &store);
             }
-            AppEvent::ScrollUp => app.handle_scroll_up(&store),
-            AppEvent::ScrollDown => app.handle_scroll_down(&store),
             AppEvent::Tick => {}
         }
 

--- a/src/tui/text_layout.rs
+++ b/src/tui/text_layout.rs
@@ -1,0 +1,73 @@
+use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthChar;
+
+pub fn wrap_visual_rows(text: &str, width: usize) -> Vec<String> {
+    wrap_spans_to_lines(vec![Span::raw(text.to_string())], width)
+        .into_iter()
+        .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+        .collect()
+}
+
+pub fn wrap_spans_to_lines(spans: Vec<Span<'static>>, width: usize) -> Vec<Line<'static>> {
+    let width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current = Vec::new();
+    let mut current_width = 0usize;
+
+    for span in spans {
+        let mut segment = String::new();
+        for ch in span.content.chars() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if ch_width > 0 && current_width > 0 && current_width + ch_width > width {
+                if !segment.is_empty() {
+                    current.push(Span::styled(std::mem::take(&mut segment), span.style));
+                }
+                lines.push(Line::from(std::mem::take(&mut current)));
+                current_width = 0;
+            }
+            segment.push(ch);
+            current_width += ch_width;
+            if current_width >= width && current_width > 0 {
+                current.push(Span::styled(std::mem::take(&mut segment), span.style));
+                lines.push(Line::from(std::mem::take(&mut current)));
+                current_width = 0;
+            }
+        }
+
+        if !segment.is_empty() {
+            current.push(Span::styled(segment, span.style));
+        }
+    }
+
+    if !current.is_empty() || lines.is_empty() {
+        lines.push(Line::from(current));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::{Color, Style};
+
+    use super::*;
+
+    #[test]
+    fn wraps_by_visual_width_including_wide_chars() {
+        assert_eq!(wrap_visual_rows("abcdef", 4), vec!["abcd", "ef"]);
+        assert_eq!(wrap_visual_rows("ＡＢＣＤ", 3), vec!["Ａ", "Ｂ", "Ｃ", "Ｄ"]);
+        assert_eq!(wrap_visual_rows("", 4), vec![""]);
+    }
+
+    #[test]
+    fn span_boundaries_do_not_change_wrap_points() {
+        let styled = vec![
+            Span::styled("abc".to_string(), Style::default().fg(Color::Red)),
+            Span::raw("def".to_string()),
+        ];
+        let wrapped: Vec<String> = wrap_spans_to_lines(styled, 4)
+            .into_iter()
+            .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+            .collect();
+        assert_eq!(wrapped, wrap_visual_rows("abcdef", 4));
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2,10 +2,14 @@ use std::collections::BTreeMap;
 
 use chrono::{Datelike, Duration, Local, NaiveDate};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::scrollbar;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, Borders, Clear, List, ListItem, Paragraph, Scrollbar, ScrollbarOrientation,
+    ScrollbarState, Wrap,
+};
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::search::TimeRange;
@@ -15,6 +19,8 @@ use crate::tui::app::{
     App, AppMode, FilterFocus, PanelFocus, PendingCommandAction, ProjectPickerRow, ResumeOrigin,
     SanitizedLine, SourcePickerRow, UsageTab,
 };
+use crate::tui::layout::{search_layout, viewing_layout};
+use crate::tui::text_layout::{wrap_spans_to_lines, wrap_visual_rows};
 use crate::types::{MatchSource, Role};
 use crate::usage::{TokenTotals, UsageReport};
 
@@ -56,14 +62,48 @@ fn highlight_spans(text: &str, hay: &str, needle_lower: &str, base: Style) -> Ve
     spans
 }
 
-fn scroll_offset(selected_line_start: usize, inner_height: usize) -> u16 {
-    if inner_height == 0 {
-        0
-    } else if selected_line_start + 4 > inner_height {
-        (selected_line_start + 4).saturating_sub(inner_height) as u16
-    } else {
-        0
+fn row_visible(row: usize, viewport_start: usize, viewport_end: usize) -> bool {
+    row >= viewport_start && row < viewport_end
+}
+
+fn line_with_background(mut line: Line<'static>, bg: Color) -> Line<'static> {
+    if bg == Color::Reset {
+        return line;
     }
+
+    for span in &mut line.spans {
+        if span.style.bg.is_none() {
+            span.style.bg = Some(bg);
+        }
+    }
+    line
+}
+
+fn render_vertical_scrollbar(
+    f: &mut Frame,
+    area: Rect,
+    content_len: usize,
+    viewport_len: usize,
+    position: usize,
+) {
+    if viewport_len == 0 || content_len <= viewport_len {
+        return;
+    }
+
+    let mut state =
+        ScrollbarState::new(content_len).viewport_content_length(viewport_len).position(position);
+    f.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .symbols(scrollbar::VERTICAL)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .thumb_symbol("▌")
+            .track_symbol(Some("▌"))
+            .thumb_style(Style::default().fg(Color::Cyan))
+            .track_style(Style::default().fg(Color::DarkGray)),
+        area.inner(Margin { vertical: 1, horizontal: 0 }),
+        &mut state,
+    );
 }
 
 pub fn render(f: &mut Frame, app: &App) {
@@ -930,29 +970,13 @@ fn format_compact(value: i64) -> String {
 }
 
 fn render_search(f: &mut Frame, app: &App) {
-    let area = f.area();
+    let layout = search_layout(f.area());
 
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3),
-            Constraint::Length(1),
-            Constraint::Min(5),
-            Constraint::Length(1),
-        ])
-        .split(area);
-
-    render_search_box(f, app, outer[0]);
-    render_filters(f, app, outer[1]);
-
-    let main_area = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
-        .split(outer[2]);
-
-    render_result_list(f, app, main_area[0]);
-    render_preview(f, app, main_area[1]);
-    render_status_bar(f, app, outer[3]);
+    render_search_box(f, app, layout.search_box);
+    render_filters(f, app, layout.filters);
+    render_result_list(f, app, layout.list);
+    render_preview(f, app, layout.preview);
+    render_status_bar(f, app, layout.status);
 }
 
 fn render_search_box(f: &mut Frame, app: &App, area: Rect) {
@@ -1106,8 +1130,13 @@ fn filter_overview_line(
 fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
     let focused = app.panel_focus == PanelFocus::SessionList;
     let border_color = if focused { Color::Cyan } else { Color::DarkGray };
+    let title = if app.results.is_empty() {
+        " Sessions (0) ".to_string()
+    } else {
+        format!(" Sessions [{}/{}] ", app.selected_index + 1, app.results.len())
+    };
     let block = Block::default()
-        .title(format!(" Sessions ({}) ", app.results.len()))
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
@@ -1119,12 +1148,7 @@ fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
     }
 
     let visible_rows = block.inner(area).height as usize;
-    let selected_index = app.selected_index.min(app.results.len().saturating_sub(1));
-    let start = if visible_rows == 0 {
-        0
-    } else {
-        selected_index.saturating_add(1).saturating_sub(visible_rows)
-    };
+    let start = app.result_list_start(visible_rows);
     let end = (start + visible_rows).min(app.results.len());
 
     let items: Vec<ListItem> = app.results[start..end]
@@ -1142,29 +1166,46 @@ fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
             };
             let title: String = s.title.chars().take(40).collect();
             let selected = i == app.selected_index;
+            let active_selected = focused && selected;
+            let passive_selected = selected && !focused;
+            let selected_text_style = if active_selected {
+                Style::default().fg(Color::Black)
+            } else if passive_selected {
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
 
             let line = Line::from(vec![
                 Span::styled(
                     source_label.to_string(),
-                    Style::default().fg(if selected { Color::Black } else { Color::Green }),
+                    if selected { selected_text_style } else { Style::default().fg(Color::Green) },
                 ),
                 Span::raw(" "),
                 Span::styled(
                     match_label.to_string(),
-                    Style::default().fg(if selected { Color::Black } else { Color::DarkGray }),
+                    if selected {
+                        selected_text_style
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    },
                 ),
                 Span::raw(" "),
                 Span::styled(
                     title,
-                    Style::default().fg(if selected { Color::Black } else { Color::White }),
+                    if selected { selected_text_style } else { Style::default().fg(Color::White) },
                 ),
                 Span::styled(
                     format!("  {age}"),
-                    Style::default().fg(if selected { Color::Black } else { Color::DarkGray }),
+                    if selected {
+                        selected_text_style
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    },
                 ),
             ]);
 
-            ListItem::new(line).style(if selected {
+            ListItem::new(line).style(if active_selected {
                 Style::default().bg(Color::Cyan).add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -1174,6 +1215,7 @@ fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
 
     let list = List::new(items).block(block);
     f.render_widget(list, area);
+    render_vertical_scrollbar(f, area, app.results.len(), visible_rows, start);
 }
 
 fn render_preview(f: &mut Frame, app: &App, area: Rect) {
@@ -1207,9 +1249,17 @@ fn render_preview(f: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
+    let inner = block.inner(area);
+    let inner_width = inner.width as usize;
+    let pane = app.preview_pane(inner_width);
+    let viewport_start = pane.scroll_start(
+        app.preview_scroll_offset,
+        app.preview_selected_msg,
+        inner.height as usize,
+    );
+    let viewport_end = viewport_start + inner.height as usize;
+    let mut visual_row = 0usize;
     let mut lines: Vec<Line> = Vec::new();
-    let mut selected_line_start: usize = 0;
-
     for (i, msg) in app.preview_messages.iter().enumerate() {
         let selected = focused && i == app.preview_selected_msg;
         let (prefix, color) = match msg.role {
@@ -1217,46 +1267,50 @@ fn render_preview(f: &mut Frame, app: &App, area: Rect) {
             Role::Assistant => ("Asst: ", Color::Green),
         };
 
-        if selected {
-            selected_line_start = lines.len();
-        }
-
-        let bg = if selected { Color::DarkGray } else { Color::Reset };
-
         let time_str = crate::utils::format_message_time(msg.timestamp);
+        let header_bg = if selected && row_visible(visual_row, viewport_start, viewport_end) {
+            Color::DarkGray
+        } else {
+            Color::Reset
+        };
         let mut header = vec![Span::styled(
             prefix,
-            Style::default().fg(color).bg(bg).add_modifier(Modifier::BOLD),
+            Style::default().fg(color).bg(header_bg).add_modifier(Modifier::BOLD),
         )];
         if !time_str.is_empty() {
-            header.push(Span::styled(time_str, Style::default().fg(Color::DarkGray).bg(bg)));
+            header.push(Span::styled(time_str, Style::default().fg(Color::DarkGray).bg(header_bg)));
         }
         lines.push(Line::from(header));
+        visual_row += 1;
 
         let text: String = msg.content.chars().take(300).collect();
         for line in text.lines().take(6) {
             let line = crate::utils::sanitize_line(line);
-            lines.push(Line::from(Span::styled(
-                format!("  {line}"),
-                Style::default().fg(Color::White).bg(bg),
-            )));
+            let line = format!("  {line}");
+            for row in wrap_visual_rows(&line, inner_width) {
+                let body_bg = if selected && row_visible(visual_row, viewport_start, viewport_end) {
+                    Color::DarkGray
+                } else {
+                    Color::Reset
+                };
+                lines.push(Line::from(Span::styled(
+                    row,
+                    Style::default().fg(Color::White).bg(body_bg),
+                )));
+                visual_row += 1;
+            }
         }
         lines.push(Line::from(""));
+        visual_row += 1;
     }
 
-    let scroll = scroll_offset(selected_line_start, block.inner(area).height as usize);
-
-    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: false }).scroll((scroll, 0));
+    let p = Paragraph::new(lines).block(block).scroll((viewport_start as u16, 0));
     f.render_widget(p, area);
+    render_vertical_scrollbar(f, area, pane.total_rows(), inner.height as usize, viewport_start);
 }
 
 fn render_viewing(f: &mut Frame, app: &App) {
-    let area = f.area();
-
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(1)])
-        .split(area);
+    let layout = viewing_layout(f.area());
 
     let session_info = app
         .results
@@ -1274,15 +1328,18 @@ fn render_viewing(f: &mut Frame, app: &App) {
         .title(session_info)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
-    let content_area = block.inner(outer[0]);
-    f.render_widget(block, outer[0]);
-    let content = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(1)])
-        .split(content_area);
+    f.render_widget(block, layout.content);
 
+    let inner_width = layout.messages.width as usize;
+    let pane = app.viewing_pane(inner_width);
+    let viewport_start = pane.scroll_start(
+        app.viewing_scroll_offset,
+        app.viewing_selected_msg,
+        layout.messages.height as usize,
+    );
+    let viewport_end = viewport_start + layout.messages.height as usize;
+    let mut visual_row = 0usize;
     let mut lines: Vec<Line> = Vec::new();
-    let mut selected_line_start: usize = 0;
     let needle_lower = app.viewing_search_query.to_lowercase();
 
     for (i, msg) in app.viewing_messages.iter().enumerate() {
@@ -1292,40 +1349,54 @@ fn render_viewing(f: &mut Frame, app: &App) {
             Role::Assistant => ("Assistant", Color::Green),
         };
 
-        if selected {
-            selected_line_start = lines.len();
-        }
-
-        let bg = if selected { Color::DarkGray } else { Color::Reset };
-
         let time_str = crate::utils::format_message_time(msg.timestamp);
+        let header_bg = if selected && row_visible(visual_row, viewport_start, viewport_end) {
+            Color::DarkGray
+        } else {
+            Color::Reset
+        };
         let mut header = vec![Span::styled(
             format!("── {prefix} ──"),
-            Style::default().fg(color).bg(bg).add_modifier(Modifier::BOLD),
+            Style::default().fg(color).bg(header_bg).add_modifier(Modifier::BOLD),
         )];
         if !time_str.is_empty() {
             header.push(Span::styled(
                 format!("  {time_str}"),
-                Style::default().fg(Color::DarkGray).bg(bg),
+                Style::default().fg(Color::DarkGray).bg(header_bg),
             ));
         }
         lines.push(Line::from(header));
+        visual_row += 1;
 
-        let body_style = Style::default().fg(Color::White).bg(bg);
         let empty: Vec<SanitizedLine> = Vec::new();
         let cached_lines = app.viewing_sanitized_lines.get(i).unwrap_or(&empty);
         for sl in cached_lines {
+            let body_style = Style::default().fg(Color::White);
             let spans = highlight_spans(&sl.text, &sl.lower, &needle_lower, body_style);
-            lines.push(Line::from(spans));
+            for line in wrap_spans_to_lines(spans, inner_width) {
+                let body_bg = if selected && row_visible(visual_row, viewport_start, viewport_end) {
+                    Color::DarkGray
+                } else {
+                    Color::Reset
+                };
+                lines.push(line_with_background(line, body_bg));
+                visual_row += 1;
+            }
         }
         lines.push(Line::from(""));
+        visual_row += 1;
     }
 
-    let scroll = scroll_offset(selected_line_start, content[1].height as usize);
-
-    render_viewing_summary(f, app, content[0]);
-    let p = Paragraph::new(lines).wrap(Wrap { trim: false }).scroll((scroll, 0));
-    f.render_widget(p, content[1]);
+    render_viewing_summary(f, app, layout.summary);
+    let p = Paragraph::new(lines).scroll((viewport_start as u16, 0));
+    f.render_widget(p, layout.messages);
+    render_vertical_scrollbar(
+        f,
+        layout.scrollbar_area(),
+        pane.total_rows(),
+        layout.messages.height as usize,
+        viewport_start,
+    );
 
     let help_spans = vec![
         Span::styled(" ↑/↓", Style::default().fg(Color::Yellow)),
@@ -1381,11 +1452,11 @@ fn render_viewing(f: &mut Frame, app: &App) {
 
     if let Some(ref input) = app.viewing_search_input {
         let cursor_byte = app.viewing_search_input_cursor.min(input.len());
-        let cursor_x = outer[1].x + 2 + UnicodeWidthStr::width(&input[..cursor_byte]) as u16;
-        f.set_cursor_position((cursor_x, outer[1].y));
+        let cursor_x = layout.help.x + 2 + UnicodeWidthStr::width(&input[..cursor_byte]) as u16;
+        f.set_cursor_position((cursor_x, layout.help.y));
     }
 
-    f.render_widget(Paragraph::new(status_line), outer[1]);
+    f.render_widget(Paragraph::new(status_line), layout.help);
 }
 
 fn render_handoff_target_picker(f: &mut Frame, app: &App) {
@@ -2012,6 +2083,76 @@ mod tests {
     use crate::tui::app::{SharePopup, ViewingSessionSummary};
     use crate::types::{Message, SearchResult, Session};
 
+    fn numbered_session_result(n: usize) -> SearchResult {
+        SearchResult {
+            session: Session {
+                id: format!("session{n}"),
+                source: "codex".to_string(),
+                source_id: format!("source{n}"),
+                title: format!("Session {n}"),
+                directory: None,
+                repo_remote: None,
+                repo_slug: None,
+                repo_name: None,
+                started_at: 0,
+                updated_at: None,
+                message_count: 1,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: None,
+                is_import: false,
+            },
+            match_source: MatchSource::Fts,
+            snippet: None,
+        }
+    }
+
+    fn render_to_text(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, app)).unwrap();
+        (0..height)
+            .map(|y| buffer_row(terminal.backend().buffer(), y, width))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn render_result_list_scrolls_selected_row_into_view() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.results = (1..=6).map(numbered_session_result).collect();
+        app.selected_index = 3;
+
+        let rendered = render_to_text(&app, 80, 10);
+
+        assert!(rendered.contains("Sessions [4/6]"));
+        assert!(!rendered.contains("Session 1"));
+        assert!(rendered.contains("Session 2"));
+        assert!(rendered.contains("Session 4"));
+    }
+
+    #[test]
+    fn render_result_list_keeps_viewport_when_selection_is_visible() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.results = (1..=6).map(numbered_session_result).collect();
+        app.selected_index = 1;
+        app.result_scroll_offset = 1;
+
+        let rendered = render_to_text(&app, 80, 10);
+
+        assert!(!rendered.contains("Session 1"));
+        assert!(rendered.contains("Session 2"));
+        assert!(rendered.contains("Session 4"));
+    }
+
     #[test]
     fn render_viewing_shows_one_line_session_summary_below_title() {
         crate::db::schema::register_sqlite_vec();
@@ -2187,53 +2328,6 @@ mod tests {
         assert!(rendered.contains("OpenCode (opencode)"));
         assert!(rendered.contains("[Enter]"));
         assert!(rendered.contains("select"));
-    }
-
-    #[test]
-    fn render_result_list_scrolls_selected_row_into_view() {
-        crate::db::schema::register_sqlite_vec();
-        let store = Store::open_in_memory().unwrap();
-        let mut app =
-            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
-        app.results = (1..=6)
-            .map(|n| SearchResult {
-                session: Session {
-                    id: format!("session{n}"),
-                    source: "codex".to_string(),
-                    source_id: format!("source{n}"),
-                    title: format!("Session {n}"),
-                    directory: None,
-                    repo_remote: None,
-                    repo_slug: None,
-                    repo_name: None,
-                    started_at: 0,
-                    updated_at: None,
-                    message_count: 1,
-                    entrypoint: None,
-                    custom_title: None,
-                    summary: None,
-                    duration_minutes: None,
-                    source_file_path: None,
-                    is_import: false,
-                },
-                match_source: MatchSource::Fts,
-                snippet: None,
-            })
-            .collect();
-        app.selected_index = 3;
-
-        let backend = TestBackend::new(80, 10);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render(f, &app)).unwrap();
-        let rendered = (0..10)
-            .map(|y| buffer_row(terminal.backend().buffer(), y, 80))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(!rendered.contains("Session 1"));
-        assert!(rendered.contains("Session 2"));
-        assert!(rendered.contains("Session 3"));
-        assert!(rendered.contains("Session 4"));
     }
 
     fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {


### PR DESCRIPTION
### What's changed?

- Extract `layout` and `text_layout` helpers for pane geometry and visual-width wrapping
- Anchor scroll offsets so selection stays visible when navigating session lists and message panes
- Add mouse click selection for the session list, preview panel, and viewing mode
- Render vertical scrollbars for long session lists and message panes

### Why

- Fixes scroll behavior where moving selection up from the bottom incorrectly rolled the viewport (#74)
- Keeps dialogue history anchored instead of jumping when navigating (#73)
- Enables mouse click to select sessions and messages (#72)
- Adds scrollbars for long lists (#77)

Closes #72
Closes #73
Closes #74
Closes #77