### PR TITLE
chore(github): add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default repository owner.
+* @samzong
+
+# Ownership config.
+/.github/CODEOWNERS @samzong
+
+# Official Recall extensions.
+/extensions/recall-probe/ @samzong


### PR DESCRIPTION
### What's changed?

- Add `.github/CODEOWNERS` with `@samzong` as the default repository owner.
- Add explicit ownership entries for the CODEOWNERS file and the current official extension directory.

### Why

- Ensure pull requests touching Recall files request the repository owner by default.
- Keep extension ownership ready to split per extension as more official extensions land.

### Validation

- `git diff --check`
- `/pre-ship --committed` review: no MUST-FIX findings
