### PR TITLE
feat(session): index portable session topology

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -115,12 +115,16 @@ Core support in v0.1:
   `recall session list --query ... --format json`;
 - `recall session show` supports `--format json|jsonl`;
 - `recall export` emits JSONL, one session record per line, with export record
-  schema version 4, and supports `--include metadata,messages,usage,events`
+  schema version 5, and supports `--include metadata,messages,usage,events`
   for field projection. Export projections must include `messages`; `usage`
-  and `events` are optional add-ons;
+  and `events` are optional add-ons. `recall session list` and `recall export`
+  also accept `--thread-role primary|subagent|unknown` to filter by topology;
 - `recall session show --format json` defaults to metadata only. Extensions
   that need transcript data must pass `--messages` or
   `--include metadata,messages,usage,events`.
+- every session record carries `session.topology` (`thread_role` plus portable
+  `parents[]`); it is additive over schema v4, so `protocol_version` stays `1`.
+  Import accepts records from schema v2 through v5.
 
 Transcript-only extensions should use `--include metadata,messages` instead of
 reading usage or event records they do not need.

--- a/docs/session.md
+++ b/docs/session.md
@@ -89,6 +89,8 @@ Options:
 - `--source <source>`: source id or label, matching existing source filters.
 - `--project <path>`: project directory boundary, including child paths.
 - `--time <today|7d|week|30d|month|all>`: time window, default `all`.
+- `--thread-role <primary|subagent|unknown>`: filter by topology role. `unknown`
+  selects sessions the source could not classify.
 - `--limit <n>`: maximum sessions to return, default `50`.
 - `--offset <n>`: skip sessions for pagination, default `0`.
 - `--sort <newest|oldest|updated|relevance>`: default `newest`, or `relevance`
@@ -106,6 +108,7 @@ JSON output:
     "source": "codex",
     "project": "/path/to/repo",
     "time": "7d",
+    "thread_role": "primary",
     "limit": 20,
     "offset": 0,
     "sort": "relevance"
@@ -122,6 +125,7 @@ JSON output:
       "updated_at": 1781235567890,
       "message_count": 42,
       "is_import": false,
+      "topology": { "thread_role": "primary", "parents": [] },
       "match_source": "hybrid",
       "snippet": "wrangler pages deploy failed..."
     }
