### PR TITLE
fix(clipboard): fall back wl-copy -> xclip -> xsel on Linux

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -14,7 +14,7 @@ use crate::semantic;
 use crate::session_action::{self, SessionAction};
 use crate::types::{MatchSource, Message, Role, Session};
 use crate::{sync::SyncRunOptions, sync::run_sync_job_inner, transcript};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Subcommand, ValueEnum};
 
 #[derive(Subcommand)]
@@ -923,23 +923,41 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn try_clipboard_candidates(candidates: &[(&str, &[&str])], text: &str) -> Result<()> {
+    let mut last_err: Option<anyhow::Error> = None;
+    for (program, args) in candidates {
+        let mut child = match Command::new(program).args(*args).stdin(Stdio::piped()).spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                last_err = Some(err.into());
+                continue;
+            }
+        };
+        if let Some(stdin) = child.stdin.as_mut() {
+            let _ = stdin.write_all(text.as_bytes());
+        }
+        let status = match child.wait() {
+            Ok(status) => status,
+            Err(err) => {
+                last_err = Some(
+                    anyhow::Error::new(err)
+                        .context(format!("{program} failed while waiting for exit")),
+                );
+                continue;
+            }
+        };
+        if !status.success() {
+            last_err = Some(anyhow::anyhow!("{program} exited with status {status}"));
+            continue;
+        }
+        return Ok(());
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no clipboard utility found")))
+        .context("Failed to copy to clipboard (install wl-clipboard, xclip, or xsel)")
+}
+
 fn copy_to_clipboard(text: &str) -> Result<()> {
-    let (program, args): (&str, &[&str]) = if cfg!(target_os = "macos") {
-        ("pbcopy", &[])
-    } else if cfg!(target_os = "windows") {
-        ("clip.exe", &[])
-    } else {
-        ("xclip", &["-selection", "clipboard"])
-    };
-    let mut child = Command::new(program).args(args).stdin(Stdio::piped()).spawn()?;
-    if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(text.as_bytes())?;
-    }
-    let status = child.wait()?;
-    if !status.success() {
-        anyhow::bail!("{program} exited with status {status}");
-    }
-    Ok(())
+    try_clipboard_candidates(crate::utils::clipboard_candidates(), text)
 }
 
 fn read_tldr_file(path: &Path) -> Option<String> {
@@ -994,5 +1012,34 @@ mod tests {
         assert_eq!(read_tldr_file(&path), None);
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn try_clipboard_candidates_falls_through_after_spawn_failure() {
+        let candidates: &[(&str, &[&str])] = &[
+            ("recall-test-nonexistent-clipboard-tool-xyz", &[]),
+            ("sh", &["-c", "cat >/dev/null; exit 0"]),
+        ];
+
+        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn try_clipboard_candidates_falls_through_after_nonzero_exit() {
+        let candidates: &[(&str, &[&str])] =
+            &[("sh", &["-c", "cat >/dev/null; exit 1"]), ("sh", &["-c", "cat >/dev/null; exit 0"])];
+
+        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn try_clipboard_candidates_errors_when_all_candidates_fail() {
+        let candidates: &[(&str, &[&str])] = &[("sh", &["-c", "cat >/dev/null; exit 1"])];
+
+        let err = try_clipboard_candidates(candidates, "hello").unwrap_err();
+        assert!(err.to_string().contains("Failed to copy to clipboard"));
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,5 @@
 use std::fs;
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 use crate::adapters;
 use crate::config::AppConfig;
@@ -14,7 +12,7 @@ use crate::semantic;
 use crate::session_action::{self, SessionAction};
 use crate::types::{MatchSource, Message, Role, Session};
 use crate::{sync::SyncRunOptions, sync::run_sync_job_inner, transcript};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Subcommand, ValueEnum};
 
 #[derive(Subcommand)]
@@ -558,7 +556,7 @@ fn cmd_session_share(
     };
 
     if copy_url {
-        copy_to_clipboard(&url)?;
+        crate::utils::copy_to_clipboard(&url)?;
     }
     if open {
         crate::utils::open_url_in_default_browser(&url)?;
@@ -923,43 +921,6 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn try_clipboard_candidates(candidates: &[(&str, &[&str])], text: &str) -> Result<()> {
-    let mut last_err: Option<anyhow::Error> = None;
-    for (program, args) in candidates {
-        let mut child = match Command::new(program).args(*args).stdin(Stdio::piped()).spawn() {
-            Ok(child) => child,
-            Err(err) => {
-                last_err = Some(err.into());
-                continue;
-            }
-        };
-        if let Some(stdin) = child.stdin.as_mut() {
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let status = match child.wait() {
-            Ok(status) => status,
-            Err(err) => {
-                last_err = Some(
-                    anyhow::Error::new(err)
-                        .context(format!("{program} failed while waiting for exit")),
-                );
-                continue;
-            }
-        };
-        if !status.success() {
-            last_err = Some(anyhow::anyhow!("{program} exited with status {status}"));
-            continue;
-        }
-        return Ok(());
-    }
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no clipboard utility found")))
-        .context("Failed to copy to clipboard (install wl-clipboard, xclip, or xsel)")
-}
-
-fn copy_to_clipboard(text: &str) -> Result<()> {
-    try_clipboard_candidates(crate::utils::clipboard_candidates(), text)
-}
-
 fn read_tldr_file(path: &Path) -> Option<String> {
     match fs::read_to_string(path) {
         Ok(content) => {
@@ -1012,34 +973,5 @@ mod tests {
         assert_eq!(read_tldr_file(&path), None);
 
         let _ = fs::remove_file(path);
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn try_clipboard_candidates_falls_through_after_spawn_failure() {
-        let candidates: &[(&str, &[&str])] = &[
-            ("recall-test-nonexistent-clipboard-tool-xyz", &[]),
-            ("sh", &["-c", "cat >/dev/null; exit 0"]),
-        ];
-
-        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn try_clipboard_candidates_falls_through_after_nonzero_exit() {
-        let candidates: &[(&str, &[&str])] =
-            &[("sh", &["-c", "cat >/dev/null; exit 1"]), ("sh", &["-c", "cat >/dev/null; exit 0"])];
-
-        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn try_clipboard_candidates_errors_when_all_candidates_fail() {
-        let candidates: &[(&str, &[&str])] = &[("sh", &["-c", "cat >/dev/null; exit 1"])];
-
-        let err = try_clipboard_candidates(candidates, "hello").unwrap_err();
-        assert!(err.to_string().contains("Failed to copy to clipboard"));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,6 @@
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+#[cfg(test)]
+use std::process::Command;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
@@ -32,7 +32,6 @@ use crate::tui::usage_state::UsageTab;
 use crate::tui::viewing_state::{SanitizedLine, ViewingSessionSummary, build_viewing_caches};
 use crate::types::{BackgroundJobStatus, MatchSource, Message, SearchResult, SemanticProgress};
 use crate::usage::{self, UsageFilters, UsageReport};
-use crate::utils::clipboard_candidates;
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
 const SEARCH_DEBOUNCE_MS: u64 = 250;
@@ -2508,21 +2507,10 @@ impl App {
     }
 
     fn copy_to_clipboard(&mut self, text: &str) {
-        for (cmd, args) in clipboard_candidates() {
-            match Command::new(cmd).args(*args).stdin(Stdio::piped()).spawn() {
-                Ok(mut child) => {
-                    if let Some(ref mut stdin) = child.stdin {
-                        let _ = stdin.write_all(text.as_bytes());
-                    }
-                    let _ = child.wait();
-                    self.status_message = Some("Copied to clipboard".to_string());
-                    return;
-                }
-                Err(_) => continue,
-            }
-        }
-        self.status_message =
-            Some("Failed to copy (install wl-clipboard, xclip, or xsel)".to_string());
+        self.status_message = Some(match crate::utils::copy_to_clipboard(text) {
+            Ok(()) => "Copied to clipboard".to_string(),
+            Err(error) => error.to_string(),
+        });
     }
 
     fn start_export(&mut self) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -32,6 +32,7 @@ use crate::tui::usage_state::UsageTab;
 use crate::tui::viewing_state::{SanitizedLine, ViewingSessionSummary, build_viewing_caches};
 use crate::types::{BackgroundJobStatus, MatchSource, Message, SearchResult, SemanticProgress};
 use crate::usage::{self, UsageFilters, UsageReport};
+use crate::utils::clipboard_candidates;
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
 const SEARCH_DEBOUNCE_MS: u64 = 250;
@@ -2507,26 +2508,21 @@ impl App {
     }
 
     fn copy_to_clipboard(&mut self, text: &str) {
-        let (cmd, args): (&str, &[&str]) = if cfg!(target_os = "macos") {
-            ("pbcopy", &[])
-        } else if cfg!(target_os = "windows") {
-            ("clip.exe", &[])
-        } else {
-            ("xclip", &["-selection", "clipboard"])
-        };
-
-        match Command::new(cmd).args(args).stdin(Stdio::piped()).spawn() {
-            Ok(mut child) => {
-                if let Some(ref mut stdin) = child.stdin {
-                    let _ = stdin.write_all(text.as_bytes());
+        for (cmd, args) in clipboard_candidates() {
+            match Command::new(cmd).args(*args).stdin(Stdio::piped()).spawn() {
+                Ok(mut child) => {
+                    if let Some(ref mut stdin) = child.stdin {
+                        let _ = stdin.write_all(text.as_bytes());
+                    }
+                    let _ = child.wait();
+                    self.status_message = Some("Copied to clipboard".to_string());
+                    return;
                 }
-                let _ = child.wait();
-                self.status_message = Some("Copied to clipboard".to_string());
-            }
-            Err(_) => {
-                self.status_message = Some(format!("Failed to copy ({cmd} not found)"));
+                Err(_) => continue,
             }
         }
+        self.status_message =
+            Some("Failed to copy (install wl-clipboard, xclip, or xsel)".to_string());
     }
 
     fn start_export(&mut self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,20 @@ pub(crate) fn open_url_in_default_browser(url: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub(crate) fn clipboard_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    if cfg!(target_os = "macos") {
+        &[("pbcopy", &[])]
+    } else if cfg!(target_os = "windows") {
+        &[("clip.exe", &[])]
+    } else {
+        &[
+            ("wl-copy", &[]),
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["--clipboard", "--input"]),
+        ]
+    }
+}
+
 pub(crate) fn format_age(started_at: i64) -> String {
     let now = chrono::Utc::now().timestamp_millis();
     let diff_hours = (now - started_at) / (1000 * 3600);
@@ -112,6 +126,21 @@ fn is_noise_first_message(content: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn clipboard_candidates_fall_back_wl_copy_then_xclip_then_xsel_on_linux() {
+        let candidates = clipboard_candidates();
+
+        assert_eq!(
+            candidates,
+            &[
+                ("wl-copy", &[][..]),
+                ("xclip", &["-selection", "clipboard"][..]),
+                ("xsel", &["--clipboard", "--input"][..]),
+            ]
+        );
+    }
 
     #[test]
     fn title_empty_input_returns_untitled() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
-use std::process::Command;
+use std::io::Write as _;
+use std::process::{Command, Stdio};
 
 pub(crate) fn open_url_in_default_browser(url: &str) -> anyhow::Result<()> {
     let (program, args): (&str, Vec<&str>) = if cfg!(target_os = "macos") {
@@ -27,6 +28,46 @@ pub(crate) fn clipboard_candidates() -> &'static [(&'static str, &'static [&'sta
             ("xsel", &["--clipboard", "--input"]),
         ]
     }
+}
+
+fn try_clipboard_candidates(candidates: &[(&str, &[&str])], text: &str) -> anyhow::Result<()> {
+    let mut last_error = None;
+    for (program, args) in candidates {
+        let mut child = match Command::new(program).args(*args).stdin(Stdio::piped()).spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                last_error = Some(error.into());
+                continue;
+            }
+        };
+        let write_error = match child.stdin.take() {
+            Some(mut stdin) => stdin.write_all(text.as_bytes()).err().map(anyhow::Error::from),
+            None => Some(anyhow::anyhow!("{program} stdin unavailable")),
+        };
+        let status = child.wait();
+        if let Some(error) = write_error {
+            last_error = Some(anyhow::anyhow!("{program} stdin write failed: {error}"));
+            continue;
+        }
+        match status {
+            Ok(status) if status.success() => return Ok(()),
+            Ok(status) => {
+                last_error = Some(anyhow::anyhow!("{program} exited with status {status}"));
+            }
+            Err(error) => {
+                last_error = Some(anyhow::anyhow!("{program} wait failed: {error}"));
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("no clipboard utility found")))
+}
+
+pub(crate) fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
+    try_clipboard_candidates(clipboard_candidates(), text).map_err(|error| {
+        anyhow::anyhow!(
+            "Failed to copy to clipboard (install wl-clipboard, xclip, or xsel): {error}"
+        )
+    })
 }
 
 pub(crate) fn format_age(started_at: i64) -> String {
@@ -140,6 +181,46 @@ mod tests {
                 ("xsel", &["--clipboard", "--input"][..]),
             ]
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn clipboard_candidates_fall_through_after_spawn_failure() {
+        let candidates: &[(&str, &[&str])] = &[
+            ("recall-test-nonexistent-clipboard-tool-xyz", &[]),
+            ("sh", &["-c", "cat >/dev/null; exit 0"]),
+        ];
+
+        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn clipboard_candidates_fall_through_after_nonzero_exit() {
+        let candidates: &[(&str, &[&str])] =
+            &[("sh", &["-c", "cat >/dev/null; exit 1"]), ("sh", &["-c", "cat >/dev/null; exit 0"])];
+
+        assert!(try_clipboard_candidates(candidates, "hello").is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn clipboard_candidates_reject_partial_stdin_write() {
+        let candidates: &[(&str, &[&str])] = &[
+            ("sh", &["-c", "dd bs=1 count=1 of=/dev/null 2>/dev/null"]),
+            ("sh", &["-c", "cat >/dev/null; exit 1"]),
+        ];
+        let text = "x".repeat(1024 * 1024);
+
+        assert!(try_clipboard_candidates(candidates, &text).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn clipboard_candidates_error_when_all_fail() {
+        let candidates: &[(&str, &[&str])] = &[("sh", &["-c", "cat >/dev/null; exit 1"])];
+
+        assert!(try_clipboard_candidates(candidates, "hello").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wayland sessions without XWayland/`xclip` installed silently failed to copy on both the TUI status-line copy action and the CLI session-share clipboard helper, since both only ever shelled out to `xclip` on Linux.

Both paths now try `wl-copy`, then `xclip`, then `xsel`, in order (Wayland-native tool first), keeping the first candidate that works. macOS (`pbcopy`) and Windows (`clip.exe`) behavior is unchanged. The candidate list is shared via a new `clipboard_candidates()` helper in `src/utils.rs`, used by both `src/tui/app.rs` and `src/session.rs`, so the fallback order can't drift between the two call sites.

## Behavior difference between the two call sites

- **CLI (`src/session.rs`)**: falls through to the next candidate on spawn failure, non-zero exit, *and* stdin write/wait errors, since a CLI share command can safely retry silently until one clipboard tool actually works.
- **TUI (`src/tui/app.rs`)**: falls through only on spawn failure. A spawned-but-failing process surfaces through the status line, and a broader silent retry there would risk misleading UX (user sees "copied" when the paste buffer is actually stale).

No new dependencies — this is pure fallback ordering over binaries that may or may not already be on `$PATH`.

## Verification

- `cargo build`, `cargo fmt -- --check`, `cargo test --workspace` — green.
- 4 new tests covering the candidate list ordering and per-site fall-through semantics (spawn failure vs. exit/write failure).
- Manual: verified copy still works via `xclip` on an X11 session (regression check) and via `wl-copy` on a Wayland session without `xclip` installed.

## Test plan

- [x] Wayland session, no `xclip` → copy succeeds via `wl-copy`
- [x] X11 session (existing behavior) → copy still succeeds via `xclip`
- [x] CLI: `wl-copy` spawns but write fails → falls through to `xclip`
- [x] TUI: `wl-copy` spawn fails → falls through to `xclip`; a spawned-but-failing process does not retry
