### PR TITLE
feat(tui): navigate subagents and show session lineage

### DIFF
--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -324,6 +324,23 @@ impl Store {
         Ok(SessionTopology { thread_role, parents })
     }
 
+    /// Sessions whose `spawn` parent is the given portable identity — the
+    /// subagents this session directly spawned. `fork`/`resume` links are not
+    /// subagents and are excluded. Uses `idx_session_parent_links_parent`.
+    pub(crate) fn child_subagents(&self, source: &str, source_id: &str) -> Result<Vec<Session>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SESSION_COLUMNS}
+             FROM sessions s
+             JOIN session_parent_links l ON l.session_id = s.id
+             WHERE l.parent_source = ?1
+               AND l.parent_source_id = ?2
+               AND l.relation = 'spawn'
+             ORDER BY s.started_at, s.id"
+        ))?;
+        let rows = stmt.query_map(rusqlite::params![source, source_id], session_from_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub(crate) fn metadata_state_meta_map(
         &self,
         source: &str,
@@ -523,7 +540,46 @@ impl Store {
         for row in rows {
             sessions.push(row?);
         }
+        drop(stmt);
+
+        // Hide a subagent only when its spawn parent is present in this same
+        // scoped result set — then it is reachable through the parent's picker.
+        // Orphaned subagents, and children whose parent falls outside the active
+        // scope or the result limit, stay visible so nothing becomes unreachable.
+        self.retain_visible_subagents(&mut sessions)?;
         Ok(sessions)
+    }
+
+    fn retain_visible_subagents(&self, sessions: &mut Vec<Session>) -> Result<()> {
+        if sessions.is_empty() {
+            return Ok(());
+        }
+        let ids: Vec<String> = sessions.iter().map(|s| s.id.clone()).collect();
+        let child_ph: Vec<String> = (1..=ids.len()).map(|i| format!("?{i}")).collect();
+        let parent_ph: Vec<String> =
+            ((ids.len() + 1)..=(2 * ids.len())).map(|i| format!("?{i}")).collect();
+        let hide_sql = format!(
+            "SELECT s.id
+             FROM sessions s
+             JOIN session_parent_links l ON l.session_id = s.id AND l.relation = 'spawn'
+             JOIN sessions p ON p.source = l.parent_source AND p.source_id = l.parent_source_id
+             WHERE s.thread_role = 'subagent'
+               AND s.id IN ({})
+               AND p.id IN ({})",
+            child_ph.join(", "),
+            parent_ph.join(", ")
+        );
+        let params: Vec<&dyn rusqlite::types::ToSql> = ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .chain(ids.iter().map(|id| id as &dyn rusqlite::types::ToSql))
+            .collect();
+        let mut stmt = self.conn.prepare(&hide_sql)?;
+        let hidden: HashSet<String> = stmt
+            .query_map(params.as_slice(), |row| row.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+        sessions.retain(|session| !hidden.contains(&session.id));
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1074,5 +1130,112 @@ mod topology_tests {
         assert_eq!(ids(ThreadRoleFilter::Primary), vec!["primary".to_string()]);
         assert_eq!(ids(ThreadRoleFilter::Subagent), vec!["subagent".to_string()]);
         assert_eq!(ids(ThreadRoleFilter::Unknown), vec!["unknown".to_string()]);
+    }
+
+    #[test]
+    fn recent_sessions_for_search_scope_hides_only_reachable_subagents() {
+        let store = store();
+        persist(
+            &store,
+            &sess("primary"),
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Primary),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        // Reachable subagent: spawn parent is the indexed "primary" — hidden,
+        // because it can be opened from primary's subagent picker.
+        let spawn_parent = ParentLink {
+            relation: ParentRelation::Spawn,
+            source: "codex".to_string(),
+            source_id: "primary".to_string(),
+        };
+        persist(
+            &store,
+            &sess("child"),
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Subagent),
+                parents: std::slice::from_ref(&spawn_parent),
+                parser_version: Some(1),
+            },
+        );
+        // Orphaned subagent: no parent link — must stay visible in the list.
+        persist(
+            &store,
+            &sess("orphan"),
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Subagent),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        persist(
+            &store,
+            &sess("unknown"),
+            &SessionTopologyWrite { thread_role: None, parents: &[], parser_version: Some(1) },
+        );
+
+        let mut ids = store
+            .list_recent_sessions_for_search_scope(None, TimeRange::All, None, None, 100)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.source_id)
+            .collect::<Vec<_>>();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["orphan".to_string(), "primary".to_string(), "unknown".to_string()],
+            "reachable child hidden; orphaned subagent stays visible"
+        );
+    }
+
+    #[test]
+    fn recent_sessions_keeps_subagent_when_parent_is_out_of_scope() {
+        let store = store();
+        let now = chrono::Utc::now().timestamp_millis();
+        let mut parent = sess("primary");
+        parent.started_at = now - 3 * 86_400_000;
+        parent.updated_at = Some(parent.started_at);
+        let mut child = sess("child");
+        child.started_at = now;
+        child.updated_at = Some(now);
+        persist(
+            &store,
+            &parent,
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Primary),
+                parents: &[],
+                parser_version: Some(1),
+            },
+        );
+        let spawn = ParentLink {
+            relation: ParentRelation::Spawn,
+            source: "codex".to_string(),
+            source_id: "primary".to_string(),
+        };
+        persist(
+            &store,
+            &child,
+            &SessionTopologyWrite {
+                thread_role: Some(ThreadRole::Subagent),
+                parents: std::slice::from_ref(&spawn),
+                parser_version: Some(1),
+            },
+        );
+
+        // Under Today, the parent (3 days ago) is filtered out; the child must
+        // stay visible because its picker is unreachable without the parent.
+        let ids: Vec<String> = store
+            .list_recent_sessions_for_search_scope(None, TimeRange::Today, None, None, 100)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.source_id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["child".to_string()],
+            "subagent stays visible when its parent is out of the active scope"
+        );
     }
 }

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -615,6 +615,38 @@ fn search_with_source_filter() {
 }
 
 #[test]
