### PR TITLE
refactor(adapters): extract shared usage helpers

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -16,7 +16,7 @@ use crate::adapters::{
     first_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct ClaudeCodeAdapter;
 
@@ -557,21 +557,16 @@ fn extract_claude_usage_event(
     };
 
     Some(RawUsageEvent {
-        event_key,
-        event_seq,
         message_seq,
-        timestamp,
         model: model.to_string(),
         provider: "anthropic".to_string(),
         input_tokens,
         output_tokens,
         cache_read_tokens,
         cache_write_tokens,
-        reasoning_tokens: 0,
-        token_source: TokenSource::Observed,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: Some(source_path.to_string()),
         raw_usage_json: Some(usage.to_string()),
+        ..RawUsageEvent::observed(event_key, event_seq, timestamp, USAGE_PARSER_VERSION)
     })
 }
 
@@ -1015,7 +1010,7 @@ mod tests {
         assert_eq!(event.output_tokens, 30);
         assert_eq!(event.cache_read_tokens, 50);
         assert_eq!(event.cache_write_tokens, 5);
-        assert_eq!(event.token_source, TokenSource::Observed);
+        assert_eq!(event.token_source, crate::types::TokenSource::Observed);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -15,7 +15,7 @@ use crate::adapters::{
     first_timestamp, last_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CodexAdapter;
 
@@ -778,21 +778,20 @@ fn extract_codex_usage_event(
         .unwrap_or_else(|| "unknown".to_string());
 
     Some(RawUsageEvent {
-        event_key: format!("token_count:{event_seq}"),
-        event_seq,
-        message_seq: None,
-        timestamp,
         model,
         provider: provider.to_string(),
         input_tokens,
         output_tokens,
         cache_read_tokens,
-        cache_write_tokens: 0,
         reasoning_tokens,
-        token_source: TokenSource::Derived,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: Some(source_path.to_string()),
         raw_usage_json: Some(info.to_string()),
+        ..RawUsageEvent::derived(
+            format!("token_count:{event_seq}"),
+            event_seq,
+            timestamp,
+            USAGE_PARSER_VERSION,
+        )
     })
 }
 
@@ -1399,7 +1398,7 @@ mod tests {
         assert_eq!(raw.usage_events[0].cache_read_tokens, 2);
         assert_eq!(raw.usage_events[0].output_tokens, 3);
         assert_eq!(raw.usage_events[0].reasoning_tokens, 1);
-        assert_eq!(raw.usage_events[0].token_source, TokenSource::Derived);
+        assert_eq!(raw.usage_events[0].token_source, crate::types::TokenSource::Derived);
 
         assert_eq!(raw.usage_events[1].input_tokens, 4);
         assert_eq!(raw.usage_events[1].cache_read_tokens, 1);

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -12,12 +12,13 @@ use walkdir::WalkDir;
 use crate::adapters::events;
 use crate::adapters::json_util::json_i64;
 use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::usage::usage_count;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
 };
 use crate::db::store::{EventSessionStateMeta, Store, UsageSessionStateMeta};
-use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CursorAdapter;
 
@@ -654,31 +655,27 @@ fn extract_bubble_usage_event(
     composer_data: &Value,
 ) -> Option<RawUsageEvent> {
     let token_count = bubble.get("tokenCount")?;
-    let input_tokens =
-        token_count.get("inputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
-    let output_tokens =
-        token_count.get("outputTokens").and_then(|value| json_i64(Some(value))).unwrap_or(0).max(0);
+    let input_tokens = usage_count(token_count, &["inputTokens"]);
+    let output_tokens = usage_count(token_count, &["outputTokens"]);
     if input_tokens == 0 && output_tokens == 0 {
         return None;
     }
 
     let model = model_from_composer(composer_data);
     Some(RawUsageEvent {
-        event_key: format!("bubble:{bubble_id}"),
-        event_seq,
         message_seq: Some(event_seq),
-        timestamp,
         model: model.clone(),
         provider: infer_cursor_provider(&model),
         input_tokens,
         output_tokens,
-        cache_read_tokens: 0,
-        cache_write_tokens: 0,
-        reasoning_tokens: 0,
-        token_source: TokenSource::Observed,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: Some(format!("composer:{composer_id}")),
         raw_usage_json: Some(token_count.to_string()),
+        ..RawUsageEvent::observed(
+            format!("bubble:{bubble_id}"),
+            event_seq,
+            timestamp,
+            USAGE_PARSER_VERSION,
+        )
     })
 }
 
@@ -745,21 +742,18 @@ fn build_session_usage_event(
         .or_else(|| json_i64(composer_data.get("lastUpdatedAt")))
         .unwrap_or(0);
     RawUsageEvent {
-        event_key: "session:prompt-token-breakdown".to_string(),
-        event_seq: 0,
-        message_seq: None,
-        timestamp,
         model: model.clone(),
         provider: infer_cursor_provider(&model),
         input_tokens,
-        output_tokens: 0,
         cache_read_tokens,
-        cache_write_tokens: 0,
-        reasoning_tokens: 0,
-        token_source: TokenSource::Derived,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: Some(format!("composer:{composer_id}")),
         raw_usage_json: if breakdown.is_null() { None } else { Some(breakdown.to_string()) },
+        ..RawUsageEvent::derived(
+            "session:prompt-token-breakdown".to_string(),
+            0,
+            timestamp,
+            USAGE_PARSER_VERSION,
+        )
     }
 }
 

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
-use crate::adapters::json_util::json_i64;
+use crate::adapters::usage::usage_count;
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::types::{RawUsageEvent, Role};
 
 pub(crate) struct GeminiAdapter;
 
@@ -180,10 +180,10 @@ fn extract_gemini_usage_event(
     source_path: Option<&str>,
 ) -> Option<RawUsageEvent> {
     let tokens = msg.get("tokens")?;
-    let input_tokens = json_i64(tokens.get("input")).unwrap_or(0).max(0);
-    let output_tokens = json_i64(tokens.get("output")).unwrap_or(0).max(0);
-    let cache_read_tokens = json_i64(tokens.get("cached")).unwrap_or(0).max(0);
-    let reasoning_tokens = json_i64(tokens.get("thoughts")).unwrap_or(0).max(0);
+    let input_tokens = usage_count(tokens, &["input"]);
+    let output_tokens = usage_count(tokens, &["output"]);
+    let cache_read_tokens = usage_count(tokens, &["cached"]);
+    let reasoning_tokens = usage_count(tokens, &["thoughts"]);
     if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
         return None;
     }
@@ -200,21 +200,16 @@ fn extract_gemini_usage_event(
         .unwrap_or_else(|| format!("line:{event_seq}"));
 
     Some(RawUsageEvent {
-        event_key,
-        event_seq,
         message_seq: Some(message_seq),
-        timestamp,
         model: model.clone(),
         provider: "google".to_string(),
         input_tokens,
         output_tokens,
         cache_read_tokens,
-        cache_write_tokens: 0,
         reasoning_tokens,
-        token_source: TokenSource::Observed,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: source_path.map(str::to_string),
         raw_usage_json: Some(tokens.to_string()),
+        ..RawUsageEvent::observed(event_key, event_seq, timestamp, USAGE_PARSER_VERSION)
     })
 }
 
@@ -287,6 +282,6 @@ mod tests {
         assert_eq!(event.output_tokens, 20);
         assert_eq!(event.cache_read_tokens, 30);
         assert_eq!(event.reasoning_tokens, 5);
-        assert_eq!(event.token_source, TokenSource::Observed);
+        assert_eq!(event.token_source, crate::types::TokenSource::Observed);
     }
 }

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -13,7 +13,7 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::types::{RawUsageEvent, Role};
 
 const USAGE_PARSER_VERSION: u32 = 1;
 
@@ -472,21 +472,16 @@ fn prompt_usage_events(prompts: Vec<PromptTokenState>) -> Vec<RawUsageEvent> {
             continue;
         }
         events.push(RawUsageEvent {
-            event_key: format!("prompt:{}", prompt.prompt_id),
-            event_seq: events.len() as u32,
-            message_seq: None,
-            timestamp: prompt.timestamp.unwrap_or_default(),
             model: prompt.model.unwrap_or_default(),
             provider: "xai".to_string(),
             input_tokens: delta,
-            output_tokens: 0,
-            cache_read_tokens: 0,
-            cache_write_tokens: 0,
-            reasoning_tokens: 0,
-            token_source: TokenSource::Derived,
-            parser_version: USAGE_PARSER_VERSION,
-            source_path: None,
             raw_usage_json: Some(format!("{{\"totalTokens\":{}}}", prompt.peak_total_tokens)),
+            ..RawUsageEvent::derived(
+                format!("prompt:{}", prompt.prompt_id),
+                events.len() as u32,
+                prompt.timestamp.unwrap_or_default(),
+                USAGE_PARSER_VERSION,
+            )
         });
     }
     events

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod opencode;
 pub(crate) mod paths;
 pub(crate) mod pi;
 pub(crate) mod sync_state;
+pub(crate) mod usage;
 
 use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -10,7 +10,7 @@ use crate::adapters::{
     SyncScanStats,
 };
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role, TokenSource};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 const USAGE_PARSER_VERSION: u32 = 1;
@@ -480,10 +480,6 @@ fn parse_usage_event(
         .unwrap_or("unknown");
 
     Some(RawUsageEvent {
-        event_key: format!("message:{message_id}"),
-        event_seq,
-        message_seq: None,
-        timestamp,
         model: model.to_string(),
         provider: provider.to_string(),
         input_tokens: token_count(tokens, "input"),
@@ -491,9 +487,6 @@ fn parse_usage_event(
         cache_read_tokens: cache_token_count(tokens, "read"),
         cache_write_tokens: cache_token_count(tokens, "write"),
         reasoning_tokens: token_count(tokens, "reasoning"),
-        token_source: TokenSource::Observed,
-        parser_version: USAGE_PARSER_VERSION,
-        source_path: None,
         raw_usage_json: Some(
             serde_json::json!({
                 "providerID": provider,
@@ -502,6 +495,12 @@ fn parse_usage_event(
             })
             .to_string(),
         ),
+        ..RawUsageEvent::observed(
+            format!("message:{message_id}"),
+            event_seq,
+            timestamp,
+            USAGE_PARSER_VERSION,
+        )
     })
 }
 

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -9,12 +9,13 @@ use walkdir::WalkDir;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
+use crate::adapters::usage::usage_count;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role, TokenSource};
+use crate::types::{RawUsageEvent, Role};
 
 pub(crate) struct PiAdapter;
 
@@ -495,10 +496,7 @@ fn extract_pi_usage_event(
         .unwrap_or_else(|| format!("line:{event_seq}"));
 
     Some(RawUsageEvent {
-        event_key,
-        event_seq,
         message_seq,
-        timestamp,
         model,
         provider,
         input_tokens: usage_count(usage, &["input", "inputTokens", "input_tokens"]),
@@ -528,19 +526,14 @@ fn extract_pi_usage_event(
                 "reasoning_output_tokens",
             ],
         ),
-        token_source: TokenSource::Observed,
-        parser_version: USAGE_PARSER_VERSION,
         source_path: Some(source_path.to_string()),
         raw_usage_json: Some(usage.to_string()),
+        ..RawUsageEvent::observed(event_key, event_seq, timestamp, USAGE_PARSER_VERSION)
     })
 }
 
 fn non_empty_str(value: Option<&Value>) -> Option<&str> {
     value.and_then(|value| value.as_str()).filter(|value| !value.trim().is_empty())
-}
-
-fn usage_count(usage: &Value, keys: &[&str]) -> i64 {
-    keys.iter().find_map(|key| json_i64(usage.get(*key))).unwrap_or(0).max(0)
 }
 
 fn extract_content(content: Option<&Value>) -> String {
@@ -831,7 +824,7 @@ mod tests {
         assert_eq!(event.output_tokens, 3);
         assert_eq!(event.cache_read_tokens, 2);
         assert_eq!(event.cache_write_tokens, 1);
-        assert_eq!(event.token_source, TokenSource::Observed);
+        assert_eq!(event.token_source, crate::types::TokenSource::Observed);
         assert_eq!(event.parser_version, USAGE_PARSER_VERSION);
         assert_eq!(event.source_path.as_deref(), Some(path.to_string_lossy().as_ref()));
 

--- a/src/adapters/usage.rs
+++ b/src/adapters/usage.rs
@@ -1,0 +1,54 @@
+use serde_json::Value;
+
+use crate::adapters::json_util::json_i64;
+use crate::types::{RawUsageEvent, TokenSource};
+
+impl RawUsageEvent {
+    pub(crate) fn observed(
+        event_key: String,
+        event_seq: u32,
+        timestamp: i64,
+        parser_version: u32,
+    ) -> Self {
+        Self::with_source(event_key, event_seq, timestamp, parser_version, TokenSource::Observed)
+    }
+
+    pub(crate) fn derived(
+        event_key: String,
+        event_seq: u32,
+        timestamp: i64,
+        parser_version: u32,
+    ) -> Self {
+        Self::with_source(event_key, event_seq, timestamp, parser_version, TokenSource::Derived)
+    }
+
+    fn with_source(
+        event_key: String,
+        event_seq: u32,
+        timestamp: i64,
+        parser_version: u32,
+        token_source: TokenSource,
+    ) -> Self {
+        Self {
+            event_key,
+            event_seq,
+            message_seq: None,
+            timestamp,
+            model: "unknown".to_string(),
+            provider: "unknown".to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: 0,
+            token_source,
+            parser_version,
+            source_path: None,
+            raw_usage_json: None,
+        }
+    }
+}
+
+pub(crate) fn usage_count(usage: &Value, keys: &[&str]) -> i64 {
+    keys.iter().find_map(|key| json_i64(usage.get(*key))).unwrap_or(0).max(0)
+}


### PR DESCRIPTION
### What's changed?

- Add `src/adapters/usage.rs` with shared `RawUsageEvent::observed` / `derived` builders and `usage_count` helper
- Refactor Claude Code, Codex, Cursor, Gemini, Grok, OpenCode, and Pi adapters to use struct-update syntax instead of repeating default token fields
- Move duplicated `usage_count` from Pi into the shared module; reuse it in Cursor and Gemini

### Why

- Adapters were repeating the same `RawUsageEvent` scaffolding (event keys, zero defaults, token source, parser version) across seven files
- Centralizing builders and token counting reduces drift and makes future usage parsing changes smaller and safer