### PR TITLE
feat(extensions): add official extension release flow

### DIFF
--- a/.agents/skills/recall-ext/SKILL.md
+++ b/.agents/skills/recall-ext/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: recall-ext
+description: Develop, release, and self-check Recall extensions. Use when working on Recall ext/extension host behavior, official extensions under extensions/recall-*, extension manifests, extension catalog and binary release flow, managed install/upgrade/remove design, or docs that explain Recall's extension model.
+---
+
+# Recall Ext
+
+## First Read
+
+Read `docs/extensions.md` before changing extension code, extension docs, or
+official extension release wiring. Treat it as the design source. Treat code as
+runtime truth if the doc and implementation disagree.
+
+## Boundaries
+
+- Keep Recall core as the data plane and stable CLI JSON/JSONL protocol.
+- Build extensions as external binaries named `recall-<name>`.
+- Use `recall extension ...` and `recall ext ...` for host commands.
+- Do not expose Rust internals, add a `recall-core` crate, or depend on SQLite
+  schema from an extension.
+- Do not add permissions/capabilities fields for native binaries; Recall cannot
+  enforce them.
+- Do not add an open registry unless real third-party distribution demand
+  exists. Official catalog first.
+
+## Develop An Official Extension
+
+Use `extensions/recall-probe/` as the minimal template.
+
+1. Create `extensions/recall-<name>/` as a workspace binary package.
+2. Name the Cargo package and binary `recall-<name>`.
+3. Keep the package version independent from Recall core.
+4. Add the package to the root workspace members, keeping `default-members = ["."]`.
+5. Implement `--recall-extension-manifest` with JSON stdout:
+
+```json
+{
+  "name": "<name>",
+  "version": "0.1.0",
+  "protocol": 1,
+  "min_recall": "0.2.10",
+  "commands": ["<name>"]
+}
+```
+
+6. Consume Recall through stable CLI commands such as `recall info --format json`,
+   `recall session list --format json`, `recall search --format json`,
+   `recall session show --format json`, and `recall export`.
+
+## Self-Check
+
+Run the smallest relevant set, then `make check` before ship:
+
+```bash
+cargo build -p recall-<name>
+cargo run -p recall-<name> -- --recall-extension-manifest
+PATH="$PWD/target/debug:$PATH" cargo run -- ext list
+PATH="$PWD/target/debug:$PATH" cargo run -- <name>
+cargo test --lib extension::tests
+make check
+```
+
+For release-only edits, also verify package output for each changed official
+extension:
+
+```bash
+cargo build -p recall-<name> --release --target <target>
+shasum -a 256 <archive>
+```
+
+## Release An Official Extension
+
+Changing an extension package version is release intent. Changing extension code
+without changing its package version is not a release.
+
+Use independent generated extension tags:
+
+```text
+recall-<name>-v<version>
+```
+
+Release flow:
+
+1. Bump `extensions/recall-<name>/Cargo.toml` only when releasing.
+2. Let PR checks verify version increase, absent tag, build, and manifest.
+3. After merge, let the workflow create `recall-<name>-v<version>`.
+4. Let the release job build archives and upload the GitHub Release.
+5. Let the catalog job generate and commit `website/public/extensions/catalog.json`.
+6. Publish the catalog through GitHub Pages at
+   `https://samzong.github.io/Recall/extensions/catalog.json`.
+7. Include `sha256`, `protocol`, `min_recall`, target URLs, and version entries.
+
+Recall core tags (`v*`) and extension tags are separate. Tag core only when core
+changes. Tag an extension only when that extension binary changes.
+
+## Managed Install Design
+
+When implementing `recall ext install`, `upgrade`, or `remove`, follow the
+managed model in `docs/extensions.md`:
+
+- install root: `<data_dir>/recall/extensions/`;
+- state file: `installed.json`;
+- packages: `packages/<name>/<version>/`;
+- command entries: `bin/recall-<name>`;
+- dispatch order: core command, managed extension, PATH extension, unknown.
+
+Install and upgrade must download from the official catalog, verify `sha256`,
+validate the manifest, move into `packages/`, update the `bin/` entry, then
+write `installed.json`. Remove must delete only managed files, never a
+user-installed PATH extension.