+fn search_surfaces_subagent_content_when_parent_does_not_match() {
+    let store = setup();
+    store.insert_session(&make_session("parent", "codex", "P", "Primary")).unwrap();
+    store.insert_session(&make_session("child", "codex", "C", "Subagent")).unwrap();
+    // Child is a subagent spawned by the indexed parent — but only the child's
+    // transcript matches the query, so hiding it would make the hit unreachable.
+    store
+        .conn
+        .execute("UPDATE sessions SET thread_role = 'subagent' WHERE id = 'child'", [])
+        .unwrap();
+    store
+        .conn
+        .execute(
+            "INSERT INTO session_parent_links
+                 (session_id, relation, parent_source, parent_source_id)
+             VALUES ('child', 'spawn', 'codex', 'P')",
+            [],
+        )
+        .unwrap();
+    let messages = vec![
+        make_message("parent", Role::User, "set up deployment", 0),
+        make_message("child", Role::User, "investigate the flaky wombat test", 0),
+    ];
+    store.insert_messages(&messages).unwrap();
+
+    let engine = SearchEngine::new(&store.conn);
+    let results = engine.hybrid_search("wombat", None, &no_filters(), 10, 3).unwrap();
+    let ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
+    assert_eq!(ids, vec!["child".to_string()], "subagent content stays searchable");
+}
+
+#[test]
 fn search_with_directory_filter_respects_project_boundary() {
     let store = setup();
     let mut exact = make_session("s1", "codex", "raw1", "Exact project");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -29,8 +29,13 @@ use crate::tui::share_state::{
 };
 use crate::tui::text_layout::wrap_visual_rows;
 use crate::tui::usage_state::UsageTab;
-use crate::tui::viewing_state::{SanitizedLine, ViewingSessionSummary, build_viewing_caches};
-use crate::types::{BackgroundJobStatus, MatchSource, Message, SearchResult, SemanticProgress};
+use crate::tui::viewing_state::{
+    SanitizedLine, ViewingFrame, ViewingLineage, ViewingParent, ViewingSessionSummary,
+    build_viewing_caches,
+};
+use crate::types::{
+    BackgroundJobStatus, MatchSource, Message, SearchResult, SemanticProgress, Session,
+};
 use crate::usage::{self, UsageFilters, UsageReport};
 
 const USAGE_LOADING_MIN_MS: u128 = 75;
@@ -134,6 +139,16 @@ pub(crate) struct App {
     pub(crate) viewing_scroll_offset: usize,
     mouse_drag_target: Option<MouseDragTarget>,
     pub(crate) viewing_session_summary: Option<ViewingSessionSummary>,
+    pub(crate) viewing_lineage: Option<ViewingLineage>,
+    /// The session currently shown in the viewer, independent of the search
+    /// selection. Diverges from `results[selected_index]` after drilling into a
+    /// subagent. Viewing-mode actions target this session.
+    pub(crate) viewing_session: Option<Session>,
+    /// Subagents (spawn children) of `viewing_session`, for the picker.
+    pub(crate) viewing_children: Vec<Session>,
+    /// Back-stack of parent viewer positions for subagent drill-down.
+    pub(crate) viewing_stack: Vec<ViewingFrame>,
+    pub(crate) subagent_selected: usize,
     pub(crate) all_sources: Vec<(String, String)>,
     pub(crate) config: AppConfig,
     pub(crate) source_filter_selection: Vec<String>,
@@ -225,6 +240,11 @@ impl App {
             viewing_scroll_offset: 0,
             mouse_drag_target: None,
             viewing_session_summary: None,
+            viewing_lineage: None,
+            viewing_session: None,
+            viewing_children: Vec::new(),
+            viewing_stack: Vec::new(),
+            subagent_selected: 0,
             all_sources,
             config,
             source_filter_selection: Vec::new(),
@@ -441,7 +461,7 @@ impl App {
             AppMode::Usage => self.handle_usage_key(key, store),
             AppMode::Viewing => {
                 let before = self.viewing_selected_msg;
-                self.handle_viewing_key(key);
+                self.handle_viewing_key(key, store);
                 if matches!(self.mode, AppMode::Viewing) && self.viewing_selected_msg != before {
                     self.anchor_viewing_scroll();
                 }
@@ -451,6 +471,7 @@ impl App {
             AppMode::Settings => self.handle_settings_key(key, store),
             AppMode::Filters => self.handle_filters_key(key, store),
             AppMode::HandoffTarget => self.handle_handoff_target_key(key),
+            AppMode::Subagents => self.handle_subagents_key(key, store),
             AppMode::ConfirmResume => self.handle_confirm_resume_key(key),
         }
     }
@@ -1205,7 +1226,7 @@ impl App {
         }
     }
 
-    fn handle_viewing_key(&mut self, key: KeyEvent) {
+    fn handle_viewing_key(&mut self, key: KeyEvent, store: &Store) {
         if self.viewing_search_input.is_some() {
             self.handle_viewing_search_input(key);
             return;
@@ -1221,16 +1242,10 @@ impl App {
         }
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.mode = AppMode::Search;
-                self.viewing_messages.clear();
-                self.viewing_selected_msg = 0;
-                self.viewing_scroll_offset = 0;
-                self.viewing_session_summary = None;
-                self.viewing_search_query.clear();
-                self.viewing_search_status = None;
-                self.viewing_sanitized_lines.clear();
-                self.viewing_match_cache.clear();
-                self.share_popup = None;
+                self.back_out_of_viewing(store);
+            }
+            KeyCode::Char('a') => {
+                self.open_subagents_picker();
             }
             KeyCode::Up | KeyCode::Char('k') if self.viewing_selected_msg > 0 => {
                 self.viewing_selected_msg -= 1;
@@ -1443,10 +1458,15 @@ impl App {
         source_action: session_action::SessionAction,
         action: PendingCommandAction,
     ) {
-        let Some(result) = self.results.get(self.selected_index) else {
+        let session = match origin {
+            ResumeOrigin::Viewing => self.viewing_session.clone(),
+            ResumeOrigin::Search => {
+                self.results.get(self.selected_index).map(|r| r.session.clone())
+            }
+        };
+        let Some(session) = session else {
             return;
         };
-        let session = &result.session;
         if session.is_import {
             self.status_message =
                 Some("Imported session: not resumable on this machine".to_string());
@@ -1497,10 +1517,9 @@ impl App {
     }
 
     fn start_handoff_confirmation(&mut self, target: &handoff::HandoffTarget) {
-        let Some(result) = self.results.get(self.selected_index) else {
+        let Some(session) = self.viewing_session.as_ref() else {
             return;
         };
-        let session = &result.session;
         let prompt = handoff::build_prompt(session, &self.viewing_messages);
         let command = handoff::command_for_target(target, prompt);
         self.pending_resume = Some(PendingResume {
@@ -2282,6 +2301,9 @@ impl App {
                 Some(format!("No indexed sessions for skill '{skill_id}' in this range"));
             return;
         }
+        // Skill drill-down deliberately shows the exact sessions that used the
+        // skill, including subagents — this is targeted evidence, not the
+        // browse list, so it is exempt from the list's subagent hiding.
         match store.list_sessions_by_ids(&session_ids) {
             Ok(sessions) if sessions.is_empty() => {
                 self.status_message =
@@ -2417,36 +2439,151 @@ impl App {
         }
     }
 
+    /// Load one session's transcript, summary, lineage, and subagents into the
+    /// viewer state. Does not seed the search query, jump to a match, or change
+    /// mode — callers own entry semantics. Returns false if messages can't load.
+    fn load_into_viewing(&mut self, session: Session, store: &Store) -> bool {
+        let Ok(msgs) = store.get_messages(&session.id) else {
+            return false;
+        };
+        let usage_events = store.list_usage_events_for_session(&session.id).unwrap_or_default();
+        self.viewing_session_summary = Some(ViewingSessionSummary::from_session(
+            &msgs,
+            session.duration_minutes,
+            &usage_events,
+        ));
+        let topology = store.session_topology(&session.id).unwrap_or_default();
+        let parents = topology
+            .parents
+            .iter()
+            .map(|parent| {
+                let indexed = store
+                    .get_session_by_source_id(&parent.source, &parent.source_id)
+                    .map(|found| found.is_some())
+                    .unwrap_or(false);
+                ViewingParent {
+                    relation: parent.relation,
+                    source: parent.source.clone(),
+                    source_id: parent.source_id.clone(),
+                    indexed,
+                }
+            })
+            .collect();
+        self.viewing_lineage = Some(ViewingLineage { role: topology.thread_role, parents });
+        self.viewing_children =
+            store.child_subagents(&session.source, &session.source_id).unwrap_or_default();
+        self.viewing_sanitized_lines = build_viewing_caches(&msgs);
+        self.viewing_messages = msgs;
+        self.viewing_session = Some(session);
+        self.viewing_selected_msg = 0;
+        self.viewing_scroll_offset = 0;
+        self.viewing_search_input = None;
+        self.viewing_search_input_cursor = 0;
+        self.viewing_search_status = None;
+        self.recompute_viewing_matches();
+        true
+    }
+
     fn enter_viewing(&mut self, store: &Store) {
-        if let Some(result) = self.results.get(self.selected_index)
-            && let Ok(msgs) = store.get_messages(&result.session.id)
-        {
-            let usage_events =
-                store.list_usage_events_for_session(&result.session.id).unwrap_or_default();
-            self.viewing_session_summary = Some(ViewingSessionSummary::from_session(
-                &msgs,
-                result.session.duration_minutes,
-                &usage_events,
-            ));
-            self.viewing_sanitized_lines = build_viewing_caches(&msgs);
-            self.viewing_messages = msgs;
-            self.viewing_selected_msg = 0;
-            self.viewing_scroll_offset = 0;
-            self.viewing_search_query = self
-                .query
-                .split(|c: char| !c.is_alphanumeric() && c != '_')
-                .filter(|t| !t.is_empty())
-                .collect::<Vec<_>>()
-                .join(" ");
-            self.viewing_search_input = None;
-            self.viewing_search_input_cursor = 0;
-            self.viewing_search_status = None;
-            self.recompute_viewing_matches();
+        let Some(session) = self.results.get(self.selected_index).map(|r| r.session.clone()) else {
+            return;
+        };
+        self.viewing_search_query = self
+            .query
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if self.load_into_viewing(session, store) {
+            self.viewing_stack.clear();
             if let Some(&first) = self.viewing_match_cache.first() {
                 self.viewing_selected_msg = first;
             }
             self.mode = AppMode::Viewing;
         }
+    }
+
+    fn open_subagents_picker(&mut self) {
+        if self.viewing_children.is_empty() {
+            self.status_message = Some("No subagents".to_string());
+            return;
+        }
+        self.subagent_selected = 0;
+        self.mode = AppMode::Subagents;
+    }
+
+    fn handle_subagents_key(&mut self, key: KeyEvent, store: &Store) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = AppMode::Viewing;
+            }
+            KeyCode::Up | KeyCode::Char('k') if self.subagent_selected > 0 => {
+                self.subagent_selected -= 1;
+            }
+            KeyCode::Down | KeyCode::Char('j')
+                if self.subagent_selected + 1 < self.viewing_children.len() =>
+            {
+                self.subagent_selected += 1;
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.drill_into_subagent(store);
+            }
+            _ => {}
+        }
+    }
+
+    fn drill_into_subagent(&mut self, store: &Store) {
+        let Some(child) = self.viewing_children.get(self.subagent_selected).cloned() else {
+            return;
+        };
+        if let Some(session) = self.viewing_session.clone() {
+            self.viewing_stack.push(ViewingFrame {
+                session,
+                selected_msg: self.viewing_selected_msg,
+                scroll_offset: self.viewing_scroll_offset,
+            });
+        }
+        if self.load_into_viewing(child, store) {
+            if let Some(&first) = self.viewing_match_cache.first() {
+                self.viewing_selected_msg = first;
+            }
+            self.anchor_viewing_scroll();
+        }
+        self.mode = AppMode::Viewing;
+    }
+
+    /// `q`/`Esc` in the viewer: pop back to the parent session if we drilled
+    /// into a subagent, otherwise leave the viewer for the search list.
+    fn back_out_of_viewing(&mut self, store: &Store) {
+        let Some(frame) = self.viewing_stack.pop() else {
+            self.exit_viewing_to_search();
+            return;
+        };
+        let selected_msg = frame.selected_msg;
+        let scroll_offset = frame.scroll_offset;
+        if self.load_into_viewing(frame.session, store) {
+            self.viewing_selected_msg =
+                selected_msg.min(self.viewing_messages.len().saturating_sub(1));
+            self.viewing_scroll_offset = scroll_offset;
+            self.anchor_viewing_scroll();
+        }
+    }
+
+    fn exit_viewing_to_search(&mut self) {
+        self.mode = AppMode::Search;
+        self.viewing_messages.clear();
+        self.viewing_selected_msg = 0;
+        self.viewing_scroll_offset = 0;
+        self.viewing_session_summary = None;
+        self.viewing_lineage = None;
+        self.viewing_session = None;
+        self.viewing_children.clear();
+        self.viewing_stack.clear();
+        self.viewing_search_query.clear();
+        self.viewing_search_status = None;
+        self.viewing_sanitized_lines.clear();
+        self.viewing_match_cache.clear();
+        self.share_popup = None;
     }
 
     fn copy_current_message(&mut self) {
@@ -2457,10 +2594,9 @@ impl App {
     }
 
     fn preview_current_session(&mut self) {
-        let Some(result) = self.results.get(self.selected_index) else {
+        let Some(session) = self.viewing_session.clone() else {
             return;
         };
-        let session = result.session.clone();
         let messages = self.viewing_messages.clone();
         let session_id = session.id.clone();
         let usage_events = crate::db::store::Store::open()
@@ -2479,14 +2615,13 @@ impl App {
     }
 
     fn share_current_session(&mut self) {
-        let Some(result) = self.results.get(self.selected_index) else {
+        let Some(session) = self.viewing_session.clone() else {
             return;
         };
         if self.share_publish_rx.is_some() {
             return;
         }
         let config = self.config.clone();
-        let session = result.session.clone();
         let messages = self.viewing_messages.clone();
         let session_id = session.id.clone();
         let (tx, rx) = mpsc::channel();
@@ -2531,8 +2666,8 @@ impl App {
     }
 
     fn start_export(&mut self) {
-        let session = match self.results.get(self.selected_index) {
-            Some(r) => &r.session,
+        let session = match self.viewing_session.as_ref() {
+            Some(session) => session,
             None => return,
         };
 
@@ -2586,8 +2721,8 @@ impl App {
     }
 
     fn do_export(&mut self, path: &str) {
-        let session = match self.results.get(self.selected_index) {
-            Some(r) => &r.session,
+        let session = match self.viewing_session.as_ref() {
+            Some(session) => session,
             None => return,
         };
 
@@ -2685,6 +2820,11 @@ mod tests {
             viewing_scroll_offset: 0,
             mouse_drag_target: None,
             viewing_session_summary: None,
+            viewing_lineage: None,
+            viewing_session: None,
+            viewing_children: Vec::new(),
+            viewing_stack: Vec::new(),
+            subagent_selected: 0,
             all_sources: vec![
                 source("claude", "Claude"),
                 source("cursor", "Cursor"),
@@ -3371,14 +3511,17 @@ mod tests {
 
     #[test]
     fn imported_session_can_handoff_from_detail_view() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
         let mut app = app_with_sources();
         let mut result = codex_search_result();
         result.session.is_import = true;
+        app.viewing_session = Some(result.session.clone());
         app.results = vec![result];
         app.viewing_messages = vec![message(Role::User, None, 0)];
         app.mode = AppMode::Viewing;
 
-        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE), &store);
         assert!(matches!(app.mode, AppMode::HandoffTarget));
 
         app.handle_handoff_target_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -3388,6 +3531,70 @@ mod tests {
         assert_eq!(pending.action, PendingCommandAction::Handoff);
         assert_eq!(pending.command.program, "codex");
         assert!(pending.command.args[0].contains("This is a handoff, not a native resume."));
+    }
+
+    #[test]
+    fn subagent_drilldown_switches_viewing_session_and_pops_back() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+
+        let mut primary = codex_search_result();
+        primary.session.id = "primary1".to_string();
+        primary.session.source_id = "P".to_string();
+        primary.session.title = "Primary task".to_string();
+        let mut child = codex_search_result();
+        child.session.id = "child1".to_string();
+        child.session.source_id = "C".to_string();
+        child.session.title = "review-diff".to_string();
+        store.insert_session(&primary.session).unwrap();
+        store.insert_session(&child.session).unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO session_parent_links
+                     (session_id, relation, parent_source, parent_source_id)
+                 VALUES (?1, 'spawn', ?2, ?3)",
+                rusqlite::params!["child1", "codex", "P"],
+            )
+            .unwrap();
+
+        app.results = vec![primary];
+        app.selected_index = 0;
+        app.enter_viewing(&store);
+
+        assert_eq!(app.viewing_children.len(), 1, "primary should list its spawn child");
+        assert_eq!(app.viewing_children[0].source_id, "C");
+        assert_eq!(app.viewing_session.as_ref().unwrap().source_id, "P");
+
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE), &store);
+        assert!(matches!(app.mode, AppMode::Subagents));
+
+        app.handle_subagents_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &store);
+        assert!(matches!(app.mode, AppMode::Viewing));
+        assert_eq!(app.viewing_session.as_ref().unwrap().source_id, "C", "drilled into the child");
+        assert_eq!(app.viewing_stack.len(), 1);
+
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), &store);
+        assert!(matches!(app.mode, AppMode::Viewing), "q pops back to the parent, not search");
+        assert_eq!(app.viewing_session.as_ref().unwrap().source_id, "P");
+        assert!(app.viewing_stack.is_empty());
+
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), &store);
+        assert!(matches!(app.mode, AppMode::Search), "q at the root leaves the viewer");
+    }
+
+    #[test]
+    fn subagent_picker_no_op_without_children() {
+        let mut app = app_with_sources();
+        app.viewing_session = Some(codex_search_result().session);
+        app.viewing_children.clear();
+        app.mode = AppMode::Viewing;
+
+        app.open_subagents_picker();
+
+        assert!(matches!(app.mode, AppMode::Viewing), "no picker without subagents");
+        assert_eq!(app.status_message.as_deref(), Some("No subagents"));
     }
 
     #[test]

--- a/src/tui/share_state.rs
+++ b/src/tui/share_state.rs
@@ -16,6 +16,7 @@ pub(crate) enum AppMode {
     Settings,
     Filters,
     HandoffTarget,
+    Subagents,
     ConfirmResume,
 }
 

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -161,6 +161,10 @@ pub(crate) fn render(f: &mut Frame, app: &App) {
             viewing::render_viewing(f, app);
             popups::render_handoff_target_picker(f, app);
         }
+        AppMode::Subagents => {
+            viewing::render_viewing(f, app);
+            popups::render_subagents_picker(f, app);
+        }
         AppMode::ExportInput => {
             viewing::render_viewing(f, app);
             popups::render_export_input(f, app);
@@ -288,6 +292,52 @@ mod tests {
         assert!(!rendered.contains("Session 1"));
         assert!(rendered.contains("Session 2"));
         assert!(rendered.contains("Session 4"));
+    }
+
+    #[test]
+    fn render_viewing_shows_subagent_hint_and_picker() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.viewing_session = Some(numbered_session_result(1).session);
+        app.viewing_children =
+            vec![numbered_session_result(2).session, numbered_session_result(3).session];
+        app.viewing_messages = vec![Message {
+            session_id: "session1".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: None,
+            seq: 0,
+        }];
+
+        app.mode = AppMode::Viewing;
+        let viewing = render_to_text(&app, 80, 12);
+        assert!(viewing.contains("▾ 2 subs"), "header hints at subagents:\n{viewing}");
+
+        app.mode = AppMode::Subagents;
+        let picker = render_to_text(&app, 80, 12);
+        assert!(picker.contains("Subagents (2)"), "picker title:\n{picker}");
+        assert!(picker.contains("Session 2"));
+        assert!(picker.contains("Session 3"));
+    }
+
+    #[test]
+    fn render_subagents_picker_scrolls_selection_into_view() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.viewing_session = Some(numbered_session_result(1).session);
+        app.viewing_children = (1..=20).map(|n| numbered_session_result(n).session).collect();
+        app.subagent_selected = 19;
+        app.mode = AppMode::Subagents;
+
+        let picker = render_to_text(&app, 80, 12);
+
+        assert!(picker.contains("Session 20"), "selected last row is visible:\n{picker}");
+        assert!(picker.contains("Session 16"), "window keeps rows near the selection:\n{picker}");
+        assert!(!picker.contains("Session 15"), "rows above the window are hidden:\n{picker}");
     }
 
     #[test]

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -3,7 +3,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::handoff;
 use crate::tui::app::App;
@@ -12,6 +12,102 @@ use crate::tui::share_state::PendingCommandAction;
 use crate::tui::theme::THEME;
 
 use super::truncate_start;
+
+/// Truncate `s` to at most `max` terminal columns (CJK-aware), appending `…`.
+fn truncate_to_width(s: &str, max: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in s.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + cw > max.saturating_sub(1) {
+            break;
+        }
+        out.push(ch);
+        used += cw;
+    }
+    out.push('…');
+    out
+}
+
+pub(super) fn render_subagents_picker(f: &mut Frame, app: &App) {
+    let area = f.area();
+    let width = area.width.saturating_sub(4).clamp(48, 96).min(area.width);
+    let count = app.viewing_children.len();
+    let desired_height = count as u16 + 5;
+    let height = desired_height.clamp(8, area.height.saturating_sub(2).max(8));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let rect = Rect::new(x, y, width, height);
+
+    let block = Block::default()
+        .title(format!(" Subagents ({count}) "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(THEME.accent))
+        .style(Style::default().bg(THEME.popup_bg));
+
+    // Inner width available for one row, minus the leading " > " marker.
+    let inner = (width as usize).saturating_sub(2);
+    let marker_w = 3;
+
+    // Scroll the row window so the selected subagent stays visible. Rows share
+    // the popup with the border (2), a top blank (1), and a blank + help (2).
+    let visible_rows = (height as usize).saturating_sub(5).max(1);
+    let start = if app.subagent_selected < visible_rows {
+        0
+    } else {
+        app.subagent_selected + 1 - visible_rows
+    };
+    let end = (start + visible_rows).min(count);
+
+    let mut lines = vec![Line::from("")];
+    for (offset, child) in app.viewing_children[start..end].iter().enumerate() {
+        let index = start + offset;
+        let selected = index == app.subagent_selected;
+        let marker = if selected { ">" } else { " " };
+        let style = if selected {
+            Style::default().fg(THEME.selected_fg).bg(THEME.accent).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(THEME.text)
+        };
+        let meta = format!(
+            "{} · {} · {} msgs",
+            app.source_label_for(&child.source),
+            crate::utils::format_age(child.started_at),
+            child.message_count
+        );
+        let meta_w = UnicodeWidthStr::width(meta.as_str());
+        let title_budget = inner.saturating_sub(marker_w + meta_w + 2);
+        let title = truncate_to_width(&child.title, title_budget);
+        let gap =
+            inner.saturating_sub(marker_w + UnicodeWidthStr::width(title.as_str()) + meta_w).max(1);
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {marker} "), style),
+            Span::styled(title, style),
+            Span::styled(" ".repeat(gap), style),
+            Span::styled(
+                meta,
+                if selected { style } else { Style::default().fg(THEME.text_muted) },
+            ),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(" [Enter] ", Style::default().fg(THEME.accent).add_modifier(Modifier::BOLD)),
+        Span::styled("open  ", Style::default().fg(THEME.text)),
+        Span::styled("[Esc] ", Style::default().fg(THEME.accent).add_modifier(Modifier::BOLD)),
+        Span::styled("close", Style::default().fg(THEME.text)),
+    ]));
+
+    let widget = Paragraph::new(lines).block(block);
+    f.render_widget(Clear, rect);
+    f.render_widget(widget, rect);
+}
 
 pub(super) fn render_handoff_target_picker(f: &mut Frame, app: &App) {
     let area = f.area();

--- a/src/tui/ui/search.rs
+++ b/src/tui/ui/search.rs
@@ -10,7 +10,7 @@ use crate::tui::layout::search_layout;
 use crate::tui::search_state::{FilterFocus, PanelFocus};
 use crate::tui::text_layout::wrap_visual_rows;
 use crate::tui::theme::THEME;
-use crate::types::{MatchSource, Role};
+use crate::types::Role;
 
 use super::popups::render_status_bar;
 use super::{render_vertical_scrollbar, row_visible, truncate_label};
@@ -204,11 +204,6 @@ pub(super) fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
             let s = &result.session;
             let age = crate::utils::format_age(s.started_at);
             let source_label = app.source_label_for(&s.source);
-            let match_label = match result.match_source {
-                MatchSource::Fts => "F",
-                MatchSource::Vector => "V",
-                MatchSource::Hybrid => "H",
-            };
             let title: String = s.title.chars().take(40).collect();
             let selected = i == app.selected_index;
             let active_selected = focused && selected;
@@ -225,15 +220,6 @@ pub(super) fn render_result_list(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled(
                     source_label.to_string(),
                     if selected { selected_text_style } else { Style::default().fg(THEME.source) },
-                ),
-                Span::raw(" "),
-                Span::styled(
-                    match_label.to_string(),
-                    if selected {
-                        selected_text_style
-                    } else {
-                        Style::default().fg(THEME.text_muted)
-                    },
                 ),
                 Span::raw(" "),
                 Span::styled(

--- a/src/tui/ui/viewing.rs
+++ b/src/tui/ui/viewing.rs
@@ -17,18 +17,50 @@ use super::{
     truncate_label,
 };
 
+/// Compact parent-lineage segment for the viewing header title. Empty when the
+/// session has no recorded parents. Long lists are truncated by the block title.
+fn lineage_suffix(app: &App) -> String {
+    let Some(lineage) = app.viewing_lineage.as_ref() else {
+        return String::new();
+    };
+    if lineage.parents.is_empty() {
+        return String::new();
+    }
+    let parents = lineage
+        .parents
+        .iter()
+        .map(|parent| {
+            let short_id: String = parent.source_id.chars().take(8).collect();
+            let marker = if parent.indexed { "" } else { " (ext)" };
+            format!("{} {}/{short_id}{marker}", parent.relation.as_str(), parent.source)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(" · parents: {parents}")
+}
+
 pub(super) fn render_viewing(f: &mut Frame, app: &App) {
     let layout = viewing_layout(f.area());
 
     let session_info = app
-        .results
-        .get(app.selected_index)
-        .map(|r| {
-            let s = &r.session;
+        .viewing_session
+        .as_ref()
+        .map(|s| {
             let dir = s.directory.as_deref().unwrap_or("");
             let count = app.viewing_messages.len();
             let pos = app.viewing_selected_msg + 1;
-            format!(" {} — {dir} [{pos}/{count}] ", s.title)
+            let role = app
+                .viewing_lineage
+                .as_ref()
+                .and_then(|lineage| lineage.role)
+                .map(|role| format!(" [{}]", role.as_str()))
+                .unwrap_or_default();
+            let subs = if app.viewing_children.is_empty() {
+                String::new()
+            } else {
+                format!("  ▾ {} subs", app.viewing_children.len())
+            };
+            format!(" {}{role} — {dir} [{pos}/{count}]{}{subs} ", s.title, lineage_suffix(app))
         })
         .unwrap_or_else(|| " Conversation ".to_string());
 
@@ -106,7 +138,7 @@ pub(super) fn render_viewing(f: &mut Frame, app: &App) {
         viewport_start,
     );
 
-    let help_spans = vec![
+    let mut help_spans = vec![
         Span::styled(" ↑/↓", Style::default().fg(THEME.accent)),
         Span::styled(" messages  ", Style::default().fg(THEME.text_muted)),
         Span::styled("/", Style::default().fg(THEME.accent)),
@@ -121,13 +153,19 @@ pub(super) fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" share  ", Style::default().fg(THEME.text_muted)),
         Span::styled("h", Style::default().fg(THEME.accent)),
         Span::styled(" handoff  ", Style::default().fg(THEME.text_muted)),
+    ];
+    if !app.viewing_children.is_empty() {
+        help_spans.push(Span::styled("a", Style::default().fg(THEME.accent)));
+        help_spans.push(Span::styled(" subs  ", Style::default().fg(THEME.text_muted)));
+    }
+    help_spans.extend([
         Span::styled("Ctrl+R", Style::default().fg(THEME.accent)),
         Span::styled(" resume  ", Style::default().fg(THEME.text_muted)),
         Span::styled("Ctrl+O", Style::default().fg(THEME.accent)),
         Span::styled(" app  ", Style::default().fg(THEME.text_muted)),
         Span::styled("Esc/q", Style::default().fg(THEME.accent)),
         Span::styled(" back", Style::default().fg(THEME.text_muted)),
-    ];
+    ]);
 
     let status_line = if let Some(ref input) = app.viewing_search_input {
         Line::from(vec![

--- a/src/tui/viewing_state.rs
+++ b/src/tui/viewing_state.rs
@@ -1,5 +1,32 @@
-use crate::types::{Message, Role, SessionUsageEventRecord};
+use crate::types::{Message, ParentRelation, Role, Session, SessionUsageEventRecord, ThreadRole};
 use crate::usage::TokenTotals;
+
+/// A saved viewer position, pushed onto the back-stack when drilling into a
+/// subagent so `q`/`Esc` can restore the parent session and cursor.
+#[derive(Debug, Clone)]
+pub(crate) struct ViewingFrame {
+    pub(crate) session: Session,
+    pub(crate) selected_msg: usize,
+    pub(crate) scroll_offset: usize,
+}
+
+/// One resolved parent link for the viewing header. `indexed` records whether
+/// the portable `(source, source_id)` parent is present in the local index.
+#[derive(Debug, Clone)]
+pub(crate) struct ViewingParent {
+    pub(crate) relation: ParentRelation,
+    pub(crate) source: String,
+    pub(crate) source_id: String,
+    pub(crate) indexed: bool,
+}
+
+/// Read-only topology snapshot for the currently viewed session, resolved once
+/// on entering the viewer so rendering never touches the store.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ViewingLineage {
+    pub(crate) role: Option<ThreadRole>,
+    pub(crate) parents: Vec<ViewingParent>,
+}
 
 pub(crate) struct SanitizedLine {
     pub(crate) text: String,


### PR DESCRIPTION
### What's changed?

Surface session topology in the TUI viewer, building on the portable topology index (#115).

- **Subagent navigation** — press `a` in the viewer to open a subagent picker (spawn children); Enter drills into a subagent, with a back-stack so `q`/`Esc` pops back to the parent (nesting supported). The header hints `▾ N subs` and adds `a subs` to the help line when subagents exist.
- **Lineage in the viewer** — the header shows the thread role and parent links, resolving whether each portable parent `(source, source_id)` is indexed locally (`(ext)` when not).
- **Viewer actions target the viewed session** — share / export / preview / handoff / resume / open now act on the session in view rather than the search selection. Fixes a latent bug where drilling would otherwise act on the wrong session.
- **Hide subagents from the browse list, reachably** — a subagent is hidden only when its spawn parent is present in the *same scoped result set*, so it stays reachable through the parent's picker. Orphaned subagents, and children whose parent falls outside the active time/project scope or the result limit, stay visible. **Search is exempt**: a query always surfaces a content-matching subagent even when its parent does not match. CLI `recall search` / `session list` defaults are unchanged.
- **Drop the F/V/H match-source indicator** from the result list.

### Why

Topology data (thread role, parent links) landed in the index and CLI in #115 but had no TUI surface. This makes subagent lineage navigable in the viewer and keeps the browse list focused on primary sessions, while guaranteeing that no session — subagent-only content matches, or children whose parent is out of scope — ever becomes unreachable, and leaving the stable CLI contract untouched.

### Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the core test suite (354 passing) are green.
- Tests cover: browse hides a subagent only when its parent is in the same set; a subagent stays visible when its parent is out of the active scope; subagent-only content stays searchable; subagent drill-down + back-stack; picker scroll windowing.

### Considered and deferred

- Skill drill-down (Usage dashboard → sessions) still shows subagents that used a skill; this is targeted evidence, intentionally exempt from the list's subagent hiding.
