### PR TITLE
feat(tui): seed viewing search from list query

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -317,6 +317,70 @@ mod tests {
     }
 
     #[test]
+    fn enter_viewing_seeds_search_query_and_jumps_to_first_match() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        let result = codex_search_result();
+        store.insert_session(&result.session).unwrap();
+        let mut first = message(Role::User, None, 0);
+        first.content = "intro".to_string();
+        let mut second = message(Role::Assistant, None, 1);
+        second.content = "Deploy finished".to_string();
+        store.insert_messages(&[first, second]).unwrap();
+        app.results = vec![result];
+        app.query = "deploy missing".to_string();
+
+        app.enter_viewing(&store);
+
+        assert!(matches!(app.mode, AppMode::Viewing));
+        assert_eq!(app.viewing_search_query, "deploy missing");
+        assert_eq!(app.viewing_match_indices(), &[1]);
+        assert_eq!(app.viewing_selected_msg, 1);
+    }
+
+    #[test]
+    fn enter_viewing_strips_punctuation_from_seeded_query_like_fts() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        let result = codex_search_result();
+        store.insert_session(&result.session).unwrap();
+        let mut first = message(Role::User, None, 0);
+        first.content = "intro".to_string();
+        let mut second = message(Role::Assistant, None, 1);
+        second.content = "run deploy(now) with config.yaml".to_string();
+        store.insert_messages(&[first, second]).unwrap();
+        app.results = vec![result];
+        app.query = "deploy() config.yaml".to_string();
+
+        app.enter_viewing(&store);
+
+        assert_eq!(app.viewing_search_query, "deploy config yaml");
+        assert_eq!(app.viewing_match_indices(), &[1]);
+        assert_eq!(app.viewing_selected_msg, 1);
+    }
+
+    #[test]
+    fn enter_viewing_with_blank_query_starts_at_first_message() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        let result = codex_search_result();
+        store.insert_session(&result.session).unwrap();
+        store.insert_messages(&[message(Role::User, None, 0)]).unwrap();
+        app.results = vec![result];
+        app.query = "   ".to_string();
+
+        app.enter_viewing(&store);
+
+        assert!(matches!(app.mode, AppMode::Viewing));
+        assert!(app.viewing_search_query.is_empty());
+        assert!(app.viewing_match_indices().is_empty());
+        assert_eq!(app.viewing_selected_msg, 0);
+    }
+
+    #[test]
     fn viewing_session_summary_counts_messages_duration_and_tokens() {
         let messages = vec![
             message(Role::User, Some(0), 0),
@@ -1932,14 +1996,18 @@ impl App {
         }
     }
 
+    pub fn viewing_search_terms(&self) -> Vec<String> {
+        self.viewing_search_query.split_whitespace().map(str::to_lowercase).collect()
+    }
+
     fn recompute_viewing_matches(&mut self) {
         self.viewing_match_cache.clear();
-        if self.viewing_search_query.is_empty() {
+        let terms = self.viewing_search_terms();
+        if terms.is_empty() {
             return;
         }
-        let needle = self.viewing_search_query.to_lowercase();
         for (i, msg_lines) in self.viewing_sanitized_lines.iter().enumerate() {
-            if msg_lines.iter().any(|l| l.lower.contains(&needle)) {
+            if msg_lines.iter().any(|l| terms.iter().any(|t| l.lower.contains(t.as_str()))) {
                 self.viewing_match_cache.push(i);
             }
         }
@@ -3117,11 +3185,19 @@ impl App {
             self.viewing_messages = msgs;
             self.viewing_selected_msg = 0;
             self.viewing_scroll_offset = 0;
-            self.viewing_search_query.clear();
+            self.viewing_search_query = self
+                .query
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .filter(|t| !t.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ");
             self.viewing_search_input = None;
             self.viewing_search_input_cursor = 0;
             self.viewing_search_status = None;
-            self.viewing_match_cache.clear();
+            self.recompute_viewing_matches();
+            if let Some(&first) = self.viewing_match_cache.first() {
+                self.viewing_selected_msg = first;
+            }
             self.mode = AppMode::Viewing;
         }
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -24,8 +24,8 @@ use crate::tui::text_layout::{wrap_spans_to_lines, wrap_visual_rows};
 use crate::types::{MatchSource, Role};
 use crate::usage::{TokenTotals, UsageReport};
 
-fn highlight_spans(text: &str, hay: &str, needle_lower: &str, base: Style) -> Vec<Span<'static>> {
-    if needle_lower.is_empty() {
+fn highlight_spans(text: &str, hay: &str, needles: &[String], base: Style) -> Vec<Span<'static>> {
+    if needles.is_empty() {
         return vec![Span::styled(text.to_string(), base)];
     }
     if hay.len() != text.len() {
@@ -36,10 +36,14 @@ fn highlight_spans(text: &str, hay: &str, needle_lower: &str, base: Style) -> Ve
     let match_style =
         Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD);
     while cursor < text.len() {
-        match hay[cursor..].find(needle_lower) {
-            Some(rel) => {
-                let start = cursor + rel;
-                let end = start + needle_lower.len();
+        let hit = needles
+            .iter()
+            .filter(|n| !n.is_empty())
+            .filter_map(|n| hay[cursor..].find(n.as_str()).map(|rel| (cursor + rel, n.len())))
+            .min_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+        match hit {
+            Some((start, len)) => {
+                let end = start + len;
                 if !text.is_char_boundary(start) || !text.is_char_boundary(end) {
                     spans.push(Span::styled(text[cursor..].to_string(), base));
                     break;
@@ -1340,7 +1344,7 @@ fn render_viewing(f: &mut Frame, app: &App) {
     let viewport_end = viewport_start + layout.messages.height as usize;
     let mut visual_row = 0usize;
     let mut lines: Vec<Line> = Vec::new();
-    let needle_lower = app.viewing_search_query.to_lowercase();
+    let needles = app.viewing_search_terms();
 
     for (i, msg) in app.viewing_messages.iter().enumerate() {
         let selected = i == app.viewing_selected_msg;
@@ -1372,7 +1376,7 @@ fn render_viewing(f: &mut Frame, app: &App) {
         let cached_lines = app.viewing_sanitized_lines.get(i).unwrap_or(&empty);
         for sl in cached_lines {
             let body_style = Style::default().fg(Color::White);
-            let spans = highlight_spans(&sl.text, &sl.lower, &needle_lower, body_style);
+            let spans = highlight_spans(&sl.text, &sl.lower, &needles, body_style);
             for line in wrap_spans_to_lines(spans, inner_width) {
                 let body_bg = if selected && row_visible(visual_row, viewport_start, viewport_end) {
                     Color::DarkGray
@@ -2117,6 +2121,36 @@ mod tests {
             .map(|y| buffer_row(terminal.backend().buffer(), y, width))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn highlight_spans_marks_each_query_term() {
+        let spans = highlight_spans(
+            "Alpha beta Gamma",
+            "alpha beta gamma",
+            &["alpha".to_string(), "gamma".to_string()],
+            Style::default(),
+        );
+
+        let texts: Vec<&str> = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(texts, vec!["Alpha", " beta ", "Gamma"]);
+        assert_eq!(spans[0].style.bg, Some(Color::Yellow));
+        assert_eq!(spans[1].style.bg, None);
+        assert_eq!(spans[2].style.bg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn highlight_spans_prefers_longest_term_at_same_position() {
+        let spans = highlight_spans(
+            "foobar baz",
+            "foobar baz",
+            &["foo".to_string(), "foobar".to_string()],
+            Style::default(),
+        );
+
+        let texts: Vec<&str> = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(texts, vec!["foobar", " baz"]);
+        assert_eq!(spans[0].style.bg, Some(Color::Yellow));
     }
 
     #[test]


### PR DESCRIPTION
Close #76 

### What's changed?

- Carry the list-page search query into viewing mode when opening a session
- Match and highlight multiple whitespace-separated search terms (OR logic)
- Jump to the first matching message on enter
- Add unit tests for enter-viewing seeding and multi-term highlighting

### Why

- Users expect the search context from the result list to persist in the detail view
- Multi-word queries like `deploy missing` should highlight each term independently rather than searching for the literal phrase