--- a/.agents/skills/recall-ext/agents/openai.yaml
+++ b/.agents/skills/recall-ext/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recall Ext"
+  short_description: "Develop and release Recall extensions"
+  default_prompt: "Use $recall-ext to develop, release, and self-check a Recall extension."

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -1,0 +1,399 @@
+name: Extension Release
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - extensions/**
+      - .github/workflows/extension-release.yml
+  push:
+    branches: [main]
+    tags: ["recall-*-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Extension release tag to build, for example recall-probe-v0.1.0
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: git fetch --force --tags
+      - name: Check changed official extensions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import subprocess
+          import sys
+          import tomllib
+
+          def run(args, **kwargs):
+              return subprocess.run(args, text=True, check=True, **kwargs)
+
+          def output(args):
+              return subprocess.check_output(args, text=True)
+
+          def package_meta(path):
+              data = tomllib.loads(pathlib.Path(path).read_text())
+              package = data["package"]
+              return package["name"], str(package["version"])
+
+          def semver(value):
+              parts = value.split("-", 1)[0].split(".")
+              if len(parts) != 3 or not all(part.isdigit() for part in parts):
+                  raise ValueError(f"official extension versions must use x.y.z: {value}")
+              return tuple(int(part) for part in parts)
+
+          base = os.environ["BASE_SHA"]
+          changed = output(["git", "diff", "--name-only", base, "HEAD"]).splitlines()
+          dirs = sorted({
+              "/".join(file.split("/")[:2])
+              for file in changed
+              if file.startswith("extensions/recall-") and len(file.split("/")) >= 2
+          })
+          if not dirs:
+              print("No official extension changes.")
+              raise SystemExit(0)
+
+          failed = False
+          for directory in dirs:
+              cargo_toml = pathlib.Path(directory) / "Cargo.toml"
+              if not cargo_toml.exists():
+                  continue
+              package, version = package_meta(cargo_toml)
+              try:
+                  base_text = output(["git", "show", f"{base}:{directory}/Cargo.toml"])
+                  base_data = tomllib.loads(base_text)
+                  base_version = str(base_data["package"]["version"])
+              except subprocess.CalledProcessError:
+                  base_version = None
+
+              version_changed = base_version != version
+              print(f"{package} {version} version_changed={str(version_changed).lower()}")
+              if version_changed:
+                  if base_version is not None and semver(version) <= semver(base_version):
+                      print(f"::error::{package} version must increase: {base_version} -> {version}")
+                      failed = True
+                  tag = f"{package}-v{version}"
+                  tag_exists = subprocess.run(
+                      ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+                      stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL,
+                      check=False,
+                  ).returncode == 0
+                  if tag_exists:
+                      print(f"::error::release tag already exists: {tag}")
+                      failed = True
+
+              run(["cargo", "build", "-p", package])
+              manifest_output = output([
+                  "cargo",
+                  "run",
+                  "-p",
+                  package,
+                  "--",
+                  "--recall-extension-manifest",
+              ])
+              manifest = json.loads(manifest_output)
+              expected_name = package.removeprefix("recall-")
+              checks = {
+                  "name": manifest.get("name") == expected_name,
+                  "version": manifest.get("version") == version,
+                  "protocol": isinstance(manifest.get("protocol"), int),
+                  "min_recall": isinstance(manifest.get("min_recall"), str),
+                  "commands": isinstance(manifest.get("commands"), list),
+              }
+              for field, ok in checks.items():
+                  if not ok:
+                      print(f"::error::{package} manifest has invalid {field}")
+                      failed = True
+
+          if failed:
+              raise SystemExit(1)
+          PY
+
+  tag:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.tag == '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - name: Find unreleased official extension versions
+        run: |
+          python3 <<'PY'
+          import pathlib
+          import subprocess
+          import tomllib
+
+          rows = []
+          for cargo_toml in sorted(pathlib.Path("extensions").glob("recall-*/Cargo.toml")):
+              data = tomllib.loads(cargo_toml.read_text())
+              package = data["package"]["name"]
+              version = str(data["package"]["version"])
+              tag = f"{package}-v{version}"
+              exists = subprocess.run(
+                  ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+                  check=False,
+              ).returncode == 0
+              if not exists:
+                  rows.append(f"{package} {version} {tag}")
+
+          pathlib.Path("extension-tags.txt").write_text("\n".join(rows) + ("\n" if rows else ""))
+          if rows:
+              print("\n".join(rows))
+          else:
+              print("No unreleased official extension versions.")
+          PY
+      - name: Push extension release tags
+        if: hashFiles('extension-tags.txt') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -s extension-tags.txt ]; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          while read -r _ _ tag; do
+            git tag -a "$tag" -m "$tag"
+          done < extension-tags.txt
+          mapfile -t tags < <(awk '{print $3}' extension-tags.txt)
+          git push origin "${tags[@]}"
+          while read -r _ _ tag; do
+            gh workflow run extension-release.yml --ref main -f tag="$tag"
+          done < extension-tags.txt
+
+  build:
+    if: startsWith(github.ref, 'refs/tags/recall-') || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-15
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: extension-${{ matrix.target }}
+      - name: Parse tag
+        shell: bash
+        run: |
+          tag="${{ inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+          fi
+          version="${tag##*-v}"
+          package="${tag:0:${#tag}-${#version}-2}"
+          {
+            echo "PACKAGE=$package"
+            echo "VERSION=$version"
+            echo "RELEASE_TAG=$tag"
+          } >> "$GITHUB_ENV"
+      - name: Validate tag
+        shell: bash
+        run: |
+          test -f "extensions/$PACKAGE/Cargo.toml"
+          python3 <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          package = os.environ["PACKAGE"]
+          version = os.environ["VERSION"]
+          data = tomllib.loads(pathlib.Path(f"extensions/{package}/Cargo.toml").read_text())
+          actual = str(data["package"]["version"])
+          if actual != version:
+              raise SystemExit(f"{package} version mismatch: tag={version} Cargo.toml={actual}")
+          PY
+      - name: Build
+        run: cargo build -p "$PACKAGE" --release --target ${{ matrix.target }}
+        shell: bash
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          archive="${PACKAGE}-v${VERSION}-${{ matrix.target }}.tar.gz"
+          tar -C "target/${{ matrix.target }}/release" -czf "$archive" "$PACKAGE"
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archive = "${env:PACKAGE}-v${env:VERSION}-${{ matrix.target }}.zip"
+          $binary = "target/${{ matrix.target }}/release/${env:PACKAGE}.exe"
+          Compress-Archive -Path $binary -DestinationPath $archive
+      - uses: actions/upload-artifact@v5
+        with:
+          name: ${{ env.PACKAGE }}-${{ matrix.target }}
+          path: |
+            ${{ env.PACKAGE }}-v${{ env.VERSION }}-*.tar.gz
+            ${{ env.PACKAGE }}-v${{ env.VERSION }}-*.zip
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/recall-') || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          merge-multiple: true
+      - name: Create release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+          fi
+          assets=( ./*.tar.gz ./*.zip )
+          sha256sum "${assets[@]}" | sort > checksums.txt
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" --clobber "${assets[@]}" checksums.txt
+          else
+            gh release create "$tag" \
+              --title "$tag" \
+              --generate-notes \
+              "${assets[@]}" checksums.txt
+          fi
+
+  catalog:
+    if: startsWith(github.ref, 'refs/tags/recall-') || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: extension-catalog
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: extension-catalog
+      - uses: actions/download-artifact@v5
+        with:
+          merge-multiple: true
+      - name: Sync main
+        run: git pull --rebase origin main
+      - name: Update catalog
+        env:
+          REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          python3 <<'PY'
+          import hashlib
+          import json
+          import os
+          import pathlib
+          import subprocess
+          import tomllib
+
+          tag = os.environ["RELEASE_TAG"]
+          version = tag.rsplit("-v", 1)[1]
+          package = tag[: -(len(version) + 2)]
+          manifest = json.loads(subprocess.check_output([
+              "cargo",
+              "run",
+              "-p",
+              package,
+              "--",
+              "--recall-extension-manifest",
+          ], text=True))
+          if manifest["version"] != version:
+              raise SystemExit(f"manifest version mismatch for {tag}")
+
+          cargo = tomllib.loads(pathlib.Path(f"extensions/{package}/Cargo.toml").read_text())
+          description = cargo["package"].get("description", "")
+          prefix = f"{package}-v{version}-"
+          targets = {}
+          for archive in sorted(pathlib.Path(".").glob(f"{prefix}*.tar.gz")) + sorted(pathlib.Path(".").glob(f"{prefix}*.zip")):
+              name = archive.name
+              if name.endswith(".tar.gz"):
+                  target = name.removeprefix(prefix).removesuffix(".tar.gz")
+              elif name.endswith(".zip"):
+                  target = name.removeprefix(prefix).removesuffix(".zip")
+              else:
+                  continue
+              targets[target] = {
+                  "url": f"https://github.com/{os.environ['REPOSITORY']}/releases/download/{tag}/{name}",
+                  "sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
+              }
+          if not targets:
+              raise SystemExit(f"no release archives found for {tag}")
+
+          path = pathlib.Path("website/public/extensions/catalog.json")
+          catalog = json.loads(path.read_text()) if path.exists() else {"schema": 1, "extensions": {}}
+          if catalog.get("schema") != 1:
+              raise SystemExit("unsupported extension catalog schema")
+
+          extension = manifest["name"]
+          entry = catalog.setdefault("extensions", {}).setdefault(extension, {})
+          entry["description"] = description
+          entry.setdefault("versions", {})[version] = {
+              "commands": manifest["commands"],
+              "min_recall": manifest["min_recall"],
+              "protocol": manifest["protocol"],
+              "targets": targets,
+          }
+          path.write_text(json.dumps(catalog, indent=2, sort_keys=True) + "\n")
+          PY
+      - name: Commit catalog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add website/public/extensions/catalog.json
+          if git diff --cached --quiet; then
+            echo "Catalog already up to date."
+            exit 0
+          fi
+          tag="${RELEASE_TAG}"
+          version="${tag##*-v}"
+          package="${tag:0:${#tag}-${#version}-2}"
+          git commit -m "chore(extensions): publish $package v$version"
+          git push origin HEAD:main
+          gh workflow run pages.yml --ref main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "recall-probe"
+version = "0.1.0"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ description = "Unified search, usage tracking, and JSONL export for AI coding se
 repository = "https://github.com/samzong/Recall"
 publish = false
 
+[workspace]
+members = [".", "extensions/recall-probe"]
+default-members = ["."]
+resolver = "2"
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/Makefile
+++ b/Makefile
@@ -23,21 +23,21 @@ release: ## Release build (LTO + strip)
 
 check: ## Full quality gate — format, lint, test
 	@printf '\n$(BOLD)[1/3] Checking format$(RESET)\n'
-	$(CARGO) fmt -- --check
+	$(CARGO) fmt --all -- --check
 	@printf '\n$(BOLD)[2/3] Running clippy$(RESET)\n'
-	$(CARGO) clippy --all-targets -- -D warnings
+	$(CARGO) clippy --workspace --all-targets -- -D warnings
 	@printf '\n$(BOLD)[3/3] Running tests$(RESET)\n'
-	$(CARGO) test
+	$(CARGO) test --workspace
 	@printf '\n$(GREEN)  ✓ All checks passed$(RESET)\n\n'
 
 test: ## Run tests
-	$(CARGO) test
+	$(CARGO) test --workspace
 
 lint: ## Run clippy
-	$(CARGO) clippy --all-targets -- -D warnings
+	$(CARGO) clippy --workspace --all-targets -- -D warnings
 
 fmt: ## Format code
-	$(CARGO) fmt
+	$(CARGO) fmt --all
 
 # ── Documentation ────────────────────────────────────────────────────────────
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -167,14 +167,14 @@ This is a later concern, not a first-stage requirement.
 
 ## Extension Model
 
-- Naming: an extension is a PATH executable named `recall-<name>`.
+- Naming: an extension binary is `recall-<name>`.
 - Dispatch: `recall <name> [args...]` executes `recall-<name> [args...]` when
   `<name>` is not a core subcommand.
-- Explicit form: `recall extension run <name> -- ...` may exist to remove
-  ambiguity.
-- First-stage host command: `recall extension list`.
-- `install` and `remove` should wait until real third-party installation demand
-  exists.
+- Host command: `recall extension ...`, with `recall ext ...` as the short
+  alias.
+- Current host surface: `recall ext list` plus implicit external dispatch from
+  PATH.
+- Managed official install/upgrade/remove use the distribution model below.
 
 ## Manifest
 
@@ -200,22 +200,212 @@ Do not add `capabilities` or `permissions` fields for native binaries. Recall
 cannot enforce them, so they would be security theater. Permission semantics
 only become meaningful in a sandboxed runtime such as WASM.
 
-## Official And Third-Party Extensions
+## Official Extension Distribution
 
 Official extensions can live in this repository as workspace binary crates:
 
 ```text
+extensions/recall-probe/
 extensions/recall-share/
 extensions/recall-reflect/
 ```
 
-They can ship through the same release pipeline as Recall.
+Each official extension owns its own Cargo package version. Recall core releases
+and official extension releases are related by protocol compatibility, not by a
+shared version number.
+
+`extensions/recall-probe/` is the official no-business-logic extension host
+probe. It exists to show the required crate layout, binary naming, manifest
+output, and `recall <name>` dispatch behavior.
+
+Local verification:
+
+```bash
+cargo build -p recall-probe
+PATH="$PWD/target/debug:$PATH" cargo run -- ext list
+PATH="$PWD/target/debug:$PATH" cargo run -- probe
+```
+
+### Versioning
+
+Use independent extension tags:
+
+```text
+v0.2.11                    # Recall core release
+recall-probe-v0.1.1        # recall-probe release
+recall-reflect-v0.3.0      # recall-reflect release
+```
+
+An extension update should not require a Recall core tag unless it needs a new
+core protocol. A Recall core update should not require extension tags unless an
+extension binary also changed.
+
+Changing extension code without changing that extension's Cargo package version
+does not release it. Changing the package version is the release intent.
+
+### Binary Releases
+
+Official extension release workflow:
+
+1. A pull request changes `extensions/recall-<name>/`.
+2. If the package version changed, CI verifies that the version increased, the
+   release tag does not already exist, the package builds, and the manifest
+   matches the package metadata.
+3. After merge to `main`, the workflow detects official extension package
+   versions whose `recall-<name>-v<version>` tag does not exist.
+4. The workflow creates the missing extension tag and dispatches the extension
+   release job for that tag.
+5. The release job builds only that package:
+
+   ```bash
+   cargo build -p recall-<name> --release --target <target>
+   ```
+
+6. The release job uploads binaries and `checksums.txt` to the GitHub Release.
+7. The catalog job updates `website/public/extensions/catalog.json` with the
+   real release URLs and SHA-256 checksums, then commits the generated catalog
+   back to `main`.
+
+Asset names:
+
+```text
+recall-probe-v0.1.1-aarch64-apple-darwin.tar.gz
+recall-probe-v0.1.1-x86_64-apple-darwin.tar.gz
+recall-probe-v0.1.1-x86_64-unknown-linux-gnu.tar.gz
+recall-probe-v0.1.1-x86_64-pc-windows-msvc.zip
+```
+
+```mermaid
+flowchart TD
+  PR["PR changes extension code"] --> Version{"package version changed?"}
+  Version -- no --> MergeOnly["merge only<br/>no extension release"]
+  Version -- yes --> Check["PR check<br/>version increased<br/>tag absent<br/>manifest valid"]
+  Check --> Merge["merge to main"]
+  Merge --> Tag["workflow creates<br/>recall-probe-v0.1.1"]
+  Tag --> Build["build target archives"]
+  Build --> Release["GitHub Release assets<br/>checksums.txt"]
+  Release --> Catalog["bot commit<br/>website/public/extensions/catalog.json"]
+  Catalog --> Pages["GitHub Pages<br/>latest catalog"]
+  Pages --> Install["recall ext install / upgrade"]
+```
+
+### Catalog
+
+Official catalog path:
+
+```text
+website/public/extensions/catalog.json
+https://samzong.github.io/Recall/extensions/catalog.json
+```
+
+When implemented, `recall ext install` and `recall ext upgrade` read the latest
+catalog from GitHub Pages. They do not depend on the catalog embedded in the
+user's current Recall binary. A release may also attach a snapshot catalog as a
+GitHub Release asset for audit and reproduction, but the live install source is
+the Pages catalog.
+
+`website/public/extensions/catalog.json` is generated release state. Humans do
+not hand-edit version entries. The extension release workflow writes them after
+the release binaries exist, because the catalog must contain real asset URLs and
+SHA-256 checksums.
+
+Catalog shape:
+
+```json
+{
+  "schema": 1,
+  "extensions": {
+    "probe": {
+      "description": "Extension host probe",
+      "versions": {
+        "0.1.1": {
+          "protocol": 1,
+          "min_recall": "0.2.10",
+          "targets": {
+            "aarch64-apple-darwin": {
+              "url": "https://github.com/samzong/Recall/releases/download/recall-probe-v0.1.1/recall-probe-v0.1.1-aarch64-apple-darwin.tar.gz",
+              "sha256": "<hex>"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Managed Install Root
+
+Official installs are managed by Recall. They do not mutate the user's PATH.
+`bin/` entries may be symlinks, launcher shims, or copied binaries depending on
+platform support.
+
+```text
+<data_dir>/recall/extensions/
+  installed.json
+  bin/
+    recall-probe
+  packages/
+    probe/
+      0.1.1/
+        recall-probe
+        manifest.json
+```
+
+`<data_dir>` follows the same `dirs::data_dir()` convention as
+`<data_dir>/recall/recall.db`.
+
+Dispatch order:
+
+1. core subcommand;
+2. managed extension binary under `<data_dir>/recall/extensions/bin`;
+3. user PATH binary named `recall-<name>`;
+4. unknown command.
+
+```mermaid
+flowchart TD
+  Command["recall probe"] --> Core{"core command?"}
+  Core -- yes --> CoreRun["run core command"]
+  Core -- no --> Managed{"managed extension?"}
+  Managed -- yes --> ManagedBin["extensions/bin/recall-probe"]
+  Managed -- no --> Path{"PATH recall-probe?"}
+  Path -- yes --> PathBin["run PATH binary"]
+  Path -- no --> Error["unknown command"]
+  ManagedBin --> Package["packages/probe/0.1.1/recall-probe"]
+```
+
+### Install, Upgrade, Remove
+
+Install:
+
+```mermaid
+flowchart LR
+  Start["recall ext install probe"] --> CatalogFetch["fetch catalog"]
+  CatalogFetch --> Select["select newest compatible version + target"]
+  Select --> Download["download archive"]
+  Download --> Checksum["verify sha256"]
+  Checksum --> Unpack["unpack to temp dir"]
+  Unpack --> Manifest["validate manifest"]
+  Manifest --> Move["move into packages/probe/<version>"]
+  Move --> Link["switch bin entry"]
+  Link --> State["update installed.json"]
+```
+
+Upgrade is the same flow starting from `installed.json`, selecting a newer
+compatible version. Remove deletes only the managed package, managed bin entry,
+and `installed.json` entry. It must not delete a user-installed PATH extension.
+
+### Third-Party Extensions
 
 Third-party extensions can live in any repository. If the binary is named
 `recall-<name>` and is on PATH, the host can dispatch it. The important
 distinction is not repository ownership. Official and third-party extensions
 must both integrate through the stable CLI protocol instead of relying on core
 modules or SQLite schema.
+
+Do not add an open registry yet. The official catalog is enough for first-party
+binary management. Custom catalogs can be added later if there is real
+third-party distribution demand.
 
 ## Non-Goals
 

--- a/extensions/recall-probe/Cargo.toml
+++ b/extensions/recall-probe/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "recall-probe"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Official Recall extension host probe"
+repository = "https://github.com/samzong/Recall"
+publish = false

--- a/extensions/recall-probe/src/main.rs
+++ b/extensions/recall-probe/src/main.rs
@@ -1,0 +1,38 @@
+use std::process::ExitCode;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const MIN_RECALL: &str = "0.2.10";
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("--recall-extension-manifest") => {
+            println!(
+                "{{\"name\":\"probe\",\"version\":\"{VERSION}\",\"protocol\":1,\"min_recall\":\"{MIN_RECALL}\",\"commands\":[\"probe\"]}}"
+            );
+            ExitCode::SUCCESS
+        }
+        Some("-h" | "--help") => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        Some("-V" | "--version") => {
+            println!("recall-probe {VERSION}");
+            ExitCode::SUCCESS
+        }
+        Some(arg) => {
+            eprintln!("unexpected argument: {arg}");
+            ExitCode::from(2)
+        }
+        None => {
+            println!("Recall extension host probe OK");
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn print_help() {
+    println!(
+        "Official Recall extension host probe\n\nUsage: recall probe [OPTIONS]\n\nOptions:\n      --recall-extension-manifest  Print Recall extension manifest JSON\n  -h, --help                       Print help\n  -V, --version                    Print version"
+    );
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,7 +212,12 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Completions { shell }) => {
             generate(shell, &mut Cli::command(), "recall", &mut std::io::stdout());
         }
-        Some(Commands::External(args)) => crate::extension::run_external(args)?,
+        Some(Commands::External(args)) => {
+            let status = crate::extension::run_external(args)?;
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
+            }
+        }
         None => crate::tui::runner::run(None)?,
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
@@ -97,12 +97,12 @@ pub(crate) fn run_list() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn run_external(args: Vec<OsString>) -> Result<()> {
+pub(crate) fn run_external(args: Vec<OsString>) -> Result<ExitStatus> {
     let path_env = std::env::var_os("PATH").unwrap_or_default();
     run_external_with_path(args, &path_env)
 }
 
-fn run_external_with_path(args: Vec<OsString>, path_env: &OsStr) -> Result<()> {
+fn run_external_with_path(args: Vec<OsString>, path_env: &OsStr) -> Result<ExitStatus> {
     let mut args = args.into_iter();
     let name = args.next().ok_or_else(|| anyhow!("missing extension name"))?;
     let Some(name) = name.to_str() else {
@@ -114,14 +114,10 @@ fn run_external_with_path(args: Vec<OsString>, path_env: &OsStr) -> Result<()> {
     let path = find_in_path(name, path_env).ok_or_else(|| {
         anyhow!("unknown recall command '{name}' and recall-{name} was not found on PATH")
     })?;
-    let status = Command::new(&path)
+    Command::new(&path)
         .args(args)
         .status()
-        .with_context(|| format!("failed to run {}", path.display()))?;
-    if !status.success() {
-        bail!("extension recall-{name} exited with status {status}");
-    }
-    Ok(())
+        .with_context(|| format!("failed to run {}", path.display()))
 }
 
 fn discover_in_path(path_env: &OsStr) -> Vec<ExtensionEntry> {
@@ -228,7 +224,7 @@ printf "%s" "$1" > "$2"
 "#,
         );
 
-        run_external_with_path(
+        let status = run_external_with_path(
             vec![
                 OsString::from("demo"),
                 OsString::from("hello"),
@@ -238,7 +234,30 @@ printf "%s" "$1" > "$2"
         )
         .unwrap();
 
+        assert!(status.success());
         assert_eq!(fs::read_to_string(output).unwrap(), "hello");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn external_dispatch_returns_child_exit_status() {
+        let dir = temp_dir("exit-status");
+        let binary = dir.join("recall-demo");
+        write_executable(
+            &binary,
+            r#"#!/bin/sh
+exit "$1"
+"#,
+        );
+
+        let status = run_external_with_path(
+            vec![OsString::from("demo"), OsString::from("7")],
+            dir.as_os_str(),
+        )
+        .unwrap();
+
+        assert_eq!(status.code(), Some(7));
         fs::remove_dir_all(dir).unwrap();
     }
 

--- a/website/public/extensions/catalog.json
+++ b/website/public/extensions/catalog.json
@@ -1,0 +1,4 @@
+{
+  "schema": 1,
+  "extensions": {}
+}


### PR DESCRIPTION
### What's changed?

- Add the official Recall extension probe package and workspace wiring.
- Add extension release automation for version-intent checks, tag creation, binary release assets, generated catalog commits, and Pages dispatch.
- Add the initial extension catalog plus docs and agent skill guidance for maintaining official extensions.
- Preserve extension child exit status during external dispatch.

### Why

- Keep Recall core small while making official extensions buildable, releasable, discoverable, and upgrade-ready through a generated catalog.

### Verification

- `actionlint`
- `cargo run -p recall-probe -- --recall-extension-manifest`
- `cargo build -p recall-probe --release --target aarch64-apple-darwin`
- `uv run /Users/x/.agents/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/recall-ext`
- `git diff --check`
- `make check`