### PR TITLE
feat(cli): add reset, vacuum, reembed, worker status/stop, config show/edit/doctor, gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ dependencies = [
  "globset",
  "hf-hub",
  "kitup",
+ "libc",
  "pulldown-cmark",
  "ratatui",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ candle-core = "0.10"
 candle-nn = "0.10"
 candle-transformers = "0.10"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,13 @@ enum Commands {
         #[arg(long, help = "Parse and report without writing")]
         dry_run: bool,
     },
+    #[command(about = "Delete all indexed data (keeps config)")]
+    Reset {
+        #[arg(long, help = "Skip the confirmation prompt")]
+        yes: bool,
+    },
+    #[command(about = "Compact the database and reclaim disk space")]
+    Vacuum,
     #[command(about = "Share session pages")]
     Share {
         #[command(subcommand)]
@@ -229,6 +236,8 @@ pub(crate) fn run() -> Result<()> {
             )?
         }
         Some(Commands::Import { file, dry_run }) => crate::import::run_cli(&file, dry_run)?,
+        Some(Commands::Reset { yes }) => crate::maintenance::run_reset(yes)?,
+        Some(Commands::Vacuum) => crate::maintenance::run_vacuum()?,
         Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
             crate::share_init::run(project_name, publish_dir)?
         }
@@ -532,6 +541,18 @@ mod tests {
             }
             _ => panic!("expected skill install command"),
         }
+    }
+
+    #[test]
+    fn reset_accepts_yes_flag() {
+        let cli = Cli::try_parse_from(["recall", "reset", "--yes"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Reset { yes: true })));
+    }
+
+    #[test]
+    fn vacuum_parses() {
+        let cli = Cli::try_parse_from(["recall", "vacuum"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Vacuum)));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,13 @@ enum Commands {
         #[arg(long, help = "Skip the confirmation prompt")]
         yes: bool,
     },
+    #[command(about = "Delete indexed sessions for disabled sources or missing backing files")]
+    Gc {
+        #[arg(long, help = "Classify and report without deleting")]
+        dry_run: bool,
+        #[arg(long, help = "Skip the confirmation prompt")]
+        yes: bool,
+    },
     #[command(about = "Inspect and control the background embedding worker")]
     Worker {
         #[command(subcommand)]
@@ -275,6 +282,7 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Reset { yes }) => crate::maintenance::run_reset(yes)?,
         Some(Commands::Vacuum) => crate::maintenance::run_vacuum()?,
         Some(Commands::Reembed { yes }) => crate::maintenance::run_reembed(yes)?,
+        Some(Commands::Gc { dry_run, yes }) => crate::maintenance::run_gc(dry_run, yes)?,
         Some(Commands::Worker { command: WorkerAction::Status }) => {
             crate::maintenance::run_worker_status()?
         }
@@ -621,6 +629,18 @@ mod tests {
     fn reembed_defaults_to_prompt() {
         let cli = Cli::try_parse_from(["recall", "reembed"]).unwrap();
         assert!(matches!(cli.command, Some(Commands::Reembed { yes: false })));
+    }
+
+    #[test]
+    fn gc_defaults_to_delete_with_prompt() {
+        let cli = Cli::try_parse_from(["recall", "gc"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Gc { dry_run: false, yes: false })));
+    }
+
+    #[test]
+    fn gc_accepts_dry_run_and_yes() {
+        let cli = Cli::try_parse_from(["recall", "gc", "--dry-run", "--yes"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Gc { dry_run: true, yes: true })));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,11 @@ enum Commands {
         #[command(subcommand)]
         command: WorkerAction,
     },
+    #[command(about = "Inspect and manage configuration")]
+    Config {
+        #[command(subcommand)]
+        command: ConfigAction,
+    },
     #[command(about = "Share session pages")]
     Share {
         #[command(subcommand)]
@@ -157,6 +162,16 @@ enum WorkerAction {
         #[arg(long, help = "Also drop computed embeddings and re-queue every session")]
         clear_queue: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    #[command(about = "Print the resolved configuration as JSON")]
+    Show,
+    #[command(about = "Open the configuration file in $EDITOR")]
+    Edit,
+    #[command(about = "Diagnose configuration problems")]
+    Doctor,
 }
 
 #[derive(Subcommand)]
@@ -265,6 +280,15 @@ pub(crate) fn run() -> Result<()> {
         }
         Some(Commands::Worker { command: WorkerAction::Stop { clear_queue } }) => {
             crate::maintenance::run_worker_stop(clear_queue)?
+        }
+        Some(Commands::Config { command: ConfigAction::Show }) => {
+            crate::maintenance::run_config_show()?
+        }
+        Some(Commands::Config { command: ConfigAction::Edit }) => {
+            crate::maintenance::run_config_edit()?
+        }
+        Some(Commands::Config { command: ConfigAction::Doctor }) => {
+            crate::maintenance::run_config_doctor()?
         }
         Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
             crate::share_init::run(project_name, publish_dir)?
@@ -382,8 +406,8 @@ fn recall_skill_bundle() -> kitup::SkillBundle {
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, Commands, ExtensionCommands, ShareCommands, Shell, SkillCommands, WorkerAction,
-        generate, insert_installed_help,
+        Cli, Commands, ConfigAction, ExtensionCommands, ShareCommands, Shell, SkillCommands,
+        WorkerAction, generate, insert_installed_help,
     };
     use crate::adapters::{
         adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
@@ -506,6 +530,7 @@ mod tests {
         assert!(
             compact_help.contains("worker Inspect and control the background embedding worker")
         );
+        assert!(compact_help.contains("config Inspect and manage configuration"));
     }
 
     #[test]
@@ -620,6 +645,24 @@ mod tests {
             cli.command,
             Some(Commands::Worker { command: WorkerAction::Stop { clear_queue: true } })
         ));
+    }
+
+    #[test]
+    fn config_show_parses() {
+        let cli = Cli::try_parse_from(["recall", "config", "show"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Config { command: ConfigAction::Show })));
+    }
+
+    #[test]
+    fn config_edit_parses() {
+        let cli = Cli::try_parse_from(["recall", "config", "edit"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Config { command: ConfigAction::Edit })));
+    }
+
+    #[test]
+    fn config_doctor_parses() {
+        let cli = Cli::try_parse_from(["recall", "config", "doctor"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Config { command: ConfigAction::Doctor })));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,11 @@ enum Commands {
         #[arg(long, help = "Skip the confirmation prompt")]
         yes: bool,
     },
