### PR TITLE
fix(extensions): set release repo context

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -276,6 +276,7 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           tag="${{ inputs.tag }}"
           if [ -z "$tag" ]; then


### PR DESCRIPTION
### What's changed?

- Set `GH_REPO` for the extension release job so `gh release` commands can run after downloading artifacts without a checkout.

### Why

- The release job currently has no `.git` directory, so `gh release create/view/edit/upload` can fail while trying to infer the repository from git state.

### Validation

- `git diff --check`
- Parsed `.github/workflows/extension-release.yml` as YAML
- Verified `GH_REPO=samzong/Recall gh release list --limit 1` succeeds from a temporary directory with no `.git`
- `/pre-ship --committed` review: no MUST-FIX findings