@@ -129,6 +133,12 @@ JSON output:
   "next_offset": null
 }
 ```
+
+`topology` is always present. `thread_role` is `primary`, `subagent`, or `null`
+when the source provides no reliable classification. `parents` lists portable
+parent links `{ "relation": "spawn|fork|resume", "source": ..., "source_id": ... }`;
+a parent may not be indexed locally. A `fork` relation alone never implies a
+subagent role.
 
 ### `recall session show`
 
@@ -165,7 +175,13 @@ JSON output:
     "started_at": 1781234567890,
     "updated_at": 1781235567890,
     "message_count": 42,
-    "is_import": false
+    "is_import": false,
+    "topology": {
+      "thread_role": "subagent",
+      "parents": [
+        { "relation": "spawn", "source": "codex", "source_id": "019e6d8d-parent" }
+      ]
+    }
   },
   "messages": [
     {
@@ -362,6 +378,36 @@ Example JSON error:
 - `session share --dry-run` should be cheap and safe enough for agents to run
   before asking for final user approval.
 
+## Session Topology
+
+Session topology records provenance without title/directory/time heuristics. It
+appears in `session list`/`show` JSON and JSONL export under `session.topology`,
+and both `recall session list` and bulk `recall export` accept
+`--thread-role <primary|subagent|unknown>`.
+
+Model (source-neutral):
+
+- `thread_role`: `primary` (top-level user-owned execution), `subagent`, or
+  `null` when the source gives no reliable classification. `primary` does not
+  mean the session has no fork history.
+- `parents[]`: portable `{ relation, source, source_id }` links. `relation` is
+  `spawn`, `fork`, or `resume`. A session may have several parents. Missing
+  parent sessions are valid — the unresolved portable identity is still exported.
+  A `fork` relation alone is never proof of a subagent.
+
+Per-adapter coverage:
+
+| Source | Role | Parent links | Source signal |
+| --- | --- | --- | --- |
+| Codex | primary / subagent | spawn + fork | `session_meta.thread_source` / `source`, `parent_thread_id` / `thread_spawn`, `forked_from_id` |
+| Claude Code | primary / subagent | spawn | `subagents/<agent>.jsonl` path + transcript `sessionId` parent |
+| Pi | primary | fork | session-header `parentSession` |
+| Others (OpenCode, Cursor, Copilot, Gemini, Grok, Antigravity, Cline, Kiro) | `null` | none | not yet classified |
+
+Grok retains its current skip-and-prune behavior; enabling classified Grok
+ingestion is a separate search/TUI visibility review before the path is turned
+on.
+
 ## Backward Compatibility
 
 - Existing commands keep working: `recall search`, `recall export`,
@@ -369,7 +415,9 @@ Example JSON error:
   unchanged.
 - Existing `recall export` remains the bulk export command.
 - Existing TUI shortcuts keep using the same internal session operations.
-- No existing JSONL export schema changes are required for the MVP.
+- Export record schema is `v5`: `session.topology` is additive, so `protocol_version`
+  stays `1`. Import accepts `v2`-`v5`; pre-topology records default to
+  `thread_role = null` with no parent links, and `v5` round-trips topology losslessly.
 
 ## Implementation Notes
 

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -16,12 +16,13 @@ use crate::adapters::{
     first_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role};
+use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct ClaudeCodeAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 5;
 const EVENT_PARSER_VERSION: u32 = 2;
+const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for ClaudeCodeAdapter {
     fn id(&self) -> &str {
@@ -115,6 +116,7 @@ fn scan_for_sync_impl(
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
             event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+            metadata_parser_version: include_events.then_some(METADATA_PARSER_VERSION),
         },
         entries,
         |entry, mtime_ms| parse_claude_session_file(entry, mtime_ms, &indexes, include_events),
@@ -316,6 +318,8 @@ fn parse_claude_session_file(
     };
     let summary =
         parsed.summary.or_else(|| indexes.project_summaries.get(&entry.session_id).cloned());
+    let (thread_role, parent_links) =
+        claude_topology(&entry.stat_target, &entry.session_id, parsed.session_id.as_deref());
     Ok(Some(RawSession {
         source_id: entry.session_id,
         directory,
@@ -331,6 +335,9 @@ fn parse_claude_session_file(
         custom_title: parsed.custom_title,
         summary,
         duration_minutes,
+        thread_role,
+        parent_links,
+        metadata_parser_version: Some(METADATA_PARSER_VERSION),
     }))
 }
 
@@ -343,6 +350,7 @@ struct ParsedConversation {
     summary: Option<String>,
     first_ts: Option<i64>,
     last_ts: Option<i64>,
+    session_id: Option<String>,
 }
 
 fn parse_conversation_jsonl(
@@ -361,6 +369,7 @@ fn parse_conversation_jsonl(
     let mut summary: Option<String> = None;
     let mut first_ts: Option<i64> = None;
     let mut last_ts: Option<i64> = None;
+    let mut session_id: Option<String> = None;
     let source_path = path.to_string_lossy().to_string();
 
     for item in jsonl_indexed(reader.lines()) {
@@ -371,6 +380,13 @@ fn parse_conversation_jsonl(
             && !c.is_empty()
         {
             cwd = Some(c.to_string());
+        }
+
+        if session_id.is_none()
+            && let Some(sid) = v.get("sessionId").and_then(|s| s.as_str())
+            && !sid.is_empty()
+        {
+            session_id = Some(sid.to_string());
         }
 
         let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
@@ -474,7 +490,31 @@ fn parse_conversation_jsonl(
         summary,
         first_ts,
         last_ts,
+        session_id,
     })
+}
+
+/// Subagent path → role subagent; parent id is the transcript's own `sessionId` field.
+/// Claude stores subagents under `…/<parent>/subagents/<agent>.jsonl`.
+fn claude_topology(
+    path: &Path,
+    own_source_id: &str,
+    parent_session_id: Option<&str>,
+) -> (Option<ThreadRole>, Vec<ParentLink>) {
+    if !path.components().any(|c| c.as_os_str() == "subagents") {
+        return (Some(ThreadRole::Primary), Vec::new());
+    }
+    let parents = parent_session_id
+        .filter(|parent| !parent.is_empty() && *parent != own_source_id)
+        .map(|parent| {
+            vec![ParentLink {
+                relation: ParentRelation::Spawn,
+                source: "claude-code".to_string(),
+                source_id: parent.to_string(),
+            }]
+        })
+        .unwrap_or_default();
+    (Some(ThreadRole::Subagent), parents)
 }
 
 fn collect_claude_content_events(
@@ -1125,6 +1165,17 @@ mod tests {
                 Some(mtime),
             )
             .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "claude-code",
+                "sess-skip",
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
+            )
+            .unwrap();
 
         let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 0);
@@ -1207,5 +1258,38 @@ mod tests {
             "usage event from the machinery turn must be preserved"
         );
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn claude_topology_classifies_primary_and_subagent() {
+        let primary = Path::new("/home/x/.claude/projects/proj/parent-uuid.jsonl");
+        assert_eq!(
+            claude_topology(primary, "parent-uuid", Some("parent-uuid")),
+            (Some(ThreadRole::Primary), Vec::new())
+        );
+
+        let sub = Path::new("/home/x/.claude/projects/proj/parent-uuid/subagents/agent-abc.jsonl");
+        assert_eq!(
+            claude_topology(sub, "agent-abc", Some("parent-uuid")),
+            (
+                Some(ThreadRole::Subagent),
+                vec![ParentLink {
+                    relation: ParentRelation::Spawn,
+                    source: "claude-code".to_string(),
+                    source_id: "parent-uuid".to_string(),
+                }]
+            )
+        );
+
+        // A subagent without a resolvable parent, or a self-referential parent,
+        // stays a subagent with no invented link.
+        assert_eq!(
+            claude_topology(sub, "agent-abc", None),
+            (Some(ThreadRole::Subagent), Vec::new())
+        );
+        assert_eq!(
+            claude_topology(sub, "agent-abc", Some("agent-abc")),
+            (Some(ThreadRole::Subagent), Vec::new())
+        );
     }
 }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -15,12 +15,13 @@ use crate::adapters::{
     first_timestamp, last_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role};
+use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct CodexAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 4;
 const EVENT_PARSER_VERSION: u32 = 1;
+const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CodexAdapter {
     fn id(&self) -> &str {
@@ -120,6 +121,7 @@ fn scan_for_sync_impl(
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
             event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+            metadata_parser_version: include_events.then_some(METADATA_PARSER_VERSION),
         },
         entries,
         |entry, mtime_ms| {
@@ -196,6 +198,56 @@ fn extract_session_id_from_filename(stem: &str) -> Option<String> {
     uuid::Uuid::try_parse(tail).ok().map(|_| tail.to_string())
 }
 
+/// Keyed by payload id so forked rollouts pick the child's meta, not an inherited parent's.
+struct CodexMetaTopology {
+    meta_id: Option<String>,
+    thread_role: Option<ThreadRole>,
+    parent_links: Vec<ParentLink>,
+}
+
+fn codex_thread_role(payload: &Value) -> Option<ThreadRole> {
+    match payload.get("thread_source").and_then(|v| v.as_str()) {
+        Some("user") => return Some(ThreadRole::Primary),
+        Some("subagent") => return Some(ThreadRole::Subagent),
+        _ => {}
+    }
+    let source = payload.get("source")?;
+    if source.get("subagent").is_some() || source.as_str() == Some("subagent") {
+        return Some(ThreadRole::Subagent);
+    }
+    source.as_str().filter(|s| !s.trim().is_empty()).map(|_| ThreadRole::Primary)
+}
+
+/// `spawn` ← `parent_thread_id` / `source.subagent.thread_spawn`; `fork` ← `forked_from_id`.
+fn codex_parent_links(payload: &Value) -> Vec<ParentLink> {
+    let mut links = Vec::new();
+    let mut push = |relation: ParentRelation, id: &str| {
+        let id = id.trim();
+        if id.is_empty() {
+            return;
+        }
+        let link = ParentLink { relation, source: "codex".to_string(), source_id: id.to_string() };
+        if !links.contains(&link) {
+            links.push(link);
+        }
+    };
+    let spawn_parent = payload.get("parent_thread_id").and_then(|v| v.as_str()).or_else(|| {
+        payload
+            .get("source")
+            .and_then(|s| s.get("subagent"))
+            .and_then(|s| s.get("thread_spawn"))
+            .and_then(|s| s.get("parent_thread_id"))
+            .and_then(|v| v.as_str())
+    });
+    if let Some(parent) = spawn_parent {
+        push(ParentRelation::Spawn, parent);
+    }
+    if let Some(parent) = payload.get("forked_from_id").and_then(|v| v.as_str()) {
+        push(ParentRelation::Fork, parent);
+    }
+    links
+}
+
 #[cfg(test)]
 fn parse_codex_session(path: &Path) -> anyhow::Result<Option<RawSession>> {
     parse_codex_session_with_options(path, true)
@@ -211,6 +263,7 @@ fn parse_codex_session_with_options(
     let mut meta_id: Option<String> = None;
     let mut meta_cwd: Option<String> = None;
     let mut meta_timestamp: Option<i64> = None;
+    let mut meta_topologies: Vec<CodexMetaTopology> = Vec::new();
     let mut messages = Vec::new();
     let mut usage_events = Vec::new();
     let mut events = Vec::new();
@@ -280,6 +333,11 @@ fn parse_codex_session_with_options(
                         );
                     }
                     meta_timestamp = rfc3339_ms(payload.get("timestamp"));
+                    meta_topologies.push(CodexMetaTopology {
+                        meta_id: meta_id.clone(),
+                        thread_role: codex_thread_role(payload),
+                        parent_links: codex_parent_links(payload),
+                    });
                     if payload.get("forked_from_id").and_then(|s| s.as_str()).is_some() {
                         forked_child_waiting_for_turn_context = true;
                         forked_child_inherited_baseline = None;
@@ -413,6 +471,19 @@ fn parse_codex_session_with_options(
     let started_at =
         first_timestamp(meta_timestamp, &messages, &usage_events, &events).unwrap_or(0);
 
+    // Prefer the metadata record whose payload id matches the source id derived
+    // from the rollout filename so inherited parent metadata in forked rollouts
+    // never overwrites the child identity; fall back to the last processed
+    // record (the child's own, since inherited parent metadata is skipped).
+    let filename_id =
+        path.file_stem().and_then(|s| s.to_str()).and_then(extract_session_id_from_filename);
+    let (thread_role, parent_links) = meta_topologies
+        .iter()
+        .find(|topo| topo.meta_id.is_some() && topo.meta_id.as_deref() == filename_id.as_deref())
+        .or_else(|| meta_topologies.last())
+        .map(|topo| (topo.thread_role, topo.parent_links.clone()))
+        .unwrap_or((None, Vec::new()));
+
     Ok(Some(RawSession {
         source_id,
         directory: meta_cwd,
@@ -428,6 +499,9 @@ fn parse_codex_session_with_options(
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        thread_role,
+        parent_links,
+        metadata_parser_version: Some(METADATA_PARSER_VERSION),
     }))
 }
 
@@ -1455,6 +1529,140 @@ mod tests {
         assert_eq!(raw.usage_events[0].output_tokens, 200);
         assert_eq!(raw.usage_events[0].reasoning_tokens, 50);
 
+        assert_eq!(raw.thread_role, Some(ThreadRole::Subagent));
+        assert_eq!(
+            raw.parent_links,
+            vec![
+                ParentLink {
+                    relation: ParentRelation::Spawn,
+                    source: "codex".to_string(),
+                    source_id: "parent-session".to_string(),
+                },
+                ParentLink {
+                    relation: ParentRelation::Fork,
+                    source: "codex".to_string(),
+                    source_id: "parent-session".to_string(),
+                },
+            ]
+        );
+        assert_eq!(raw.metadata_parser_version, Some(METADATA_PARSER_VERSION));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    fn write_codex_topology_rollout(sessions_dir: &Path, uuid: &str, payload: Value) -> PathBuf {
+        fs::create_dir_all(sessions_dir).unwrap();
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let meta = serde_json::json!({ "type": "session_meta", "payload": payload });
+        // A turn_context clears the forked-child inheritance guard so the message
+        // that follows is retained, matching real forked rollouts.
+        let turn_context = serde_json::json!({
+            "type": "turn_context",
+            "timestamp": "2026-04-13T10:00:29Z",
+            "payload": { "model": "gpt-5.5", "cwd": "/repo" }
+        });
+        let msg = serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2026-04-13T10:00:30Z",
+            "payload": { "type": "user_message", "message": "hi" }
+        });
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{meta}").unwrap();
+        writeln!(f, "{turn_context}").unwrap();
+        writeln!(f, "{msg}").unwrap();
+        path
+    }
+
+    #[test]
+    fn parse_codex_session_classifies_user_source_as_primary_without_parents() {
+        let root = temp_codex_root("primary-topology");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2401";
+        let path = write_codex_topology_rollout(
+            &root.join("sessions"),
+            uuid,
+            serde_json::json!({
+                "id": uuid,
+                "thread_source": "user",
+                "source": "interactive",
+                "cwd": "/repo"
+            }),
+        );
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, Some(ThreadRole::Primary));
+        assert!(raw.parent_links.is_empty());
+        assert_eq!(raw.metadata_parser_version, Some(METADATA_PARSER_VERSION));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_user_fork_primary_with_fork_link() {
+        let root = temp_codex_root("fork-primary");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2402";
+        let path = write_codex_topology_rollout(
+            &root.join("sessions"),
+            uuid,
+            serde_json::json!({
+                "id": uuid,
+                "thread_source": "user",
+                "forked_from_id": "parent-abc",
+                "cwd": "/repo"
+            }),
+        );
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, Some(ThreadRole::Primary));
+        assert_eq!(
+            raw.parent_links,
+            vec![ParentLink {
+                relation: ParentRelation::Fork,
+                source: "codex".to_string(),
+                source_id: "parent-abc".to_string(),
+            }]
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_legacy_subagent_without_parent() {
+        let root = temp_codex_root("legacy-subagent");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2403";
+        let path = write_codex_topology_rollout(
+            &root.join("sessions"),
+            uuid,
+            serde_json::json!({ "id": uuid, "thread_source": "subagent", "cwd": "/repo" }),
+        );
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, Some(ThreadRole::Subagent));
+        assert!(raw.parent_links.is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_leaves_role_unknown_without_markers() {
+        let root = temp_codex_root("unknown-topology");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2404";
+        let path = write_codex_topology_rollout(
+            &root.join("sessions"),
+            uuid,
+            serde_json::json!({ "id": uuid, "cwd": "/repo" }),
+        );
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, None);
+        assert!(raw.parent_links.is_empty());
+        // Even unknown-role sessions get a metadata parser version so topology
+        // backfill runs for them once a classifier improves.
+        assert_eq!(raw.metadata_parser_version, Some(METADATA_PARSER_VERSION));
+
         let _ = fs::remove_dir_all(&root);
     }
 
@@ -1510,6 +1718,17 @@ mod tests {
                 &[],
                 EVENT_PARSER_VERSION,
                 Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "codex",
+                uuid,
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
             )
             .unwrap();
 

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -88,6 +88,7 @@ fn scan_for_sync_impl(
         FileScanOptions {
             usage_parser_version: None,
             event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+            metadata_parser_version: None,
         },
         entries,
         |entry, mtime_ms| parse_copilot_session_for_entry(entry, mtime_ms, include_events),

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -5,7 +5,8 @@ use std::time::UNIX_EPOCH;
 use anyhow::Result;
 
 use crate::adapters::sync_state::{
-    event_state_is_current_for_mtime, usage_state_is_current_for_mtime,
+    event_state_is_current_for_mtime, metadata_state_is_current_for_mtime,
+    usage_state_is_current_for_mtime,
 };
 use crate::adapters::{RawSession, SyncScanResult, SyncScanStats};
 use crate::db::store::Store;
@@ -14,6 +15,7 @@ use crate::db::store::Store;
 pub(crate) struct FileScanOptions {
     pub(crate) usage_parser_version: Option<u32>,
     pub(crate) event_parser_version: Option<u32>,
+    pub(crate) metadata_parser_version: Option<u32>,
 }
 
 pub(crate) struct FileScanEntry {
@@ -65,6 +67,10 @@ where
         Some(_) => store.event_state_meta_map(source_id)?,
         None => Default::default(),
     };
+    let metadata_state = match options.metadata_parser_version {
+        Some(_) => store.metadata_state_meta_map(source_id)?,
+        None => Default::default(),
+    };
     let mut sessions = Vec::new();
     let mut stats = SyncScanStats::default();
 
@@ -106,6 +112,11 @@ where
             && event_state_is_current_for_mtime(
                 options.event_parser_version,
                 event_state.get(&entry.session_id).copied(),
+                mtime_ms,
+            )
+            && metadata_state_is_current_for_mtime(
+                options.metadata_parser_version,
+                metadata_state.get(&entry.session_id).copied(),
                 mtime_ms,
             )
         {
@@ -295,7 +306,11 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: Some(1), event_parser_version: None },
+            FileScanOptions {
+                usage_parser_version: Some(1),
+                event_parser_version: None,
+                metadata_parser_version: None,
+            },
             vec![entry],
             |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
         )
@@ -321,7 +336,11 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: Some(1), event_parser_version: None },
+            FileScanOptions {
+                usage_parser_version: Some(1),
+                event_parser_version: None,
+                metadata_parser_version: None,
+            },
             vec![entry],
             |_, _| panic!("current usage state should skip parsing"),
         )
@@ -347,7 +366,11 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: None, event_parser_version: Some(1) },
+            FileScanOptions {
+                usage_parser_version: None,
+                event_parser_version: Some(1),
+                metadata_parser_version: None,
+            },
             vec![entry],
             |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
         )
@@ -373,9 +396,74 @@ mod tests {
             &store,
             "test-source",
             None,
-            FileScanOptions { usage_parser_version: None, event_parser_version: Some(1) },
+            FileScanOptions {
+                usage_parser_version: None,
+                event_parser_version: Some(1),
+                metadata_parser_version: None,
+            },
             vec![entry],
             |_, _| panic!("current event state should skip parsing"),
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 0);
+        assert_eq!(result.stats.skipped_sessions, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn matching_mtime_reparses_until_metadata_state_is_current() {
+        use crate::db::store::SessionTopologyWrite;
+        let store = setup_store();
+        let path = temp_file_with_mtime("metadata-backfill");
+        let mtime_ms = stat_mtime_ms(&path).unwrap();
+        store.insert_session(&make_session("s1", "sess-meta", Some(mtime_ms), 1)).unwrap();
+
+        // An unchanged file whose topology parser version is stale must reparse,
+        // even though usage and events are not tracked here.
+        let entry = FileScanEntry {
+            session_id: "sess-meta".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions {
+                usage_parser_version: None,
+                event_parser_version: None,
+                metadata_parser_version: Some(1),
+            },
+            vec![entry],
+            |entry, mtime_ms| Ok(Some(stub_raw_session(&entry.session_id, mtime_ms))),
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+
+        store
+            .persist_topology_for_existing_session(
+                "test-source",
+                "sess-meta",
+                &SessionTopologyWrite { thread_role: None, parents: &[], parser_version: Some(1) },
+            )
+            .unwrap();
+        let entry = FileScanEntry {
+            session_id: "sess-meta".to_string(),
+            stat_target: path.clone(),
+            directory: None,
+        };
+        let result = run_file_scan_with_options(
+            &store,
+            "test-source",
+            None,
+            FileScanOptions {
+                usage_parser_version: None,
+                event_parser_version: None,
+                metadata_parser_version: Some(1),
+            },
+            vec![entry],
+            |_, _| panic!("current metadata state should skip parsing"),
         )
         .unwrap();
         assert_eq!(result.sessions.len(), 0);

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -120,6 +120,7 @@ fn scan_for_sync_impl(
         FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
             event_parser_version: None,
+            metadata_parser_version: None,
         },
         entries,
         |entry, mtime_ms| parse_grok_session_for_entry(&entry, mtime_ms),

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod sync_state;
 pub(crate) mod usage;
 
 use crate::db::store::Store;
-use crate::types::{RawSessionEvent, RawUsageEvent, Role};
+use crate::types::{ParentLink, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) trait SourceAdapter {
     fn id(&self) -> &str;
@@ -61,6 +61,9 @@ pub(crate) struct RawSession {
     pub(crate) custom_title: Option<String>,
     pub(crate) summary: Option<String>,
     pub(crate) duration_minutes: Option<u32>,
+    pub(crate) thread_role: Option<ThreadRole>,
+    pub(crate) parent_links: Vec<ParentLink>,
+    pub(crate) metadata_parser_version: Option<u32>,
 }
 
 impl RawSession {
@@ -87,6 +90,9 @@ impl RawSession {
             custom_title: None,
             summary: None,
             duration_minutes: None,
+            thread_role: None,
+            parent_links: Vec::new(),
+            metadata_parser_version: None,
         }
     }
 

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -15,9 +15,11 @@ use crate::adapters::{
     first_timestamp,
 };
 use crate::db::store::Store;
-use crate::types::{RawUsageEvent, Role};
+use crate::types::{ParentLink, ParentRelation, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct PiAdapter;
+
+const METADATA_PARSER_VERSION: u32 = 1;
 
 const USAGE_PARSER_VERSION: u32 = 1;
 
@@ -64,14 +66,14 @@ impl SourceAdapter for PiAdapter {
         &self,
         store: &Store,
         since_ts: Option<i64>,
-        _include_events: bool,
+        include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let session_dirs = resolve_pi_session_dirs()?;
         if session_dirs.is_empty() {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         }
 
-        Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts)?))
+        Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts, include_events)?))
     }
 }
 
@@ -81,6 +83,7 @@ struct ParsedPiSession {
     started_at: Option<i64>,
     messages: Vec<RawMessage>,
     usage_events: Vec<RawUsageEvent>,
+    parent_session: Option<String>,
 }
 
 fn resolve_pi_session_dirs() -> anyhow::Result<Vec<PathBuf>> {
@@ -176,6 +179,7 @@ fn scan_for_sync_impl(
     session_dirs: &[PathBuf],
     store: &Store,
     since_ts: Option<i64>,
+    include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_pi_entries(session_dirs);
     file_scan::run_file_scan_with_options(
@@ -185,6 +189,7 @@ fn scan_for_sync_impl(
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
             event_parser_version: None,
+            metadata_parser_version: include_events.then_some(METADATA_PARSER_VERSION),
         },
         entries,
         parse_pi_session_file,
@@ -238,6 +243,12 @@ fn extract_session_id_from_filename(stem: &str) -> Option<String> {
     uuid::Uuid::try_parse(candidate).ok().map(|_| candidate.to_string())
 }
 
+/// Pi `parentSession` is a local path; return the portable id or `None` (never store a path).
+fn normalize_pi_parent_id(parent: &str) -> Option<String> {
+    let stem = Path::new(parent).file_stem().and_then(|stem| stem.to_str()).unwrap_or(parent);
+    extract_session_id_from_filename(stem)
+}
+
 fn decode_session_dir_name(name: &str) -> Option<String> {
     let inner = name.strip_prefix("--")?.strip_suffix("--")?;
     if inner.is_empty() {
@@ -266,8 +277,24 @@ fn parse_pi_session_file(
         first_timestamp(parsed.started_at, &parsed.messages, &parsed.usage_events, &[])
             .unwrap_or(0);
 
+    let source_id = parsed.session_id.unwrap_or(entry.session_id);
+    // Pi has no subagent role; parentSession is a fork lineage path (not a UUID).
+    let parent_links = match parsed
+        .parent_session
+        .as_deref()
+        .and_then(normalize_pi_parent_id)
+        .filter(|parent| parent != &source_id)
+    {
+        Some(parent) => vec![ParentLink {
+            relation: ParentRelation::Fork,
+            source: "pi".to_string(),
+            source_id: parent,
+        }],
+        None => Vec::new(),
+    };
+
     Ok(Some(RawSession {
-        source_id: parsed.session_id.unwrap_or(entry.session_id),
+        source_id,
         directory: parsed.cwd.or(entry.directory),
         started_at,
         updated_at: Some(mtime_ms),
@@ -281,6 +308,9 @@ fn parse_pi_session_file(
         custom_title: None,
         summary: None,
         duration_minutes: None,
+        thread_role: Some(ThreadRole::Primary),
+        parent_links,
+        metadata_parser_version: Some(METADATA_PARSER_VERSION),
     }))
 }
 
@@ -295,6 +325,7 @@ fn parse_pi_session(path: &Path, fallback_timestamp: i64) -> anyhow::Result<Pars
     let mut current_provider: Option<String> = None;
     let mut current_model: Option<String> = None;
     let mut inherited_usage_cutoff = None;
+    let mut parent_session = None;
     let mut messages = Vec::new();
     let mut usage_events = Vec::new();
 
@@ -317,12 +348,14 @@ fn parse_pi_session(path: &Path, fallback_timestamp: i64) -> anyhow::Result<Pars
                     .map(str::to_string)
                     .or(cwd);
                 started_at = header_timestamp.or(started_at);
-                if entry
+                if let Some(parent) = entry
                     .get("parentSession")
                     .and_then(|value| value.as_str())
-                    .is_some_and(|value| !value.trim().is_empty())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
                 {
                     inherited_usage_cutoff = header_timestamp;
+                    parent_session = Some(parent.to_string());
                 }
             }
             "model_change" => {
@@ -383,7 +416,7 @@ fn parse_pi_session(path: &Path, fallback_timestamp: i64) -> anyhow::Result<Pars
         }
     }
 
-    Ok(ParsedPiSession { session_id, cwd, started_at, messages, usage_events })
+    Ok(ParsedPiSession { session_id, cwd, started_at, messages, usage_events, parent_session })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1077,10 +1110,118 @@ mod tests {
                 Some(mtime),
             )
             .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "pi",
+                session_id,
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
+            )
+            .unwrap();
 
-        let result = scan_for_sync_impl(&[root.join("--tmp-pi-project--")], &store, None).unwrap();
+        let result =
+            scan_for_sync_impl(&[root.join("--tmp-pi-project--")], &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_pi_session_maps_parent_session_to_primary_fork() {
+        let root = temp_pi_root("parent-session");
+        let session_dir = root.join("--tmp-pi-project--");
+        let session_id = "019e5af2-5528-7d10-888a-b299c21d0e2e";
+        let path = write_pi_session(
+            &session_dir,
+            session_id,
+            &[
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": session_id,
+                    "parentSession": "/home/x/.pi/agent/sessions/--proj--/2026-05-24T17-04-51-496Z_019e0000-0000-0000-0000-000000000001.jsonl",
+                    "timestamp": "1970-01-01T00:00:01.000Z",
+                    "cwd": "/tmp/pi-project"
+                }),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "user1",
+                    "timestamp": "1970-01-01T00:00:02.000Z",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello pi"}],
+                        "timestamp": 2000
+                    }
+                }),
+            ],
+        );
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+        let entry = FileScanEntry {
+            session_id: session_id.to_string(),
+            stat_target: path,
+            directory: None,
+        };
+
+        let raw = parse_pi_session_file(entry, mtime).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, Some(ThreadRole::Primary));
+        assert_eq!(
+            raw.parent_links,
+            vec![ParentLink {
+                relation: ParentRelation::Fork,
+                source: "pi".to_string(),
+                source_id: "019e0000-0000-0000-0000-000000000001".to_string(),
+            }]
+        );
+        assert_eq!(raw.metadata_parser_version, Some(METADATA_PARSER_VERSION));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_pi_session_drops_unresolvable_parent_session() {
+        let root = temp_pi_root("parent-unresolvable");
+        let session_dir = root.join("--tmp-pi-project--");
+        let session_id = "019e5af2-5528-7d10-888a-b299c21d0e2f";
+        let path = write_pi_session(
+            &session_dir,
+            session_id,
+            &[
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": session_id,
+                    "parentSession": "not-a-session-path",
+                    "timestamp": "1970-01-01T00:00:01.000Z",
+                    "cwd": "/tmp/pi-project"
+                }),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "user1",
+                    "timestamp": "1970-01-01T00:00:02.000Z",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hello pi"}],
+                        "timestamp": 2000
+                    }
+                }),
+            ],
+        );
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+        let entry = FileScanEntry {
+            session_id: session_id.to_string(),
+            stat_target: path,
+            directory: None,
+        };
+
+        let raw = parse_pi_session_file(entry, mtime).unwrap().unwrap();
+
+        assert_eq!(raw.thread_role, Some(ThreadRole::Primary));
+        assert!(raw.parent_links.is_empty(), "an unparseable parent must not leak a path");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/sync_state.rs
+++ b/src/adapters/sync_state.rs
@@ -1,14 +1,15 @@
-use crate::db::store::{EventSessionStateMeta, UsageSessionStateMeta};
+use crate::db::store::{EventSessionStateMeta, MetadataSessionStateMeta, UsageSessionStateMeta};
 
 pub(crate) fn usage_state_is_current(
     required_parser_version: u32,
     state: Option<UsageSessionStateMeta>,
     source_updated_at: Option<i64>,
 ) -> bool {
-    state.is_some_and(|state| {
-        state.parser_version >= required_parser_version
-            && state.source_updated_at == source_updated_at
-    })
+    parser_state_is_current(
+        required_parser_version,
+        state.map(|s| (s.parser_version, s.source_updated_at)),
+        source_updated_at,
+    )
 }
 
 pub(crate) fn event_state_is_current(
@@ -16,10 +17,23 @@ pub(crate) fn event_state_is_current(
     state: Option<EventSessionStateMeta>,
     source_updated_at: Option<i64>,
 ) -> bool {
-    state.is_some_and(|state| {
-        state.parser_version >= required_parser_version
-            && state.source_updated_at == source_updated_at
-    })
+    parser_state_is_current(
+        required_parser_version,
+        state.map(|s| (s.parser_version, s.source_updated_at)),
+        source_updated_at,
+    )
+}
+
+pub(crate) fn metadata_state_is_current(
+    required_parser_version: u32,
+    state: Option<MetadataSessionStateMeta>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    parser_state_is_current(
+        required_parser_version,
+        state.map(|s| (s.parser_version, s.source_updated_at)),
+        source_updated_at,
+    )
 }
 
 pub(crate) fn session_state_is_current(
@@ -55,4 +69,25 @@ pub(crate) fn event_state_is_current_for_mtime(
         None => true,
         Some(required) => event_state_is_current(required, state, Some(mtime_ms)),
     }
+}
+
+pub(crate) fn metadata_state_is_current_for_mtime(
+    required_parser_version: Option<u32>,
+    state: Option<MetadataSessionStateMeta>,
+    mtime_ms: i64,
+) -> bool {
+    match required_parser_version {
+        None => true,
+        Some(required) => metadata_state_is_current(required, state, Some(mtime_ms)),
+    }
+}
+
+fn parser_state_is_current(
+    required_parser_version: u32,
+    state: Option<(u32, Option<i64>)>,
+    source_updated_at: Option<i64>,
+) -> bool {
+    state.is_some_and(|(parser_version, state_updated_at)| {
+        parser_version >= required_parser_version && state_updated_at == source_updated_at
+    })
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -172,8 +172,13 @@ pub(crate) fn run_search(query: &str) -> Result<()> {
     let embed_ms = t_embed.elapsed().as_millis();
 
     let engine = SearchEngine::new(&store.conn);
-    let filters =
-        SearchFilters { sources: None, time_range: TimeRange::All, directory: None, repo: None };
+    let filters = SearchFilters {
+        sources: None,
+        time_range: TimeRange::All,
+        directory: None,
+        repo: None,
+        thread_role: None,
+    };
 
     let t_search = Instant::now();
     let results = engine.hybrid_search(query, Some(&query_embedding), &filters, 20, 3)?;
@@ -311,8 +316,13 @@ pub(crate) fn evaluate<F>(
 where
     F: Fn(&str) -> Option<Vec<f32>>,
 {
-    let filters =
-        SearchFilters { sources: None, time_range: TimeRange::All, directory: None, repo: None };
+    let filters = SearchFilters {
+        sources: None,
+        time_range: TimeRange::All,
+        directory: None,
+        repo: None,
+        thread_role: None,
+    };
     let mut report = EvalReport { total: entries.len(), ..Default::default() };
 
     for entry in entries {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,8 @@ enum Commands {
         project: Option<String>,
         #[arg(long, help = "Filter by repository identity")]
         repo: Option<String>,
+        #[arg(long, value_enum, help = "Filter by topology thread role")]
+        thread_role: Option<crate::db::search::ThreadRoleFilter>,
         #[arg(
             long,
             default_value_t = 0,
@@ -218,12 +220,13 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Usage { json, source, time }) => {
             crate::usage::run_cli(json, source.as_deref(), time.as_deref())?
         }
-        Some(Commands::Export { source, time, project, repo, limit, include }) => {
+        Some(Commands::Export { source, time, project, repo, thread_role, limit, include }) => {
             crate::export::run_cli(
                 source.as_deref(),
                 time.as_deref(),
                 project.as_deref(),
                 repo.as_deref(),
+                thread_role,
                 limit,
                 include.as_deref(),
             )?

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 
-const SCHEMA_VERSION: i64 = 10;
+const SCHEMA_VERSION: i64 = 11;
 
 #[allow(clippy::missing_transmute_annotations)]
 pub(crate) fn register_sqlite_vec() {
@@ -40,8 +40,11 @@ pub(crate) fn init(conn: &Connection) -> anyhow::Result<()> {
     if version < 9 {
         migrate_v9(conn)?;
     }
-    if version < SCHEMA_VERSION {
+    if version < 10 {
         migrate_v10(conn)?;
+    }
+    if version < SCHEMA_VERSION {
+        migrate_v11(conn)?;
     }
     Ok(())
 }
@@ -324,7 +327,33 @@ fn migrate_v10(conn: &Connection) -> anyhow::Result<()> {
     if table_exists("usage_session_state")? {
         conn.execute("DELETE FROM usage_session_state WHERE source = 'grok'", [])?;
     }
-    conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION};"))?;
+    conn.execute_batch("PRAGMA user_version = 10;")?;
+    Ok(())
+}
+
+fn migrate_v11(conn: &Connection) -> anyhow::Result<()> {
+    add_column_if_missing(
+        conn,
+        "ALTER TABLE sessions ADD COLUMN thread_role TEXT
+             CHECK (thread_role IN ('primary', 'subagent'))",
+    )?;
+    add_column_if_missing(conn, "ALTER TABLE sessions ADD COLUMN metadata_parser_version INTEGER")?;
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS session_parent_links (
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            relation TEXT NOT NULL CHECK (relation IN ('spawn', 'fork', 'resume')),
+            parent_source TEXT NOT NULL,
+            parent_source_id TEXT NOT NULL,
+            PRIMARY KEY (session_id, relation, parent_source, parent_source_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_session_parent_links_parent
+            ON session_parent_links(parent_source, parent_source_id);
+
+        PRAGMA user_version = 11;
+        ",
+    )?;
     Ok(())
 }
 
@@ -505,6 +534,71 @@ mod tests {
             )
             .unwrap();
         assert_eq!(counts, (0, 1, 0, 1));
+    }
+
+    #[test]
+    fn migrate_v11_adds_topology_columns_and_table_to_existing_v10_db() {
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_v1(&conn).unwrap();
+        migrate_v2(&conn).unwrap();
+        migrate_v3(&conn).unwrap();
+        migrate_v4(&conn).unwrap();
+        migrate_v5(&conn).unwrap();
+        migrate_v6(&conn).unwrap();
+        migrate_v7(&conn).unwrap();
+        migrate_v8(&conn).unwrap();
+        migrate_v9(&conn).unwrap();
+        migrate_v10(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO sessions (id, source, source_id, title, started_at)
+             VALUES ('s1', 'codex', 'c1', 'existing', 0);",
+        )
+        .unwrap();
+
+        assert_eq!(schema_version(&conn).unwrap(), 10);
+        init(&conn).unwrap();
+
+        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        for col in ["thread_role", "metadata_parser_version"] {
+            let sql = format!("SELECT {col} FROM sessions");
+            conn.prepare(&sql)
+                .unwrap_or_else(|e| panic!("column {col} missing after migrate_v11: {e}"));
+        }
+        let (role, version): (Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT thread_role, metadata_parser_version FROM sessions WHERE id = 's1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(role, None, "existing sessions default to unknown role");
+        assert_eq!(version, None);
+
+        conn.execute(
+            "INSERT INTO session_parent_links (session_id, relation, parent_source, parent_source_id)
+             VALUES ('s1', 'spawn', 'codex', 'p1')",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM sessions WHERE id = 's1'", []).unwrap();
+        let links: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_parent_links", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(links, 0, "parent links cascade when their session is removed");
+    }
+
+    #[test]
+    fn migrate_v11_rejects_invalid_thread_role() {
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        init(&conn).unwrap();
+        let err = conn.execute(
+            "INSERT INTO sessions (id, source, source_id, title, started_at, thread_role)
+             VALUES ('s1', 'codex', 'c1', 't', 0, 'bogus')",
+            [],
+        );
+        assert!(err.is_err(), "thread_role CHECK must reject values outside primary/subagent");
     }
 
     #[test]

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -17,6 +17,7 @@ pub(crate) struct SearchFilters {
     pub(crate) time_range: TimeRange,
     pub(crate) directory: Option<String>,
     pub(crate) repo: Option<RepoFilter>,
+    pub(crate) thread_role: Option<ThreadRoleFilter>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +33,32 @@ impl RepoFilter {
             RepoFilter::Remote(remote) => ("repo_remote", remote),
             RepoFilter::Slug(slug) => ("repo_slug", slug),
             RepoFilter::Name(name) => ("repo_name", name),
+        }
+    }
+}
+
+/// `Unknown` maps to persisted `thread_role IS NULL` (source could not classify).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum ThreadRoleFilter {
+    Primary,
+    Subagent,
+    Unknown,
+}
+
+impl ThreadRoleFilter {
+    pub(crate) fn sql_predicate(self) -> &'static str {
+        match self {
+            ThreadRoleFilter::Primary => " AND s.thread_role = 'primary'",
+            ThreadRoleFilter::Subagent => " AND s.thread_role = 'subagent'",
+            ThreadRoleFilter::Unknown => " AND s.thread_role IS NULL",
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ThreadRoleFilter::Primary => "primary",
+            ThreadRoleFilter::Subagent => "subagent",
+            ThreadRoleFilter::Unknown => "unknown",
         }
     }
 }
@@ -253,6 +280,9 @@ fn apply_filters(
         sql.push_str(&format!(" AND s.{column} = ?{}", *param_idx));
         params.push(Box::new(value.to_string()));
         *param_idx += 1;
+    }
+    if let Some(thread_role) = filters.thread_role {
+        sql.push_str(thread_role.sql_predicate());
     }
 }
 

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -6,9 +6,14 @@ use rusqlite::OptionalExtension;
 
 use super::event_store::replace_session_events;
 use super::project_store::apply_scope_filters;
-use super::store::{SESSION_COLUMNS, SessionListSort, Store, session_from_row};
-use crate::db::search::{RepoFilter, TimeRange};
-use crate::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session};
+use super::store::{
+    MetadataSessionStateMeta, SESSION_COLUMNS, SessionListSort, SessionTopologyWrite, Store,
+    session_from_row,
+};
+use crate::db::search::{RepoFilter, ThreadRoleFilter, TimeRange};
+use crate::types::{
+    Message, ParentLink, RawSessionEvent, RawUsageEvent, Role, Session, SessionTopology, ThreadRole,
+};
 
 impl Store {
     pub(crate) fn session_meta(
@@ -155,6 +160,7 @@ impl Store {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn persist_session_with_usage_and_events(
         &self,
         session: &Session,
@@ -163,6 +169,28 @@ impl Store {
         usage_parser_version: Option<u32>,
         session_events: &[RawSessionEvent],
         event_parser_version: Option<u32>,
+    ) -> Result<()> {
+        self.persist_session_with_usage_and_events_with_topology(
+            session,
+            messages,
+            usage_events,
+            usage_parser_version,
+            session_events,
+            event_parser_version,
+            &SessionTopologyWrite::none(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn persist_session_with_usage_and_events_with_topology(
+        &self,
+        session: &Session,
+        messages: &[Message],
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: Option<u32>,
+        session_events: &[RawSessionEvent],
+        event_parser_version: Option<u32>,
+        topology: &SessionTopologyWrite<'_>,
     ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         persist_session_with_usage_and_events_tx(
@@ -173,11 +201,13 @@ impl Store {
             usage_parser_version,
             session_events,
             event_parser_version,
+            topology,
         )?;
         tx.commit()?;
         Ok(())
     }
 
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn replace_session_with_usage_and_events(
         &self,
@@ -190,6 +220,32 @@ impl Store {
         session_events: &[RawSessionEvent],
         event_parser_version: Option<u32>,
     ) -> Result<()> {
+        self.replace_session_with_usage_and_events_with_topology(
+            old_source,
+            old_source_id,
+            session,
+            messages,
+            usage_events,
+            usage_parser_version,
+            session_events,
+            event_parser_version,
+            &SessionTopologyWrite::none(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn replace_session_with_usage_and_events_with_topology(
+        &self,
+        old_source: &str,
+        old_source_id: &str,
+        session: &Session,
+        messages: &[Message],
+        usage_events: &[RawUsageEvent],
+        usage_parser_version: Option<u32>,
+        session_events: &[RawSessionEvent],
+        event_parser_version: Option<u32>,
+        topology: &SessionTopologyWrite<'_>,
+    ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         delete_session_data_tx(&tx, old_source, old_source_id)?;
         persist_session_with_usage_and_events_tx(
@@ -200,9 +256,93 @@ impl Store {
             usage_parser_version,
             session_events,
             event_parser_version,
+            topology,
         )?;
         tx.commit()?;
         Ok(())
+    }
+
+    /// Topology-only write for an already-indexed session: does not touch
+    /// messages, usage, events, embeddings, or the local session id.
+    pub(crate) fn persist_topology_for_existing_session(
+        &self,
+        source: &str,
+        source_id: &str,
+        topology: &SessionTopologyWrite<'_>,
+    ) -> Result<bool> {
+        let tx = self.conn.unchecked_transaction()?;
+        let session_id: Option<String> = tx
+            .query_row(
+                "SELECT id FROM sessions WHERE source = ?1 AND source_id = ?2",
+                rusqlite::params![source, source_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let Some(session_id) = session_id else {
+            return Ok(false);
+        };
+        tx.execute(
+            "UPDATE sessions SET thread_role = ?1, metadata_parser_version = ?2 WHERE id = ?3",
+            rusqlite::params![
+                topology.thread_role.map(|role| role.as_str()),
+                topology.parser_version,
+                session_id,
+            ],
+        )?;
+        replace_parent_links_tx(&tx, &session_id, topology.parents)?;
+        tx.commit()?;
+        Ok(true)
+    }
+
+    pub(crate) fn session_topology(&self, session_id: &str) -> Result<SessionTopology> {
+        let thread_role = self
+            .conn
+            .query_row(
+                "SELECT thread_role FROM sessions WHERE id = ?1",
+                rusqlite::params![session_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten()
+            .and_then(|role| role.parse::<ThreadRole>().ok());
+        let mut stmt = self.conn.prepare(
+            "SELECT relation, parent_source, parent_source_id
+             FROM session_parent_links
+             WHERE session_id = ?1
+             ORDER BY relation, parent_source, parent_source_id",
+        )?;
+        let parents = stmt
+            .query_map(rusqlite::params![session_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get(1)?, row.get(2)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter_map(|(relation, source, source_id)| {
+                relation.parse().ok().map(|relation| ParentLink { relation, source, source_id })
+            })
+            .collect();
+        Ok(SessionTopology { thread_role, parents })
+    }
+
+    pub(crate) fn metadata_state_meta_map(
+        &self,
+        source: &str,
+    ) -> Result<HashMap<String, MetadataSessionStateMeta>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source_id, metadata_parser_version, updated_at
+             FROM sessions
+             WHERE source = ?1 AND metadata_parser_version IS NOT NULL",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![source], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                MetadataSessionStateMeta {
+                    parser_version: row.get(1)?,
+                    source_updated_at: row.get(2)?,
+                },
+            ))
+        })?;
+        rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
     pub(crate) fn delete_session_data(&self, source: &str, source_id: &str) -> Result<()> {
@@ -393,39 +533,7 @@ impl Store {
         time_range: TimeRange,
         directory: Option<&str>,
         repo: Option<&RepoFilter>,
-        limit: Option<usize>,
-        offset: usize,
-        sort: SessionListSort,
-    ) -> Result<Vec<Session>> {
-        self.list_sessions_for_scope(sources, time_range, directory, repo, limit, offset, sort)
-    }
-
-    pub(crate) fn list_export_sessions(
-        &self,
-        sources: Option<&[String]>,
-        time_range: TimeRange,
-        directory: Option<&str>,
-        repo: Option<&RepoFilter>,
-        limit: Option<usize>,
-    ) -> Result<Vec<Session>> {
-        self.list_sessions_for_scope(
-            sources,
-            time_range,
-            directory,
-            repo,
-            limit,
-            0,
-            SessionListSort::Newest,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn list_sessions_for_scope(
-        &self,
-        sources: Option<&[String]>,
-        time_range: TimeRange,
-        directory: Option<&str>,
-        repo: Option<&RepoFilter>,
+        thread_role: Option<ThreadRoleFilter>,
         limit: Option<usize>,
         offset: usize,
         sort: SessionListSort,
@@ -446,6 +554,9 @@ impl Store {
             directory,
             repo,
         );
+        if let Some(thread_role) = thread_role {
+            sql.push_str(thread_role.sql_predicate());
+        }
         let order_by = match sort {
             SessionListSort::Newest => "s.started_at DESC, source ASC, source_id ASC",
             SessionListSort::Oldest => "s.started_at ASC, source ASC, source_id ASC",
@@ -472,6 +583,55 @@ impl Store {
         let rows = stmt.query_map(param_refs.as_slice(), session_from_row)?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
+
+    pub(crate) fn list_export_sessions(
+        &self,
+        sources: Option<&[String]>,
+        time_range: TimeRange,
+        directory: Option<&str>,
+        repo: Option<&RepoFilter>,
+        thread_role: Option<ThreadRoleFilter>,
+        limit: Option<usize>,
+    ) -> Result<Vec<Session>> {
+        self.list_indexed_sessions(
+            sources,
+            time_range,
+            directory,
+            repo,
+            thread_role,
+            limit,
+            0,
+            SessionListSort::Newest,
+        )
+    }
+}
+
+fn replace_parent_links_tx(
+    tx: &rusqlite::Transaction<'_>,
+    session_id: &str,
+    parents: &[ParentLink],
+) -> Result<()> {
+    tx.execute(
+        "DELETE FROM session_parent_links WHERE session_id = ?1",
+        rusqlite::params![session_id],
+    )?;
+    if parents.is_empty() {
+        return Ok(());
+    }
+    let mut stmt = tx.prepare(
+        "INSERT OR IGNORE INTO session_parent_links
+            (session_id, relation, parent_source, parent_source_id)
+         VALUES (?1, ?2, ?3, ?4)",
+    )?;
+    for parent in parents {
+        stmt.execute(rusqlite::params![
+            session_id,
+            parent.relation.as_str(),
+            parent.source,
+            parent.source_id,
+        ])?;
+    }
+    Ok(())
 }
 
 fn delete_session_data_tx(
@@ -507,10 +667,11 @@ fn persist_session_with_usage_and_events_tx(
     usage_parser_version: Option<u32>,
     session_events: &[RawSessionEvent],
     event_parser_version: Option<u32>,
+    topology: &SessionTopologyWrite<'_>,
 ) -> Result<()> {
     tx.execute(
-        "INSERT INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+        "INSERT INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import, thread_role, metadata_parser_version)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         rusqlite::params![
             session.id,
             session.source,
@@ -529,8 +690,12 @@ fn persist_session_with_usage_and_events_tx(
             session.duration_minutes,
             session.source_file_path,
             session.is_import,
+            topology.thread_role.map(|role| role.as_str()),
+            topology.parser_version,
         ],
     )?;
+
+    replace_parent_links_tx(tx, &session.id, topology.parents)?;
 
     {
         let mut stmt = tx.prepare(
@@ -679,4 +844,235 @@ fn persist_session_with_usage_and_events_tx(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod topology_tests {
+    use super::*;
+    use crate::db::schema;
+    use crate::db::store::SessionListSort;
+    use crate::types::{Message, ParentLink, ParentRelation, Role, Session, ThreadRole};
+
+    fn store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn sess(source_id: &str) -> Session {
+        Session {
+            id: format!("local-{source_id}"),
+            source: "codex".to_string(),
+            source_id: source_id.to_string(),
+            title: "t".to_string(),
+            directory: None,
+            repo_remote: None,
+            repo_slug: None,
+            repo_name: None,
+            started_at: 0,
+            updated_at: Some(10),
+            message_count: 1,
+            entrypoint: None,
+            custom_title: None,
+            summary: None,
+            duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
+        }
+    }
+
+    fn msg(session_id: &str) -> Vec<Message> {
+        vec![Message {
+            session_id: session_id.to_string(),
+            role: Role::User,
+            content: "hello world".to_string(),
+            timestamp: Some(1),
+            seq: 0,
+        }]
+    }
+
+    fn persist(store: &Store, session: &Session, topology: &SessionTopologyWrite<'_>) {
+        store
+            .persist_session_with_usage_and_events_with_topology(
+                session,
+                &msg(&session.id),
+                &[],
+                None,
+                &[],
+                None,
+                topology,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn session_topology_round_trips_role_and_parents() {
+        let store = store();
+        let session = sess("s1");
+        let parents = vec![
+            ParentLink {
+                relation: ParentRelation::Spawn,
+                source: "codex".to_string(),
+                source_id: "p-spawn".to_string(),
+            },
+            ParentLink {
+                relation: ParentRelation::Fork,
+                source: "codex".to_string(),
+                source_id: "p-fork".to_string(),
+            },
+        ];
+        persist(
+            &store,
+            &session,
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Subagent),
+                parents: &parents,
+                parser_version: Some(1),
+            },
+        );
+
+        let topology = store.session_topology(&session.id).unwrap();
+        assert_eq!(topology.thread_role, Some(ThreadRole::Subagent));
+        assert_eq!(
+            topology.parents,
+            vec![
+                ParentLink {
+                    relation: ParentRelation::Fork,
+                    source: "codex".to_string(),
+                    source_id: "p-fork".to_string(),
+                },
+                ParentLink {
+                    relation: ParentRelation::Spawn,
+                    source: "codex".to_string(),
+                    source_id: "p-spawn".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn metadata_backfill_updates_topology_without_touching_messages() {
+        let store = store();
+        let session = sess("s1");
+        persist(
+            &store,
+            &session,
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Primary),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        let embedding_before: i64 = store
+            .conn
+            .query_row(
+                "SELECT units_total FROM session_embedding_state WHERE session_id = ?1",
+                [&session.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        let parents = vec![ParentLink {
+            relation: ParentRelation::Fork,
+            source: "codex".to_string(),
+            source_id: "p1".to_string(),
+        }];
+        let updated = store
+            .persist_topology_for_existing_session(
+                "codex",
+                "s1",
+                &SessionTopologyWrite {
+                    thread_role: Some(ThreadRole::Subagent),
+                    parents: &parents,
+                    parser_version: Some(2),
+                },
+            )
+            .unwrap();
+        assert!(updated);
+
+        let topology = store.session_topology(&session.id).unwrap();
+        assert_eq!(topology.thread_role, Some(ThreadRole::Subagent));
+        assert_eq!(topology.parents, parents);
+
+        assert_eq!(store.get_messages(&session.id).unwrap().len(), 1);
+        let same_id: String = store
+            .conn
+            .query_row(
+                "SELECT id FROM sessions WHERE source = 'codex' AND source_id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(same_id, session.id);
+        let embedding_after: i64 = store
+            .conn
+            .query_row(
+                "SELECT units_total FROM session_embedding_state WHERE session_id = ?1",
+                [&session.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(embedding_before, embedding_after);
+
+        let meta = store.metadata_state_meta_map("codex").unwrap();
+        assert_eq!(meta.get("s1").map(|m| m.parser_version), Some(2));
+    }
+
+    #[test]
+    fn persist_topology_for_missing_session_reports_false() {
+        let store = store();
+        let updated = store
+            .persist_topology_for_existing_session("codex", "absent", &SessionTopologyWrite::none())
+            .unwrap();
+        assert!(!updated);
+    }
+
+    #[test]
+    fn list_indexed_sessions_filters_by_thread_role() {
+        let store = store();
+        persist(
+            &store,
+            &sess("primary"),
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Primary),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        persist(
+            &store,
+            &sess("subagent"),
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Subagent),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        persist(
+            &store,
+            &sess("unknown"),
+            &SessionTopologyWrite { thread_role: None, parents: &[], parser_version: Some(1) },
+        );
+
+        let ids = |filter| {
+            store
+                .list_indexed_sessions(
+                    None,
+                    TimeRange::All,
+                    None,
+                    None,
+                    Some(filter),
+                    None,
+                    0,
+                    SessionListSort::Newest,
+                )
+                .unwrap()
+                .into_iter()
+                .map(|s| s.source_id)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(ids(ThreadRoleFilter::Primary), vec!["primary".to_string()]);
+        assert_eq!(ids(ThreadRoleFilter::Subagent), vec!["subagent".to_string()]);
+        assert_eq!(ids(ThreadRoleFilter::Unknown), vec!["unknown".to_string()]);
+    }
 }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::types::Session;
+use crate::types::{ParentLink, Session, ThreadRole};
 
 pub(crate) const SESSION_COLUMNS: &str = "id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import";
 
@@ -65,6 +65,26 @@ pub(crate) struct UsageSessionStateMeta {
 pub(crate) struct EventSessionStateMeta {
     pub(crate) parser_version: u32,
     pub(crate) source_updated_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MetadataSessionStateMeta {
+    pub(crate) parser_version: u32,
+    pub(crate) source_updated_at: Option<i64>,
+}
+
+/// `parser_version: None` leaves topology and the version unset (import path).
+pub(crate) struct SessionTopologyWrite<'a> {
+    pub(crate) thread_role: Option<ThreadRole>,
+    pub(crate) parents: &'a [ParentLink],
+    pub(crate) parser_version: Option<u32>,
+}
+
+impl SessionTopologyWrite<'_> {
+    #[cfg(test)]
+    pub(crate) fn none() -> SessionTopologyWrite<'static> {
+        SessionTopologyWrite { thread_role: None, parents: &[], parser_version: None }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,12 +4,14 @@ use anyhow::{Result, anyhow};
 use serde::Serialize;
 
 use crate::adapters;
-use crate::db::search::{RepoFilter, TimeRange};
+use crate::db::search::{RepoFilter, ThreadRoleFilter, TimeRange};
 use crate::db::store::Store;
 use crate::query::{parse_time_range, resolve_source_filter};
-use crate::types::{Message, Role, Session, SessionEventRecord, SessionUsageEventRecord};
+use crate::types::{
+    Message, Role, Session, SessionEventRecord, SessionTopology, SessionUsageEventRecord,
+};
 
-pub(crate) const RECORD_SCHEMA_VERSION: u32 = 4;
+pub(crate) const RECORD_SCHEMA_VERSION: u32 = 5;
 const RECORD_TYPE: &str = "session";
 
 #[derive(Clone, Copy)]
@@ -31,6 +33,7 @@ pub(crate) struct ExportOptions {
     pub(crate) time_range: TimeRange,
     pub(crate) project: Option<String>,
     pub(crate) repo: Option<RepoFilter>,
+    pub(crate) thread_role: Option<ThreadRoleFilter>,
     pub(crate) limit: Option<usize>,
     pub(crate) includes: ExportIncludes,
 }
@@ -40,6 +43,7 @@ pub(crate) fn run_cli(
     time_filter: Option<&str>,
     project_filter: Option<&str>,
     repo_filter: Option<&str>,
+    thread_role: Option<ThreadRoleFilter>,
     limit: usize,
     include_filter: Option<&str>,
 ) -> Result<()> {
@@ -52,6 +56,7 @@ pub(crate) fn run_cli(
         time_range: parse_time_range(time_filter),
         project: directory,
         repo,
+        thread_role,
         limit: if limit == 0 { None } else { Some(limit) },
         includes: parse_export_includes(include_filter)?,
     };
@@ -119,6 +124,7 @@ struct ExportSession {
     summary: Option<String>,
     duration_minutes: Option<u32>,
     source_file_path: Option<String>,
+    topology: SessionTopology,
 }
 
 #[derive(Serialize)]
@@ -176,6 +182,7 @@ pub(crate) fn write_jsonl<W: Write>(
             options.time_range,
             options.project.as_deref(),
             options.repo.as_ref(),
+            options.thread_role,
             options.limit,
         )?
     } else {
@@ -194,11 +201,18 @@ pub(crate) fn write_jsonl<W: Write>(
 
 pub(crate) fn session_record_value(
     session: Session,
+    topology: SessionTopology,
     messages: Vec<Message>,
     usage_events: Vec<SessionUsageEventRecord>,
     events: Vec<SessionEventRecord>,
 ) -> Result<serde_json::Value> {
-    Ok(serde_json::to_value(build_session_record(session, messages, usage_events, events))?)
+    Ok(serde_json::to_value(build_session_record(
+        session,
+        topology,
+        messages,
+        usage_events,
+        events,
+    ))?)
 }
 
 fn write_jsonl_for_sessions<W: Write>(
@@ -208,6 +222,7 @@ fn write_jsonl_for_sessions<W: Write>(
     mut writer: W,
 ) -> Result<()> {
     for session in sessions {
+        let topology = store.session_topology(&session.id)?;
         let messages =
             if includes.messages { store.get_messages(&session.id)? } else { Vec::new() };
         let usage_events = if includes.usage {
@@ -220,7 +235,7 @@ fn write_jsonl_for_sessions<W: Write>(
         } else {
             Vec::new()
         };
-        let record = build_session_record(session, messages, usage_events, events);
+        let record = build_session_record(session, topology, messages, usage_events, events);
         serde_json::to_writer(&mut writer, &record)?;
         writer.write_all(b"\n")?;
     }
@@ -230,6 +245,7 @@ fn write_jsonl_for_sessions<W: Write>(
 
 fn build_session_record(
     session: Session,
+    topology: SessionTopology,
     messages: Vec<Message>,
     usage_events: Vec<SessionUsageEventRecord>,
     events: Vec<SessionEventRecord>,
@@ -237,33 +253,32 @@ fn build_session_record(
     ExportSessionRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         record_type: RECORD_TYPE,
-        session: session.into(),
+        session: export_session(session, topology),
         messages: messages.into_iter().map(Into::into).collect(),
         usage_events: usage_events.into_iter().map(Into::into).collect(),
         events: events.into_iter().map(Into::into).collect(),
     }
 }
 
-impl From<Session> for ExportSession {
-    fn from(session: Session) -> Self {
-        Self {
-            id: session.id,
-            source: session.source,
-            source_id: session.source_id,
-            title: session.title,
-            directory: session.directory,
-            repo_remote: session.repo_remote,
-            repo_slug: session.repo_slug,
-            repo_name: session.repo_name,
-            started_at: session.started_at,
-            updated_at: session.updated_at,
-            message_count: session.message_count,
-            entrypoint: session.entrypoint,
-            custom_title: session.custom_title,
-            summary: session.summary,
-            duration_minutes: session.duration_minutes,
-            source_file_path: session.source_file_path,
-        }
+fn export_session(session: Session, topology: SessionTopology) -> ExportSession {
+    ExportSession {
+        id: session.id,
+        source: session.source,
+        source_id: session.source_id,
+        title: session.title,
+        directory: session.directory,
+        repo_remote: session.repo_remote,
+        repo_slug: session.repo_slug,
+        repo_name: session.repo_name,
+        started_at: session.started_at,
+        updated_at: session.updated_at,
+        message_count: session.message_count,
+        entrypoint: session.entrypoint,
+        custom_title: session.custom_title,
+        summary: session.summary,
+        duration_minutes: session.duration_minutes,
+        source_file_path: session.source_file_path,
+        topology,
     }
 }
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -4,8 +4,10 @@ use std::io::BufRead;
 use anyhow::{Result, anyhow, bail};
 use serde::Deserialize;
 
-use crate::db::store::Store;
-use crate::types::{Message, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource};
+use crate::db::store::{SessionTopologyWrite, Store};
+use crate::types::{
+    Message, ParentLink, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource,
+};
 
 const RECORD_TYPE: &str = "session";
 
@@ -73,6 +75,23 @@ struct ImportSession {
     duration_minutes: Option<u32>,
     #[serde(default)]
     source_file_path: Option<String>,
+    #[serde(default)]
+    topology: ImportTopology,
+}
+
+#[derive(Deserialize, Default)]
+struct ImportTopology {
+    #[serde(default)]
+    thread_role: Option<String>,
+    #[serde(default)]
+    parents: Vec<ImportParentLink>,
+}
+
+#[derive(Deserialize)]
+struct ImportParentLink {
+    relation: String,
+    source: String,
+    source_id: String,
 }
 
 #[derive(Deserialize)]
@@ -154,7 +173,7 @@ pub(crate) fn import_jsonl<R: BufRead>(
         if record.record_type != RECORD_TYPE {
             bail!("line {line_no}: unsupported record_type '{}'", record.record_type);
         }
-        if !matches!(record.schema_version, 2..=4) {
+        if !matches!(record.schema_version, 2..=5) {
             bail!("line {line_no}: unsupported schema_version {}", record.schema_version);
         }
 
@@ -268,13 +287,32 @@ fn persist_record(store: &Store, record: ImportRecord, line_no: usize) -> Result
         })
         .collect();
 
-    store.persist_session_with_usage_and_events(
+    // Persist topology without a metadata parser version so a later local sync of
+    // the same source still backfills from source. Missing/invalid values default
+    // to unknown role and no parents, keeping v2-v4 imports safe.
+    let thread_role = s.topology.thread_role.and_then(|role| role.parse().ok());
+    let parents: Vec<ParentLink> = s
+        .topology
+        .parents
+        .into_iter()
+        .filter_map(|parent| {
+            Some(ParentLink {
+                relation: parent.relation.parse().ok()?,
+                source: parent.source,
+                source_id: parent.source_id,
+            })
+        })
+        .collect();
+    let topology = SessionTopologyWrite { thread_role, parents: &parents, parser_version: None };
+
+    store.persist_session_with_usage_and_events_with_topology(
         &session,
         &messages,
         &usage_events,
         None,
         &events,
         None,
+        &topology,
     )
 }
 
@@ -284,6 +322,7 @@ mod tests {
     use crate::db::schema;
     use crate::db::search::TimeRange;
     use crate::export::{ExportIncludes, ExportOptions, write_jsonl};
+    use crate::types::{ParentRelation, ThreadRole};
 
     fn setup() -> Store {
         schema::register_sqlite_vec();
@@ -372,8 +411,25 @@ mod tests {
     fn persist_full(store: &Store, source: &str, source_id: &str, title: &str) {
         let session = full_session(source, source_id, title);
         let messages = full_messages(&session.id);
+        let parents = vec![
+            ParentLink {
+                relation: ParentRelation::Spawn,
+                source: "codex".to_string(),
+                source_id: "parent-session".to_string(),
+            },
+            ParentLink {
+                relation: ParentRelation::Fork,
+                source: "codex".to_string(),
+                source_id: "parent-session".to_string(),
+            },
+        ];
+        let topology = SessionTopologyWrite {
+            thread_role: Some(ThreadRole::Subagent),
+            parents: &parents,
+            parser_version: Some(1),
+        };
         store
-            .replace_session_with_usage_and_events(
+            .replace_session_with_usage_and_events_with_topology(
                 source,
                 source_id,
                 &session,
@@ -382,6 +438,7 @@ mod tests {
                 Some(4),
                 &[full_event()],
                 Some(5),
+                &topology,
             )
             .unwrap();
     }
@@ -393,6 +450,7 @@ mod tests {
             time_range: TimeRange::All,
             project: None,
             repo: None,
+            thread_role: None,
             limit: None,
             includes: ExportIncludes::full(),
         };

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -111,7 +111,13 @@ fn first_message_id(store: &Store, session_id: &str) -> i64 {
 }
 
 fn no_filters() -> SearchFilters {
-    SearchFilters { sources: None, time_range: TimeRange::All, directory: None, repo: None }
+    SearchFilters {
+        sources: None,
+        time_range: TimeRange::All,
+        directory: None,
+        repo: None,
+        thread_role: None,
+    }
 }
 
 #[test]
@@ -310,6 +316,7 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
         time_range: TimeRange::All,
         project: None,
         repo: None,
+        thread_role: None,
         limit: Some(10),
         includes: ExportIncludes::full(),
     };
@@ -320,10 +327,12 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     let lines: Vec<_> = text.lines().collect();
     assert_eq!(lines.len(), 1);
     let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(value["schema_version"], 4);
+    assert_eq!(value["schema_version"], 5);
     assert_eq!(value["record_type"], "session");
     assert_eq!(value["session"]["source"], "codex");
     assert_eq!(value["session"]["source_id"], "raw1");
+    assert_eq!(value["session"]["topology"]["thread_role"], serde_json::Value::Null);
+    assert_eq!(value["session"]["topology"]["parents"], serde_json::json!([]));
     assert_eq!(value["session"]["directory"], "/tmp/test");
     assert_eq!(value["session"]["repo_remote"], "github.com/samzong/Recall");
     assert_eq!(value["session"]["repo_slug"], "samzong/Recall");
@@ -374,6 +383,7 @@ fn export_jsonl_applies_include_projection() {
         time_range: TimeRange::All,
         project: None,
         repo: None,
+        thread_role: None,
         limit: None,
         includes: ExportIncludes { messages: true, usage: false, events: false },
     };
@@ -412,6 +422,7 @@ fn export_jsonl_can_select_sessions_by_id() {
         time_range: TimeRange::All,
         project: None,
         repo: None,
+        thread_role: None,
         limit: None,
         includes: ExportIncludes::full(),
     };
@@ -459,6 +470,7 @@ fn export_jsonl_applies_source_time_project_and_limit_filters() {
         time_range: TimeRange::Month,
         project: Some("/tmp/project".to_string()),
         repo: None,
+        thread_role: None,
         limit: Some(1),
         includes: ExportIncludes::full(),
     };
@@ -595,6 +607,7 @@ fn search_with_source_filter() {
         time_range: TimeRange::All,
         directory: None,
         repo: None,
+        thread_role: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     assert_eq!(results.len(), 1);
@@ -630,6 +643,7 @@ fn search_with_directory_filter_respects_project_boundary() {
         time_range: TimeRange::All,
         directory: Some("/tmp/project".to_string()),
         repo: None,
+        thread_role: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     let mut ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
@@ -687,6 +701,7 @@ fn search_with_repo_filter_matches_sibling_worktrees() {
         time_range: TimeRange::All,
         directory: None,
         repo: Some(RepoFilter::Slug("samzong/Recall".to_string())),
+        thread_role: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     let mut ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
@@ -716,6 +731,7 @@ fn export_jsonl_applies_repo_filter() {
         time_range: TimeRange::All,
         project: None,
         repo: Some(RepoFilter::Slug("samzong/Recall".to_string())),
+        thread_role: None,
         limit: None,
         includes: ExportIncludes::full(),
     };
@@ -1321,4 +1337,62 @@ fn config_drops_obsolete_disabled_entries() {
 
     assert!(!config.disabled_sources.iter().any(|id| id == "ghost-adapter"));
     assert!(config.is_source_enabled("claude-code"), "cleared to avoid zero-source state");
+}
+
+#[test]
+fn hybrid_search_filters_by_thread_role_in_sql() {
+    use crate::db::search::ThreadRoleFilter;
+    use crate::db::store::SessionTopologyWrite;
+    use crate::types::ThreadRole;
+
+    let store = setup();
+    let persist = |id: &str, source_id: &str, role: ThreadRole| {
+        let session = make_session(id, "codex", source_id, "Topology search");
+        let messages = vec![make_message(id, Role::User, "cloudflare deploy token", 0)];
+        store
+            .persist_session_with_usage_and_events_with_topology(
+                &session,
+                &messages,
+                &[],
+                None,
+                &[],
+                None,
+                &SessionTopologyWrite {
+                    thread_role: Some(role),
+                    parents: &[],
+                    parser_version: Some(1),
+                },
+            )
+            .unwrap();
+    };
+    persist("p", "primary-src", ThreadRole::Primary);
+    persist("s", "sub-src", ThreadRole::Subagent);
+
+    let engine = SearchEngine::new(&store.conn);
+    let filter = |thread_role| SearchFilters {
+        sources: None,
+        time_range: TimeRange::All,
+        directory: None,
+        repo: None,
+        thread_role,
+    };
+    let source_ids = |results: Vec<crate::types::SearchResult>| {
+        let mut ids = results.into_iter().map(|r| r.session.source_id).collect::<Vec<_>>();
+        ids.sort();
+        ids
+    };
+
+    // Role filtering happens in the SQL, so limit/offset apply to the filtered set.
+    let all = engine.hybrid_search("cloudflare", None, &filter(None), 10, 3).unwrap();
+    assert_eq!(source_ids(all), vec!["primary-src".to_string(), "sub-src".to_string()]);
+
+    let subs = engine
+        .hybrid_search("cloudflare", None, &filter(Some(ThreadRoleFilter::Subagent)), 10, 3)
+        .unwrap();
+    assert_eq!(source_ids(subs), vec!["sub-src".to_string()]);
+
+    let prims = engine
+        .hybrid_search("cloudflare", None, &filter(Some(ThreadRoleFilter::Primary)), 10, 3)
+        .unwrap();
+    assert_eq!(source_ids(prims), vec!["primary-src".to_string()]);
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -29,6 +29,7 @@ pub(crate) fn run_search(
             time_filter,
             project_filter,
             repo_filter,
+            None,
             20,
             0,
             false,
@@ -46,7 +47,8 @@ pub(crate) fn run_search(
     let (directory, repo) = store.resolve_project_repo_filters(project_filter, repo_filter)?;
     let embedding = query_embedding(&store, query, |message| println!("{message}"))?;
 
-    let filters = SearchFilters { sources: resolved_source, time_range, directory, repo };
+    let filters =
+        SearchFilters { sources: resolved_source, time_range, directory, repo, thread_role: None };
 
     let results = engine.hybrid_search(query, embedding.as_deref(), &filters, 20, 3)?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -5,14 +5,14 @@ use std::process::{Command, Stdio};
 
 use crate::adapters;
 use crate::config::AppConfig;
-use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
+use crate::db::search::{SearchEngine, SearchFilters, ThreadRoleFilter, TimeRange};
 use crate::db::store::{SessionListSort, Store};
 use crate::export::{ExportIncludes, ExportOptions};
 use crate::handoff;
 use crate::query::{parse_time_range, query_embedding, resolve_source_filter};
 use crate::semantic;
 use crate::session_action::{self, SessionAction};
-use crate::types::{MatchSource, Message, Role, Session};
+use crate::types::{MatchSource, Message, Role, Session, SessionTopology};
 use crate::{sync::SyncRunOptions, sync::run_sync_job_inner, transcript};
 use anyhow::Result;
 use clap::{Subcommand, ValueEnum};
@@ -31,6 +31,8 @@ pub(crate) enum SessionCommands {
         project: Option<String>,
         #[arg(long, help = "Filter by repository identity")]
         repo: Option<String>,
+        #[arg(long, value_enum, help = "Filter by topology thread role")]
+        thread_role: Option<ThreadRoleFilter>,
         #[arg(long, default_value_t = 50, help = "Maximum sessions to return")]
         limit: usize,
         #[arg(long, default_value_t = 0, help = "Skip sessions for pagination")]
@@ -200,6 +202,7 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             time,
             project,
             repo,
+            thread_role,
             limit,
             offset,
             all,
@@ -212,6 +215,7 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             time.as_deref(),
             project.as_deref(),
             repo.as_deref(),
+            thread_role,
             limit,
             offset,
             all,
@@ -309,6 +313,7 @@ pub(crate) fn run_session_list(
     time_filter: Option<&str>,
     project_filter: Option<&str>,
     repo_filter: Option<&str>,
+    thread_role: Option<ThreadRoleFilter>,
     limit: usize,
     offset: usize,
     all: bool,
@@ -349,6 +354,7 @@ pub(crate) fn run_session_list(
             time_range,
             directory: directory.clone(),
             repo: repo.clone(),
+            thread_role,
         };
         let search_limit = effective_limit.unwrap_or(10_000).saturating_add(offset).max(1);
         let results =
@@ -375,6 +381,7 @@ pub(crate) fn run_session_list(
                 time_range,
                 directory.as_deref(),
                 repo.as_ref(),
+                thread_role,
                 effective_limit,
                 offset,
                 sort,
@@ -387,6 +394,7 @@ pub(crate) fn run_session_list(
     match format {
         SessionListFormat::Table => print_session_list_table(&rows, &sources),
         SessionListFormat::Json => print_session_list_json(
+            &store,
             &rows,
             &sources,
             query,
@@ -394,6 +402,7 @@ pub(crate) fn run_session_list(
             time_filter,
             project_filter,
             effective_repo_filter,
+            thread_role,
             limit,
             offset,
             all,
@@ -401,7 +410,10 @@ pub(crate) fn run_session_list(
         )?,
         SessionListFormat::Jsonl => {
             for row in &rows {
-                println!("{}", serde_json::to_string(&session_list_row_json(row, &sources))?);
+                println!(
+                    "{}",
+                    serde_json::to_string(&session_list_row_json(&store, row, &sources)?)?
+                );
             }
         }
     }
@@ -448,13 +460,25 @@ fn cmd_session_show(
             }
         }
         SessionDetailFormat::Json => {
-            let value =
-                crate::export::session_record_value(session, messages, usage_events, events)?;
+            let topology = store.session_topology(&session.id)?;
+            let value = crate::export::session_record_value(
+                session,
+                topology,
+                messages,
+                usage_events,
+                events,
+            )?;
             println!("{}", serde_json::to_string_pretty(&value)?);
         }
         SessionDetailFormat::Jsonl => {
-            let value =
-                crate::export::session_record_value(session, messages, usage_events, events)?;
+            let topology = store.session_topology(&session.id)?;
+            let value = crate::export::session_record_value(
+                session,
+                topology,
+                messages,
+                usage_events,
+                events,
+            )?;
             println!("{}", serde_json::to_string(&value)?);
         }
     }
@@ -485,6 +509,7 @@ fn cmd_session_export(
                 time_range: TimeRange::All,
                 project: None,
                 repo: None,
+                thread_role: None,
                 limit: None,
                 includes: crate::export::parse_export_includes(include)?,
             };
@@ -786,6 +811,7 @@ fn print_session_list_table(rows: &[SessionListRow], sources: &[(String, String)
 
 #[allow(clippy::too_many_arguments)]
 fn print_session_list_json(
+    store: &Store,
     rows: &[SessionListRow],
     sources: &[(String, String)],
     query: Option<&str>,
@@ -793,11 +819,16 @@ fn print_session_list_json(
     time: Option<&str>,
     project: Option<&str>,
     repo: Option<&str>,
+    thread_role: Option<ThreadRoleFilter>,
     limit: usize,
     offset: usize,
     all: bool,
     sort: Option<SessionSort>,
 ) -> Result<()> {
+    let sessions = rows
+        .iter()
+        .map(|row| session_list_row_json(store, row, sources))
+        .collect::<Result<Vec<_>>>()?;
     println!(
         "{}",
         serde_json::to_string_pretty(&serde_json::json!({
@@ -807,11 +838,12 @@ fn print_session_list_json(
                 "project": project,
                 "repo": repo,
                 "time": time.unwrap_or("all"),
+                "thread_role": thread_role.map(|role| role.as_str()),
                 "limit": if all { serde_json::Value::Null } else { serde_json::json!(limit) },
                 "offset": offset,
                 "sort": sort.map(session_sort_label)
             },
-            "sessions": rows.iter().map(|row| session_list_row_json(row, sources)).collect::<Vec<_>>(),
+            "sessions": sessions,
             "next_offset": if all || rows.len() < limit {
                 serde_json::Value::Null
             } else {
@@ -822,9 +854,14 @@ fn print_session_list_json(
     Ok(())
 }
 
-fn session_list_row_json(row: &SessionListRow, sources: &[(String, String)]) -> serde_json::Value {
+fn session_list_row_json(
+    store: &Store,
+    row: &SessionListRow,
+    sources: &[(String, String)],
+) -> Result<serde_json::Value> {
     let session = &row.session;
-    let mut value = session_json(session, sources);
+    let topology = store.session_topology(&session.id)?;
+    let mut value = session_json(session, &topology, sources);
     if let Some(map) = value.as_object_mut() {
         map.insert(
             "match_source".to_string(),
@@ -842,10 +879,14 @@ fn session_list_row_json(row: &SessionListRow, sources: &[(String, String)]) -> 
                 .unwrap_or(serde_json::Value::Null),
         );
     }
-    value
+    Ok(value)
 }
 
-fn session_json(session: &Session, sources: &[(String, String)]) -> serde_json::Value {
+fn session_json(
+    session: &Session,
+    topology: &SessionTopology,
+    sources: &[(String, String)],
+) -> serde_json::Value {
     serde_json::json!({
         "id": session.id,
         "source": session.source,
@@ -864,7 +905,23 @@ fn session_json(session: &Session, sources: &[(String, String)]) -> serde_json::
         "summary": session.summary,
         "duration_minutes": session.duration_minutes,
         "source_file_path": session.source_file_path,
-        "is_import": session.is_import
+        "is_import": session.is_import,
+        "topology": topology_json(topology)
+    })
+}
+
+fn topology_json(topology: &SessionTopology) -> serde_json::Value {
+    serde_json::json!({
+        "thread_role": topology.thread_role.map(|role| role.as_str()),
+        "parents": topology
+            .parents
+            .iter()
+            .map(|parent| serde_json::json!({
+                "relation": parent.relation.as_str(),
+                "source": parent.source,
+                "source_id": parent.source_id
+            }))
+            .collect::<Vec<_>>()
     })
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,7 +5,10 @@ use tracing::info;
 
 use crate::adapters;
 use crate::config::AppConfig;
-use crate::db::store::{EventSessionStateMeta, SessionPath, Store, UsageSessionStateMeta};
+use crate::db::store::{
+    EventSessionStateMeta, MetadataSessionStateMeta, SessionPath, SessionTopologyWrite, Store,
+    UsageSessionStateMeta,
+};
 use crate::query::resolve_source_filter;
 use crate::repo_identity::{RepoIdentity, RepoIdentityCache};
 use crate::semantic;
@@ -71,6 +74,7 @@ pub(crate) fn run_background_worker(sync_first: bool) -> Result<()> {
 struct BackfillPlan {
     usage: bool,
     events: bool,
+    metadata: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,6 +107,7 @@ struct ExistingState {
     imported_ids: HashSet<String>,
     usage_meta: HashMap<String, UsageSessionStateMeta>,
     event_meta: HashMap<String, EventSessionStateMeta>,
+    metadata_meta: HashMap<String, MetadataSessionStateMeta>,
 }
 
 impl ExistingState {
@@ -111,6 +116,7 @@ impl ExistingState {
             self.paths.remove(source_id);
             self.usage_meta.remove(source_id);
             self.event_meta.remove(source_id);
+            self.metadata_meta.remove(source_id);
             true
         } else {
             false
@@ -122,6 +128,7 @@ impl ExistingState {
         session: &Session,
         usage_parser_version: Option<u32>,
         event_parser_version: Option<u32>,
+        metadata_parser_version: Option<u32>,
     ) {
         self.meta.insert(session.source_id.clone(), (session.updated_at, session.message_count));
         self.paths.insert(
@@ -145,6 +152,12 @@ impl ExistingState {
             self.event_meta.insert(
                 session.source_id.clone(),
                 EventSessionStateMeta { parser_version, source_updated_at: session.updated_at },
+            );
+        }
+        if let Some(parser_version) = metadata_parser_version {
+            self.metadata_meta.insert(
+                session.source_id.clone(),
+                MetadataSessionStateMeta { parser_version, source_updated_at: session.updated_at },
             );
         }
     }
@@ -338,7 +351,12 @@ impl SyncJob {
         } else {
             self.store.event_state_meta_map(source_id)?
         };
-        Ok(ExistingState { meta, paths, imported_ids, usage_meta, event_meta })
+        let metadata_meta = if self.options.usage_only {
+            Default::default()
+        } else {
+            self.store.metadata_state_meta_map(source_id)?
+        };
+        Ok(ExistingState { meta, paths, imported_ids, usage_meta, event_meta, metadata_meta })
     }
 
     fn process_raw_session(
@@ -402,6 +420,15 @@ impl SyncJob {
                     raw.updated_at,
                 )
             });
+        let metadata_parser_version = raw.metadata_parser_version;
+        let metadata_backfill_needed = !self.options.usage_only
+            && metadata_parser_version.is_some_and(|version| {
+                !crate::adapters::sync_state::metadata_state_is_current(
+                    version,
+                    existing.metadata_meta.get(&raw_source_id).copied(),
+                    raw.updated_at,
+                )
+            });
 
         match existing.meta.get(&raw_source_id).copied() {
             Some((old_updated_at, old_msg_count)) => {
@@ -419,6 +446,7 @@ impl SyncJob {
                     content_changed,
                     usage_backfill_needed,
                     event_backfill_needed,
+                    metadata_backfill_needed,
                 ) {
                     ExistingSessionAction::Skip => {
                         if was_imported {
@@ -442,6 +470,7 @@ impl SyncJob {
                 }
                 existing.usage_meta.remove(&raw_source_id);
                 existing.event_meta.remove(&raw_source_id);
+                existing.metadata_meta.remove(&raw_source_id);
                 if content_changed {
                     self.stats.updated_sessions += 1;
                 } else {
@@ -500,7 +529,12 @@ impl SyncJob {
             (Vec::new(), None)
         };
 
-        self.store.replace_session_with_usage_and_events(
+        let topology = SessionTopologyWrite {
+            thread_role: raw.thread_role,
+            parents: &raw.parent_links,
+            parser_version: metadata_parser_version,
+        };
+        self.store.replace_session_with_usage_and_events_with_topology(
             source_id,
             &raw_source_id,
             &session,
@@ -509,8 +543,14 @@ impl SyncJob {
             raw.usage_parser_version,
             &events,
             event_parser_version,
+            &topology,
         )?;
-        existing.record_replaced(&session, raw.usage_parser_version, event_parser_version);
+        existing.record_replaced(
+            &session,
+            raw.usage_parser_version,
+            event_parser_version,
+            metadata_parser_version,
+        );
         self.stats.total_messages += msg_count;
         Ok(())
     }
@@ -556,6 +596,26 @@ impl SyncJob {
                 EventSessionStateMeta { parser_version, source_updated_at: raw.updated_at },
             );
             reprocessed = true;
+        }
+        if plan.metadata
+            && let Some(parser_version) = raw.metadata_parser_version
+        {
+            let topology = SessionTopologyWrite {
+                thread_role: raw.thread_role,
+                parents: &raw.parent_links,
+                parser_version: Some(parser_version),
+            };
+            if self.store.persist_topology_for_existing_session(
+                source_id,
+                raw_source_id,
+                &topology,
+            )? {
+                existing.metadata_meta.insert(
+                    raw_source_id.to_string(),
+                    MetadataSessionStateMeta { parser_version, source_updated_at: raw.updated_at },
+                );
+                reprocessed = true;
+            }
         }
         if raw.custom_title.is_some() || raw.summary.is_some() || raw.duration_minutes.is_some() {
             self.store.update_session_fields(
@@ -642,6 +702,7 @@ impl SyncJob {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn decide_existing_session_action(
     usage_only: bool,
     backfill_events: bool,
@@ -649,6 +710,7 @@ fn decide_existing_session_action(
     content_changed: bool,
     usage_backfill_needed: bool,
     event_backfill_needed: bool,
+    metadata_backfill_needed: bool,
 ) -> ExistingSessionAction {
     if usage_only {
         let needs_usage = usage_backfill_needed;
@@ -657,6 +719,7 @@ fn decide_existing_session_action(
             ExistingSessionAction::BackfillOnly(BackfillPlan {
                 usage: needs_usage,
                 events: needs_events,
+                metadata: false,
             })
         } else {
             ExistingSessionAction::Skip
@@ -664,10 +727,11 @@ fn decide_existing_session_action(
     }
 
     if !content_changed && !force {
-        return if usage_backfill_needed || event_backfill_needed {
+        return if usage_backfill_needed || event_backfill_needed || metadata_backfill_needed {
             ExistingSessionAction::BackfillOnly(BackfillPlan {
                 usage: usage_backfill_needed,
                 events: event_backfill_needed,
+                metadata: metadata_backfill_needed,
             })
         } else {
             ExistingSessionAction::Skip
@@ -827,11 +891,15 @@ mod tests {
     #[test]
     fn usage_only_never_refreshes_existing_session() {
         assert_eq!(
-            decide_existing_session_action(true, false, false, true, true, true),
-            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: false })
+            decide_existing_session_action(true, false, false, true, true, true, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: true,
+                events: false,
+                metadata: false
+            })
         );
         assert_eq!(
-            decide_existing_session_action(true, false, false, true, false, true),
+            decide_existing_session_action(true, false, false, true, false, true, true),
             ExistingSessionAction::Skip
         );
     }
@@ -839,19 +907,27 @@ mod tests {
     #[test]
     fn usage_only_can_backfill_events_without_refresh() {
         assert_eq!(
-            decide_existing_session_action(true, true, false, true, false, true),
-            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: false, events: true })
+            decide_existing_session_action(true, true, false, true, false, true, false),
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: false,
+                events: true,
+                metadata: false
+            })
         );
         assert_eq!(
-            decide_existing_session_action(true, true, false, true, true, true),
-            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: true })
+            decide_existing_session_action(true, true, false, true, true, true, false),
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: true,
+                events: true,
+                metadata: false
+            })
         );
     }
 
     #[test]
     fn full_sync_refreshes_changed_existing_session() {
         assert_eq!(
-            decide_existing_session_action(false, false, false, true, true, true),
+            decide_existing_session_action(false, false, false, true, true, true, false),
             ExistingSessionAction::RefreshSession
         );
     }
@@ -859,11 +935,31 @@ mod tests {
     #[test]
     fn full_sync_backfills_unchanged_existing_session_in_place() {
         assert_eq!(
-            decide_existing_session_action(false, false, false, false, true, true),
-            ExistingSessionAction::BackfillOnly(BackfillPlan { usage: true, events: true })
+            decide_existing_session_action(false, false, false, false, true, true, false),
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: true,
+                events: true,
+                metadata: false
+            })
         );
         assert_eq!(
-            decide_existing_session_action(false, false, false, false, false, false),
+            decide_existing_session_action(false, false, false, false, false, false, false),
+            ExistingSessionAction::Skip
+        );
+    }
+
+    #[test]
+    fn full_sync_backfills_metadata_only_when_topology_parser_advances() {
+        assert_eq!(
+            decide_existing_session_action(false, false, false, false, false, false, true),
+            ExistingSessionAction::BackfillOnly(BackfillPlan {
+                usage: false,
+                events: false,
+                metadata: true
+            })
+        );
+        assert_eq!(
+            decide_existing_session_action(true, false, false, false, false, false, true),
             ExistingSessionAction::Skip
         );
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2111,6 +2111,7 @@ impl App {
             time_range: self.time_filter,
             directory: self.project_filter.clone(),
             repo: self.repo_filter.clone(),
+            thread_role: None,
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,81 @@ impl std::str::FromStr for Role {
     }
 }
 
+/// `None` means the source provided no reliable classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ThreadRole {
+    Primary,
+    Subagent,
+}
+
+impl ThreadRole {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ThreadRole::Primary => "primary",
+            ThreadRole::Subagent => "subagent",
+        }
+    }
+}
+
+impl std::str::FromStr for ThreadRole {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "primary" => Ok(ThreadRole::Primary),
+            "subagent" => Ok(ThreadRole::Subagent),
+            _ => Err(()),
+        }
+    }
+}
+
+/// `Fork` alone never implies a subagent role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ParentRelation {
+    Spawn,
+    Fork,
+    Resume,
+}
+
+impl ParentRelation {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ParentRelation::Spawn => "spawn",
+            ParentRelation::Fork => "fork",
+            ParentRelation::Resume => "resume",
+        }
+    }
+}
+
+impl std::str::FromStr for ParentRelation {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "spawn" => Ok(ParentRelation::Spawn),
+            "fork" => Ok(ParentRelation::Fork),
+            "resume" => Ok(ParentRelation::Resume),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Parent identity is `(source, source_id)`; the parent may not be indexed locally.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct ParentLink {
+    pub(crate) relation: ParentRelation,
+    pub(crate) source: String,
+    pub(crate) source_id: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub(crate) struct SessionTopology {
+    pub(crate) thread_role: Option<ThreadRole>,
+    pub(crate) parents: Vec<ParentLink>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct Session {
     pub(crate) id: String,


### PR DESCRIPTION
### What's changed?

- Persist source-neutral session topology (`thread_role` + portable parent links) from Codex, Claude Code, and Pi adapters
- Backfill topology via metadata parser version without full session refresh
- Filter `session list` / export by `--thread-role`; echo the filter in list JSON
- Export schema v5 carries `session.topology` (additive; protocol_version stays 1); import accepts v2–v5

### Why

- Agents need fork/spawn provenance without directory/title heuristics so they can list primary vs subagent sessions and follow parent links across sources

### Verification

- `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test --lib` (347 passed)
- Workspace `make check` also exercises `recall-reflect` CLI tests; two macOS path assertions fail on `/private/var` vs `/var` from `git rev-parse` and are unrelated to this diff (Linux CI unaffected)

## Considered and deferred

- src/import.rs:294 [BOT-NIT]: invalid topology enums soft-default instead of hard error; intentional for v2-v4 safety and corrupt-input hygiene; not a runtime break on valid export/import round-trips.
- src/db/session_store.rs:622 [BOT-NIT]: INSERT OR IGNORE on parent links is intentional primary-key dedupe after DELETE, not swallowed constraint failure for valid relations.