### PR TITLE
feat(extensions): add cli list and external dispatch

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
@@ -16,38 +17,6 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    #[command(about = "Show indexed source and background job status")]
-    Info {
-        #[arg(long, value_enum, default_value_t = crate::info::InfoFormat::Text)]
-        format: crate::info::InfoFormat,
-    },
-    #[command(about = "Scan configured AI coding session sources")]
-    Sync {
-        #[arg(long, help = "Reprocess every session, even if unchanged")]
-        force: bool,
-        #[arg(short, long, help = "Show per-source scan progress and settings")]
-        verbose: bool,
-        #[arg(long, help = "Sync only this source (id or label, e.g. cursor or CUR)")]
-        source: Option<String>,
-    },
-    #[command(hide = true, name = "__background-worker")]
-    BackgroundWorker {
-        #[arg(long)]
-        sync_first: bool,
-    },
-    #[command(hide = true, name = "__bench-semantic")]
-    BenchSemantic,
-    #[command(hide = true, name = "__bench-search")]
-    BenchSearch { query: String },
-    #[command(hide = true, name = "__bench-eval")]
-    BenchEval {
-        #[arg(long)]
-        dataset: Option<String>,
-        #[arg(short, long)]
-        verbose: bool,
-    },
-    #[command(hide = true, name = "__bench-dump-sessions")]
-    BenchDumpSessions,
     #[command(about = "Search indexed coding sessions")]
     Search {
         #[arg(help = "Search query text")]
@@ -62,6 +31,25 @@ enum Commands {
         repo: Option<String>,
         #[arg(long, value_enum, default_value_t = crate::query::SearchFormat::Text)]
         format: crate::query::SearchFormat,
+    },
+    #[command(about = "Operate on indexed sessions")]
+    Session {
+        #[command(subcommand)]
+        command: session::SessionCommands,
+    },
+    #[command(about = "Scan configured AI coding session sources")]
+    Sync {
+        #[arg(long, help = "Reprocess every session, even if unchanged")]
+        force: bool,
+        #[arg(short, long, help = "Show per-source scan progress and settings")]
+        verbose: bool,
+        #[arg(long, help = "Sync only this source (id or label, e.g. cursor or CUR)")]
+        source: Option<String>,
+    },
+    #[command(about = "Show indexed source and background job status")]
+    Info {
+        #[arg(long, value_enum, default_value_t = crate::info::InfoFormat::Text)]
+        format: crate::info::InfoFormat,
     },
     #[command(about = "Show token usage reports")]
     Usage {
@@ -106,16 +94,36 @@ enum Commands {
         #[command(subcommand)]
         command: SkillCommands,
     },
-    #[command(about = "Operate on indexed sessions")]
-    Session {
+    #[command(about = "Manage Recall extensions", visible_alias = "ext")]
+    Extension {
         #[command(subcommand)]
-        command: session::SessionCommands,
+        command: ExtensionCommands,
     },
     #[command(about = "Generate shell completion script")]
     Completions {
         #[arg(help = "Target shell")]
         shell: Shell,
     },
+    #[command(hide = true, name = "__background-worker")]
+    BackgroundWorker {
+        #[arg(long)]
+        sync_first: bool,
+    },
+    #[command(hide = true, name = "__bench-semantic")]
+    BenchSemantic,
+    #[command(hide = true, name = "__bench-search")]
+    BenchSearch { query: String },
+    #[command(hide = true, name = "__bench-eval")]
+    BenchEval {
+        #[arg(long)]
+        dataset: Option<String>,
+        #[arg(short, long)]
+        verbose: bool,
+    },
+    #[command(hide = true, name = "__bench-dump-sessions")]
+    BenchDumpSessions,
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
 }
 
 #[derive(Subcommand)]
@@ -145,6 +153,12 @@ enum SkillCommands {
         #[arg(short, long, help = "Skip prompts and accept policy-selected targets")]
         yes: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum ExtensionCommands {
+    #[command(about = "List extensions available on PATH")]
+    List,
 }
 
 pub(crate) fn run() -> Result<()> {
@@ -191,10 +205,14 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Skill {
             command: SkillCommands::Install { scope, agents, dry_run, yes },
         }) => run_skill_install(scope, agents, dry_run, yes)?,
+        Some(Commands::Extension { command: ExtensionCommands::List }) => {
+            crate::extension::run_list()?
+        }
         Some(Commands::Session { command }) => session::cmd_session(command)?,
         Some(Commands::Completions { shell }) => {
             generate(shell, &mut Cli::command(), "recall", &mut std::io::stdout());
         }
+        Some(Commands::External(args)) => crate::extension::run_external(args)?,
         None => crate::tui::runner::run(None)?,
     }
 
@@ -253,7 +271,7 @@ fn recall_skill_bundle() -> kitup::SkillBundle {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ShareCommands, Shell, SkillCommands, generate};
+    use super::{Cli, Commands, ExtensionCommands, ShareCommands, Shell, SkillCommands, generate};
     use crate::adapters::{
         adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
     };
@@ -360,6 +378,7 @@ mod tests {
         assert!(compact_help.contains("import Import session records from JSON Lines"));
         assert!(compact_help.contains("share Share session pages"));
         assert!(compact_help.contains("skill Manage bundled Agent Skill"));
+        assert!(compact_help.contains("extension Manage Recall extensions"));
         assert!(compact_help.contains("session Operate on indexed sessions"));
         assert!(compact_help.contains("completions Generate shell completion script"));
     }
@@ -415,6 +434,35 @@ mod tests {
                 assert!(yes);
             }
             _ => panic!("expected skill install command"),
+        }
+    }
+
+    #[test]
+    fn extension_list_parses() {
+        let cli = Cli::try_parse_from(["recall", "extension", "list"]).unwrap();
+        match cli.command {
+            Some(Commands::Extension { command: ExtensionCommands::List }) => {}
+            _ => panic!("expected extension list command"),
+        }
+    }
+
+    #[test]
+    fn extension_list_accepts_ext_alias() {
+        let cli = Cli::try_parse_from(["recall", "ext", "list"]).unwrap();
+        match cli.command {
+            Some(Commands::Extension { command: ExtensionCommands::List }) => {}
+            _ => panic!("expected extension list command"),
+        }
+    }
+
+    #[test]
+    fn unknown_subcommand_parses_as_external_extension() {
+        let cli = Cli::try_parse_from(["recall", "reflect", "--limit", "3"]).unwrap();
+        match cli.command {
+            Some(Commands::External(args)) => {
+                assert_eq!(args, ["reflect", "--limit", "3"]);
+            }
+            _ => panic!("expected external command"),
         }
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,285 @@
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ExtensionManifest {
+    name: String,
+    version: String,
+    protocol: u32,
+    min_recall: String,
+    commands: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ExtensionEntry {
+    name: String,
+    path: PathBuf,
+    manifest: Option<ExtensionManifest>,
+    error: Option<String>,
+}
+
+pub(crate) fn run_list() -> Result<()> {
+    let path_env = std::env::var_os("PATH").unwrap_or_default();
+    let extensions = discover_in_path(&path_env);
+
+    if extensions.is_empty() {
+        println!("No extensions found on PATH.");
+        return Ok(());
+    }
+
+    let name_width = extensions
+        .iter()
+        .map(|extension| extension.name.len())
+        .max()
+        .unwrap_or(9)
+        .max("Extension".len());
+    let version_width = extensions
+        .iter()
+        .filter_map(|extension| extension.manifest.as_ref())
+        .map(|manifest| manifest.version.len())
+        .max()
+        .unwrap_or(7)
+        .max("Version".len());
+    let protocol_width = extensions
+        .iter()
+        .filter_map(|extension| extension.manifest.as_ref())
+        .map(|manifest| manifest.protocol.to_string().len())
+        .max()
+        .unwrap_or(8)
+        .max("Protocol".len());
+    let min_recall_width = extensions
+        .iter()
+        .filter_map(|extension| extension.manifest.as_ref())
+        .map(|manifest| manifest.min_recall.len())
+        .max()
+        .unwrap_or(10)
+        .max("Min Recall".len());
+
+    println!(
+        "{name:<name_width$}  {version:<version_width$}  {protocol:>protocol_width$}  {min_recall:<min_recall_width$}  Commands",
+        name = "Extension",
+        version = "Version",
+        protocol = "Protocol",
+        min_recall = "Min Recall"
+    );
+    for extension in extensions {
+        match (extension.manifest, extension.error) {
+            (Some(manifest), _) => {
+                println!(
+                    "{name:<name_width$}  {version:<version_width$}  {protocol:>protocol_width$}  {min_recall:<min_recall_width$}  {commands}",
+                    name = extension.name,
+                    version = manifest.version,
+                    protocol = manifest.protocol,
+                    min_recall = manifest.min_recall,
+                    commands = manifest.commands.join(",")
+                );
+                println!("  {}", extension.path.display());
+            }
+            (_, Some(error)) => {
+                println!(
+                    "{name:<name_width$}  {version:<version_width$}  {protocol:>protocol_width$}  {min_recall:<min_recall_width$}  error: {error}",
+                    name = extension.name,
+                    version = "-",
+                    protocol = "-",
+                    min_recall = "-"
+                );
+                println!("  {}", extension.path.display());
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn run_external(args: Vec<OsString>) -> Result<()> {
+    let path_env = std::env::var_os("PATH").unwrap_or_default();
+    run_external_with_path(args, &path_env)
+}
+
+fn run_external_with_path(args: Vec<OsString>, path_env: &OsStr) -> Result<()> {
+    let mut args = args.into_iter();
+    let name = args.next().ok_or_else(|| anyhow!("missing extension name"))?;
+    let Some(name) = name.to_str() else {
+        bail!("extension name must be valid UTF-8");
+    };
+    if name.is_empty() || name.contains('/') || name.contains('\\') {
+        bail!("invalid extension name: {name}");
+    }
+    let path = find_in_path(name, path_env).ok_or_else(|| {
+        anyhow!("unknown recall command '{name}' and recall-{name} was not found on PATH")
+    })?;
+    let status = Command::new(&path)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run {}", path.display()))?;
+    if !status.success() {
+        bail!("extension recall-{name} exited with status {status}");
+    }
+    Ok(())
+}
+
+fn discover_in_path(path_env: &OsStr) -> Vec<ExtensionEntry> {
+    let mut extensions = BTreeMap::new();
+    for dir in std::env::split_paths(path_env) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !is_executable_file(&path) {
+                continue;
+            }
+            let Some(name) = extension_name(&path) else {
+                continue;
+            };
+            extensions.entry(name).or_insert(path);
+        }
+    }
+
+    extensions
+        .into_iter()
+        .map(|(name, path)| match read_manifest(&name, &path) {
+            Ok(manifest) => ExtensionEntry { name, path, manifest: Some(manifest), error: None },
+            Err(error) => {
+                ExtensionEntry { name, path, manifest: None, error: Some(error.to_string()) }
+            }
+        })
+        .collect()
+}
+
+fn find_in_path(name: &str, path_env: &OsStr) -> Option<PathBuf> {
+    let extension = std::env::consts::EXE_EXTENSION;
+    let binary = if extension.is_empty() {
+        format!("recall-{name}")
+    } else {
+        format!("recall-{name}.{extension}")
+    };
+    std::env::split_paths(path_env)
+        .map(|dir| dir.join(&binary))
+        .find(|path| is_executable_file(path))
+}
+
+fn read_manifest(name: &str, path: &Path) -> Result<ExtensionManifest> {
+    let output = Command::new(path)
+        .arg("--recall-extension-manifest")
+        .output()
+        .with_context(|| format!("failed to read manifest from {}", path.display()))?;
+    if !output.status.success() {
+        bail!("manifest command exited with status {}", output.status);
+    }
+    let manifest: ExtensionManifest =
+        serde_json::from_slice(&output.stdout).context("invalid extension manifest JSON")?;
+    if manifest.name != name {
+        bail!("manifest name '{}' does not match executable name '{}'", manifest.name, name);
+    }
+    Ok(manifest)
+}
+
+fn extension_name(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    let name = file_name.strip_prefix("recall-")?;
+    let extension = std::env::consts::EXE_EXTENSION;
+    let name = if extension.is_empty() {
+        name
+    } else {
+        name.strip_suffix(&format!(".{extension}")).unwrap_or(name)
+    };
+    if name.is_empty() { None } else { Some(name.to_string()) }
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(metadata) = path.metadata() else {
+        return false;
+    };
+    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{discover_in_path, run_external_with_path};
+    use std::ffi::OsString;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    #[cfg(unix)]
+    fn external_dispatch_runs_recall_binary_from_path() {
+        let dir = temp_dir("dispatch");
+        let output = dir.join("out.txt");
+        let binary = dir.join("recall-demo");
+        write_executable(
+            &binary,
+            r#"#!/bin/sh
+printf "%s" "$1" > "$2"
+"#,
+        );
+
+        run_external_with_path(
+            vec![
+                OsString::from("demo"),
+                OsString::from("hello"),
+                output.as_os_str().to_os_string(),
+            ],
+            dir.as_os_str(),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(output).unwrap(), "hello");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn list_reads_extension_manifest() {
+        let dir = temp_dir("manifest");
+        let binary = dir.join("recall-demo");
+        write_executable(
+            &binary,
+            r#"#!/bin/sh
+cat <<'JSON'
+{"name":"demo","version":"0.1.0","protocol":1,"min_recall":"0.2.10","commands":["demo"]}
+JSON
+"#,
+        );
+
+        let extensions = discover_in_path(dir.as_os_str());
+
+        assert_eq!(extensions.len(), 1);
+        assert_eq!(extensions[0].name, "demo");
+        let manifest = extensions[0].manifest.as_ref().unwrap();
+        assert_eq!(manifest.version, "0.1.0");
+        assert_eq!(manifest.protocol, 1);
+        assert_eq!(manifest.min_recall, "0.2.10");
+        assert_eq!(manifest.commands, ["demo"]);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("recall-extension-{label}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, contents).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod config;
 pub(crate) mod db;
 pub(crate) mod embedding;
 pub(crate) mod export;
+pub(crate) mod extension;
 pub(crate) mod handoff;
 pub(crate) mod import;
 pub(crate) mod info;


### PR DESCRIPTION
### What's changed?

- Add `extension` / `ext` subcommand with `list` to discover `recall-*` binaries on PATH and show manifests
- Route unknown subcommands through external extension dispatch (`recall-<name>`)
- Add `src/extension.rs` with discovery, manifest reading, and dispatch logic
- Add CLI parsing tests for extension list, `ext` alias, and external dispatch

### Why

- Wire the extension protocol into the Recall CLI so users can list installed extensions and invoke them as first-class commands