### PR TITLE
feat(export): add jsonl include projection

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -103,7 +103,7 @@ recall session list --project /repo --format json
 recall session list --query "query" --project /repo --format json
 recall search "query" --project /repo --format json
 recall session show --id <id> --format json --include metadata,messages,usage,events
-recall export --project /repo
+recall export --project /repo --include metadata,messages,usage,events
 ```
 
 Core support in v0.1:
@@ -115,10 +115,15 @@ Core support in v0.1:
   `recall session list --query ... --format json`;
 - `recall session show` supports `--format json|jsonl`;
 - `recall export` emits JSONL, one session record per line, with export record
-  schema version 4;
+  schema version 4, and supports `--include metadata,messages,usage,events`
+  for field projection. Export projections must include `messages`; `usage`
+  and `events` are optional add-ons;
 - `recall session show --format json` defaults to metadata only. Extensions
   that need transcript data must pass `--messages` or
   `--include metadata,messages,usage,events`.
+
+Transcript-only extensions should use `--include metadata,messages` instead of
+reading usage or event records they do not need.
 
 ### Stability Rules
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,11 @@ enum Commands {
             help = "Maximum sessions to export; 0 means all (default)"
         )]
         limit: usize,
+        #[arg(
+            long,
+            help = "Comma-separated JSONL fields; messages is required: metadata,messages,usage,events"
+        )]
+        include: Option<String>,
     },
     #[command(about = "Import session records from JSON Lines")]
     Import {
@@ -213,13 +218,16 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Usage { json, source, time }) => {
             crate::usage::run_cli(json, source.as_deref(), time.as_deref())?
         }
-        Some(Commands::Export { source, time, project, repo, limit }) => crate::export::run_cli(
-            source.as_deref(),
-            time.as_deref(),
-            project.as_deref(),
-            repo.as_deref(),
-            limit,
-        )?,
+        Some(Commands::Export { source, time, project, repo, limit, include }) => {
+            crate::export::run_cli(
+                source.as_deref(),
+                time.as_deref(),
+                project.as_deref(),
+                repo.as_deref(),
+                limit,
+                include.as_deref(),
+            )?
+        }
         Some(Commands::Import { file, dry_run }) => crate::import::run_cli(&file, dry_run)?,
         Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
             crate::share_init::run(project_name, publish_dir)?
@@ -348,10 +356,19 @@ mod tests {
 
     #[test]
     fn export_accepts_default_jsonl_without_format_flag() {
-        let cli = Cli::try_parse_from(["recall", "export", "--source", "grok"]).unwrap();
+        let cli = Cli::try_parse_from([
+            "recall",
+            "export",
+            "--source",
+            "grok",
+            "--include",
+            "metadata,messages",
+        ])
+        .unwrap();
         match cli.command {
-            Some(Commands::Export { source, .. }) => {
+            Some(Commands::Export { source, include, .. }) => {
                 assert_eq!(source.as_deref(), Some("grok"));
+                assert_eq!(include.as_deref(), Some("metadata,messages"));
             }
             _ => panic!("expected export command"),
         }

--- a/src/export.rs
+++ b/src/export.rs
@@ -12,6 +12,19 @@ use crate::types::{Message, Role, Session, SessionEventRecord, SessionUsageEvent
 pub(crate) const RECORD_SCHEMA_VERSION: u32 = 4;
 const RECORD_TYPE: &str = "session";
 
+#[derive(Clone, Copy)]
+pub(crate) struct ExportIncludes {
+    pub(crate) messages: bool,
+    pub(crate) usage: bool,
+    pub(crate) events: bool,
+}
+
+impl ExportIncludes {
+    pub(crate) fn full() -> Self {
+        Self { messages: true, usage: true, events: true }
+    }
+}
+
 pub(crate) struct ExportOptions {
     pub(crate) session_ids: Vec<String>,
     pub(crate) sources: Option<Vec<String>>,
@@ -19,6 +32,7 @@ pub(crate) struct ExportOptions {
     pub(crate) project: Option<String>,
     pub(crate) repo: Option<RepoFilter>,
     pub(crate) limit: Option<usize>,
+    pub(crate) includes: ExportIncludes,
 }
 
 pub(crate) fn run_cli(
@@ -27,6 +41,7 @@ pub(crate) fn run_cli(
     project_filter: Option<&str>,
     repo_filter: Option<&str>,
     limit: usize,
+    include_filter: Option<&str>,
 ) -> Result<()> {
     let store = Store::open()?;
     let sources = adapters::source_labels();
@@ -38,10 +53,42 @@ pub(crate) fn run_cli(
         project: directory,
         repo,
         limit: if limit == 0 { None } else { Some(limit) },
+        includes: parse_export_includes(include_filter)?,
     };
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     write_jsonl(&store, &options, &mut handle)
+}
+
+pub(crate) fn parse_export_includes(include: Option<&str>) -> Result<ExportIncludes> {
+    let Some(include) = include else {
+        return Ok(ExportIncludes::full());
+    };
+    let includes = apply_include_filter(
+        ExportIncludes { messages: false, usage: false, events: false },
+        include,
+    )?;
+    if !includes.messages {
+        return Err(anyhow!("--include must include messages"));
+    }
+    Ok(includes)
+}
+
+pub(crate) fn apply_include_filter(
+    mut includes: ExportIncludes,
+    include: &str,
+) -> Result<ExportIncludes> {
+    for part in include.split(',').map(|part| part.trim().to_lowercase()) {
+        match part.as_str() {
+            "all" => includes = ExportIncludes::full(),
+            "metadata" | "" => {}
+            "messages" => includes.messages = true,
+            "usage" => includes.usage = true,
+            "events" => includes.events = true,
+            _ => return Err(anyhow!("unknown include field: {part}")),
+        }
+    }
+    Ok(includes)
 }
 
 #[derive(Serialize)]
@@ -142,7 +189,7 @@ pub(crate) fn write_jsonl<W: Write>(
         sessions
     };
 
-    write_jsonl_for_sessions(store, sessions, &mut writer)
+    write_jsonl_for_sessions(store, sessions, options.includes, &mut writer)
 }
 
 pub(crate) fn session_record_value(
@@ -157,12 +204,22 @@ pub(crate) fn session_record_value(
 fn write_jsonl_for_sessions<W: Write>(
     store: &Store,
     sessions: Vec<Session>,
+    includes: ExportIncludes,
     mut writer: W,
 ) -> Result<()> {
     for session in sessions {
-        let messages = store.get_messages(&session.id)?;
-        let usage_events = store.list_usage_events_for_session(&session.id)?;
-        let events = store.list_session_events_for_session(&session.id)?;
+        let messages =
+            if includes.messages { store.get_messages(&session.id)? } else { Vec::new() };
+        let usage_events = if includes.usage {
+            store.list_usage_events_for_session(&session.id)?
+        } else {
+            Vec::new()
+        };
+        let events = if includes.events {
+            store.list_session_events_for_session(&session.id)?
+        } else {
+            Vec::new()
+        };
         let record = build_session_record(session, messages, usage_events, events);
         serde_json::to_writer(&mut writer, &record)?;
         writer.write_all(b"\n")?;

--- a/src/import.rs
+++ b/src/import.rs
@@ -283,7 +283,7 @@ mod tests {
     use super::*;
     use crate::db::schema;
     use crate::db::search::TimeRange;
-    use crate::export::{ExportOptions, write_jsonl};
+    use crate::export::{ExportIncludes, ExportOptions, write_jsonl};
 
     fn setup() -> Store {
         schema::register_sqlite_vec();
@@ -394,6 +394,7 @@ mod tests {
             project: None,
             repo: None,
             limit: None,
+            includes: ExportIncludes::full(),
         };
         let mut out = Vec::new();
         write_jsonl(store, &options, &mut out).unwrap();

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -5,7 +5,7 @@ use crate::config::AppConfig;
 use crate::db::schema;
 use crate::db::search::{RepoFilter, SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::Store;
-use crate::export::{ExportOptions, write_jsonl};
+use crate::export::{ExportIncludes, ExportOptions, write_jsonl};
 use crate::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource};
 use crate::usage::{UsageFilters, build_usage_report};
 
@@ -311,6 +311,7 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
         project: None,
         repo: None,
         limit: Some(10),
+        includes: ExportIncludes::full(),
     };
     let mut out = Vec::new();
     write_jsonl(&store, &options, &mut out).unwrap();
@@ -350,6 +351,53 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
 }
 
 #[test]
+fn export_jsonl_applies_include_projection() {
+    let store = setup();
+    let session = make_session("s1", "codex", "raw1", "Projected export");
+    let messages = vec![make_message("s1", Role::User, "hello", 0)];
+    let usage = vec![make_usage_event("evt-1", 1_800_000_001_000, "gpt-5")];
+    let events = vec![make_session_event("file_read", Some("read_file"), Some("src/main.rs"))];
+    store
+        .persist_session_with_usage_and_events(
+            &session,
+            &messages,
+            &usage,
+            Some(1),
+            &events,
+            Some(1),
+        )
+        .unwrap();
+
+    let options = ExportOptions {
+        session_ids: Vec::new(),
+        sources: None,
+        time_range: TimeRange::All,
+        project: None,
+        repo: None,
+        limit: None,
+        includes: ExportIncludes { messages: true, usage: false, events: false },
+    };
+    let mut out = Vec::new();
+    write_jsonl(&store, &options, &mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+    let value: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(value["messages"][0]["content"], "hello");
+    assert_eq!(value["usage_events"].as_array().unwrap().len(), 0);
+    assert_eq!(value["events"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn export_include_requires_messages() {
+    let err = match crate::export::parse_export_includes(Some("metadata,usage")) {
+        Ok(_) => panic!("messages should be required"),
+        Err(err) => err,
+    };
+    assert_eq!(err.to_string(), "--include must include messages");
+    assert!(crate::export::parse_export_includes(Some("metadata,messages")).unwrap().messages);
+}
+
+#[test]
 fn export_jsonl_can_select_sessions_by_id() {
     let store = setup();
     for id in ["s1", "s2", "s3"] {
@@ -365,6 +413,7 @@ fn export_jsonl_can_select_sessions_by_id() {
         project: None,
         repo: None,
         limit: None,
+        includes: ExportIncludes::full(),
     };
     let mut out = Vec::new();
     write_jsonl(&store, &options, &mut out).unwrap();
@@ -411,6 +460,7 @@ fn export_jsonl_applies_source_time_project_and_limit_filters() {
         project: Some("/tmp/project".to_string()),
         repo: None,
         limit: Some(1),
+        includes: ExportIncludes::full(),
     };
     let mut out = Vec::new();
     write_jsonl(&store, &options, &mut out).unwrap();
@@ -667,6 +717,7 @@ fn export_jsonl_applies_repo_filter() {
         project: None,
         repo: Some(RepoFilter::Slug("samzong/Recall".to_string())),
         limit: None,
+        includes: ExportIncludes::full(),
     };
     let mut out = Vec::new();
     write_jsonl(&store, &options, &mut out).unwrap();

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,7 +7,7 @@ use crate::adapters;
 use crate::config::AppConfig;
 use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
 use crate::db::store::{SessionListSort, Store};
-use crate::export::ExportOptions;
+use crate::export::{ExportIncludes, ExportOptions};
 use crate::handoff;
 use crate::query::{parse_time_range, query_embedding, resolve_source_filter};
 use crate::semantic;
@@ -77,6 +77,11 @@ pub(crate) enum SessionCommands {
         ids_file: Option<PathBuf>,
         #[arg(long, value_enum, default_value_t = SessionExportFormat::Jsonl)]
         format: SessionExportFormat,
+        #[arg(
+            long,
+            help = "Comma-separated JSONL fields; messages is required: metadata,messages,usage,events"
+        )]
+        include: Option<String>,
         #[arg(long, help = "Output path; stdout when omitted")]
         output: Option<PathBuf>,
     },
@@ -187,12 +192,6 @@ struct SessionListRow {
     snippet: Option<String>,
 }
 
-struct SessionIncludes {
-    messages: bool,
-    usage: bool,
-    events: bool,
-}
-
 pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
     match command {
         SessionCommands::List {
@@ -241,13 +240,14 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             role,
             format,
         ),
-        SessionCommands::Export { ids, source, source_id, ids_file, format, output } => {
+        SessionCommands::Export { ids, source, source_id, ids_file, format, include, output } => {
             cmd_session_export(
                 ids,
                 source.as_deref(),
                 source_id.as_deref(),
                 ids_file,
                 format,
+                include.as_deref(),
                 output,
             )
         }
@@ -423,7 +423,7 @@ fn cmd_session_show(
     let store = Store::open()?;
     let sources = adapters::source_labels();
     let session = resolve_session_ref(&store, &sources, id, source_filter, source_id)?;
-    let includes = parse_session_includes(include, messages_flag, format);
+    let includes = parse_session_includes(include, messages_flag, format)?;
     let messages = if includes.messages {
         filter_session_messages(store.get_messages(&session.id)?, from_seq, to_seq, role)
     } else {
@@ -467,6 +467,7 @@ fn cmd_session_export(
     source_id: Option<&str>,
     ids_file: Option<PathBuf>,
     format: SessionExportFormat,
+    include: Option<&str>,
     output: Option<PathBuf>,
 ) -> Result<()> {
     let store = Store::open()?;
@@ -485,6 +486,7 @@ fn cmd_session_export(
                 project: None,
                 repo: None,
                 limit: None,
+                includes: crate::export::parse_export_includes(include)?,
             };
             if let Some(path) = output {
                 ensure_parent_dir(&path)?;
@@ -733,30 +735,16 @@ fn parse_session_includes(
     include: Option<&str>,
     messages_flag: bool,
     format: SessionDetailFormat,
-) -> SessionIncludes {
-    let mut includes = SessionIncludes {
+) -> Result<ExportIncludes> {
+    let includes = ExportIncludes {
         messages: matches!(format, SessionDetailFormat::Text) || messages_flag,
         usage: false,
         events: false,
     };
     let Some(include) = include else {
-        return includes;
+        return Ok(includes);
     };
-    for part in include.split(',').map(|part| part.trim().to_lowercase()) {
-        match part.as_str() {
-            "all" => {
-                includes.messages = true;
-                includes.usage = true;
-                includes.events = true;
-            }
-            "metadata" | "" => {}
-            "messages" => includes.messages = true,
-            "usage" => includes.usage = true,
-            "events" => includes.events = true,
-            _ => {}
-        }
-    }
-    includes
+    crate::export::apply_include_filter(includes, include)
 }
 
 fn filter_session_messages(


### PR DESCRIPTION
### What's changed?

- Add `--include metadata,messages,usage,events` projection support to `recall export` and `recall session export`.
- Require export projections to include `messages`; `usage` and `events` are optional add-ons.
- Reuse the include parser for session detail/export JSON surfaces and reject unknown include fields.
- Document transcript-only extension usage with `--include metadata,messages`.

### Why

- Gives extensions a stable JSONL projection protocol without binding them to negative internal-table flags.
- Keeps exported records message-bearing so they are still useful as transcript/search artifacts.
- Keeps default full export/import roundtrip behavior unchanged.

### Verification

- `cargo test export_jsonl_applies_include_projection`
- `cargo test export_include_requires_messages`
- `cargo test export_accepts_default_jsonl_without_format_flag`
- `cargo test roundtrip_preserves_all_fields`
- `cargo run --quiet -- export --project /Users/x/git/samzong/Recall --limit 1 --include metadata,messages`
- `cargo run --quiet -- export --limit 1 --include metadata,usage` (expected failure)
- `cargo run --quiet -- export --limit 1 --include nope` (expected failure)
- `python3 /Users/x/.agents/skills/codex-review/scripts/run_codex_review.py --uncommitted`
- `make check`
