### PR TITLE
feat(extensions): add core protocol outputs

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,227 @@
+# Recall Extensions Design
+
+Status: long-lived design draft. Feature migration notes live in
+`docs/extension-migrations.md`.
+
+## Goal
+
+Keep Recall core small and stable: a local session index plus a stable query
+surface. As product features grow, workflow, report, publish, and UI surfaces
+should evolve as optional, independently shippable extensions, including
+third-party extensions.
+
+## Problem
+
+Recall's core data flow is:
+
+```text
+source adapters -> sync -> SQLite -> search -> CLI/TUI
+```
+
+Feature pressure will keep building around that core: sharing, reflection,
+dashboards, search UIs, token/scale analytics, and agent-facing workflows. Each
+feature can be reasonable on its own, but merging all of them into core grows
+the binary, CLI surface, TUI surface, and test matrix.
+
+Without an explicit boundary, core bloats one reasonable feature at a time.
+
+## Decision
+
+1. Core is the data plane plus a stable query protocol.
+2. Extensions are external executables that consume that protocol.
+3. The extension model is Cargo/Git-style external subcommands.
+4. Extension binaries are named `recall-<name>`; `recall <name>` dispatches to
+   them.
+5. The stable contract is CLI JSON/JSONL output, not Rust API and not SQLite
+   schema.
+6. Reject Rust dylib plugins, in-process plugin API, and a WASM runtime for now.
+   Revisit WASM only if running untrusted third-party code becomes a real
+   requirement.
+
+## Boundary
+
+The criterion is not "read-only". The sharper boundary is:
+
+- Capabilities that write the Recall index, data plane, or schema migrations
+  belong in core.
+- Capabilities that do not mutate the Recall index/data plane/schema and only
+  consume the stable query protocol are extension candidates.
+- Extensions may write their own local artifacts, config, or external provider
+  resources after explicit user action, but they should not write the Recall
+  SQLite index directly.
+
+Core owns:
+
+- source adapters, sync, import, storage, and schema migrations;
+- full-text search and semantic search;
+- session identity and repo/project resolution;
+- minimal session operations: list, show, export, resume, open;
+- machine-readable output for those operations: `--format json|jsonl`;
+- the extension host: discovery, dispatch, and later list/install/remove;
+- bundled Agent Skill install.
+
+Extensions own:
+
+- workflow, report, and calibration products;
+- provider-specific publishing;
+- web UI dashboards and search surfaces;
+- token/scale analytics views beyond the built-in usage report;
+- agent-facing discussion, proposal, and calibration loops.
+
+Usage tracking stays in core. Token events are data-plane records written by
+source adapters during sync.
+
+Skills and extensions are different:
+
+- bundled skills (`recall skill install`) are agent-facing prompt bundles;
+- extensions are executables;
+- one feature can ship both a skill and an extension.
+
+## Why External Subcommands
+
+Rust CLI extension options:
+
+| Approach | Verdict |
+| --- | --- |
+| External subcommand binaries (`cargo-*`, `git-*`, `gh` extensions) | Chosen. No ABI risk, language-agnostic, and proven in long-lived tools. Cargo also recommends integrating through the CLI instead of linking Cargo as a library. |
+| Long-lived protocol subprocesses (Nushell plugins, Terraform providers) | Worth it only when plugins join the host's inner loop. Recall extensions are command-shaped for now. |
+| WASM sandbox (Zellij, Extism) | Solves untrusted-code execution. Recall's current problem is product boundary and optional feature distribution, not sandboxing. |
+| Rust dylib (`libloading`, `abi_stable`) | Rust has no stable ABI. `unsafe extern "C"` boundaries and per-platform symbol issues are permanent maintenance debt. |
+| Cargo features | Compile-time trimming, not user-installable extensions. Orthogonal to this model. |
+
+References:
+[Cargo external tools](https://doc.rust-lang.org/cargo/reference/external-tools.html),
+[gh extensions](https://cli.github.com/manual/gh_extension),
+[Extism plug-in system](https://extism.org/docs/concepts/plug-in-system/),
+[Rust linkage](https://doc.rust-lang.org/reference/linkage.html),
+[libloading](https://docs.rs/libloading/latest/libloading/).
+
+## Protocol Contract
+
+Extensions consume Recall through the CLI:
+
+```bash
+recall info --format json
+recall session list --project /repo --format json
+recall session list --query "query" --project /repo --format json
+recall search "query" --project /repo --format json
+recall session show --id <id> --format json --include metadata,messages,usage,events
+recall export --project /repo
+```
+
+Current core support:
+
+- `recall info --format json` exposes `protocol_version`, database schema
+  version, and export record schema version;
+- `recall session list` supports `--format json|jsonl`;
+- `recall search --format json` is a thin wrapper over the same JSON shape as
+  `recall session list --query ... --format json`;
+- `recall session show` supports `--format json|jsonl`;
+- `recall export` emits JSONL, one session record per line, with export record
+  schema version 4;
+- `recall session show --format json` defaults to metadata only. Extensions
+  that need transcript data must pass `--messages` or
+  `--include metadata,messages,usage,events`.
+
+### Stability Rules
+
+Stable protocol means machine output on stdout:
+
+- stdout contains only the requested JSON/JSONL data;
+- progress, warnings, sync status, and deploy status go to stderr;
+- JSON objects may add fields;
+- published fields must not be silently removed, renamed, or changed in meaning;
+- breaking changes must bump `protocol_version`;
+- each JSONL line must be one complete JSON object;
+- pretty formatting is not the stable contract, field semantics are;
+- non-zero exit code means failure.
+
+Error output remains human-readable stderr until an extension needs structured
+error handling. When that happens, add a machine-readable error envelope instead
+of letting each command invent its own shape:
+
+```json
+{
+  "error": {
+    "code": "session_not_found",
+    "message": "session not found: <id>"
+  }
+}
+```
+
+### Explicitly Unstable
+
+- SQLite schema is unstable. Third parties cannot be prevented from reading the
+  database file, but doing so is unsupported and may break in any release.
+- Rust internals are unstable. Modules stay `pub(crate)`, `publish = false`
+  stays intentional, and Recall does not expose a `recall-core` library crate.
+
+### High-Frequency Consumers
+
+High-frequency consumers such as live search web UIs pay a process-spawn cost
+per query. Semantic search may also need a resident embedding model. If that
+need becomes real, core should add a long-lived serve mode that speaks the same
+JSON protocol. It should not open SQLite direct access or expose Rust internals.
+
+This is a later concern, not a first-stage requirement.
+
+## Extension Model
+
+- Naming: an extension is a PATH executable named `recall-<name>`.
+- Dispatch: `recall <name> [args...]` executes `recall-<name> [args...]` when
+  `<name>` is not a core subcommand.
+- Explicit form: `recall extension run <name> -- ...` may exist to remove
+  ambiguity.
+- First-stage host command: `recall extension list`.
+- `install` and `remove` should wait until real third-party installation demand
+  exists.
+
+## Manifest
+
+`recall extension list` needs extension metadata. Each extension must support:
+
+```bash
+recall-<name> --recall-extension-manifest
+```
+
+stdout returns JSON:
+
+```json
+{
+  "name": "reflect",
+  "version": "0.1.0",
+  "protocol": 1,
+  "min_recall": "0.2.10",
+  "commands": ["reflect"]
+}
+```
+
+Do not add `capabilities` or `permissions` fields for native binaries. Recall
+cannot enforce them, so they would be security theater. Permission semantics
+only become meaningful in a sandboxed runtime such as WASM.
+
+## Official And Third-Party Extensions
+
+Official extensions can live in this repository as workspace binary crates:
+
+```text
+extensions/recall-share/
+extensions/recall-reflect/
+```
+
+They can ship through the same release pipeline as Recall.
+
+Third-party extensions can live in any repository. If the binary is named
+`recall-<name>` and is on PATH, the host can dispatch it. The important
+distinction is not repository ownership. Official and third-party extensions
+must both integrate through the stable CLI protocol instead of relying on core
+modules or SQLite schema.
+
+## Non-Goals
+
+- Rust dylib plugins;
+- in-process plugin API;
+- WASM runtime;
+- plugin marketplace;
+- direct SQLite reads or writes by extensions;
+- a published `recall-core` library crate.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,10 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     #[command(about = "Show indexed source and background job status")]
-    Info,
+    Info {
+        #[arg(long, value_enum, default_value_t = crate::info::InfoFormat::Text)]
+        format: crate::info::InfoFormat,
+    },
     #[command(about = "Scan configured AI coding session sources")]
     Sync {
         #[arg(long, help = "Reprocess every session, even if unchanged")]
@@ -57,6 +60,8 @@ enum Commands {
         project: Option<String>,
         #[arg(long, help = "Filter by repository identity")]
         repo: Option<String>,
+        #[arg(long, value_enum, default_value_t = crate::query::SearchFormat::Text)]
+        format: crate::query::SearchFormat,
     },
     #[command(about = "Show token usage reports")]
     Usage {
@@ -146,7 +151,7 @@ pub(crate) fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Info) => crate::info::run()?,
+        Some(Commands::Info { format }) => crate::info::run(format)?,
         Some(Commands::Sync { force, verbose, source }) => {
             crate::sync::run_cli(force, verbose, source.as_deref())?
         }
@@ -159,13 +164,16 @@ pub(crate) fn run() -> Result<()> {
             crate::bench::run_eval(dataset.as_deref(), verbose)?
         }
         Some(Commands::BenchDumpSessions) => crate::bench::dump_sessions()?,
-        Some(Commands::Search { query, source, time, project, repo }) => crate::query::run_search(
-            &query,
-            source.as_deref(),
-            time.as_deref(),
-            project.as_deref(),
-            repo.as_deref(),
-        )?,
+        Some(Commands::Search { query, source, time, project, repo, format }) => {
+            crate::query::run_search(
+                &query,
+                source.as_deref(),
+                time.as_deref(),
+                project.as_deref(),
+                repo.as_deref(),
+                format,
+            )?
+        }
         Some(Commands::Usage { json, source, time }) => {
             crate::usage::run_cli(json, source.as_deref(), time.as_deref())?
         }
@@ -266,6 +274,30 @@ mod tests {
     #[test]
     fn export_rejects_removed_jsonl_flag() {
         assert!(Cli::try_parse_from(["recall", "export", "--jsonl"]).is_err());
+    }
+
+    #[test]
+    fn info_accepts_json_format() {
+        let cli = Cli::try_parse_from(["recall", "info", "--format", "json"]).unwrap();
+        match cli.command {
+            Some(Commands::Info { format }) => {
+                assert_eq!(format, crate::info::InfoFormat::Json);
+            }
+            _ => panic!("expected info command"),
+        }
+    }
+
+    #[test]
+    fn search_accepts_json_format() {
+        let cli =
+            Cli::try_parse_from(["recall", "search", "extension", "--format", "json"]).unwrap();
+        match cli.command {
+            Some(Commands::Search { query, format, .. }) => {
+                assert_eq!(query, "extension");
+                assert_eq!(format, crate::query::SearchFormat::Json);
+            }
+            _ => panic!("expected search command"),
+        }
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -343,7 +343,6 @@ pub(crate) fn schema_version(conn: &Connection) -> anyhow::Result<i64> {
     conn.query_row("PRAGMA user_version", [], |row| row.get(0)).map_err(Into::into)
 }
 
-#[cfg(test)]
 pub(crate) const fn current_schema_version() -> i64 {
     SCHEMA_VERSION
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -9,7 +9,7 @@ use crate::db::store::Store;
 use crate::query::{parse_time_range, resolve_source_filter};
 use crate::types::{Message, Role, Session, SessionEventRecord, SessionUsageEventRecord};
 
-const SCHEMA_VERSION: u32 = 4;
+pub(crate) const RECORD_SCHEMA_VERSION: u32 = 4;
 const RECORD_TYPE: &str = "session";
 
 pub(crate) struct ExportOptions {
@@ -178,7 +178,7 @@ fn build_session_record(
     events: Vec<SessionEventRecord>,
 ) -> ExportSessionRecord {
     ExportSessionRecord {
-        schema_version: SCHEMA_VERSION,
+        schema_version: RECORD_SCHEMA_VERSION,
         record_type: RECORD_TYPE,
         session: session.into(),
         messages: messages.into_iter().map(Into::into).collect(),

--- a/src/info.rs
+++ b/src/info.rs
@@ -4,6 +4,13 @@ use crate::adapters;
 use crate::config::AppConfig;
 use crate::db::store::Store;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum InfoFormat {
+    Text,
+    Json,
+}
+
+#[derive(serde::Serialize)]
 struct SourceSummary {
     label: String,
     id: String,
@@ -13,7 +20,7 @@ struct SourceSummary {
     error: Option<String>,
 }
 
-pub(crate) fn run() -> Result<()> {
+pub(crate) fn run(format: InfoFormat) -> Result<()> {
     let all = adapters::all_adapters();
     let labels = adapters::source_labels();
     let mut config = AppConfig::load_or_default();
@@ -86,6 +93,40 @@ pub(crate) fn run() -> Result<()> {
                 });
             }
         }
+    }
+
+    if matches!(format, InfoFormat::Json) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "protocol_version": crate::PROTOCOL_VERSION,
+                "schemas": {
+                    "export_record": crate::export::RECORD_SCHEMA_VERSION,
+                    "database": crate::db::schema::current_schema_version()
+                },
+                "sources": rows,
+                "settings": {
+                    "enabled_sources": labels
+                        .iter()
+                        .filter(|(id, _)| config.is_source_enabled(id))
+                        .map(|(id, label)| serde_json::json!({
+                            "id": id,
+                            "label": label
+                        }))
+                        .collect::<Vec<_>>(),
+                    "time_scope": config.sync_window.label()
+                },
+                "semantic_queue": {
+                    "indexed_sessions": progress.total_sessions,
+                    "done_sessions": progress.done_sessions,
+                    "pending_sessions": progress.pending_sessions + progress.processing_sessions,
+                    "failed_sessions": progress.failed_sessions,
+                    "worker_phase": worker.phase,
+                    "worker_detail": worker.detail
+                }
+            }))?
+        );
+        return Ok(());
     }
 
     let source_width = rows

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub(crate) mod types;
 pub(crate) mod usage;
 pub(crate) mod utils;
 
+pub(crate) const PROTOCOL_VERSION: u32 = 1;
+
 #[cfg(test)]
 mod integration;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -4,8 +4,15 @@ use crate::adapters;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::Store;
 use crate::embedding::EmbeddingProvider;
+use crate::session::{self, SessionListFormat, SessionSort};
 use crate::types;
 use crate::utils;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum SearchFormat {
+    Text,
+    Json,
+}
 
 pub(crate) fn run_search(
     query: &str,
@@ -13,7 +20,24 @@ pub(crate) fn run_search(
     time_filter: Option<&str>,
     project_filter: Option<&str>,
     repo_filter: Option<&str>,
+    format: SearchFormat,
 ) -> Result<()> {
+    if matches!(format, SearchFormat::Json) {
+        return session::run_session_list(
+            Some(query),
+            source_filter,
+            time_filter,
+            project_filter,
+            repo_filter,
+            20,
+            0,
+            false,
+            false,
+            Some(SessionSort::Relevance),
+            SessionListFormat::Json,
+        );
+    }
+
     let store = Store::open()?;
     let engine = SearchEngine::new(&store.conn);
     let sources = adapters::source_labels();

--- a/src/session.rs
+++ b/src/session.rs
@@ -207,7 +207,7 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             sync,
             sort,
             format,
-        } => cmd_session_list(
+        } => run_session_list(
             query.as_deref(),
             source.as_deref(),
             time.as_deref(),
@@ -303,7 +303,7 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn cmd_session_list(
+pub(crate) fn run_session_list(
     query: Option<&str>,
     source_filter: Option<&str>,
     time_filter: Option<&str>,


### PR DESCRIPTION
### What's changed?

- Add JSON output for `recall info` with protocol, database schema, and export record schema versions.
- Add `recall search --format json` as a thin wrapper over the existing `session list --query` JSON shape.
- Add the long-lived Recall extensions design document in English.

### Why

- Establish the stable CLI protocol surface needed before moving workflow and publishing features into extensions.

### Verification

- `cargo test --lib cli::tests`
- `cargo check`
- `cargo run --quiet -- info --format json` parsed with `python3 -m json.tool`
- `cargo run --quiet -- search extension --format json` parsed with `python3 -m json.tool`
- `make check`