### PR TITLE
fix(bench): measure steady state, and pin the measurement environment

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -23,10 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # A benchmark comparison is only meaningful when the measurement
+      # instrument is identical on both sides, so everything that shapes the
+      # generated code or the measurement is pinned to an exact revision. CI's
+      # correctness workflow deliberately keeps tracking current stable; this
+      # one must not, or a toolchain release would show up as a performance
+      # change. Bump these deliberately, on their own commit.
       - name: Setup rust toolchain, cache and cargo-codspeed binary
-        uses: moonrepo/setup-rust@v1
+        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
         with:
-          channel: stable
+          channel: "1.97.1"
           cache-target: release
           bins: cargo-codspeed
 
@@ -34,7 +40,7 @@ jobs:
         run: cargo codspeed build --features bench
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v5
+        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         with:
           mode: simulation
           run: cargo codspeed run

--- a/benches/recall.rs
+++ b/benches/recall.rs
@@ -21,6 +21,22 @@ fn main() {
     divan::main();
 }
 
+/// Under CodSpeed the benchmarked closure runs exactly once between the
+/// instrumentation start and stop, with no warm-up, so first-execution costs
+/// are measured as if they were steady-state work: page faults for a freshly
+/// grown buffer, an allocator that has not yet seen this size class, cold
+/// caches and branch predictors. Those costs vary with the environment rather
+/// than with the code, which is what made `plain_transcript[256]` — a 167 KB
+/// output, past the mmap threshold — swing by 25% between runs of identical
+/// code and produce false regressions.
+///
+/// Running the same work once before the measured region moves those costs out
+/// of it. Every benchmark whose work is side-effect free does this; the numbers
+/// it reports are therefore steady-state, not first-call.
+fn warm_up<T, F: Fn() -> T>(work: &F) {
+    divan::black_box(work());
+}
+
 /// Turning raw agent transcripts into sessions, messages, usage and events.
 mod parsing {
     use super::*;
@@ -31,7 +47,9 @@ mod parsing {
     #[divan::bench(args = TURNS)]
     fn claude_code(bencher: divan::Bencher, turns: usize) {
         let transcript = Transcript::claude(turns);
-        bencher.bench(|| divan::black_box(transcript.parse_claude(true)));
+        let parse = || divan::black_box(transcript.parse_claude(true));
+        warm_up(&parse);
+        bencher.bench(parse);
     }
 
     /// Same transcript without the tool-call event stream, the path taken when
@@ -39,13 +57,17 @@ mod parsing {
     #[divan::bench]
     fn claude_code_messages_only(bencher: divan::Bencher) {
         let transcript = Transcript::claude(64);
-        bencher.bench(|| divan::black_box(transcript.parse_claude(false)));
+        let parse = || divan::black_box(transcript.parse_claude(false));
+        warm_up(&parse);
+        bencher.bench(parse);
     }
 
     #[divan::bench(args = TURNS)]
     fn codex(bencher: divan::Bencher, turns: usize) {
         let transcript = Transcript::codex(turns);
-        bencher.bench(|| divan::black_box(transcript.parse_codex(true)));
+        let parse = || divan::black_box(transcript.parse_codex(true));
+        warm_up(&parse);
+        bencher.bench(parse);
     }
 }
 
@@ -53,9 +75,17 @@ mod parsing {
 mod indexing {
     use super::*;
 
+    /// The measured store is generated per iteration, so the warm-up needs its
+    /// own throwaway store rather than the one being measured.
+    fn warm_up_persist(workload: &IndexWorkload) {
+        let store = BenchStore::empty();
+        divan::black_box(workload.persist(&store));
+    }
+
     #[divan::bench(args = [8, 64])]
     fn persist_sessions(bencher: divan::Bencher, sessions: usize) {
         let workload = IndexWorkload::generate(sessions, 24);
+        warm_up_persist(&workload);
         bencher
             .with_inputs(BenchStore::empty)
             .bench_local_refs(|store| divan::black_box(workload.persist(store)));
@@ -65,6 +95,7 @@ mod indexing {
     #[divan::bench]
     fn persist_long_session(bencher: divan::Bencher) {
         let workload = IndexWorkload::generate(1, 512);
+        warm_up_persist(&workload);
         bencher
             .with_inputs(BenchStore::empty)
             .bench_local_refs(|store| divan::black_box(workload.persist(store)));
@@ -78,25 +109,33 @@ mod search {
     #[divan::bench]
     fn keyword_single_term(bencher: divan::Bencher) {
         let index = SearchIndex::build(64, 24, false);
-        bencher.bench_local(|| divan::black_box(index.keyword_search("embedding")));
+        let search = || divan::black_box(index.keyword_search("embedding"));
+        warm_up(&search);
+        bencher.bench_local(search);
     }
 
     #[divan::bench]
     fn keyword_multi_term(bencher: divan::Bencher) {
         let index = SearchIndex::build(64, 24, false);
-        bencher.bench_local(|| divan::black_box(index.keyword_search("sqlite vector index")));
+        let search = || divan::black_box(index.keyword_search("sqlite vector index"));
+        warm_up(&search);
+        bencher.bench_local(search);
     }
 
     #[divan::bench]
     fn hybrid_fts_and_vector(bencher: divan::Bencher) {
         let index = SearchIndex::build(64, 24, true);
-        bencher.bench_local(|| divan::black_box(index.hybrid_search("sqlite vector index")));
+        let search = || divan::black_box(index.hybrid_search("sqlite vector index"));
+        warm_up(&search);
+        bencher.bench_local(search);
     }
 
     #[divan::bench]
     fn export_jsonl(bencher: divan::Bencher) {
         let index = SearchIndex::build(32, 24, false);
-        bencher.bench_local(|| divan::black_box(index.export_jsonl()));
+        let export = || divan::black_box(index.export_jsonl());
+        warm_up(&export);
+        bencher.bench_local(export);
     }
 }
 
@@ -107,22 +146,35 @@ mod analytics {
     #[divan::bench(args = [1_000, 10_000])]
     fn aggregate_usage(bencher: divan::Bencher, events: usize) {
         let workload = UsageWorkload::generate(events);
-        bencher.bench(|| divan::black_box(workload.aggregate()));
+        let aggregate = || divan::black_box(workload.aggregate());
+        warm_up(&aggregate);
+        bencher.bench(aggregate);
     }
 
     #[divan::bench]
-    fn embedding_text() {
+    fn embedding_text(bencher: divan::Bencher) {
         let content = "\
             Recall keeps every local coding session in one SQLite index, then \
             layers FTS5 keyword search and sqlite-vec similarity on top of it.";
-        divan::black_box(build_embedding_text(divan::black_box("Index a long session"), content));
+        let build = || {
+            divan::black_box(build_embedding_text(
+                divan::black_box("Index a long session"),
+                content,
+            ))
+        };
+        warm_up(&build);
+        bencher.bench(build);
     }
 
     #[divan::bench]
-    fn remote_url_normalization() {
-        divan::black_box(normalize_remote_url(divan::black_box(
-            "git@github.com:samzong/Recall.git",
-        )));
+    fn remote_url_normalization(bencher: divan::Bencher) {
+        let normalize = || {
+            divan::black_box(normalize_remote_url(divan::black_box(
+                "git@github.com:samzong/Recall.git",
+            )))
+        };
+        warm_up(&normalize);
+        bencher.bench(normalize);
     }
 }
 
@@ -133,12 +185,16 @@ mod rendering {
     #[divan::bench(args = [32, 256])]
     fn plain_transcript(bencher: divan::Bencher, messages: usize) {
         let workload = RenderWorkload::generate(messages);
-        bencher.bench(|| divan::black_box(workload.render_plain()));
+        let render = || divan::black_box(workload.render_plain());
+        warm_up(&render);
+        bencher.bench(render);
     }
 
     #[divan::bench(args = [32, 256])]
     fn share_html(bencher: divan::Bencher, messages: usize) {
         let workload = RenderWorkload::generate(messages);
-        bencher.bench(|| divan::black_box(workload.render_html()));
+        let render = || divan::black_box(workload.render_html());
+        warm_up(&render);
+        bencher.bench(render);
     }
 }

--- a/benches/recall.rs
+++ b/benches/recall.rs
@@ -151,27 +151,42 @@ mod analytics {
         bencher.bench(aggregate);
     }
 
-    #[divan::bench]
-    fn embedding_text(bencher: divan::Bencher) {
+    /// The instrumented region costs a few microseconds no matter what runs
+    /// inside it. These two helpers take ~80 ns and ~226 ns per call, so a
+    /// single call would report almost pure overhead — which is how a URL parse
+    /// came to be measured at 31.6 us, and why its reported value moved by
+    /// double digits without the code changing. Measure a batch instead, so the
+    /// work dominates. The batch size is part of the benchmark name, so the
+    /// reported figure is never mistaken for a per-call cost.
+    const MICRO_BATCH: usize = 4_096;
+
+    #[divan::bench(args = [MICRO_BATCH])]
+    fn embedding_text(bencher: divan::Bencher, batch: usize) {
         let content = "\
             Recall keeps every local coding session in one SQLite index, then \
             layers FTS5 keyword search and sqlite-vec similarity on top of it.";
         let build = || {
-            divan::black_box(build_embedding_text(
-                divan::black_box("Index a long session"),
-                content,
-            ))
+            let mut bytes = 0;
+            for _ in 0..batch {
+                bytes +=
+                    build_embedding_text(divan::black_box("Index a long session"), content).len();
+            }
+            divan::black_box(bytes)
         };
         warm_up(&build);
         bencher.bench(build);
     }
 
-    #[divan::bench]
-    fn remote_url_normalization(bencher: divan::Bencher) {
+    #[divan::bench(args = [MICRO_BATCH])]
+    fn remote_url_normalization(bencher: divan::Bencher, batch: usize) {
         let normalize = || {
-            divan::black_box(normalize_remote_url(divan::black_box(
-                "git@github.com:samzong/Recall.git",
-            )))
+            let mut matched = 0;
+            for _ in 0..batch {
+                matched +=
+                    normalize_remote_url(divan::black_box("git@github.com:samzong/Recall.git"))
+                        .map_or(0, |slug| slug.len());
+            }
+            divan::black_box(matched)
         };
         warm_up(&normalize);
         bencher.bench(normalize);


### PR DESCRIPTION
Follow-up to #118, whose CodSpeed check failed with `Performance Regression: -28.05%` on `plain_transcript[256]` — a benchmark whose code that PR never touched.

## What actually happened

Under CodSpeed, `bencher.bench(...)` runs the closure **exactly once** between instrumentation start and stop, with no warm-up and no sampling (`codspeed-divan-compat`'s `bench_local_values`: generate input → `start_benchmark()` → run once → `end_benchmark()`). Every number in this suite is therefore a single cold execution.

`plain_transcript[256]` renders a **167 KB** string. That is past glibc's 128 KiB mmap threshold, so the one measured execution pays for a fresh `mmap` and the page faults behind it — costs that depend on the environment, not on our code. `plain_transcript[32]` (21 KB) stays inside the arena, and `share_html[256]` does ~10× more work so the same fixed cost is proportionally invisible. That is exactly the pattern we saw.

The same unchanged rendering code has measured:

| when | commit | runner | `plain_transcript[256]` |
| --- | --- | --- | --- |
| 08-02 | 4092e31 (the PR that added the suite) | 5.0.1 | 1.9 ms |
| 08-03 | 29bbdde (main) | 5.0.1 | 1.8 ms |
| 08-11 | value used as #118's BASE | — | **1.4 ms** |
| 08-11 | #118 HEAD | 5.0.2 | 1.9 ms |

The 1.4 ms baseline was the outlier. Re-measuring main and re-running #118 turned the check green with no code change.

## Changes

**Warm up before the measured region.** Each benchmark runs its work once before handing the closure to the bencher — outside the instrumented window under CodSpeed, and outside the timed section under wall-clock divan. Measured locally, 12 processes each timing a single execution of `render_plain` on the 256-message workload:

| | median | fastest | slowest | spread |
| --- | --- | --- | --- | --- |
| cold | 69.0 µs | 56.0 µs | 118.5 µs | **2.12×** |
| warmed | 46.4 µs | 41.6 µs | 58.3 µs | **1.40×** |

About a third of a cold measurement is first-execution cost, and it is the more variable third.

`embedding_text` and `remote_url_normalization` measured the whole function body rather than a closure, which is why a single URL parse reported 31.6 µs. They now measure a warmed closure like everything else. (This also explains the `+80%` "improvement" CodSpeed attributed to #118's `normalize_remote_url` rewrite — the rewrite is real, but a measurement that is ~99% fixed overhead could not have shown its true size.)

The two `indexing` benchmarks build a throwaway store for their warm-up so the measured store stays untouched.

**Pin the measurement environment.** `CodSpeedHQ/action@v5` → `0ca9cbbf` (v5.0.2) and `moonrepo/setup-rust@v1` → `abb2d323` (v1.3.0) with `channel: "1.97.1"`. A comparison is only meaningful when the instrument is identical on both sides; #118's two sides were measured by runner 5.0.1 and 5.0.2. The correctness workflow deliberately keeps tracking current stable — only the benchmark toolchain is frozen, and the workflow says so, so nobody "fixes" it later.

## Expect a large reported improvement

Every benchmark's absolute value drops once first-call cost leaves the measurement, so the first run against this commit will report improvements across the board. That is a baseline reset, not an optimization.

## Verification

- `make check` green.
- Local `cargo bench` unchanged (`plain_transcript[256]` median 38.06 µs vs 38.1 µs on main), confirming the same work is still being measured — wall-clock divan already warmed up via repeated iterations, so only the single-shot CodSpeed path changes.

## Second commit: the sub-microsecond benchmarks

The first commit turned the check green for the rendering benchmarks but left `embedding_text` reporting a 12% regression. Measured locally, `build_embedding_text` takes **~80 ns** and `normalize_remote_url` **~226 ns** per call, while CodSpeed reported them at 11–12.5 µs and 17.5–31.6 µs. Over 99% of those numbers was the fixed cost of the instrumented region, so their reported value moved with the environment and never with the code — including the `+80%` "improvement" #118 appeared to make to `normalize_remote_url`, which no measurement at that granularity could have shown.

Both now measure a batch of 4096 calls, which puts the fixed cost at 1–3% of the reading. The batch size is part of the benchmark name (`embedding_text[4096]`), so the number cannot be misread as a per-call cost, and CodSpeed registers them as new benchmarks rather than reporting a 30× phantom regression.

## Result

`Performance Gate Passed`: 20 untouched, 2 new (`embedding_text[4096]` 5.6 ms, `remote_url_normalization[4096]` 11.5 ms), 0 regressions.

One green run is not proof that the flapping is gone — that takes a few runs over time. If `plain_transcript[256]` still swings, the next lever is pre-sizing the `String` in `transcript::render_plain`, which grows a 167 KB buffer from `String::new()`. That is worth doing on its own merits but changes production code, so it is not in this PR.
