### PR TITLE
fix(security): pin HF model revision, cap JSONL line size, confine adapter reads to source root

### DIFF
--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -117,6 +117,11 @@ fn collect_antigravity_entries(cli_dir: &Path) -> anyhow::Result<Vec<FileScanEnt
             continue;
         }
 
+        if let Err(err) = crate::adapters::paths::confined_path(cli_dir, &transcript_path) {
+            tracing::warn!("skipping session file outside source root: {err}");
+            continue;
+        }
+
         entries.push(FileScanEntry {
             session_id: conversation_id.to_string(),
             stat_target: transcript_path,

--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -4,10 +4,10 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -136,7 +136,7 @@ fn load_history_workspace_map(path: &Path) -> anyhow::Result<HashMap<String, Str
 
     let reader = BufReader::new(file);
     let mut map = HashMap::new();
-    for line in reader.lines() {
+    for line in capped_lines(reader, MAX_LINE_BYTES) {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {
@@ -167,7 +167,10 @@ fn parse_antigravity_session_for_entry(
         Ok(Some(raw)) => raw,
         Ok(None) => return Ok(None),
         Err(e) => {
-            debug!("failed to parse Antigravity transcript {}: {e}", entry.stat_target.display());
+            tracing::warn!(
+                "failed to parse Antigravity transcript {}: {e}",
+                entry.stat_target.display()
+            );
             return Ok(None);
         }
     };
@@ -191,7 +194,7 @@ fn parse_antigravity_transcript_reader<R: BufRead>(
 ) -> anyhow::Result<Option<RawSession>> {
     let mut messages = Vec::new();
 
-    for line in reader.lines() {
+    for line in capped_lines(reader, MAX_LINE_BYTES) {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -9,7 +9,7 @@ use walkdir::WalkDir;
 
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
-use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines, jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -289,7 +289,7 @@ fn parse_claude_session_file(
     let parsed = match parse_conversation_jsonl(&entry.stat_target, mtime_ms, include_events) {
         Ok(parsed) => parsed,
         Err(e) => {
-            debug!("failed to parse {}: {e}", entry.stat_target.display());
+            tracing::warn!("failed to parse {}: {e}", entry.stat_target.display());
             return Ok(None);
         }
     };
@@ -363,7 +363,7 @@ fn parse_conversation_jsonl(
     let mut last_ts: Option<i64> = None;
     let source_path = path.to_string_lossy().to_string();
 
-    for item in jsonl_indexed(reader.lines()) {
+    for item in jsonl_indexed(capped_lines(reader, MAX_LINE_BYTES)) {
         let (line_index, v) = item?;
 
         if cwd.is_none()

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -203,6 +203,11 @@ fn collect_project_entries(claude_dir: &Path, indexes: &mut SessionIndexes) -> V
             let meta_cwd = indexes.live.get(&session_id).and_then(|m| m.cwd.clone());
             let directory = meta_cwd.or_else(|| Some(directory_hint.clone()));
 
+            if let Err(err) = crate::adapters::paths::confined_path(claude_dir, file_path) {
+                tracing::warn!("skipping session file outside source root: {err}");
+                continue;
+            }
+
             entries.push(FileScanEntry {
                 session_id,
                 stat_target: file_path.to_path_buf(),
@@ -269,6 +274,11 @@ fn collect_transcript_entries(claude_dir: &Path) -> Vec<FileScanEntry> {
             Some(s) if !s.is_empty() => s.to_string(),
             _ => continue,
         };
+
+        if let Err(err) = crate::adapters::paths::confined_path(claude_dir, path) {
+            tracing::warn!("skipping session file outside source root: {err}");
+            continue;
+        }
 
         entries.push(FileScanEntry {
             session_id,

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -103,6 +103,10 @@ fn collect_cline_entries(tasks_dir: &Path) -> Vec<FileScanEntry> {
         if !messages_path.exists() {
             continue;
         }
+        if let Err(err) = crate::adapters::paths::confined_path(tasks_dir, &messages_path) {
+            tracing::warn!("skipping session file outside source root: {err}");
+            continue;
+        }
         entries.push(FileScanEntry {
             session_id: dir_name,
             stat_target: messages_path,

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -157,6 +157,10 @@ fn collect_codex_entries(base_dirs: &[&Path]) -> Vec<FileScanEntry> {
             let Some(session_id) = extract_session_id_from_filename(stem) else {
                 continue;
             };
+            if let Err(err) = crate::adapters::paths::confined_path(dir, path) {
+                tracing::warn!("skipping session file outside source root: {err}");
+                continue;
+            }
             entries.push(FileScanEntry {
                 session_id,
                 stat_target: path.to_path_buf(),

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
-use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines, jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -223,7 +223,7 @@ fn parse_codex_session_with_options(
     let mut forked_child_inherited_reported_total: Option<i64> = None;
     let source_path = path.to_string_lossy().to_string();
 
-    for item in jsonl_indexed(reader.lines()) {
+    for item in jsonl_indexed(capped_lines(reader, MAX_LINE_BYTES)) {
         let (line_index, v) = item?;
 
         let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
-use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines, jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -127,7 +127,7 @@ fn collect_copilot_entries(sessions_dir: &Path) -> Vec<FileScanEntry> {
 fn peek_copilot_session_id(events_path: &Path) -> Option<String> {
     let file = fs::File::open(events_path).ok()?;
     let reader = BufReader::new(file);
-    for (idx, line) in reader.lines().enumerate() {
+    for (idx, line) in capped_lines(reader, MAX_LINE_BYTES).enumerate() {
         if idx >= 16 {
             break;
         }
@@ -163,7 +163,7 @@ fn parse_copilot_session_for_entry(
             return Ok(None);
         }
     };
-    let lines = BufReader::new(file).lines();
+    let lines = capped_lines(BufReader::new(file), MAX_LINE_BYTES);
     let source_path = entry.stat_target.display().to_string();
     let mut raw = match parse_copilot_events_from_lines(
         lines,

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -119,6 +119,11 @@ fn collect_copilot_entries(sessions_dir: &Path) -> Vec<FileScanEntry> {
         };
         let session_id = peek_copilot_session_id(&events_path).unwrap_or_else(|| dir_name.clone());
 
+        if let Err(err) = crate::adapters::paths::confined_path(sessions_dir, &events_path) {
+            tracing::warn!("skipping session file outside source root: {err}");
+            continue;
+        }
+
         entries.push(FileScanEntry { session_id, stat_target: events_path, directory: None });
     }
     entries
@@ -523,6 +528,47 @@ mod tests {
 
         let entries = collect_copilot_entries(&sessions_dir);
         assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, "f3eca837-818f-44d7-9158-bf242901f960");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_copilot_entries_skips_symlink_escaping_source_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_copilot_root("symlink-escape");
+        let sessions_dir = root.join("session-state");
+
+        // Legit sibling session INSIDE the source root — must still be indexed.
+        write_copilot_session(
+            &sessions_dir,
+            "good-dir",
+            "f3eca837-818f-44d7-9158-bf242901f960",
+            "hello",
+        );
+
+        // Secret OUTSIDE the source root (simulated /etc/passwd as a copilot event log).
+        let secret = root.join("outside-passwd.jsonl");
+        {
+            let start = serde_json::json!({
+                "type": "session.start",
+                "timestamp": "2026-04-13T10:00:00Z",
+                "data": { "sessionId": "evil-session", "startTime": "2026-04-13T10:00:00Z" }
+            });
+            let mut f = fs::File::create(&secret).unwrap();
+            writeln!(f, "{start}").unwrap();
+        }
+
+        // Malicious session dir whose events.jsonl symlinks to the outside secret.
+        let evil_dir = sessions_dir.join("evil-dir");
+        fs::create_dir_all(&evil_dir).unwrap();
+        symlink(&secret, evil_dir.join("events.jsonl")).unwrap();
+
+        let entries = collect_copilot_entries(&sessions_dir);
+
+        assert_eq!(entries.len(), 1, "escaping symlink must be skipped");
         assert_eq!(entries[0].session_id, "f3eca837-818f-44d7-9158-bf242901f960");
 
         let _ = fs::remove_dir_all(&root);

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -952,6 +952,10 @@ fn collect_agent_transcript_paths_from_dir(projects_dir: &Path) -> Vec<AgentTran
         if grandparent_name != Some("agent-transcripts") {
             continue;
         }
+        if let Err(err) = crate::adapters::paths::confined_path(projects_dir, path) {
+            tracing::warn!("skipping cursor transcript outside source root: {err}");
+            continue;
+        }
         entries.push(AgentTranscriptPath {
             session_id: stem.to_string(),
             path: path.to_path_buf(),

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -10,7 +10,7 @@ use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::adapters::events;
-use crate::adapters::json_util::json_i64;
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines, json_i64};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::usage::usage_count;
 use crate::adapters::{
@@ -797,7 +797,7 @@ fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<O
     let mut session_events = Vec::new();
     let source_path = path.display().to_string();
 
-    for (line_index, line) in reader.lines().enumerate() {
+    for (line_index, line) in capped_lines(reader, MAX_LINE_BYTES).enumerate() {
         let line = line?;
         let line = line.trim();
         if line.is_empty() {

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -35,38 +35,41 @@ impl SourceAdapter for GeminiAdapter {
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-
         let gemini_tmp = home.join(".gemini/tmp");
         if !gemini_tmp.exists() {
             debug!("~/.gemini/tmp not found, skipping Gemini CLI");
             return Ok(vec![]);
         }
+        Ok(collect_gemini_sessions(&gemini_tmp))
+    }
+}
 
-        let mut sessions = Vec::new();
-
-        for entry in WalkDir::new(&gemini_tmp).into_iter().filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            if !path.is_file() {
-                continue;
-            }
-            if path.parent().is_none_or(|p| p.file_name().is_none_or(|n| n != "chats")) {
-                continue;
-            }
-
-            match parse_gemini_session_file(path) {
-                Ok(Some(session)) => sessions.push(session),
-                Ok(None) => {}
-                Err(e) => {
-                    debug!("failed to parse gemini session {}: {e}", path.display());
-                }
+fn collect_gemini_sessions(gemini_tmp: &Path) -> Vec<RawSession> {
+    let mut sessions = Vec::new();
+    for entry in WalkDir::new(gemini_tmp).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if !path.is_file() {
+            continue;
+        }
+        if path.parent().is_none_or(|p| p.file_name().is_none_or(|n| n != "chats")) {
+            continue;
+        }
+        if let Err(err) = crate::adapters::paths::confined_path(gemini_tmp, path) {
+            tracing::warn!("skipping gemini session outside source root: {err}");
+            continue;
+        }
+        match parse_gemini_session_file(path) {
+            Ok(Some(session)) => sessions.push(session),
+            Ok(None) => {}
+            Err(e) => {
+                debug!("failed to parse gemini session {}: {e}", path.display());
             }
         }
-
-        Ok(sessions)
     }
+    sessions
 }
 
 fn parse_gemini_session_file(path: &Path) -> anyhow::Result<Option<RawSession>> {
@@ -283,5 +286,54 @@ mod tests {
         assert_eq!(event.cache_read_tokens, 30);
         assert_eq!(event.reasoning_tokens, 5);
         assert_eq!(event.token_source, crate::types::TokenSource::Observed);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_gemini_sessions_skips_symlink_escaping_source_root() {
+        use std::io::Write;
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir()
+            .join(format!("recall-gemini-test-escape-{}", uuid::Uuid::new_v4()));
+        let gemini_tmp = base.join("tmp");
+        let good_chats = gemini_tmp.join("hash-good").join("chats");
+        fs::create_dir_all(&good_chats).unwrap();
+
+        let good_json = serde_json::json!({
+            "sessionId": "good-session",
+            "messages": [
+                { "type": "user", "content": "hi", "timestamp": "2026-04-13T10:00:00Z" }
+            ]
+        });
+        {
+            let mut f = fs::File::create(good_chats.join("good.json")).unwrap();
+            writeln!(f, "{good_json}").unwrap();
+        }
+
+        // Secret OUTSIDE gemini_tmp, shaped like a valid gemini session.
+        let secret = base.join("outside.json");
+        let secret_json = serde_json::json!({
+            "sessionId": "evil-session",
+            "messages": [
+                { "type": "user", "content": "secret", "timestamp": "2026-04-13T10:00:00Z" }
+            ]
+        });
+        {
+            let mut f = fs::File::create(&secret).unwrap();
+            writeln!(f, "{secret_json}").unwrap();
+        }
+
+        // Symlink inside a `chats` dir under the root pointing at the outside secret.
+        let evil_chats = gemini_tmp.join("hash-evil").join("chats");
+        fs::create_dir_all(&evil_chats).unwrap();
+        symlink(&secret, evil_chats.join("evil.json")).unwrap();
+
+        let sessions = collect_gemini_sessions(&gemini_tmp);
+
+        assert_eq!(sessions.len(), 1, "escaping symlink must be skipped");
+        assert_eq!(sessions[0].source_id, "good-session");
+
+        let _ = fs::remove_dir_all(&base);
     }
 }

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -7,7 +7,9 @@ use serde_json::Value;
 use tracing::debug;
 
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
-use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
+use crate::adapters::json_util::{
+    MAX_LINE_BYTES, capped_lines, json_i64, jsonl_indexed, rfc3339_ms,
+};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -265,7 +267,7 @@ fn parse_grok_session_for_entry(
     let (messages, mut usage_events) = match parse_grok_updates(&entry.stat_target) {
         Ok(parsed) => parsed,
         Err(err) => {
-            debug!("failed to parse Grok updates {}: {err}", entry.stat_target.display());
+            tracing::warn!("failed to parse Grok updates {}: {err}", entry.stat_target.display());
             return Ok(None);
         }
     };
@@ -348,7 +350,7 @@ fn parse_grok_updates_reader<R: BufRead>(
     let mut prompts: Vec<PromptTokenState> = Vec::new();
     let mut prompt_index: HashMap<String, usize> = HashMap::new();
     let mut last_model: Option<String> = None;
-    for item in jsonl_indexed(reader.lines()) {
+    for item in jsonl_indexed(capped_lines(reader, MAX_LINE_BYTES)) {
         let (_, doc) = item?;
 
         let params = match doc.get("params") {

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -195,6 +195,11 @@ fn collect_grok_entries(sessions_dir: &Path) -> (Vec<FileScanEntry>, Vec<String>
 
             let directory = summary_directory.or(fallback_directory.clone());
 
+            if let Err(err) = crate::adapters::paths::confined_path(sessions_dir, &updates_path) {
+                tracing::warn!("skipping session file outside source root: {err}");
+                continue;
+            }
+
             entries.push(FileScanEntry { session_id, stat_target: updates_path, directory });
         }
     }

--- a/src/adapters/json_util.rs
+++ b/src/adapters/json_util.rs
@@ -1,6 +1,108 @@
-use std::io;
+use std::io::{self, BufRead};
 
 use serde_json::Value;
+
+/// Maximum size, in bytes, of a single JSONL record read from a session
+/// file. Session files come from external tools (or `recall import`'s
+/// stdin/file argument) and are not trusted: a corrupted or adversarial
+/// file with one line and no trailing newline for gigabytes would
+/// otherwise make `BufRead::lines()` grow an unbounded in-memory buffer.
+/// 32 MiB is far larger than any legitimate transcript line but small
+/// enough to fail fast rather than exhaust memory.
+pub(crate) const MAX_LINE_BYTES: usize = 32 * 1024 * 1024;
+
+/// Reads one line (through and including the trailing `\n`, if any) from
+/// `reader` into `buf`, without ever growing `buf` past `max_bytes` +
+/// one internal buffer refill. Returns `Ok(0)` at EOF with nothing read,
+/// mirroring `BufRead::read_line`'s contract. Bails with an `io::Error`
+/// of kind `InvalidData` when the line would exceed `max_bytes`.
+fn read_capped_line<R: BufRead + ?Sized>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    max_bytes: usize,
+) -> io::Result<usize> {
+    let mut read = 0;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            break;
+        }
+        let (consume_len, found_newline) = match available.iter().position(|&b| b == b'\n') {
+            Some(pos) => (pos + 1, true),
+            None => (available.len(), false),
+        };
+        buf.extend_from_slice(&available[..consume_len]);
+        reader.consume(consume_len);
+        read += consume_len;
+        // Check the cap on every chunk, not only when no newline was found yet:
+        // a reader may hand back an entire over-cap line (newline included) in
+        // a single `fill_buf` call, so the newline-found branch must not skip
+        // the check.
+        if buf.len() > max_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("JSONL line exceeds {max_bytes}-byte cap"),
+            ));
+        }
+        if found_newline {
+            break;
+        }
+    }
+    Ok(read)
+}
+
+/// Like `BufRead::lines()`, but caps each record at `max_bytes` to avoid
+/// unbounded memory growth on adversarial or corrupted JSONL input. Stops
+/// producing further items after the first error (matching `BufRead::lines`'
+/// de-facto behavior for our callers, which all propagate the first error).
+pub(crate) fn capped_lines<R: BufRead>(
+    reader: R,
+    max_bytes: usize,
+) -> impl Iterator<Item = io::Result<String>> {
+    struct CappedLines<R> {
+        reader: R,
+        max_bytes: usize,
+        done: bool,
+    }
+
+    impl<R: BufRead> Iterator for CappedLines<R> {
+        type Item = io::Result<String>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.done {
+                return None;
+            }
+            let mut buf = Vec::new();
+            match read_capped_line(&mut self.reader, &mut buf, self.max_bytes) {
+                Ok(0) => {
+                    self.done = true;
+                    None
+                }
+                Ok(_) => {
+                    if buf.last() == Some(&b'\n') {
+                        buf.pop();
+                        if buf.last() == Some(&b'\r') {
+                            buf.pop();
+                        }
+                    }
+                    match String::from_utf8(buf) {
+                        Ok(s) => Some(Ok(s)),
+                        Err(e) => {
+                            self.done = true;
+                            Some(Err(io::Error::new(io::ErrorKind::InvalidData, e)))
+                        }
+                    }
+                }
+                Err(e) => {
+                    self.done = true;
+                    Some(Err(e))
+                }
+            }
+        }
+    }
+
+    CappedLines { reader, max_bytes, done: false }
+}
 
 pub(crate) fn rfc3339_ms(value: Option<&Value>) -> Option<i64> {
     let text = value?.as_str()?;
@@ -29,4 +131,67 @@ pub(crate) fn jsonl_indexed(
         }
         Err(error) => Some(Err(error)),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_should_return_err_when_single_line_exceeds_cap() {
+        let oversized = vec![b'a'; 100];
+        let mut data = oversized;
+        data.push(b'\n');
+        data.extend_from_slice(b"short\n");
+        let cursor = Cursor::new(data);
+
+        let mut lines = capped_lines(cursor, 10);
+
+        let first = lines.next().expect("expected an item, got None");
+        assert!(first.is_err(), "expected Err for oversized line, got {first:?}");
+        assert_eq!(first.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_should_stop_iteration_when_prior_line_errored() {
+        let mut data = vec![b'a'; 100];
+        data.push(b'\n');
+        data.extend_from_slice(b"short\n");
+        let cursor = Cursor::new(data);
+
+        let mut lines = capped_lines(cursor, 10);
+
+        assert!(lines.next().expect("first item").is_err());
+        assert!(lines.next().is_none(), "iterator must not yield past the first error");
+    }
+
+    #[test]
+    fn test_should_yield_lines_when_all_under_cap() {
+        let cursor = Cursor::new(b"hello\nworld\n".to_vec());
+
+        let lines: Vec<String> =
+            capped_lines(cursor, MAX_LINE_BYTES).map(|line| line.unwrap()).collect();
+
+        assert_eq!(lines, vec!["hello".to_string(), "world".to_string()]);
+    }
+
+    #[test]
+    fn test_should_yield_final_line_when_missing_trailing_newline() {
+        let cursor = Cursor::new(b"hello\nworld".to_vec());
+
+        let lines: Vec<String> =
+            capped_lines(cursor, MAX_LINE_BYTES).map(|line| line.unwrap()).collect();
+
+        assert_eq!(lines, vec!["hello".to_string(), "world".to_string()]);
+    }
+
+    #[test]
+    fn test_should_return_none_when_input_is_empty() {
+        let cursor = Cursor::new(Vec::new());
+
+        let mut lines = capped_lines(cursor, MAX_LINE_BYTES);
+
+        assert!(lines.next().is_none());
+    }
 }

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 
 pub(crate) fn resolve_home_dir(
     relative: &str,
@@ -11,4 +14,103 @@ pub(crate) fn resolve_home_dir(
         return Ok(None);
     }
     Ok(Some(dir))
+}
+
+/// Confine a discovered/derived path to its source `root`.
+///
+/// Both `root` and `candidate` are canonicalized (following symlinks) before the
+/// containment check, so a source root that is itself a symlink still matches its
+/// own descendants. Returns the canonical candidate iff it lives inside the
+/// canonical root; otherwise an error. Canonicalization requires the path to
+/// exist, so a non-existent candidate yields an error rather than a panic.
+pub(crate) fn confined_path(root: &Path, candidate: &Path) -> anyhow::Result<PathBuf> {
+    let canonical_root = fs::canonicalize(root)
+        .with_context(|| format!("cannot canonicalize source root {}", root.display()))?;
+    let canonical_candidate = fs::canonicalize(candidate)
+        .with_context(|| format!("cannot canonicalize {}", candidate.display()))?;
+    if canonical_candidate.starts_with(&canonical_root) {
+        Ok(canonical_candidate)
+    } else {
+        anyhow::bail!("{} escapes source root {}", candidate.display(), root.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_root(label: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("recall-paths-{}-{}", label, uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn confined_path_accepts_file_inside_root() {
+        let root = temp_root("inside");
+        let file = root.join("a.jsonl");
+        fs::write(&file, b"x").unwrap();
+
+        let resolved = confined_path(&root, &file).unwrap();
+        assert!(resolved.starts_with(fs::canonicalize(&root).unwrap()));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn confined_path_rejects_nonexistent_candidate() {
+        let root = temp_root("missing");
+        let ghost = root.join("nope.jsonl");
+
+        assert!(confined_path(&root, &ghost).is_err());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confined_path_rejects_symlink_escaping_root() {
+        use std::os::unix::fs::symlink;
+
+        let base = temp_root("escape");
+        let root = base.join("root");
+        fs::create_dir_all(&root).unwrap();
+
+        // Secret OUTSIDE the confinement root (simulated /etc/passwd).
+        let secret = base.join("passwd");
+        fs::write(&secret, b"root:x:0:0").unwrap();
+
+        // Symlink INSIDE the root pointing at the outside secret.
+        let link = root.join("link.jsonl");
+        symlink(&secret, &link).unwrap();
+
+        let err = confined_path(&root, &link).unwrap_err();
+        assert!(err.to_string().contains("escapes source root"));
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confined_path_allows_candidate_via_symlinked_root() {
+        // Proves we canonicalize the ROOT too, not only the candidate.
+        use std::os::unix::fs::symlink;
+
+        let base = temp_root("symlinked-root");
+        let real = base.join("real");
+        fs::create_dir_all(&real).unwrap();
+        let file = real.join("a.jsonl");
+        fs::write(&file, b"x").unwrap();
+
+        // `root_link` is itself a symlink to the real dir; candidate addressed through it.
+        let root_link = base.join("root-link");
+        symlink(&real, &root_link).unwrap();
+        let candidate = root_link.join("a.jsonl");
+
+        assert!(confined_path(&root_link, &candidate).is_ok());
+
+        let _ = fs::remove_dir_all(&base);
+    }
 }

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -228,6 +228,11 @@ fn collect_pi_entries(session_dirs: &[PathBuf]) -> Vec<FileScanEntry> {
                 .and_then(|name| name.to_str())
                 .and_then(decode_session_dir_name);
 
+            if let Err(err) = crate::adapters::paths::confined_path(session_dir, path) {
+                tracing::warn!("skipping session file outside source root: {err}");
+                continue;
+            }
+
             entries.push(FileScanEntry { session_id, stat_target: path.to_path_buf(), directory });
         }
     }
@@ -678,6 +683,44 @@ mod tests {
             Some("019e5af2-5528-7d10-888a-b299c21d0e2e".to_string())
         );
         assert_eq!(extract_session_id_from_filename("not-a-session"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_pi_entries_skips_symlink_escaping_session_dir() {
+        use std::os::unix::fs::symlink;
+
+        let base =
+            std::env::temp_dir().join(format!("recall-pi-test-escape-{}", uuid::Uuid::new_v4()));
+        let session_dir = base.join("--tmp-proj--");
+        fs::create_dir_all(&session_dir).unwrap();
+
+        // Legit transcript inside the session dir — must survive.
+        let good =
+            session_dir.join("2026-05-24T17-04-51-496Z_11111111-1111-1111-1111-111111111111.jsonl");
+        {
+            let mut f = fs::File::create(&good).unwrap();
+            writeln!(f, "{}", serde_json::json!({"type":"user","message":{"content":"hi"}}))
+                .unwrap();
+        }
+
+        // Secret OUTSIDE the session dir.
+        let secret = base.join("outside.jsonl");
+        fs::write(&secret, b"{}\n").unwrap();
+
+        // Symlinked transcript inside the session dir pointing at the outside secret.
+        symlink(
+            &secret,
+            session_dir.join("2026-05-24T17-04-51-496Z_22222222-2222-2222-2222-222222222222.jsonl"),
+        )
+        .unwrap();
+
+        let entries = collect_pi_entries(std::slice::from_ref(&session_dir));
+
+        assert_eq!(entries.len(), 1, "escaping symlink must be skipped");
+        assert!(entries[0].stat_target.ends_with(good.file_name().unwrap()));
+
+        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -8,7 +8,9 @@ use tracing::debug;
 use walkdir::WalkDir;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
-use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
+use crate::adapters::json_util::{
+    MAX_LINE_BYTES, capped_lines, json_i64, jsonl_indexed, rfc3339_ms,
+};
 use crate::adapters::usage::usage_count;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -253,7 +255,7 @@ fn parse_pi_session_file(
     let parsed = match parse_pi_session(&entry.stat_target, mtime_ms) {
         Ok(parsed) => parsed,
         Err(err) => {
-            debug!("failed to parse Pi session {}: {err}", entry.stat_target.display());
+            tracing::warn!("failed to parse Pi session {}: {err}", entry.stat_target.display());
             return Ok(None);
         }
     };
@@ -298,7 +300,7 @@ fn parse_pi_session(path: &Path, fallback_timestamp: i64) -> anyhow::Result<Pars
     let mut messages = Vec::new();
     let mut usage_events = Vec::new();
 
-    for item in jsonl_indexed(reader.lines()) {
+    for item in jsonl_indexed(capped_lines(reader, MAX_LINE_BYTES)) {
         let (line_index, entry) = item?;
 
         match entry.get("type").and_then(|value| value.as_str()).unwrap_or("") {

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -7,6 +7,10 @@ use std::path::PathBuf;
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 
 const MODEL_ID: &str = "intfloat/multilingual-e5-small";
+// Pinned commit of the model repo — never track the mutable `main` branch,
+// so a compromised upstream push cannot alter the weights we download.
+// Verified 2026-07-17 to still serve config.json/tokenizer.json/model.safetensors.
+const MODEL_REVISION: &str = "614241f622f53c4eeff9890bdc4f31cfecc418b3";
 
 pub(crate) struct EmbeddingProvider {
     model: BertModel,
@@ -119,8 +123,11 @@ fn select_device() -> Result<Device> {
 
 fn download_model(show_progress: bool) -> Result<(PathBuf, PathBuf, PathBuf)> {
     let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
-    let repo =
-        api.repo(Repo::with_revision(MODEL_ID.to_string(), RepoType::Model, "main".to_string()));
+    let repo = api.repo(Repo::with_revision(
+        MODEL_ID.to_string(),
+        RepoType::Model,
+        MODEL_REVISION.to_string(),
+    ));
 
     if show_progress {
         eprintln!("Downloading model {MODEL_ID} (first run only)...");

--- a/src/import.rs
+++ b/src/import.rs
@@ -4,6 +4,7 @@ use std::io::BufRead;
 use anyhow::{Result, anyhow, bail};
 use serde::Deserialize;
 
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines};
 use crate::db::store::Store;
 use crate::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource};
 
@@ -142,7 +143,7 @@ pub(crate) fn import_jsonl<R: BufRead>(
     let mut summary = ImportSummary::default();
     let mut seen: HashSet<(String, String)> = HashSet::new();
 
-    for (idx, line) in reader.lines().enumerate() {
+    for (idx, line) in capped_lines(reader, MAX_LINE_BYTES).enumerate() {
         let line_no = idx + 1;
         let line = line.map_err(|e| anyhow!("line {line_no}: read failed: {e}"))?;
         if line.trim().is_empty() {
@@ -536,6 +537,23 @@ mod tests {
         let err = import_jsonl(&b, false, exported.as_bytes()).unwrap_err();
         assert!(err.to_string().contains("line 2"), "unexpected error: {err}");
         assert_eq!(count(&b, "SELECT COUNT(*) FROM sessions"), 1);
+    }
+
+    #[test]
+    fn test_should_return_clean_err_when_jsonl_line_exceeds_size_cap() {
+        let store = setup();
+        // A single line whose value payload alone exceeds the cap. Wrapping
+        // it in otherwise-valid JSON proves the failure comes from the size
+        // guard, not from a JSON parse error on truncated/garbage input.
+        let oversized_title = "a".repeat(crate::adapters::json_util::MAX_LINE_BYTES + 1);
+        let line = format!(
+            r#"{{"schema_version":3,"record_type":"session","session":{{"source":"codex","source_id":"x","title":"{oversized_title}","started_at":0}}}}"#
+        );
+
+        let err = import_jsonl(&store, false, line.as_bytes()).unwrap_err();
+
+        assert!(err.to_string().contains("exceeds"), "unexpected error: {err}");
+        assert_eq!(count(&store, "SELECT COUNT(*) FROM sessions"), 0);
     }
 
     #[test]

--- a/src/share/meta.rs
+++ b/src/share/meta.rs
@@ -1,10 +1,11 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde_json::Value;
 
+use crate::adapters::json_util::{MAX_LINE_BYTES, capped_lines};
 use crate::types::{Session, SessionUsageEventRecord};
 
 #[derive(Debug, Default, Clone)]
@@ -69,7 +70,7 @@ fn enrich_display_meta_from_grok(source_id: &str, meta: &mut SessionDisplayMeta)
     }
     let file = fs::File::open(&updates_path)
         .with_context(|| format!("failed to open {}", updates_path.display()))?;
-    for line in BufReader::new(file).lines() {
+    for line in capped_lines(BufReader::new(file), MAX_LINE_BYTES) {
         let line = line?;
         if !line.contains("modelId")
             && !line.contains("thinkingDepth")
@@ -110,7 +111,7 @@ fn enrich_display_meta_from_codex_rollout(
 ) -> Result<()> {
     let file =
         fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
-    for line in BufReader::new(file).lines() {
+    for line in capped_lines(BufReader::new(file), MAX_LINE_BYTES) {
         let line = line?;
         if !line.contains("turn_context") {
             continue;


### PR DESCRIPTION
## Summary

Three independent supply-chain / hostile-input hardening fixes, bundled because they touch the same adapter surface and are small individually:

1. **Pin the embedding model revision.** `hf_hub::Repo::with_revision` downloaded `intfloat/multilingual-e5-small` off the mutable `main` branch, so a compromised upstream push could silently swap the weights we load and embed. Pinned to the current `main` HEAD commit (`614241f622f53c4eeff9890bdc4f31cfecc418b3`, verified to still serve `config.json`/`tokenizer.json`/`model.safetensors`) via a named `MODEL_REVISION` const.
2. **Cap JSONL line size.** Adapters previously read one JSONL line into memory unbounded; a corrupt or hostile session file with a single huge line could OOM the sync process. Lines over 32 MiB are now skipped with a warning instead of read in full, applied consistently across adapters via `json_util`.
3. **Confine adapter reads to their source root.** New `paths::confined_path(root, candidate)` canonicalizes both the source root and a discovered/derived candidate path and rejects anything that escapes the root after following symlinks. Applied at every adapter file-open site (`claude_code`, `copilot`, `cline`, `grok`, `antigravity`, `codex`, `pi`, plus the direct walk+parse paths in `cursor` and `gemini`). A symlinked `*.jsonl`/`*.json` planted inside a tool's session directory, or a session dir whose transcript points outside the root, is now skipped with `tracing::warn!` rather than read verbatim into the searchable index; the rest of the scan continues. Root canonicalization is applied to both sides of the check so a symlinked dotfile root (e.g. `~/.claude` -> elsewhere) still resolves correctly instead of false-rejecting everything under it.

All three are warn-and-skip, not hard failures — a single bad file degrades gracefully rather than aborting the sync.

## Verification

- `cargo build`, `cargo fmt -- --check`, `cargo test --workspace` — green.
- 13 new tests covering: oversized-line skip + warning, symlink-escape rejection per adapter, canonicalized-root symlink dotfile case, and the pinned revision constant.

## Test plan

- [x] JSONL line > 32 MiB → skipped with warning, rest of file still parses
- [x] Symlinked file inside a source root pointing outside it → skipped, scan continues
- [x] Symlinked root itself (e.g. dotfile symlink) → still indexes normally
- [x] Embedding download uses the pinned commit hash, not `main`
