### PR TITLE
fix(extensions): keep extension releases out of latest

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -285,14 +285,23 @@ jobs:
           if [ -z "$tag" ]; then
             tag="${GITHUB_REF_NAME}"
           fi
+          version="${tag##*-v}"
+          package="${tag:0:${#tag}-${#version}-2}"
           assets=( ./*.tar.gz ./*.zip )
           sha256sum "${assets[@]}" | sort > checksums.txt
+          cat > release-notes.md <<EOF
+          Official Recall extension release for \`$package\` v$version.
+
+          Assets are published for supported target triples. Checksums are available in \`checksums.txt\`.
+          EOF
           if gh release view "$tag" >/dev/null 2>&1; then
+            gh release edit "$tag" --notes-file release-notes.md
             gh release upload "$tag" --clobber "${assets[@]}" checksums.txt
           else
             gh release create "$tag" \
               --title "$tag" \
-              --generate-notes \
+              --latest=false \
+              --notes-file release-notes.md \
               "${assets[@]}" checksums.txt
           fi
 
@@ -396,4 +405,14 @@ jobs:
           package="${tag:0:${#tag}-${#version}-2}"
           git commit -m "chore(extensions): publish $package v$version"
           git push origin HEAD:main
-          gh workflow run pages.yml --ref main
+          expected_sha="$(git rev-parse HEAD)"
+          for _ in $(seq 1 20); do
+            git fetch --quiet origin refs/heads/main:refs/remotes/origin/main
+            if git merge-base --is-ancestor "$expected_sha" origin/main; then
+              gh workflow run pages.yml --ref main
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "main did not contain $expected_sha before Pages dispatch" >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v5
         with:
           merge-multiple: true
@@ -71,7 +73,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          tag="${GITHUB_REF_NAME}"
+          previous_tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | awk -v tag="$tag" '$0 != tag { print; exit }')"
+          notes_args=()
+          if [ -n "$previous_tag" ]; then
+            notes_args=(--notes-start-tag "$previous_tag")
+          fi
+          gh release create "$tag" \
+            --title "$tag" \
             --generate-notes \
+            "${notes_args[@]}" \
             recall-*.tar.gz recall-*.zip


### PR DESCRIPTION
## Summary
- prevent official extension GitHub Releases from becoming the repository Latest release
- use deterministic extension release notes instead of repository-wide generated changelogs
- keep Recall core release notes scoped to the previous v* core tag
- wait for the catalog commit to be visible on origin/main before dispatching Pages

## Verification
- actionlint .github/workflows/release.yml .github/workflows/extension-release.yml
- tag=v0.2.10; git tag --list "v[0-9]*" --sort=-version:refname | awk -v tag="$tag" '$0 != tag { print; exit }'\n