### PR TITLE
chore(github): add reflect code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 
 # Official Recall extensions.
 /extensions/recall-probe/ @samzong
+/extensions/recall-reflect/ @samzong @zhexulong


### PR DESCRIPTION
### What's changed?

- Add `@zhexulong` as a CODEOWNER for `extensions/recall-reflect/`.
- Keep `@samzong` on the extension ownership rule.

### Why

- Route review requests for Reflect extension changes to its contributor while preserving repository-owner coverage.

### Validation

- `git diff --check`
- Verified `extensions/recall-reflect/` exists.
- Verified `zhexulong` has repository `write` permission for CODEOWNERS eligibility.
- `/pre-ship --committed` review: no MUST-FIX findings
