### PR TITLE
fix(sync): make session refresh atomic

### DIFF
--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -90,7 +90,7 @@ impl Store {
     #[cfg(test)]
     pub(crate) fn insert_session(&self, session: &Session) -> Result<()> {
         self.conn.execute(
-            "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
+            "INSERT INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             rusqlite::params![
                 session.id,
@@ -165,200 +165,50 @@ impl Store {
         event_parser_version: Option<u32>,
     ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        {
-            tx.execute(
-                "INSERT OR REPLACE INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
-                rusqlite::params![
-                    session.id,
-                    session.source,
-                    session.source_id,
-                    session.title,
-                    session.directory,
-                    session.repo_remote,
-                    session.repo_slug,
-                    session.repo_name,
-                    session.started_at,
-                    session.updated_at,
-                    session.message_count,
-                    session.entrypoint,
-                    session.custom_title,
-                    session.summary,
-                    session.duration_minutes,
-                    session.source_file_path,
-                    session.is_import,
-                ],
-            )?;
+        persist_session_with_usage_and_events_tx(
+            &tx,
+            session,
+            messages,
+            usage_events,
+            usage_parser_version,
+            session_events,
+            event_parser_version,
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
 
-            {
-                let mut stmt = tx.prepare(
-                    "INSERT INTO messages (session_id, role, content, timestamp, seq)
-                     VALUES (?1, ?2, ?3, ?4, ?5)",
-                )?;
-                for msg in messages {
-                    stmt.execute(rusqlite::params![
-                        msg.session_id,
-                        msg.role.as_str(),
-                        msg.content,
-                        msg.timestamp,
-                        msg.seq,
-                    ])?;
-                }
-            }
-
-            {
-                tx.execute(
-                    "DELETE FROM usage_events WHERE session_id = ?1",
-                    rusqlite::params![session.id],
-                )?;
-                let created_at = Utc::now().timestamp_millis();
-                let mut stmt = tx.prepare(
-                    "INSERT INTO usage_events (
-                        session_id, source, source_id, event_key, event_seq, message_seq,
-                        timestamp, model, provider, input_tokens, output_tokens,
-                        cache_read_tokens, cache_write_tokens, reasoning_tokens,
-                        token_source, parser_version, source_path, raw_usage_json, created_at
-                     )
-                     VALUES (
-                        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-                        ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19
-                     )
-                     ON CONFLICT(session_id, event_key) DO UPDATE SET
-                        event_seq = excluded.event_seq,
-                        message_seq = excluded.message_seq,
-                        timestamp = excluded.timestamp,
-                        model = excluded.model,
-                        provider = excluded.provider,
-                        input_tokens = excluded.input_tokens,
-                        output_tokens = excluded.output_tokens,
-                        cache_read_tokens = excluded.cache_read_tokens,
-                        cache_write_tokens = excluded.cache_write_tokens,
-                        reasoning_tokens = excluded.reasoning_tokens,
-                        token_source = excluded.token_source,
-                        parser_version = excluded.parser_version,
-                        source_path = excluded.source_path,
-                        raw_usage_json = excluded.raw_usage_json",
-                )?;
-                for event in usage_events {
-                    stmt.execute(rusqlite::params![
-                        session.id,
-                        session.source,
-                        session.source_id,
-                        event.event_key,
-                        event.event_seq,
-                        event.message_seq,
-                        event.timestamp,
-                        event.model,
-                        event.provider,
-                        event.input_tokens,
-                        event.output_tokens,
-                        event.cache_read_tokens,
-                        event.cache_write_tokens,
-                        event.reasoning_tokens,
-                        event.token_source.as_str(),
-                        event.parser_version,
-                        event.source_path,
-                        event.raw_usage_json,
-                        created_at,
-                    ])?;
-                }
-            }
-
-            if let Some(parser_version) = usage_parser_version {
-                let synced_at = Utc::now().timestamp_millis();
-                tx.execute(
-                    "INSERT INTO usage_session_state (
-                        session_id, source, source_id, parser_version,
-                        source_updated_at, event_count, synced_at
-                     )
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-                     ON CONFLICT(source, source_id) DO UPDATE SET
-                        session_id = excluded.session_id,
-                        parser_version = excluded.parser_version,
-                        source_updated_at = excluded.source_updated_at,
-                        event_count = excluded.event_count,
-                        synced_at = excluded.synced_at",
-                    rusqlite::params![
-                        session.id,
-                        session.source,
-                        session.source_id,
-                        parser_version,
-                        session.updated_at,
-                        usage_events.len() as u32,
-                        synced_at,
-                    ],
-                )?;
-            }
-
-            replace_session_events(
-                &tx,
-                &session.id,
-                &session.source,
-                &session.source_id,
-                session_events,
-                event_parser_version,
-                session.updated_at,
-            )?;
-
-            let units_total: i64 = tx.query_row(
-                "SELECT COUNT(*) FROM messages
-                 WHERE session_id = ?1 AND role = 'user' AND LENGTH(content) > 2",
-                rusqlite::params![session.id],
-                |row| row.get(0),
-            )?;
-
-            let now = Utc::now().timestamp_millis();
-            if units_total == 0 {
-                tx.execute(
-                    "INSERT INTO session_embedding_state (session_id, status, units_total, units_done, finished_at, last_error)
-                     VALUES (?1, 'done', 0, 0, ?2, NULL)
-                     ON CONFLICT(session_id) DO UPDATE SET
-                        status = 'done',
-                        units_total = 0,
-                        units_done = 0,
-                        started_at = NULL,
-                        finished_at = excluded.finished_at,
-                        last_error = NULL",
-                    rusqlite::params![session.id, now],
-                )?;
-            } else {
-                tx.execute(
-                    "INSERT INTO session_embedding_state (session_id, status, units_total, units_done, started_at, finished_at, last_error)
-                     VALUES (?1, 'pending', ?2, 0, NULL, NULL, NULL)
-                     ON CONFLICT(session_id) DO UPDATE SET
-                        status = 'pending',
-                        units_total = excluded.units_total,
-                        units_done = 0,
-                        started_at = NULL,
-                        finished_at = NULL,
-                        last_error = NULL",
-                    rusqlite::params![session.id, units_total],
-                )?;
-            }
-        }
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn replace_session_with_usage_and_events(
+        &self,
+        old_source: &str,
+        old_source_id: &str,
+        session: &Session,
+        messages: &[Message],
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: Option<u32>,
+        session_events: &[RawSessionEvent],
+        event_parser_version: Option<u32>,
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        delete_session_data_tx(&tx, old_source, old_source_id)?;
+        persist_session_with_usage_and_events_tx(
+            &tx,
+            session,
+            messages,
+            usage_events,
+            usage_parser_version,
+            session_events,
+            event_parser_version,
+        )?;
         tx.commit()?;
         Ok(())
     }
 
     pub(crate) fn delete_session_data(&self, source: &str, source_id: &str) -> Result<()> {
-        let session_ids: Vec<String> = {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT id FROM sessions WHERE source = ?1 AND source_id = ?2")?;
-            stmt.query_map(rusqlite::params![source, source_id], |row| row.get(0))?
-                .filter_map(|r| r.ok())
-                .collect()
-        };
-        for sid in &session_ids {
-            self.conn.execute(
-                "DELETE FROM message_vec WHERE message_id IN (SELECT id FROM messages WHERE session_id = ?1)",
-                rusqlite::params![sid],
-            )?;
-        }
-        self.conn.execute(
-            "DELETE FROM sessions WHERE source = ?1 AND source_id = ?2",
-            rusqlite::params![source, source_id],
-        )?;
+        let tx = self.conn.unchecked_transaction()?;
+        delete_session_data_tx(&tx, source, source_id)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -622,4 +472,211 @@ impl Store {
         let rows = stmt.query_map(param_refs.as_slice(), session_from_row)?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
+}
+
+fn delete_session_data_tx(
+    tx: &rusqlite::Transaction<'_>,
+    source: &str,
+    source_id: &str,
+) -> Result<()> {
+    let session_ids: Vec<String> = {
+        let mut stmt =
+            tx.prepare("SELECT id FROM sessions WHERE source = ?1 AND source_id = ?2")?;
+        stmt.query_map(rusqlite::params![source, source_id], |row| row.get(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+    };
+    for sid in &session_ids {
+        tx.execute(
+            "DELETE FROM message_vec WHERE message_id IN (SELECT id FROM messages WHERE session_id = ?1)",
+            rusqlite::params![sid],
+        )?;
+    }
+    tx.execute(
+        "DELETE FROM sessions WHERE source = ?1 AND source_id = ?2",
+        rusqlite::params![source, source_id],
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_session_with_usage_and_events_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session: &Session,
+    messages: &[Message],
+    usage_events: &[RawUsageEvent],
+    usage_parser_version: Option<u32>,
+    session_events: &[RawSessionEvent],
+    event_parser_version: Option<u32>,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+        rusqlite::params![
+            session.id,
+            session.source,
+            session.source_id,
+            session.title,
+            session.directory,
+            session.repo_remote,
+            session.repo_slug,
+            session.repo_name,
+            session.started_at,
+            session.updated_at,
+            session.message_count,
+            session.entrypoint,
+            session.custom_title,
+            session.summary,
+            session.duration_minutes,
+            session.source_file_path,
+            session.is_import,
+        ],
+    )?;
+
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO messages (session_id, role, content, timestamp, seq)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+        )?;
+        for msg in messages {
+            stmt.execute(rusqlite::params![
+                msg.session_id,
+                msg.role.as_str(),
+                msg.content,
+                msg.timestamp,
+                msg.seq,
+            ])?;
+        }
+    }
+
+    {
+        tx.execute(
+            "DELETE FROM usage_events WHERE session_id = ?1",
+            rusqlite::params![session.id],
+        )?;
+        let created_at = Utc::now().timestamp_millis();
+        let mut stmt = tx.prepare(
+            "INSERT INTO usage_events (
+                session_id, source, source_id, event_key, event_seq, message_seq,
+                timestamp, model, provider, input_tokens, output_tokens,
+                cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                token_source, parser_version, source_path, raw_usage_json, created_at
+             )
+             VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19
+             )
+             ON CONFLICT(session_id, event_key) DO UPDATE SET
+                event_seq = excluded.event_seq,
+                message_seq = excluded.message_seq,
+                timestamp = excluded.timestamp,
+                model = excluded.model,
+                provider = excluded.provider,
+                input_tokens = excluded.input_tokens,
+                output_tokens = excluded.output_tokens,
+                cache_read_tokens = excluded.cache_read_tokens,
+                cache_write_tokens = excluded.cache_write_tokens,
+                reasoning_tokens = excluded.reasoning_tokens,
+                token_source = excluded.token_source,
+                parser_version = excluded.parser_version,
+                source_path = excluded.source_path,
+                raw_usage_json = excluded.raw_usage_json",
+        )?;
+        for event in usage_events {
+            stmt.execute(rusqlite::params![
+                session.id,
+                session.source,
+                session.source_id,
+                event.event_key,
+                event.event_seq,
+                event.message_seq,
+                event.timestamp,
+                event.model,
+                event.provider,
+                event.input_tokens,
+                event.output_tokens,
+                event.cache_read_tokens,
+                event.cache_write_tokens,
+                event.reasoning_tokens,
+                event.token_source.as_str(),
+                event.parser_version,
+                event.source_path,
+                event.raw_usage_json,
+                created_at,
+            ])?;
+        }
+    }
+
+    if let Some(parser_version) = usage_parser_version {
+        let synced_at = Utc::now().timestamp_millis();
+        tx.execute(
+            "INSERT INTO usage_session_state (
+                session_id, source, source_id, parser_version,
+                source_updated_at, event_count, synced_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(source, source_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                parser_version = excluded.parser_version,
+                source_updated_at = excluded.source_updated_at,
+                event_count = excluded.event_count,
+                synced_at = excluded.synced_at",
+            rusqlite::params![
+                session.id,
+                session.source,
+                session.source_id,
+                parser_version,
+                session.updated_at,
+                usage_events.len() as u32,
+                synced_at,
+            ],
+        )?;
+    }
+
+    replace_session_events(
+        tx,
+        &session.id,
+        &session.source,
+        &session.source_id,
+        session_events,
+        event_parser_version,
+        session.updated_at,
+    )?;
+
+    let units_total: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM messages
+         WHERE session_id = ?1 AND role = 'user' AND LENGTH(content) > 2",
+        rusqlite::params![session.id],
+        |row| row.get(0),
+    )?;
+
+    let now = Utc::now().timestamp_millis();
+    if units_total == 0 {
+        tx.execute(
+            "INSERT INTO session_embedding_state (session_id, status, units_total, units_done, finished_at, last_error)
+             VALUES (?1, 'done', 0, 0, ?2, NULL)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = 'done',
+                units_total = 0,
+                units_done = 0,
+                started_at = NULL,
+                finished_at = excluded.finished_at,
+                last_error = NULL",
+            rusqlite::params![session.id, now],
+        )?;
+    } else {
+        tx.execute(
+            "INSERT INTO session_embedding_state (session_id, status, units_total, units_done, started_at, finished_at, last_error)
+             VALUES (?1, 'pending', ?2, 0, NULL, NULL, NULL)
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = 'pending',
+                units_total = excluded.units_total,
+                units_done = 0,
+                started_at = NULL,
+                finished_at = NULL,
+                last_error = NULL",
+            rusqlite::params![session.id, units_total],
+        )?;
+    }
+
+    Ok(())
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -373,7 +373,9 @@ mod tests {
         let session = full_session(source, source_id, title);
         let messages = full_messages(&session.id);
         store
-            .persist_session_with_usage_and_events(
+            .replace_session_with_usage_and_events(
+                source,
+                source_id,
                 &session,
                 &messages,
                 &[full_usage_event()],

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -84,6 +84,32 @@ fn make_session_event(kind: &str, name: Option<&str>, target: Option<&str>) -> R
     }
 }
 
+fn count_rows(store: &Store, sql: &str) -> i64 {
+    store.conn.query_row(sql, [], |row| row.get(0)).unwrap()
+}
+
+fn count_fts_matches(store: &Store, query: &str) -> i64 {
+    store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH ?1",
+            [query],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn first_message_id(store: &Store, session_id: &str) -> i64 {
+    store
+        .conn
+        .query_row(
+            "SELECT id FROM messages WHERE session_id = ?1 ORDER BY id LIMIT 1",
+            [session_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
 fn no_filters() -> SearchFilters {
     SearchFilters { sources: None, time_range: TimeRange::All, directory: None, repo: None }
 }
@@ -778,10 +804,188 @@ fn sync_detects_new_messages() {
     let changed = old_msg_count != new_msg_count
         || (new_updated_at.is_some() && new_updated_at != old_updated_at);
     assert!(changed, "sync must detect message count change");
+}
 
-    store.delete_session_data("test", "raw1").unwrap();
-    let after = store.session_meta("test", "raw1").unwrap();
-    assert!(after.is_none(), "old session must be deleted before re-insert");
+#[test]
+fn replace_session_rolls_back_delete_when_reinsert_fails() {
+    let store = setup();
+    let mut old_session = Session {
+        id: "s1".to_string(),
+        source: "test".to_string(),
+        source_id: "raw1".to_string(),
+        title: "Original".to_string(),
+        directory: None,
+        repo_remote: None,
+        repo_slug: None,
+        repo_name: None,
+        started_at: 1000,
+        updated_at: Some(2000),
+        message_count: 1,
+        entrypoint: None,
+        custom_title: None,
+        summary: None,
+        duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
+    };
+    old_session.is_import = true;
+    let old_usage = [make_usage_event("old-usage", 1_800_000_000_000, "old-model")];
+    let old_events = [make_session_event("old_event", Some("old_tool"), Some("old-target"))];
+    store
+        .persist_session_with_usage_and_events(
+            &old_session,
+            &[make_message("s1", Role::User, "oldrollbacktoken", 0)],
+            &old_usage,
+            Some(1),
+            &old_events,
+            Some(1),
+        )
+        .unwrap();
+    let old_message_id = first_message_id(&store, "s1");
+    store.upsert_embeddings(&[(old_message_id, &vec![0.1f32; 384])]).unwrap();
+
+    let replacement = Session {
+        id: "s2".to_string(),
+        source: "test".to_string(),
+        source_id: "raw1".to_string(),
+        title: "Replacement".to_string(),
+        directory: None,
+        repo_remote: None,
+        repo_slug: None,
+        repo_name: None,
+        started_at: 1000,
+        updated_at: Some(3000),
+        message_count: 1,
+        entrypoint: None,
+        custom_title: None,
+        summary: None,
+        duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
+    };
+    // Foreign keys are enabled in setup(); this fails after the replacement deletes old rows.
+    let invalid_messages = [make_message("missing-session", Role::User, "new message", 0)];
+
+    let result = store.replace_session_with_usage_and_events(
+        "test",
+        "raw1",
+        &replacement,
+        &invalid_messages,
+        &[],
+        None,
+        &[],
+        None,
+    );
+    assert!(result.is_err(), "replacement must fail before commit");
+
+    assert_eq!(store.session_meta("test", "raw1").unwrap(), Some((Some(2000), 1)));
+    let messages = store.get_messages("s1").unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content, "oldrollbacktoken");
+    assert!(store.imported_source_ids("test").unwrap().contains("raw1"));
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM message_vec"), 1);
+    assert_eq!(count_fts_matches(&store, "oldrollbacktoken"), 1);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM usage_events"), 1);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM usage_session_state"), 1);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM session_events"), 1);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM event_session_state"), 1);
+    assert_eq!(
+        count_rows(&store, "SELECT COUNT(*) FROM session_embedding_state WHERE session_id = 's1'"),
+        1
+    );
+}
+
+#[test]
+fn replace_session_clears_import_marker_on_success() {
+    let store = setup();
+    let mut old_session = Session {
+        id: "s1".to_string(),
+        source: "test".to_string(),
+        source_id: "raw1".to_string(),
+        title: "Original".to_string(),
+        directory: None,
+        repo_remote: None,
+        repo_slug: None,
+        repo_name: None,
+        started_at: 1000,
+        updated_at: Some(2000),
+        message_count: 1,
+        entrypoint: None,
+        custom_title: None,
+        summary: None,
+        duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
+    };
+    old_session.is_import = true;
+    let old_usage = [make_usage_event("old-usage", 1_800_000_000_000, "old-model")];
+    let old_events = [make_session_event("old_event", Some("old_tool"), Some("old-target"))];
+    store
+        .persist_session_with_usage_and_events(
+            &old_session,
+            &[make_message("s1", Role::User, "oldsuccesstoken", 0)],
+            &old_usage,
+            Some(1),
+            &old_events,
+            Some(1),
+        )
+        .unwrap();
+    let old_message_id = first_message_id(&store, "s1");
+    store.upsert_embeddings(&[(old_message_id, &vec![0.1f32; 384])]).unwrap();
+
+    let replacement = Session {
+        id: "s2".to_string(),
+        source: "test".to_string(),
+        source_id: "raw1".to_string(),
+        title: "Replacement".to_string(),
+        directory: None,
+        repo_remote: None,
+        repo_slug: None,
+        repo_name: None,
+        started_at: 1000,
+        updated_at: Some(3000),
+        message_count: 1,
+        entrypoint: None,
+        custom_title: None,
+        summary: None,
+        duration_minutes: None,
+        source_file_path: None,
+        is_import: false,
+    };
+    let messages = [make_message("s2", Role::User, "newsuccesstoken", 0)];
+
+    store
+        .replace_session_with_usage_and_events(
+            "test",
+            "raw1",
+            &replacement,
+            &messages,
+            &[],
+            None,
+            &[],
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(store.session_meta("test", "raw1").unwrap(), Some((Some(3000), 1)));
+    assert!(store.get_messages("s1").unwrap().is_empty());
+    assert_eq!(store.get_messages("s2").unwrap()[0].content, "newsuccesstoken");
+    assert!(store.imported_source_ids("test").unwrap().is_empty());
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM message_vec"), 0);
+    assert_eq!(count_fts_matches(&store, "oldsuccesstoken"), 0);
+    assert_eq!(count_fts_matches(&store, "newsuccesstoken"), 1);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM usage_events"), 0);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM usage_session_state"), 0);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM session_events"), 0);
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM event_session_state"), 0);
+    assert_eq!(
+        count_rows(&store, "SELECT COUNT(*) FROM session_embedding_state WHERE session_id = 's1'"),
+        0
+    );
+    assert_eq!(
+        count_rows(&store, "SELECT COUNT(*) FROM session_embedding_state WHERE session_id = 's2'"),
+        1
+    );
 }
 
 #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -276,9 +276,7 @@ pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
 
             match existing_meta.get(&raw_source_id) {
                 Some(&(old_updated_at, old_msg_count)) => {
-                    if imported_ids.remove(&raw_source_id) {
-                        store.clear_import_marker(source_id, &raw_source_id)?;
-                    }
+                    let was_imported = imported_ids.remove(&raw_source_id);
                     let metadata_changed = existing_paths.get(&raw_source_id).is_some_and(|old| {
                         raw_session_metadata_changed(&raw, repo_identity.as_ref(), old)
                     });
@@ -294,6 +292,9 @@ pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                         event_backfill_needed,
                     ) {
                         ExistingSessionAction::Skip => {
+                            if was_imported {
+                                store.clear_import_marker(source_id, &raw_source_id)?;
+                            }
                             skipped += 1;
                             continue;
                         }
@@ -350,6 +351,9 @@ pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                                     None,
                                 )?;
                             }
+                            if was_imported {
+                                store.clear_import_marker(source_id, &raw_source_id)?;
+                            }
                             if reprocessed {
                                 reprocessed_sessions += 1;
                             }
@@ -357,7 +361,7 @@ pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                         }
                         ExistingSessionAction::RefreshSession => {}
                     }
-                    store.delete_session_data(source_id, &raw_source_id)?;
+                    existing_usage_meta.remove(&raw_source_id);
                     existing_event_meta.remove(&raw_source_id);
                     if content_changed {
                         updated_sessions += 1;
@@ -417,7 +421,9 @@ pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
                 (Vec::new(), None)
             };
 
-            store.persist_session_with_usage_and_events(
+            store.replace_session_with_usage_and_events(
+                source_id,
+                &raw_source_id,
                 &session,
                 &messages,
                 &raw.usage_events,


### PR DESCRIPTION
### What's changed?

- Add an atomic session replacement path that deletes the old session data and inserts the refreshed session in one SQLite transaction.
- Remove session-level `INSERT OR REPLACE` usage so replacement always goes through the explicit cleanup path, including `message_vec` cleanup.
- Route sync refreshes and imported-session convergence through the atomic replacement path.
- Add regression coverage for rollback, import marker behavior, FTS cleanup, `message_vec`, usage/events, parser state, and embedding state.

### Why

- Prevent permanent data loss when sync is interrupted after deleting old session rows but before reinserting refreshed rows.

### Verification

- `make check`