### PR TITLE
docs(agents): add agent guidance and align development docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, OpenCode,
+etc.) when working with code in this repository.
+
+## Overview
+
+Recall is a Rust CLI/TUI application that indexes AI coding sessions from local
+tools (Claude Code, Codex, OpenCode, Cursor, ...) into one SQLite database for
+full-text/semantic search, usage tracking, JSONL export/import, session
+sharing, and resume. It is an application crate, not a reusable Rust library.
+
+## Commands
+
+```bash
+make check                            # full gate: fmt --check → clippy -D warnings → test
+make build                            # debug build
+make run                              # launch TUI
+make sync                             # cargo run -- sync (FORCE=1 reprocesses all)
+make search Q="query"                 # CLI search
+cargo test <name>                     # run a single test by name filter
+cargo test integration::regression    # regression suite
+cargo test integration::eval_harness  # eval harness
+```
+
+`make check` must pass before push. CI runs exactly the same command — there is
+no CI-only logic.
+
+Releases use cargo-release: `make release-patch` is a dry run; add `EXECUTE=1`
+to bump, commit, tag, and push. The `v*` tag triggers the GitHub Actions binary
+build. One-time setup: `git config core.hooksPath .githooks` enables the DCO
+signoff hook.
+
+## Architecture
+
+Data flow: source adapters → sync → SQLite → search → CLI/TUI.
+
+- `src/adapters/` — one adapter per tool implements the `SourceAdapter` trait
+  (`scan()` returns `RawSession`s) and is registered in `all_adapters()` in
+  `src/adapters/mod.rs`. Registration alone wires the adapter into the DB
+  schema, search, TUI source filter, and CLI `--source` flag. DEVELOPMENT.md
+  documents the full adapter contract. Usage tracking is an optional extension
+  on the same adapter — token events attached to the `RawSession` with a
+  `parser_version` for backfill — never a separate adapter.
+- `src/sync.rs` — incremental sync writes scanned sessions into SQLite.
+- `src/db/` — rusqlite storage split by domain: sessions, events, projects,
+  semantic index, skill audit, usage, schema, and search. Full-text search is
+  SQLite FTS5; vector search is sqlite-vec.
+- `src/embedding.rs`, `src/semantic.rs` — local embeddings via candle with
+  `intfloat/multilingual-e5-small` (Metal on macOS, optional `cuda` feature).
+- `src/tui/` — ratatui app: app state, event handling, layout, background
+  search worker, share/usage/viewing state, and `ui/` rendering modules.
+- `src/share/` — renders sessions to HTML and publishes share assets.
+- `src/cli.rs` — clap subcommands dispatching to the modules above.
+- `website/` — Next.js docs site (pnpm), independent of the Rust crate.
+
+## Boundaries
+
+- `src/lib.rs` exposes only `init()` and `run()`; `src/main.rs` only
+  initializes tracing and calls them. Internal modules are `pub(crate)` by
+  default — do not widen module, type, or function visibility unless a current
+  in-repo caller requires it.
+- `publish = false` in Cargo.toml is intentional: Recall ships binaries and
+  Homebrew assets, not a crates.io package. Do not remove it or add public
+  Rust API for external consumers unless the release strategy changes.
+- Tests live in `src/integration/` inside the library crate, compiled through
+  `#[cfg(test)] mod integration;`. Do not recreate standalone `tests/*.rs`
+  test targets; `tests/fixtures/` holds fixture data only.
+- Adapter rules (see DEVELOPMENT.md): return `Ok(vec![])` when a tool is not
+  installed; open external databases read-only; extract text content only;
+  `tracing::warn!` and skip on recoverable parse errors.
+- `.local/` is local scratch and external comparisons, not an architecture
+  source.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ Create `src/adapters/<tool>.rs`:
 use crate::adapters::{RawMessage, RawSession, SourceAdapter};
 use crate::types::Role;
 
-pub struct MyToolAdapter;
+pub(crate) struct MyToolAdapter;
 
 impl SourceAdapter for MyToolAdapter {
     fn id(&self) -> &str { "my-tool" }       // stored in DB, used for filtering
@@ -63,11 +63,11 @@ impl SourceAdapter for MyToolAdapter {
 In `src/adapters/mod.rs`, add two lines:
 
 ```rust
-pub mod my_tool;  // add module declaration
+pub(crate) mod my_tool;  // add module declaration
 ```
 
 ```rust
-pub fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
+pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
     vec![
         Box::new(claude_code::ClaudeCodeAdapter),
         Box::new(opencode::OpenCodeAdapter),
@@ -193,6 +193,9 @@ Releases are driven by `cargo-release`, which bumps `Cargo.toml`, updates
 release workflow triggers on `v*` tag push and builds cross-platform
 binaries.
 
+Recall is not published to crates.io. `publish = false` in `Cargo.toml` is the
+current application release boundary, not a package metadata bug.
+
 ### One-time setup
 
 ```bash
@@ -213,20 +216,6 @@ make release-patch EXECUTE=1    # apply: bump, commit, tag, push
 
 `release-minor` and `release-major` work the same way. The tag name is
 `v{{version}}` and the commit subject is `chore(release): bump to v{{version}}`.
-
-### Update Homebrew tap
-
-After the GitHub release assets are published, run the project skill to update
-`samzong/homebrew-tap`:
-
-```bash
-/skill:update-recall-homebrew-tap
-```
-
-The skill lives in `.agents/skills/update-recall-homebrew-tap/` so shared
-agent-skill tooling can discover it. It reads the current `Cargo.toml` version,
-verifies the matching GitHub release assets, updates `Formula/recall.rb`
-checksums, and opens a tap PR.
 
 ### First release after a stale baseline
 


### PR DESCRIPTION
### What's changed?

- Add `AGENTS.md` with commands, architecture overview, and crate boundaries for AI coding agents
- Add `CLAUDE.md` as a symlink to `AGENTS.md`
- Update `DEVELOPMENT.md` adapter examples to use `pub(crate)`, document the crates.io release boundary, and remove the stale Homebrew tap skill section

### Why

- Give AI coding agents a single, accurate entry point for working in this repo
- Keep contributor docs aligned with the current `pub(crate)` API surface and application-only release model