+    #[command(about = "Inspect and control the background embedding worker")]
+    Worker {
+        #[command(subcommand)]
+        command: WorkerAction,
+    },
     #[command(about = "Share session pages")]
     Share {
         #[command(subcommand)]
@@ -141,6 +146,17 @@ enum Commands {
     BenchDumpSessions,
     #[command(external_subcommand)]
     External(Vec<OsString>),
+}
+
+#[derive(Subcommand)]
+enum WorkerAction {
+    #[command(about = "Show background worker status")]
+    Status,
+    #[command(about = "Stop the background worker")]
+    Stop {
+        #[arg(long, help = "Also drop computed embeddings and re-queue every session")]
+        clear_queue: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -244,6 +260,12 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Reset { yes }) => crate::maintenance::run_reset(yes)?,
         Some(Commands::Vacuum) => crate::maintenance::run_vacuum()?,
         Some(Commands::Reembed { yes }) => crate::maintenance::run_reembed(yes)?,
+        Some(Commands::Worker { command: WorkerAction::Status }) => {
+            crate::maintenance::run_worker_status()?
+        }
+        Some(Commands::Worker { command: WorkerAction::Stop { clear_queue } }) => {
+            crate::maintenance::run_worker_stop(clear_queue)?
+        }
         Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
             crate::share_init::run(project_name, publish_dir)?
         }
@@ -360,8 +382,8 @@ fn recall_skill_bundle() -> kitup::SkillBundle {
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, Commands, ExtensionCommands, ShareCommands, Shell, SkillCommands, generate,
-        insert_installed_help,
+        Cli, Commands, ExtensionCommands, ShareCommands, Shell, SkillCommands, WorkerAction,
+        generate, insert_installed_help,
     };
     use crate::adapters::{
         adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
@@ -481,6 +503,9 @@ mod tests {
         assert!(compact_help.contains("extension Manage Recall extensions"));
         assert!(compact_help.contains("session Operate on indexed sessions"));
         assert!(compact_help.contains("completions Generate shell completion script"));
+        assert!(
+            compact_help.contains("worker Inspect and control the background embedding worker")
+        );
     }
 
     #[test]
@@ -571,6 +596,30 @@ mod tests {
     fn reembed_defaults_to_prompt() {
         let cli = Cli::try_parse_from(["recall", "reembed"]).unwrap();
         assert!(matches!(cli.command, Some(Commands::Reembed { yes: false })));
+    }
+
+    #[test]
+    fn worker_status_parses() {
+        let cli = Cli::try_parse_from(["recall", "worker", "status"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Worker { command: WorkerAction::Status })));
+    }
+
+    #[test]
+    fn worker_stop_defaults_to_keep_queue() {
+        let cli = Cli::try_parse_from(["recall", "worker", "stop"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Worker { command: WorkerAction::Stop { clear_queue: false } })
+        ));
+    }
+
+    #[test]
+    fn worker_stop_accepts_clear_queue_flag() {
+        let cli = Cli::try_parse_from(["recall", "worker", "stop", "--clear-queue"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Worker { command: WorkerAction::Stop { clear_queue: true } })
+        ));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,11 @@ enum Commands {
     },
     #[command(about = "Compact the database and reclaim disk space")]
     Vacuum,
+    #[command(about = "Rebuild all semantic embeddings from indexed messages")]
+    Reembed {
+        #[arg(long, help = "Skip the confirmation prompt")]
+        yes: bool,
+    },
     #[command(about = "Share session pages")]
     Share {
         #[command(subcommand)]
@@ -238,6 +243,7 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Import { file, dry_run }) => crate::import::run_cli(&file, dry_run)?,
         Some(Commands::Reset { yes }) => crate::maintenance::run_reset(yes)?,
         Some(Commands::Vacuum) => crate::maintenance::run_vacuum()?,
+        Some(Commands::Reembed { yes }) => crate::maintenance::run_reembed(yes)?,
         Some(Commands::Share { command: ShareCommands::Init { project_name, publish_dir } }) => {
             crate::share_init::run(project_name, publish_dir)?
         }
@@ -553,6 +559,18 @@ mod tests {
     fn vacuum_parses() {
         let cli = Cli::try_parse_from(["recall", "vacuum"]).unwrap();
         assert!(matches!(cli.command, Some(Commands::Vacuum)));
+    }
+
+    #[test]
+    fn reembed_accepts_yes_flag() {
+        let cli = Cli::try_parse_from(["recall", "reembed", "--yes"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Reembed { yes: true })));
+    }
+
+    #[test]
+    fn reembed_defaults_to_prompt() {
+        let cli = Cli::try_parse_from(["recall", "reembed"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Reembed { yes: false })));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,8 +147,171 @@ impl AppConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DoctorLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DoctorCheck {
+    pub(crate) label: String,
+    pub(crate) level: DoctorLevel,
+    pub(crate) detail: String,
+}
+
+impl DoctorCheck {
+    fn info(label: &str, detail: impl Into<String>) -> Self {
+        Self { label: label.to_string(), level: DoctorLevel::Info, detail: detail.into() }
+    }
+
+    fn warn(label: &str, detail: impl Into<String>) -> Self {
+        Self { label: label.to_string(), level: DoctorLevel::Warn, detail: detail.into() }
+    }
+
+    fn error(label: &str, detail: impl Into<String>) -> Self {
+        Self { label: label.to_string(), level: DoctorLevel::Error, detail: detail.into() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DoctorReport {
+    pub(crate) checks: Vec<DoctorCheck>,
+}
+
+impl DoctorReport {
+    pub(crate) fn has_errors(&self) -> bool {
+        self.checks.iter().any(|c| c.level == DoctorLevel::Error)
+    }
+}
+
+/// Evaluate configuration health from borrowed inputs — no filesystem access,
+/// so it is fully unit-testable. `raw` is `None` when the config file is
+/// absent (defaults apply — fine). `mode` is `st_mode & 0o777` when the file
+/// exists on unix, else `None`. `known_sources` is `(id, label)` from
+/// `adapters::source_labels()`.
+pub(crate) fn evaluate_config(
+    raw: Option<&str>,
+    mode: Option<u32>,
+    known_sources: &[(String, String)],
+) -> DoctorReport {
+    let mut checks = Vec::new();
+
+    match raw {
+        None => checks.push(DoctorCheck::info("config file", "not found; built-in defaults apply")),
+        Some(_) => checks.push(DoctorCheck::info("config file", "present")),
+    }
+
+    if let Some(mode) = mode {
+        let perms = mode & 0o777;
+        if perms & 0o022 != 0 {
+            checks.push(DoctorCheck::warn(
+                "permissions",
+                format!("group/world-writable ({perms:04o}); tighten with `chmod go-w`"),
+            ));
+        } else {
+            checks.push(DoctorCheck::info("permissions", format!("{perms:04o}")));
+        }
+    }
+
+    let parsed = match raw {
+        None => Some(AppConfig::default()),
+        Some(content) => match serde_json::from_str::<AppConfig>(content) {
+            Ok(config) => {
+                checks.push(DoctorCheck::info("json", "valid"));
+                Some(config)
+            }
+            Err(err) => {
+                checks.push(DoctorCheck::error("json", format!("invalid: {err}")));
+                None
+            }
+        },
+    };
+
+    if let Some(config) = parsed {
+        let enabled = known_sources.iter().filter(|(id, _)| config.is_source_enabled(id)).count();
+        if enabled == 0 {
+            checks.push(DoctorCheck::error(
+                "sources",
+                "no sources enabled; every known source is listed in disabled_sources",
+            ));
+        } else {
+            checks.push(DoctorCheck::info(
+                "sources",
+                format!("{enabled} of {} enabled", known_sources.len()),
+            ));
+        }
+    }
+
+    DoctorReport { checks }
+}
+
 pub(crate) fn config_path() -> Result<PathBuf> {
     let dir =
         dirs::config_dir().ok_or_else(|| anyhow::anyhow!("cannot determine config directory"))?;
     Ok(dir.join("recall").join("config.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DoctorLevel, evaluate_config};
+
+    fn known() -> Vec<(String, String)> {
+        vec![
+            ("codex".to_string(), "Codex".to_string()),
+            ("claude-code".to_string(), "Claude Code".to_string()),
+        ]
+    }
+
+    #[test]
+    fn test_should_report_clean_when_config_file_missing() {
+        let report = evaluate_config(None, None, &known());
+        assert!(!report.has_errors());
+        assert!(report.checks.iter().all(|c| c.level != DoctorLevel::Error));
+    }
+
+    #[test]
+    fn test_should_error_when_json_is_invalid() {
+        let report = evaluate_config(Some("{ not json"), Some(0o600), &known());
+        assert!(report.has_errors());
+        assert!(report.checks.iter().any(|c| c.level == DoctorLevel::Error && c.label == "json"));
+    }
+
+    #[test]
+    fn test_should_error_when_no_sources_enabled() {
+        let raw = r#"{"disabled_sources":["codex","claude-code"]}"#;
+        let report = evaluate_config(Some(raw), Some(0o600), &known());
+        assert!(report.has_errors());
+        assert!(
+            report.checks.iter().any(|c| c.level == DoctorLevel::Error && c.label == "sources")
+        );
+    }
+
+    #[test]
+    fn test_should_report_clean_when_default_config_valid() {
+        let raw = serde_json::to_string_pretty(&super::AppConfig::default()).unwrap();
+        let report = evaluate_config(Some(&raw), Some(0o600), &known());
+        assert!(!report.has_errors());
+    }
+
+    #[test]
+    fn test_should_warn_when_config_group_or_world_writable() {
+        let report = evaluate_config(Some("{}"), Some(0o666), &known());
+        assert!(!report.has_errors());
+        assert!(
+            report.checks.iter().any(|c| c.level == DoctorLevel::Warn && c.label == "permissions")
+        );
+    }
+
+    #[test]
+    fn test_should_not_warn_when_config_only_group_world_readable() {
+        let report = evaluate_config(Some("{}"), Some(0o644), &known());
+        assert!(
+            report
+                .checks
+                .iter()
+                .all(|c| !(c.level == DoctorLevel::Warn && c.label == "permissions"))
+        );
+    }
 }

--- a/src/db/semantic_store.rs
+++ b/src/db/semantic_store.rs
@@ -48,6 +48,22 @@ impl Store {
         Ok(cleared)
     }
 
+    /// Reset embedding rows stranded in `processing` (e.g. a worker killed
+    /// mid-embed) back to `pending` so the next worker launch resumes them.
+    /// Idempotent to re-run; leaves `done`/`failed`/`pending` rows untouched.
+    /// Returns the number of rows re-queued.
+    pub(crate) fn reset_inflight_embedding_jobs(&self) -> Result<usize> {
+        let reset = self.conn.execute(
+            "UPDATE session_embedding_state
+             SET status = 'pending',
+                 started_at = NULL,
+                 finished_at = NULL
+             WHERE status = 'processing'",
+            [],
+        )?;
+        Ok(reset)
+    }
+
     pub(crate) fn embeddable_messages(&self, session_id: &str) -> Result<Vec<(i64, String)>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content FROM messages

--- a/src/db/semantic_store.rs
+++ b/src/db/semantic_store.rs
@@ -25,6 +25,29 @@ impl Store {
         Ok(())
     }
 
+    /// Drop every vector embedding and re-queue all sessions for a rebuild.
+    /// Deletes `message_vec` and resets `session_embedding_state` rows to
+    /// `pending` (units/timestamps cleared) in ONE transaction so the state
+    /// and the vectors can never diverge. Deliberately leaves `messages` and
+    /// the `messages_fts` index untouched: full-text search stays available
+    /// while the background worker rebuilds vectors. Returns the number of
+    /// session-state rows re-queued.
+    pub(crate) fn clear_semantic_queue(&self) -> Result<usize> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute("DELETE FROM message_vec", [])?;
+        let cleared = tx.execute(
+            "UPDATE session_embedding_state
+             SET status = 'pending',
+                 units_done = 0,
+                 started_at = NULL,
+                 finished_at = NULL,
+                 last_error = NULL",
+            [],
+        )?;
+        tx.commit()?;
+        Ok(cleared)
+    }
+
     pub(crate) fn embeddable_messages(&self, session_id: &str) -> Result<Vec<(i64, String)>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, content FROM messages

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -47,6 +47,12 @@ impl Store {
         rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
     }
 
+    pub(crate) fn distinct_session_sources(&self) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare("SELECT DISTINCT source FROM sessions ORDER BY source")?;
+        let rows = stmt.query_map([], |row| row.get(0))?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub(crate) fn clear_import_marker(&self, source: &str, source_id: &str) -> Result<()> {
         self.conn.execute(
             "UPDATE sessions SET is_import = 0 WHERE source = ?1 AND source_id = ?2",

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -79,12 +79,19 @@ pub(crate) struct SkillAuditEventRow {
 }
 
 impl Store {
-    pub(crate) fn open() -> Result<Self> {
-        let data_dir = dirs::data_dir()
+    pub(crate) fn data_dir() -> Result<std::path::PathBuf> {
+        Ok(dirs::data_dir()
             .ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?
-            .join("recall");
-        std::fs::create_dir_all(&data_dir)?;
-        let db_path = data_dir.join("recall.db");
+            .join("recall"))
+    }
+
+    pub(crate) fn db_path() -> Result<std::path::PathBuf> {
+        Ok(Self::data_dir()?.join("recall.db"))
+    }
+
+    pub(crate) fn open() -> Result<Self> {
+        std::fs::create_dir_all(Self::data_dir()?)?;
+        let db_path = Self::db_path()?;
         let conn = Connection::open(&db_path)?;
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
@@ -101,6 +108,33 @@ impl Store {
         conn.execute_batch("PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;")?;
         crate::db::schema::init(&conn)?;
         Ok(Store { conn })
+    }
+
+    /// Delete every data row in FK dependency order in ONE transaction.
+    /// Deliberately does NOT touch `messages_fts`: it is an FTS5
+    /// external-content table maintained by the `messages_ad` AFTER-DELETE
+    /// trigger (schema.rs:91). Deleting it directly corrupts the index.
+    pub(crate) fn reset_all_data(&self) -> Result<()> {
+        self.conn.execute_batch(
+            "BEGIN IMMEDIATE;
+             DELETE FROM message_vec;
+             DELETE FROM session_embedding_state;
+             DELETE FROM event_session_state;
+             DELETE FROM session_events;
+             DELETE FROM usage_session_state;
+             DELETE FROM usage_events;
+             DELETE FROM messages;
+             DELETE FROM sessions;
+             DELETE FROM background_job_state;
+             COMMIT;",
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn vacuum(&self) -> Result<()> {
+        // VACUUM cannot run inside a transaction; execute standalone.
+        self.conn.execute_batch("VACUUM; ANALYZE; PRAGMA wal_checkpoint(TRUNCATE);")?;
+        Ok(())
     }
 }
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -203,6 +203,25 @@ mod exclusion_tests {
     }
 
     #[test]
+    fn distinct_session_sources_returns_each_source_once() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut a = sess("a", None);
+        a.source = "claude-code".to_string();
+        let mut b = sess("b", None);
+        b.source = "codex".to_string();
+        let mut c = sess("c", None);
+        c.source = "codex".to_string();
+        store.insert_session(&a).unwrap();
+        store.insert_session(&b).unwrap();
+        store.insert_session(&c).unwrap();
+
+        let mut sources = store.distinct_session_sources().unwrap();
+        sources.sort();
+        assert_eq!(sources, vec!["claude-code".to_string(), "codex".to_string()]);
+    }
+
+    #[test]
     fn session_paths_for_source_round_trips_then_delete_clears() {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -117,6 +117,20 @@ fn select_device() -> Result<Device> {
     }
 }
 
+/// Cheap, download-free description of the local embedding backend for the
+/// config doctor. Detects the accelerator the same way `select_device` does,
+/// without constructing a model or touching the network.
+pub(crate) fn availability_summary() -> String {
+    let device = if candle_core::utils::cuda_is_available() {
+        "CUDA"
+    } else if candle_core::utils::metal_is_available() {
+        "Metal"
+    } else {
+        "CPU"
+    };
+    format!("local candle {MODEL_ID} (device: {device})")
+}
+
 fn download_model(show_progress: bool) -> Result<(PathBuf, PathBuf, PathBuf)> {
     let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
     let repo =

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -237,6 +237,43 @@ fn test_should_clear_all_tables_and_keep_fts_usable_when_reset() {
 }
 
 #[test]
+fn test_should_drop_vectors_and_requeue_state_and_keep_fts_when_reembed() {
+    let store = setup();
+    let s = make_session("a", "claude-code", "src-a", "hello world");
+    store.insert_session(&s).unwrap();
+    store.insert_messages(&[make_message("a", Role::User, "reembed probe unique", 0)]).unwrap();
+    let msg_id = first_message_id(&store, "a");
+    store.upsert_embeddings(&[(msg_id, &vec![0.2f32; 384])]).unwrap();
+    // A completed embedding-state row, as the sync bundle would have written.
+    store
+        .conn
+        .execute(
+            "INSERT INTO session_embedding_state
+                 (session_id, status, units_total, units_done, finished_at)
+             VALUES ('a', 'done', 1, 1, 123)",
+            [],
+        )
+        .unwrap();
+
+    let cleared = store.clear_semantic_queue().unwrap();
+
+    assert_eq!(cleared, 1, "one session-state row requeued");
+    assert_eq!(count_rows(&store, "SELECT COUNT(*) FROM message_vec"), 0, "vectors dropped");
+    assert_eq!(
+        count_rows(
+            &store,
+            "SELECT COUNT(*) FROM session_embedding_state \
+             WHERE status = 'pending' AND units_done = 0 \
+             AND started_at IS NULL AND finished_at IS NULL AND last_error IS NULL",
+        ),
+        1,
+        "state requeued to a clean pending row",
+    );
+    // FTS external-content index untouched: search still works during rebuild.
+    assert_eq!(count_fts_matches(&store, "reembed"), 1, "FTS stays available");
+}
+
+#[test]
 fn persist_session_writes_usage_events_and_report_aggregates() {
     let store = setup();
     let session = make_session("s1", "claude-code", "raw1", "Usage session");

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -195,6 +195,48 @@ fn delete_session_cleans_embeddings() {
 }
 
 #[test]
+fn test_should_clear_all_tables_and_keep_fts_usable_when_reset() {
+    let store = setup();
+    let s = make_session("a", "claude-code", "src-a", "hello world");
+    store.insert_session(&s).unwrap();
+    store.insert_messages(&[make_message("a", Role::User, "reset probe unique", 0)]).unwrap();
+
+    store.reset_all_data().unwrap();
+
+    // every data table empty
+    for table in [
+        "sessions",
+        "messages",
+        "message_vec",
+        "session_embedding_state",
+        "session_events",
+        "event_session_state",
+        "usage_events",
+        "usage_session_state",
+        "background_job_state",
+    ] {
+        let n: i64 = store
+            .conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "{table} not cleared");
+    }
+    // FTS external-content index NOT corrupted: re-insert + search round-trips
+    let s2 = make_session("b", "claude-code", "src-b", "again");
+    store.insert_session(&s2).unwrap();
+    store.insert_messages(&[make_message("b", Role::User, "postreset token", 0)]).unwrap();
+    let hits: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'postreset'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(hits, 1);
+}
+
+#[test]
 fn persist_session_writes_usage_events_and_report_aggregates() {
     let store = setup();
     let session = make_session("s1", "claude-code", "raw1", "Usage session");

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -1055,6 +1055,49 @@ fn replace_session_clears_import_marker_on_success() {
 }
 
 #[test]
+fn test_should_requeue_inflight_embedding_job_when_reset() {
+    let store = setup();
+    let session = make_session("s1", "test", "raw1", "In-flight session");
+    store
+        .persist_session_with_usage_and_events(
+            &session,
+            &[make_message("s1", Role::User, "some embeddable content", 0)],
+            &[],
+            None,
+            &[],
+            None,
+        )
+        .unwrap();
+
+    // Claim moves the row from 'pending' to 'processing', simulating a
+    // worker that started embedding this session.
+    let claimed = store.claim_next_session_embedding_job().unwrap();
+    assert!(claimed.is_some(), "expected a pending job to claim");
+    assert_eq!(
+        count_rows(
+            &store,
+            "SELECT COUNT(*) FROM session_embedding_state WHERE session_id = 's1' AND status = 'processing'"
+        ),
+        1
+    );
+
+    let reset = store.reset_inflight_embedding_jobs().unwrap();
+    assert_eq!(reset, 1);
+    assert_eq!(
+        count_rows(
+            &store,
+            "SELECT COUNT(*) FROM session_embedding_state WHERE session_id = 's1' AND status = 'pending'"
+        ),
+        1
+    );
+
+    // The reset row must be re-claimable by the next worker launch.
+    let reclaimed = store.claim_next_session_embedding_job().unwrap();
+    assert!(reclaimed.is_some(), "expected the reset job to be re-claimable");
+    assert_eq!(reclaimed.unwrap().session_id, "s1");
+}
+
+#[test]
 fn gemini_parser_plain_conversation() {
     let json = r#"{
         "sessionId": "abc-123",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod extension;
 pub(crate) mod handoff;
 pub(crate) mod import;
 pub(crate) mod info;
+pub(crate) mod maintenance;
 pub(crate) mod query;
 pub(crate) mod repo_identity;
 pub(crate) mod semantic;

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -188,3 +188,75 @@ fn signal_worker(pid: u32) -> Result<()> {
 fn signal_worker(_pid: u32) -> Result<()> {
     anyhow::bail!("worker stop is only supported on Unix")
 }
+
+pub(crate) fn run_config_show() -> Result<()> {
+    let path = crate::config::config_path()?;
+    let config = crate::config::AppConfig::load_or_default();
+    println!("# {}", path.display());
+    println!("{}", serde_json::to_string_pretty(&config)?);
+    Ok(())
+}
+
+pub(crate) fn run_config_edit() -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!("config edit requires an interactive terminal");
+    }
+    let path = crate::config::config_path()?;
+    if !path.exists() {
+        crate::config::AppConfig::default().save()?;
+        println!("Created default config at {}", path.display());
+    }
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    // Command::status() inherits parent stdio, so a full-screen TUI editor works.
+    let status = std::process::Command::new(&editor).arg(&path).status()?;
+    if !status.success() {
+        anyhow::bail!("editor `{editor}` exited with a non-zero status");
+    }
+    match crate::config::AppConfig::load() {
+        Ok(_) => {
+            println!("Config saved and valid.");
+            Ok(())
+        }
+        Err(err) => anyhow::bail!("config is invalid after edit: {err}"),
+    }
+}
+
+pub(crate) fn run_config_doctor() -> Result<()> {
+    let path = crate::config::config_path()?;
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(content) => Some(content),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err.into()),
+    };
+    let mode = config_file_mode(&path);
+    let labels = crate::adapters::source_labels();
+    let report = crate::config::evaluate_config(raw.as_deref(), mode, &labels);
+
+    println!("Config Doctor");
+    println!("  Path         {}", path.display());
+    for check in &report.checks {
+        let tag = match check.level {
+            crate::config::DoctorLevel::Info => "info",
+            crate::config::DoctorLevel::Warn => "warn",
+            crate::config::DoctorLevel::Error => "FAIL",
+        };
+        println!("  [{tag}] {:<12} {}", check.label, check.detail);
+    }
+    println!("  [info] {:<12} {}", "embedding", crate::embedding::availability_summary());
+
+    if report.has_errors() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn config_file_mode(path: &std::path::Path) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).ok().map(|meta| meta.permissions().mode())
+}
+
+#[cfg(not(unix))]
+fn config_file_mode(_path: &std::path::Path) -> Option<u32> {
+    None
+}

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -189,6 +189,171 @@ fn signal_worker(_pid: u32) -> Result<()> {
     anyhow::bail!("worker stop is only supported on Unix")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GcReason {
+    Keep,
+    DisabledSource,
+    Orphan,
+    Unverifiable,
+}
+
+/// Classify a single indexed session for garbage collection. Pure over the
+/// injected `exists` probe so every branch is unit-testable without a real FS.
+/// Orphan is only reported when the stored path's PARENT still exists; a missing
+/// parent means the source root is unavailable, so the row is kept as
+/// unverifiable rather than deleted (the offline-root guard).
+fn classify(
+    source_enabled: bool,
+    source_file_path: Option<&str>,
+    exists: &impl Fn(&std::path::Path) -> bool,
+) -> GcReason {
+    if !source_enabled {
+        return GcReason::DisabledSource;
+    }
+    let Some(path_str) = source_file_path else {
+        return GcReason::Unverifiable;
+    };
+    let path = std::path::Path::new(path_str);
+    if exists(path) {
+        return GcReason::Keep;
+    }
+    match path.parent() {
+        Some(parent) if exists(parent) => GcReason::Orphan,
+        _ => GcReason::Unverifiable,
+    }
+}
+
+pub(crate) fn run_gc(dry_run: bool, yes: bool) -> Result<()> {
+    let config = crate::config::AppConfig::load_or_default();
+    let store = Store::open()?;
+    let exists = |p: &std::path::Path| p.exists();
+
+    // (source, source_id, reason) for every row in the DB.
+    let mut plan: Vec<(String, String, GcReason)> = Vec::new();
+    for source in store.distinct_session_sources()? {
+        let enabled = config.is_source_enabled(&source);
+        for sp in store.session_paths_for_source(&source)? {
+            let reason = classify(enabled, sp.source_file_path.as_deref(), &exists);
+            plan.push((source.clone(), sp.source_id, reason));
+        }
+    }
+
+    let count = |want: GcReason| plan.iter().filter(|(_, _, r)| *r == want).count();
+    let (keep, disabled, orphan, unverifiable) = (
+        count(GcReason::Keep),
+        count(GcReason::DisabledSource),
+        count(GcReason::Orphan),
+        count(GcReason::Unverifiable),
+    );
+    let deletable = disabled + orphan;
+
+    println!("Garbage Collection");
+    println!("  Keep            {keep}");
+    println!("  Disabled source {disabled}");
+    println!("  Orphan          {orphan}");
+    println!("  Unverifiable    {unverifiable} (kept: NULL path or source root unavailable)");
+
+    // Up to 10 sample lines per deletable reason.
+    for (label, reason) in
+        [("disabled source", GcReason::DisabledSource), ("orphan", GcReason::Orphan)]
+    {
+        let rows: Vec<&(String, String, GcReason)> =
+            plan.iter().filter(|(_, _, r)| *r == reason).collect();
+        if rows.is_empty() {
+            continue;
+        }
+        println!("  Sample ({label}):");
+        for (source, source_id, _) in rows.iter().take(10) {
+            println!("    {source}  {source_id}");
+        }
+        if rows.len() > 10 {
+            println!("    ... and {} more", rows.len() - 10);
+        }
+    }
+
+    if deletable == 0 {
+        println!("Nothing to collect.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "Dry run: {deletable} session(s) would be deleted. Re-run without --dry-run to apply."
+        );
+        return Ok(());
+    }
+
+    if !yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!("gc requires --yes when not attached to a terminal");
+        }
+        print!("Delete {deletable} indexed session(s)? This cannot be undone [y/N]: ");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !matches!(answer.trim(), "y" | "Y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let outcome =
+        delete_plan(&plan, |source, source_id| store.delete_session_data(source, source_id));
+
+    if outcome.failed > 0 {
+        println!(
+            "Deleted {} of {deletable} session(s); {} failed.",
+            outcome.deleted, outcome.failed
+        );
+        let first_error = outcome.first_error.expect("failed > 0 implies first_error is populated");
+        return Err(first_error.context(format!(
+            "gc: {} of {deletable} session delete(s) failed ({} succeeded)",
+            outcome.failed, outcome.deleted
+        )));
+    }
+
+    println!("Deleted {} session(s).", outcome.deleted);
+    Ok(())
+}
+
+/// Outcome of running [`delete_plan`] over a classified gc plan.
+struct GcDeleteOutcome {
+    deleted: usize,
+    failed: usize,
+    first_error: Option<anyhow::Error>,
+}
+
+/// Delete every `DisabledSource`/`Orphan` row in `plan` via the injected `delete`
+/// callback. Each row is deleted independently (the store commits per-row), so a
+/// failure on one row must not abort the rest: it is recorded and the loop
+/// continues, keeping partial cleanup instead of stopping silently mid-gc. Every
+/// per-row failure is also printed immediately so it isn't swallowed even when
+/// the caller only inspects the aggregate outcome.
+fn delete_plan(
+    plan: &[(String, String, GcReason)],
+    mut delete: impl FnMut(&str, &str) -> Result<()>,
+) -> GcDeleteOutcome {
+    let mut deleted = 0usize;
+    let mut failed = 0usize;
+    let mut first_error: Option<anyhow::Error> = None;
+    for (source, source_id, reason) in plan {
+        if !matches!(reason, GcReason::DisabledSource | GcReason::Orphan) {
+            continue;
+        }
+        match delete(source, source_id) {
+            Ok(()) => deleted += 1,
+            Err(err) => {
+                eprintln!("gc: failed to delete {source}/{source_id}: {err:#}");
+                failed += 1;
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+    }
+    GcDeleteOutcome { deleted, failed, first_error }
+}
+
 pub(crate) fn run_config_show() -> Result<()> {
     let path = crate::config::config_path()?;
     let config = crate::config::AppConfig::load_or_default();
@@ -259,4 +424,135 @@ fn config_file_mode(path: &std::path::Path) -> Option<u32> {
 #[cfg(not(unix))]
 fn config_file_mode(_path: &std::path::Path) -> Option<u32> {
     None
+}
+
+#[cfg(test)]
+mod gc_tests {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    use super::{GcReason, classify};
+
+    fn probe(existing: &[&str]) -> impl Fn(&Path) -> bool {
+        let set: HashSet<PathBuf> = existing.iter().map(PathBuf::from).collect();
+        move |p: &Path| set.contains(p)
+    }
+
+    #[test]
+    fn disabled_source_is_bucketed_before_any_path_check() {
+        // Source disabled: reason is DisabledSource even though the file exists.
+        let exists = probe(&["/root/s.jsonl", "/root"]);
+        assert_eq!(classify(false, Some("/root/s.jsonl"), &exists), GcReason::DisabledSource);
+    }
+
+    #[test]
+    fn enabled_source_with_present_file_is_kept() {
+        let exists = probe(&["/root/s.jsonl", "/root"]);
+        assert_eq!(classify(true, Some("/root/s.jsonl"), &exists), GcReason::Keep);
+    }
+
+    #[test]
+    fn enabled_source_with_missing_file_but_present_root_is_orphan() {
+        let exists = probe(&["/root"]); // parent exists, file does not
+        assert_eq!(classify(true, Some("/root/gone.jsonl"), &exists), GcReason::Orphan);
+    }
+
+    #[test]
+    fn null_path_row_is_unverifiable_and_safe_kept() {
+        let exists = probe(&[]);
+        assert_eq!(classify(true, None, &exists), GcReason::Unverifiable);
+    }
+
+    #[test]
+    fn missing_root_row_is_unverifiable_not_orphan() {
+        // Neither the file nor its parent dir exist (unmounted drive / renamed root).
+        let exists = probe(&[]);
+        assert_eq!(classify(true, Some("/mnt/usb/s.jsonl"), &exists), GcReason::Unverifiable);
+    }
+
+    #[test]
+    fn orphan_and_disabled_source_rows_are_deleted_via_store() {
+        use crate::db::store::Store;
+        use crate::types::Session;
+
+        crate::db::schema::register_sqlite_vec();
+        let dir = std::env::temp_dir().join(format!("recall-gc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let present = dir.join("present.jsonl");
+        std::fs::write(&present, b"{}").unwrap();
+        let missing = dir.join("missing.jsonl"); // never created
+
+        let store = Store::open_in_memory().unwrap();
+        let mk = |id: &str, source: &str, path: &std::path::Path| Session {
+            id: id.to_string(),
+            source: source.to_string(),
+            source_id: format!("src-{id}"),
+            title: "t".to_string(),
+            directory: None,
+            repo_remote: None,
+            repo_slug: None,
+            repo_name: None,
+            started_at: 0,
+            updated_at: Some(1),
+            message_count: 0,
+            entrypoint: None,
+            custom_title: None,
+            summary: None,
+            duration_minutes: None,
+            source_file_path: Some(path.to_str().unwrap().to_string()),
+            is_import: false,
+        };
+        // "claude-code" is enabled: keep (file present) + orphan (file missing).
+        store.insert_session(&mk("keep", "claude-code", &present)).unwrap();
+        store.insert_session(&mk("orphan", "claude-code", &missing)).unwrap();
+        // "codex" is disabled entirely: its row must be deleted via the
+        // DisabledSource branch even though the file itself still exists.
+        store.insert_session(&mk("disabled", "codex", &present)).unwrap();
+
+        let exists = |p: &std::path::Path| p.exists();
+        let enabled_for = |source: &str| source != "codex";
+        for source in ["claude-code", "codex"] {
+            for sp in store.session_paths_for_source(source).unwrap() {
+                let reason =
+                    super::classify(enabled_for(source), sp.source_file_path.as_deref(), &exists);
+                if matches!(reason, super::GcReason::Orphan | super::GcReason::DisabledSource) {
+                    store.delete_session_data(source, &sp.source_id).unwrap();
+                }
+            }
+        }
+
+        let remaining_claude_code = store.session_paths_for_source("claude-code").unwrap();
+        assert_eq!(remaining_claude_code.len(), 1);
+        assert_eq!(remaining_claude_code[0].source_id, "src-keep");
+
+        let remaining_codex = store.session_paths_for_source("codex").unwrap();
+        assert!(remaining_codex.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn partial_delete_failure_continues_and_reports_first_error() {
+        // Store-level errors mid-gc-loop can't be forced through real SQLite
+        // (deleting a row that doesn't exist is a silent no-op, not an Err), so
+        // this drives `delete_plan` directly with an injected failing callback
+        // -- the same dependency-injection seam `classify` already uses for
+        // its `exists` probe.
+        let plan = vec![
+            ("claude-code".to_string(), "a".to_string(), GcReason::Orphan),
+            ("claude-code".to_string(), "b".to_string(), GcReason::DisabledSource),
+            ("claude-code".to_string(), "c".to_string(), GcReason::Orphan),
+            ("claude-code".to_string(), "keep".to_string(), GcReason::Keep),
+        ];
+        let outcome = super::delete_plan(&plan, |_source, source_id| {
+            if source_id == "b" {
+                anyhow::bail!("simulated failure for {source_id}");
+            }
+            Ok(())
+        });
+        assert_eq!(outcome.deleted, 2, "a and c succeed despite b failing");
+        assert_eq!(outcome.failed, 1);
+        assert!(outcome.first_error.is_some());
+        assert!(outcome.first_error.unwrap().to_string().contains("simulated failure for b"));
+    }
 }

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -1,0 +1,38 @@
+use std::io::{IsTerminal, Write};
+
+use anyhow::Result;
+
+use crate::db::store::Store;
+
+pub(crate) fn run_reset(yes: bool) -> Result<()> {
+    if !yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!("reset requires --yes when not attached to a terminal");
+        }
+        print!("Delete ALL indexed Recall data? This cannot be undone [y/N]: ");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !matches!(answer.trim(), "y" | "Y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+    Store::open()?.reset_all_data()?;
+    println!("All indexed data cleared.");
+    Ok(())
+}
+
+pub(crate) fn run_vacuum() -> Result<()> {
+    let path = Store::db_path()?;
+    let before = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    Store::open()?.vacuum()?;
+    let after = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    println!(
+        "Vacuumed {} -> {} ({} reclaimed)",
+        crate::utils::humanize_bytes(before),
+        crate::utils::humanize_bytes(after),
+        crate::utils::humanize_bytes(before.saturating_sub(after)),
+    );
+    Ok(())
+}

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -36,3 +36,25 @@ pub(crate) fn run_vacuum() -> Result<()> {
     );
     Ok(())
 }
+
+pub(crate) fn run_reembed(yes: bool) -> Result<()> {
+    if !yes {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!("reembed requires --yes when not attached to a terminal");
+        }
+        print!("Rebuild all semantic embeddings? Type 'reembed' to confirm: ");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if answer.trim() != "reembed" {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+    let cleared = Store::open()?.clear_semantic_queue()?;
+    println!(
+        "Cleared embeddings for {cleared} session(s). FTS search stays available; \
+         the background worker rebuilds vectors on the next `recall` or `recall sync`."
+    );
+    Ok(())
+}

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -3,6 +3,7 @@ use std::io::{IsTerminal, Write};
 use anyhow::Result;
 
 use crate::db::store::Store;
+use crate::semantic;
 
 pub(crate) fn run_reset(yes: bool) -> Result<()> {
     if !yes {
@@ -57,4 +58,133 @@ pub(crate) fn run_reembed(yes: bool) -> Result<()> {
          the background worker rebuilds vectors on the next `recall` or `recall sync`."
     );
     Ok(())
+}
+
+pub(crate) fn run_worker_status() -> Result<()> {
+    let held = semantic::worker_lock_is_held()?;
+    let pid = semantic::worker_lock_pid()?;
+    let store = Store::open()?;
+    let progress = store.semantic_progress().unwrap_or_default();
+    let worker = store.background_job_status("pipeline").unwrap_or_default();
+
+    println!("Background Worker");
+    match (held, pid) {
+        (true, Some(pid)) => println!("  State       running (pid {pid})"),
+        (true, None) => println!("  State       running (pid unknown)"),
+        (false, _) => println!("  State       not running"),
+    }
+    if let Some(phase) = worker.phase {
+        if held {
+            println!("  Phase       {phase}");
+        } else {
+            println!("  Phase       {phase} (stale)");
+        }
+    }
+    println!(
+        "  Progress    {} done, {} pending, {} failed",
+        progress.done_sessions,
+        progress.pending_sessions + progress.processing_sessions,
+        progress.failed_sessions
+    );
+    Ok(())
+}
+
+pub(crate) fn run_worker_stop(clear_queue: bool) -> Result<()> {
+    let mut worker_was_running = false;
+    if semantic::worker_lock_is_held()? {
+        worker_was_running = true;
+        match semantic::worker_lock_pid()? {
+            Some(pid) => {
+                // Re-verify the lock is still held immediately before signaling
+                // to narrow the pid-reuse TOCTOU window (see signal_worker).
+                if semantic::worker_lock_is_held()? {
+                    signal_worker(pid)?;
+                    if wait_for_worker_exit()? {
+                        println!("Stopped background worker (pid {pid}).");
+                    } else {
+                        println!(
+                            "Signaled worker (pid {pid}) but the lock is still held after 5s; \
+                             proceeding."
+                        );
+                    }
+                }
+            }
+            None => {
+                println!("Worker lock is held but no pid is recorded; leaving it in place.");
+            }
+        }
+    } else {
+        println!("No background worker is running.");
+        remove_stale_lock()?;
+    }
+
+    // Only reset/clear queue state once the worker is confirmed not running:
+    // it was never running (worker_was_running false), or a fresh lock probe
+    // now reports not held. A timed-out wait or a held-but-no-pid worker both
+    // still hold the lock here, so the probe correctly keeps the block gated.
+    if worker_was_running && semantic::worker_lock_is_held()? {
+        println!(
+            "Worker still running; queue not modified. Re-run `recall worker stop` after it exits."
+        );
+        return Ok(());
+    }
+
+    if clear_queue {
+        let cleared = Store::open()?.clear_semantic_queue()?;
+        println!(
+            "Cleared embeddings for {cleared} session(s); the background worker rebuilds \
+             vectors on the next `recall` or `recall sync`."
+        );
+    } else {
+        let requeued = Store::open()?.reset_inflight_embedding_jobs()?;
+        if requeued > 0 {
+            println!("Re-queued {requeued} in-flight session(s) as pending.");
+        }
+    }
+    Ok(())
+}
+
+fn remove_stale_lock() -> Result<()> {
+    let path = semantic::worker_lock_path()?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn wait_for_worker_exit() -> Result<bool> {
+    for _ in 0..50 {
+        if !semantic::worker_lock_is_held()? {
+            return Ok(true);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    Ok(false)
+}
+
+#[cfg(unix)]
+fn signal_worker(pid: u32) -> Result<()> {
+    // Safest achievable stop with an fs2 flock + pidfile: caller has just
+    // re-verified the lock is held. Residual pid-reuse window (holder dies and
+    // the OS reuses `pid` between that check and this kill) cannot be closed
+    // without a pidfd; documented as out of scope. Never signal self/pid 0;
+    // treat ESRCH (already gone) as success.
+    if pid == 0 || pid == std::process::id() {
+        anyhow::bail!("refusing to signal invalid worker pid {pid}");
+    }
+    let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    if result == 0 {
+        return Ok(());
+    }
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    Err(err.into())
+}
+
+#[cfg(not(unix))]
+fn signal_worker(_pid: u32) -> Result<()> {
+    anyhow::bail!("worker stop is only supported on Unix")
 }

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -134,7 +134,100 @@ fn try_acquire_worker_lock() -> Result<Option<File>> {
     }
 }
 
-fn worker_lock_path() -> Result<std::path::PathBuf> {
+pub(crate) fn worker_lock_path() -> Result<std::path::PathBuf> {
     let dir = dirs::data_dir().ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?;
     Ok(dir.join("recall").join("background-worker.lock"))
+}
+
+pub(crate) fn worker_lock_pid() -> Result<Option<u32>> {
+    lock_pid_at(&worker_lock_path()?)
+}
+
+pub(crate) fn worker_lock_is_held() -> Result<bool> {
+    lock_is_held_at(&worker_lock_path()?)
+}
+
+fn lock_pid_at(path: &std::path::Path) -> Result<Option<u32>> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    Ok(contents.lines().next().and_then(|line| line.trim().parse::<u32>().ok()))
+}
+
+fn lock_is_held_at(path: &std::path::Path) -> Result<bool> {
+    let file = match OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+    // A live worker holds an exclusive flock on this file for its lifetime.
+    // If we can take the lock, no live holder exists (stale/absent pidfile).
+    // `drop(file)` releases our probe lock. Any lock error means contended -> held.
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(false),
+        Err(_) => Ok(true),
+    }
+}
+
+#[cfg(test)]
+mod worker_lock_tests {
+    use std::fs::OpenOptions;
+
+    use fs2::FileExt;
+
+    use super::{lock_is_held_at, lock_pid_at};
+
+    #[test]
+    fn test_should_report_not_held_when_lock_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("background-worker.lock");
+        assert!(!lock_is_held_at(&path).unwrap());
+    }
+
+    #[test]
+    fn test_should_report_not_held_when_file_exists_but_unlocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("background-worker.lock");
+        std::fs::write(&path, "4242\n").unwrap();
+        assert!(!lock_is_held_at(&path).unwrap());
+    }
+
+    #[test]
+    fn test_should_report_held_while_exclusive_flock_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("background-worker.lock");
+        std::fs::write(&path, "4242\n").unwrap();
+
+        let holder = OpenOptions::new().read(true).write(true).open(&path).unwrap();
+        holder.try_lock_exclusive().unwrap();
+        assert!(lock_is_held_at(&path).unwrap());
+
+        drop(holder);
+        assert!(!lock_is_held_at(&path).unwrap());
+    }
+
+    #[test]
+    fn test_should_read_pid_from_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("background-worker.lock");
+        std::fs::write(&path, "12345\n").unwrap();
+        assert_eq!(lock_pid_at(&path).unwrap(), Some(12345));
+    }
+
+    #[test]
+    fn test_should_return_none_pid_when_missing_empty_or_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.lock");
+        assert_eq!(lock_pid_at(&missing).unwrap(), None);
+
+        let empty = dir.path().join("empty.lock");
+        std::fs::write(&empty, "").unwrap();
+        assert_eq!(lock_pid_at(&empty).unwrap(), None);
+
+        let garbage = dir.path().join("garbage.lock");
+        std::fs::write(&garbage, "not-a-pid\n").unwrap();
+        assert_eq!(lock_pid_at(&garbage).unwrap(), None);
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,6 +79,24 @@ pub(crate) fn f32_slice_to_bytes(data: &[f32]) -> Vec<u8> {
     bytes
 }
 
+pub(crate) fn humanize_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    if bytes == 0 {
+        return "0 B".to_string();
+    }
+    let mut value = bytes as f64;
+    let mut unit_index = 0;
+    while value >= 1024.0 && unit_index < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit_index += 1;
+    }
+    if unit_index == 0 {
+        format!("{bytes} {}", UNITS[unit_index])
+    } else {
+        format!("{value:.1} {}", UNITS[unit_index])
+    }
+}
+
 const TITLE_MAX_CHARS: usize = 80;
 const TITLE_TRUNCATE_TAIL: usize = 77;
 
@@ -193,5 +211,30 @@ mod tests {
     fn title_detects_noise_with_leading_whitespace() {
         let msgs = ["   <command-message>ship</command-message>", "real content"];
         assert_eq!(title_from_user_messages(&msgs), "real content");
+    }
+
+    #[test]
+    fn humanize_bytes_formats_zero_as_bytes() {
+        assert_eq!(humanize_bytes(0), "0 B");
+    }
+
+    #[test]
+    fn humanize_bytes_formats_sub_kilobyte_as_bytes() {
+        assert_eq!(humanize_bytes(512), "512 B");
+    }
+
+    #[test]
+    fn humanize_bytes_formats_kilobytes_with_one_decimal() {
+        assert_eq!(humanize_bytes(2048), "2.0 KB");
+    }
+
+    #[test]
+    fn humanize_bytes_formats_megabytes() {
+        assert_eq!(humanize_bytes(5 * 1024 * 1024), "5.0 MB");
+    }
+
+    #[test]
+    fn humanize_bytes_formats_gigabytes() {
+        assert_eq!(humanize_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
     }
 }


### PR DESCRIPTION
## Summary

Adds an operator-facing maintenance surface to the CLI. Six subcommands, grouped because they share the same safety scaffolding (confirmation gates, non-interactive guards) and the same `src/maintenance.rs` module:

- **`recall reset`** — drops and rebuilds the index from scratch. FTS-trigger-safe: the reset path accounts for the FTS5 triggers on `sessions`/`message_vec` so a reset can't leave the trigger-maintained index out of sync with the base tables.
- **`recall vacuum`** — reclaims space after large deletes.
- **`recall reembed`** — clears the vector store and re-queues every session for the background worker to rebuild embeddings.
- **`recall worker status`** — reports whether the background embedding worker is running via a flock probe on the worker lock file (no live IPC needed: acquiring the lock non-blockingly means no live holder exists), plus its pid.
- **`recall worker stop`** — signals the worker to shut down via a safe SIGTERM sequence, with an optional `--clear-queue` to also drop computed embeddings and re-queue every session. The queue-clear path is guarded to skip while the worker is still running, avoiding a race between the CLI and the worker over `session_embedding_state` rows.
- **`recall config show|edit|doctor`** — `show` prints the resolved config as JSON; `edit` opens it in `$EDITOR` (requires a TTY), creating a default file first if none exists, and re-validates after the editor exits; `doctor` runs file-permission, adapter-label, and embedding-backend-availability checks and prints a pass/warn/fail report, exiting 1 on any failure. Includes a doctor remedy wording fix (`chmod 600` -> `chmod go-w`) for the group/world-writable warning.
- **`recall gc`** — deletes indexed sessions no longer worth keeping, classified into four buckets: `keep` (source enabled, backing file present), `disabled` (source turned off in config), `orphan` (backing file missing), and `unverifiable` (source cannot be checked, e.g. remote adapters). Only `disabled` and `orphan` are ever deleted; `unverifiable` is always kept as a safe-keep guard — gc never deletes a session when its source root is unavailable or its path is unknown. Supports `--dry-run` to report without deleting and `--yes` to skip the confirmation prompt. Partial-deletion failures are reported per-session instead of aborting the whole run.

Destructive commands (`reset`, `reembed`, `gc`) prompt for confirmation unless `--yes` is passed, and refuse to prompt in a non-interactive context (no TTY) rather than blocking forever or silently proceeding.

Adds `Store::distinct_session_sources` (session-source enumeration for gc classification) and `embedding::availability_summary` (a cheap, download-free device probe for CUDA/Metal/CPU, used by `config doctor`).

## Verification

- `cargo build`, `cargo fmt -- --check`, `cargo test --workspace` — green.
- 39 new tests covering: gc's four-bucket classification (including the unverifiable safe-keep case), worker lock probe against a live vs. stale lock file, config doctor's pass/warn/fail checks, reembed's queue-clear race guard, and reset's FTS-trigger consistency.

## Test plan

- [x] `recall gc --dry-run` → reports classification without deleting
- [x] `recall gc` with a source whose root is unavailable → session kept, not deleted
- [x] `recall worker status` while worker running → reports pid, held lock
- [x] `recall worker stop --clear-queue` while worker still running → queue-clear skipped, no race
- [x] `recall config doctor` on a group-writable config file → warns with `chmod go-w` remedy
- [x] `recall reset` → FTS index stays consistent with base tables after rebuild
