### PR TITLE
refactor(adapters): extract shared session_state_is_current helper

### DIFF
--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -17,7 +17,7 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
 };
-use crate::db::store::{EventSessionStateMeta, Store, UsageSessionStateMeta};
+use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CursorAdapter;
@@ -105,7 +105,9 @@ impl SourceAdapter for CursorAdapter {
             let source_updated_at = updated_at.or(global_mtime);
             if let Some((old_updated_at, _)) = existing.get(&composer_id)
                 && *old_updated_at == source_updated_at
-                && session_state_is_current(
+                && crate::adapters::sync_state::session_state_is_current(
+                    USAGE_PARSER_VERSION,
+                    EVENT_PARSER_VERSION,
                     usage_state.get(&composer_id).copied(),
                     event_state.get(&composer_id).copied(),
                     source_updated_at,
@@ -1033,27 +1035,6 @@ fn open_global_db() -> anyhow::Result<Option<Connection>> {
 
 fn global_db_mtime() -> Option<i64> {
     resolve_global_state_db_path().and_then(|path| stat_mtime_ms(&path))
-}
-
-fn session_state_is_current(
-    usage_state: Option<UsageSessionStateMeta>,
-    event_state: Option<EventSessionStateMeta>,
-    source_updated_at: Option<i64>,
-    include_events: bool,
-) -> bool {
-    if !crate::adapters::sync_state::usage_state_is_current(
-        USAGE_PARSER_VERSION,
-        usage_state,
-        source_updated_at,
-    ) {
-        return false;
-    }
-    !include_events
-        || crate::adapters::sync_state::event_state_is_current(
-            EVENT_PARSER_VERSION,
-            event_state,
-            source_updated_at,
-        )
 }
 
 fn build_agent_cwd_map(db_path: Option<&Path>) -> HashMap<String, String> {

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -647,17 +647,14 @@ fn scan_for_sync_conn(
             let current_message_count = current_counts.get(&session.id).copied().unwrap_or(0);
             if session.time_updated == old_updated_at
                 && current_message_count == old_message_count
-                && crate::adapters::sync_state::usage_state_is_current(
+                && crate::adapters::sync_state::session_state_is_current(
                     USAGE_PARSER_VERSION,
+                    EVENT_PARSER_VERSION,
                     usage_state.get(&session.id).copied(),
+                    event_state.get(&session.id).copied(),
                     session.time_updated,
+                    include_events,
                 )
-                && (!include_events
-                    || crate::adapters::sync_state::event_state_is_current(
-                        EVENT_PARSER_VERSION,
-                        event_state.get(&session.id).copied(),
-                        session.time_updated,
-                    ))
             {
                 stats.skipped_sessions += 1;
                 continue;

--- a/src/adapters/sync_state.rs
+++ b/src/adapters/sync_state.rs
@@ -22,6 +22,19 @@ pub(crate) fn event_state_is_current(
     })
 }
 
+pub(crate) fn session_state_is_current(
+    usage_parser_version: u32,
+    event_parser_version: u32,
+    usage_state: Option<UsageSessionStateMeta>,
+    event_state: Option<EventSessionStateMeta>,
+    source_updated_at: Option<i64>,
+    include_events: bool,
+) -> bool {
+    usage_state_is_current(usage_parser_version, usage_state, source_updated_at)
+        && (!include_events
+            || event_state_is_current(event_parser_version, event_state, source_updated_at))
+}
+
 pub(crate) fn usage_state_is_current_for_mtime(
     required_parser_version: Option<u32>,
     state: Option<UsageSessionStateMeta>,


### PR DESCRIPTION
### What's changed?

- Extract `session_state_is_current` into `src/adapters/sync_state.rs` as a shared helper combining usage and event state checks
- Update Cursor adapter to call the shared helper instead of a local duplicate
- Update OpenCode adapter to use the same helper, replacing inline usage/event checks

### Why

- Deduplicate identical incremental-sync skip logic across adapters
- Keep parser-version and `include_events` handling in one place for consistency

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p recall adapters::cursor` (9 passed)
- `cargo test -p recall adapters::opencode` (13 passed)