### PR TITLE
fix(tui): capture scrollbar drag

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -18,7 +18,7 @@ use crate::skill_audit::{self, SkillAuditFilters, SkillAuditReport};
 use crate::transcript;
 use crate::tui::layout::{
     MessagePane, SearchLayout, ViewingLayout, search_layout, vertical_scrollbar_position,
-    viewing_layout,
+    vertical_scrollbar_row_position, viewing_layout,
 };
 use crate::tui::search_state::{
     FilterFocus, PanelFocus, ProjectPickerRow, SearchMouseTarget, SortOrder, SourcePickerRow,
@@ -36,6 +36,13 @@ use crate::usage::{self, UsageFilters, UsageReport};
 const USAGE_LOADING_MIN_MS: u128 = 75;
 const SEARCH_DEBOUNCE_MS: u64 = 250;
 
+#[derive(Clone, Copy)]
+enum MouseDragTarget {
+    SearchList,
+    SearchPreview,
+    Viewing,
+}
+
 pub(crate) struct App {
     terminal_area: Rect,
     pub(crate) mode: AppMode,
@@ -51,6 +58,7 @@ pub(crate) struct App {
     pub(crate) viewing_messages: Vec<Message>,
     pub(crate) viewing_selected_msg: usize,
     pub(crate) viewing_scroll_offset: usize,
+    mouse_drag_target: Option<MouseDragTarget>,
     pub(crate) viewing_session_summary: Option<ViewingSessionSummary>,
     pub(crate) all_sources: Vec<(String, String)>,
     pub(crate) config: AppConfig,
@@ -149,6 +157,7 @@ impl App {
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
             viewing_scroll_offset: 0,
+            mouse_drag_target: None,
             viewing_session_summary: None,
             all_sources,
             config,
@@ -741,9 +750,48 @@ impl App {
     }
 
     pub(crate) fn handle_mouse_down(&mut self, column: u16, row: u16, store: &Store) {
+        self.mouse_drag_target = None;
+        self.handle_mouse_down_at(column, row, store, true);
+    }
+
+    pub(crate) fn handle_mouse_drag(&mut self, column: u16, row: u16, store: &Store) {
+        match self.mouse_drag_target {
+            Some(MouseDragTarget::SearchList) if matches!(self.mode, AppMode::Search) => {
+                let layout = search_layout(self.terminal_area);
+                self.drag_search_list_scrollbar(row, &layout, store);
+            }
+            Some(MouseDragTarget::SearchPreview) if matches!(self.mode, AppMode::Search) => {
+                let layout = search_layout(self.terminal_area);
+                self.drag_search_preview_scrollbar(row, &layout);
+            }
+            Some(MouseDragTarget::Viewing) if matches!(self.mode, AppMode::Viewing) => {
+                let layout = viewing_layout(self.terminal_area);
+                self.drag_viewing_scrollbar(row, &layout);
+            }
+            Some(_) => {
+                self.mouse_drag_target = None;
+            }
+            None => self.handle_mouse_down_at(column, row, store, false),
+        }
+    }
+
+    pub(crate) fn handle_mouse_up(&mut self) {
+        self.mouse_drag_target = None;
+    }
+
+    fn handle_mouse_down_at(
+        &mut self,
+        column: u16,
+        row: u16,
+        store: &Store,
+        capture_scrollbar: bool,
+    ) {
         if matches!(self.mode, AppMode::Viewing) {
             let layout = viewing_layout(self.terminal_area);
             if self.handle_viewing_scrollbar_down(column, row, &layout) {
+                if capture_scrollbar {
+                    self.mouse_drag_target = Some(MouseDragTarget::Viewing);
+                }
                 return;
             }
             if let Some((index, start)) = self.viewing_message_at_row(row, &layout) {
@@ -758,7 +806,10 @@ impl App {
         }
 
         let layout = search_layout(self.terminal_area);
-        if self.handle_search_scrollbar_down(column, row, &layout, store) {
+        if let Some(target) = self.handle_search_scrollbar_down(column, row, &layout, store) {
+            if capture_scrollbar {
+                self.mouse_drag_target = Some(target);
+            }
             return;
         }
 
@@ -789,48 +840,35 @@ impl App {
         row: u16,
         layout: &SearchLayout,
         store: &Store,
-    ) -> bool {
+    ) -> Option<MouseDragTarget> {
         let list_viewport = layout.list_inner().height as usize;
-        if let Some(position) =
-            vertical_scrollbar_position(column, row, layout.list, self.results.len(), list_viewport)
+        if vertical_scrollbar_position(column, row, layout.list, self.results.len(), list_viewport)
+            .is_some()
         {
-            self.panel_focus = PanelFocus::SessionList;
-            self.result_scroll_offset = position;
-            let max_position = self.results.len().saturating_sub(list_viewport);
-            self.selected_index = if position == max_position {
-                self.results.len().saturating_sub(1)
-            } else {
-                position.min(self.results.len().saturating_sub(1))
-            };
-            self.load_preview(store);
-            return true;
+            self.drag_search_list_scrollbar(row, layout, store);
+            return Some(MouseDragTarget::SearchList);
         }
 
         if self.preview_messages.is_empty() {
-            return false;
+            return None;
         }
 
         let inner = layout.preview_inner();
         let pane = self.preview_pane(inner.width as usize);
-        if let Some(position) = vertical_scrollbar_position(
+        if vertical_scrollbar_position(
             column,
             row,
             layout.preview,
             pane.total_rows(),
             inner.height as usize,
-        ) {
-            self.panel_focus = PanelFocus::Preview;
-            self.preview_scroll_offset = position;
-            let max_position = pane.total_rows().saturating_sub(inner.height as usize);
-            if position == max_position {
-                self.preview_selected_msg = self.preview_messages.len() - 1;
-            } else if let Some(index) = pane.index_at(position) {
-                self.preview_selected_msg = index;
-            }
-            return true;
+        )
+        .is_some()
+        {
+            self.drag_search_preview_scrollbar(row, layout);
+            return Some(MouseDragTarget::SearchPreview);
         }
 
-        false
+        None
     }
 
     fn handle_viewing_scrollbar_down(
@@ -841,24 +879,86 @@ impl App {
     ) -> bool {
         let messages = layout.messages;
         let pane = self.viewing_pane(messages.width as usize);
-        if let Some(position) = vertical_scrollbar_position(
+        if vertical_scrollbar_position(
             column,
             row,
             layout.scrollbar_area(),
             pane.total_rows(),
             messages.height as usize,
-        ) {
-            self.viewing_scroll_offset = position;
-            let max_position = pane.total_rows().saturating_sub(messages.height as usize);
-            if position == max_position {
-                self.viewing_selected_msg = self.viewing_messages.len() - 1;
-            } else if let Some(index) = pane.index_at(position) {
-                self.viewing_selected_msg = index;
-            }
+        )
+        .is_some()
+        {
+            self.drag_viewing_scrollbar(row, layout);
             return true;
         }
 
         false
+    }
+
+    fn drag_search_list_scrollbar(&mut self, row: u16, layout: &SearchLayout, store: &Store) {
+        let list_viewport = layout.list_inner().height as usize;
+        let Some(position) =
+            vertical_scrollbar_row_position(row, layout.list, self.results.len(), list_viewport)
+        else {
+            return;
+        };
+
+        self.panel_focus = PanelFocus::SessionList;
+        self.result_scroll_offset = position;
+        let max_position = self.results.len().saturating_sub(list_viewport);
+        self.selected_index = if position == max_position {
+            self.results.len().saturating_sub(1)
+        } else {
+            position.min(self.results.len().saturating_sub(1))
+        };
+        self.load_preview(store);
+    }
+
+    fn drag_search_preview_scrollbar(&mut self, row: u16, layout: &SearchLayout) {
+        if self.preview_messages.is_empty() {
+            return;
+        }
+
+        let inner = layout.preview_inner();
+        let pane = self.preview_pane(inner.width as usize);
+        let Some(position) = vertical_scrollbar_row_position(
+            row,
+            layout.preview,
+            pane.total_rows(),
+            inner.height as usize,
+        ) else {
+            return;
+        };
+
+        self.panel_focus = PanelFocus::Preview;
+        self.preview_scroll_offset = position;
+        let max_position = pane.total_rows().saturating_sub(inner.height as usize);
+        if position == max_position {
+            self.preview_selected_msg = self.preview_messages.len() - 1;
+        } else if let Some(index) = pane.index_at(position) {
+            self.preview_selected_msg = index;
+        }
+    }
+
+    fn drag_viewing_scrollbar(&mut self, row: u16, layout: &ViewingLayout) {
+        let messages = layout.messages;
+        let pane = self.viewing_pane(messages.width as usize);
+        let Some(position) = vertical_scrollbar_row_position(
+            row,
+            layout.scrollbar_area(),
+            pane.total_rows(),
+            messages.height as usize,
+        ) else {
+            return;
+        };
+
+        self.viewing_scroll_offset = position;
+        let max_position = pane.total_rows().saturating_sub(messages.height as usize);
+        if position == max_position {
+            self.viewing_selected_msg = self.viewing_messages.len() - 1;
+        } else if let Some(index) = pane.index_at(position) {
+            self.viewing_selected_msg = index;
+        }
     }
 
     pub(crate) fn handle_mouse_scroll_up(&mut self, column: u16, row: u16, store: &Store) {
@@ -2684,6 +2784,7 @@ mod tests {
             viewing_messages: Vec::new(),
             viewing_selected_msg: 0,
             viewing_scroll_offset: 0,
+            mouse_drag_target: None,
             viewing_session_summary: None,
             all_sources: vec![
                 source("claude", "Claude"),
@@ -3042,6 +3143,29 @@ mod tests {
 
         assert_eq!(app.result_scroll_offset, 15);
         assert_eq!(app.selected_index, 19);
+    }
+
+    #[test]
+    fn search_scrollbar_drag_keeps_capture_outside_scrollbar_column() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.set_terminal_size(80, 12);
+        app.results = numbered_results(20);
+
+        let layout = search_layout(app.terminal_area);
+        let scrollbar_column = layout.list.x + layout.list.width - 1;
+        let list_column = layout.list_inner().x;
+        app.handle_mouse_down(scrollbar_column, layout.list.y + 2, &store);
+        app.handle_mouse_drag(list_column, layout.list.y + layout.list.height - 2, &store);
+
+        assert_eq!(app.result_scroll_offset, 15);
+        assert_eq!(app.selected_index, 19);
+
+        app.handle_mouse_up();
+        app.handle_mouse_drag(list_column, layout.list_inner().y, &store);
+
+        assert_eq!(app.selected_index, 15);
     }
 
     #[test]

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -8,6 +8,8 @@ use crossterm::event::{
 pub(crate) enum AppEvent {
     Key(KeyEvent),
     MouseDown { column: u16, row: u16 },
+    MouseDrag { column: u16, row: u16 },
+    MouseUp,
     ScrollUp { column: u16, row: u16 },
     ScrollDown { column: u16, row: u16 },
     Tick,
@@ -18,10 +20,13 @@ pub(crate) fn poll_event(tick_rate: Duration) -> Result<AppEvent> {
         match event::read()? {
             Event::Key(key) if key.kind == KeyEventKind::Press => return Ok(AppEvent::Key(key)),
             Event::Mouse(MouseEvent { kind, column, row, .. }) => match kind {
-                MouseEventKind::Down(MouseButton::Left)
-                | MouseEventKind::Drag(MouseButton::Left) => {
+                MouseEventKind::Down(MouseButton::Left) => {
                     return Ok(AppEvent::MouseDown { column, row });
                 }
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    return Ok(AppEvent::MouseDrag { column, row });
+                }
+                MouseEventKind::Up(MouseButton::Left) => return Ok(AppEvent::MouseUp),
                 MouseEventKind::ScrollUp => return Ok(AppEvent::ScrollUp { column, row }),
                 MouseEventKind::ScrollDown => return Ok(AppEvent::ScrollDown { column, row }),
                 _ => {}

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -159,8 +159,26 @@ pub(crate) fn vertical_scrollbar_position(
         return None;
     }
 
+    vertical_scrollbar_row_position(row, area, content_len, viewport_len)
+}
+
+pub(crate) fn vertical_scrollbar_row_position(
+    row: u16,
+    area: Rect,
+    content_len: usize,
+    viewport_len: usize,
+) -> Option<usize> {
+    if viewport_len == 0 || content_len <= viewport_len {
+        return None;
+    }
+
+    let track = area.inner(Margin { horizontal: 0, vertical: 1 });
+    if track.width == 0 || track.height == 0 {
+        return None;
+    }
+
     let max_position = content_len - viewport_len;
-    let rel = usize::from(row - track.y);
+    let rel = usize::from(row.saturating_sub(track.y).min(track.height - 1));
     match usize::from(track.height - 1) {
         0 => Some(0),
         denom => Some((rel * max_position + denom / 2) / denom),
@@ -229,5 +247,12 @@ mod tests {
         assert_eq!(vertical_scrollbar_position(bar, 12, area, 100, 8), Some(92));
         assert_eq!(vertical_scrollbar_position(bar - 1, 5, area, 100, 8), None);
         assert_eq!(vertical_scrollbar_position(bar, 5, area, 8, 8), None);
+    }
+
+    #[test]
+    fn scrollbar_row_position_clamps_drag_outside_track() {
+        let area = Rect::new(0, 4, 20, 10);
+        assert_eq!(vertical_scrollbar_row_position(0, area, 100, 8), Some(0));
+        assert_eq!(vertical_scrollbar_row_position(99, area, 100, 8), Some(92));
     }
 }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -84,6 +84,8 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
         match poll_event(tick_rate)? {
             AppEvent::Key(key) => app.handle_key(key, &store),
             AppEvent::MouseDown { column, row } => app.handle_mouse_down(column, row, &store),
+            AppEvent::MouseDrag { column, row } => app.handle_mouse_drag(column, row, &store),
+            AppEvent::MouseUp => app.handle_mouse_up(),
             AppEvent::ScrollUp { column, row } => app.handle_mouse_scroll_up(column, row, &store),
             AppEvent::ScrollDown { column, row } => {
                 app.handle_mouse_scroll_down(column, row, &store);

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -88,8 +88,10 @@ pub(super) fn render_vertical_scrollbar(
         return;
     }
 
-    let mut state =
-        ScrollbarState::new(content_len).viewport_content_length(viewport_len).position(position);
+    let max_position = content_len - viewport_len;
+    let mut state = ScrollbarState::new(max_position + 1)
+        .viewport_content_length(viewport_len)
+        .position(position.min(max_position));
     f.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .symbols(scrollbar::VERTICAL)
@@ -225,6 +227,19 @@ mod tests {
             .map(|y| buffer_row(terminal.backend().buffer(), y, width))
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn render_scrollbar_thumb_touches_bottom_at_max_position() {
+        let backend = TestBackend::new(2, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let frame = terminal
+            .draw(|f| {
+                render_vertical_scrollbar(f, ratatui::layout::Rect::new(0, 0, 2, 10), 20, 5, 15)
+            })
+            .unwrap();
+
+        assert_eq!(frame.buffer[(1, 8)].style().fg, Some(Color::Cyan));
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- Capture active scrollbar drags until left mouse release so horizontal drift does not select list rows.
- Split mouse down, drag, and release events for TUI mouse handling.
- Clamp scrollbar drag row mapping and keep the thumb visually reaching the bottom.

### Why

- Dragging a scrollbar should remain a scrollbar gesture even when the pointer leaves the narrow scrollbar column.
- Fixes #86.