### PR TITLE
perf(sync): account for what each adapter actually costs

### DIFF
--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -75,7 +75,9 @@ where
     let mut stats = SyncScanStats::default();
 
     for entry in entries {
+        stats.candidates += 1;
         let Some(mtime_ms) = stat_mtime_ms(&entry.stat_target) else {
+            stats.rejected_before_parse += 1;
             continue;
         };
 
@@ -99,6 +101,7 @@ where
             && mtime_ms < cutoff
         {
             stats.filtered_sessions += 1;
+            stats.rejected_before_parse += 1;
             continue;
         }
 
@@ -121,9 +124,11 @@ where
             )
         {
             stats.skipped_sessions += 1;
+            stats.rejected_before_parse += 1;
             continue;
         }
 
+        stats.parsed += 1;
         if let Some(raw) = parse_fn(entry, mtime_ms)? {
             sessions.push(raw);
         }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -145,6 +145,15 @@ pub(crate) fn last_timestamp(
 pub(crate) struct SyncScanStats {
     pub(crate) skipped_sessions: u32,
     pub(crate) filtered_sessions: u32,
+    /// Every session the adapter considered, before any filtering. The three
+    /// counters below partition it, so `candidates - skipped - filtered -
+    /// parsed` is the number an adapter dropped without accounting for it.
+    pub(crate) candidates: u32,
+    /// Candidates rejected without reading their transcript. This is the
+    /// counter a scan-level optimisation has to move; sessions dropped after
+    /// parsing cost the same as sessions that were kept.
+    pub(crate) rejected_before_parse: u32,
+    pub(crate) parsed: u32,
 }
 
 pub(crate) struct SyncScanResult {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -116,6 +116,17 @@ struct SyncStats {
     out_of_scope: u32,
 }
 
+/// Per-adapter accounting for `--verbose`. Without it a sync reports only
+/// totals, which cannot show whether a candidate was rejected before its
+/// transcript was read — the only rejection that saves work.
+struct AdapterRun {
+    label: String,
+    scan: adapters::SyncScanStats,
+    out_of_scope: u32,
+    touched: u32,
+    elapsed_ms: u128,
+}
+
 impl SyncStats {
     fn touched(&self) -> u32 {
         self.new_sessions + self.updated_sessions + self.reprocessed_sessions
@@ -199,6 +210,7 @@ struct SyncJob {
     path_excluder: Option<globset::GlobSet>,
     repo_cache: RepoIdentityCache,
     stats: SyncStats,
+    adapter_runs: Vec<AdapterRun>,
 }
 
 impl SyncJob {
@@ -224,6 +236,7 @@ impl SyncJob {
             path_excluder,
             repo_cache: RepoIdentityCache::default(),
             stats: SyncStats::default(),
+            adapter_runs: Vec::new(),
         })
     }
 
@@ -257,6 +270,10 @@ impl SyncJob {
             return Ok(());
         }
 
+        let started = std::time::Instant::now();
+        let touched_before = self.stats.touched();
+        let out_of_scope_before = self.stats.out_of_scope;
+
         let mut purged_excluded_ids = HashSet::new();
         if let Some(matcher) = &self.path_excluder {
             let n = delete_excluded_sessions_for_source(
@@ -269,7 +286,7 @@ impl SyncJob {
             self.stats.excluded_out += n;
         }
 
-        let Some(raw_sessions) =
+        let Some((raw_sessions, scan)) =
             self.scan_sessions(adapter, source_id, label, &mut purged_excluded_ids)?
         else {
             return Ok(());
@@ -279,6 +296,14 @@ impl SyncJob {
         for raw in raw_sessions {
             self.process_raw_session(source_id, raw, &mut existing, &mut purged_excluded_ids)?;
         }
+
+        self.adapter_runs.push(AdapterRun {
+            label: label.to_string(),
+            scan,
+            out_of_scope: self.stats.out_of_scope - out_of_scope_before,
+            touched: self.stats.touched() - touched_before,
+            elapsed_ms: started.elapsed().as_millis(),
+        });
 
         info!("{label} done");
         Ok(())
@@ -290,7 +315,7 @@ impl SyncJob {
         source_id: &str,
         label: &str,
         purged_excluded_ids: &mut HashSet<String>,
-    ) -> Result<Option<Vec<adapters::RawSession>>> {
+    ) -> Result<Option<(Vec<adapters::RawSession>, adapters::SyncScanStats)>> {
         if self.options.verbose {
             println!("Scanning {label}...");
         }
@@ -317,10 +342,8 @@ impl SyncJob {
                 }
             }
         };
-        let (raw_sessions, pre_skipped, pre_filtered) = match optimized {
-            Some(scan) => {
-                (scan.sessions, scan.stats.skipped_sessions, scan.stats.filtered_sessions)
-            }
+        let (raw_sessions, scan_stats) = match optimized {
+            Some(scan) => (scan.sessions, scan.stats),
             None => {
                 let raw_sessions = match adapter.scan() {
                     Ok(s) => s,
@@ -331,11 +354,17 @@ impl SyncJob {
                         return Ok(None);
                     }
                 };
-                (raw_sessions, 0, 0)
+                // A full scan parses everything it finds; there is no
+                // candidate stage to account for separately.
+                let parsed = raw_sessions.len() as u32;
+                (
+                    raw_sessions,
+                    adapters::SyncScanStats { candidates: parsed, parsed, ..Default::default() },
+                )
             }
         };
-        self.stats.skipped += pre_skipped;
-        self.stats.filtered_out += pre_filtered;
+        self.stats.skipped += scan_stats.skipped_sessions;
+        self.stats.filtered_out += scan_stats.filtered_sessions;
         if let Some(matcher) = &self.path_excluder {
             let n = delete_excluded_sessions_for_source(
                 &self.store,
@@ -349,7 +378,7 @@ impl SyncJob {
         if self.options.verbose {
             println!("  Found {} sessions", raw_sessions.len());
         }
-        Ok(Some(raw_sessions))
+        Ok(Some((raw_sessions, scan_stats)))
     }
 
     fn load_existing_state(&mut self, source_id: &str) -> Result<ExistingState> {
@@ -679,6 +708,45 @@ impl SyncJob {
         Ok(())
     }
 
+    /// The evidence a scan-level optimisation has to move: how many candidates
+    /// each adapter considered, how many it rejected without reading the
+    /// transcript, and how many transcripts it actually parsed.
+    fn report_adapter_breakdown(&self) {
+        let runs: Vec<&AdapterRun> = self.adapter_runs.iter().collect();
+        if runs.is_empty() {
+            return;
+        }
+
+        println!();
+        println!(
+            "{:<6} {:>10} {:>14} {:>8} {:>8} {:>9} {:>8}",
+            "Source", "candidates", "pre-parse rej", "parsed", "scoped", "touched", "ms"
+        );
+        for run in &runs {
+            println!(
+                "{:<6} {:>10} {:>14} {:>8} {:>8} {:>9} {:>8}",
+                run.label,
+                run.scan.candidates,
+                run.scan.rejected_before_parse,
+                run.scan.parsed,
+                run.out_of_scope,
+                run.touched,
+                run.elapsed_ms
+            );
+        }
+        let total = |f: fn(&AdapterRun) -> u32| runs.iter().map(|run| f(run)).sum::<u32>();
+        println!(
+            "{:<6} {:>10} {:>14} {:>8} {:>8} {:>9} {:>8}",
+            "total",
+            total(|run| run.scan.candidates),
+            total(|run| run.scan.rejected_before_parse),
+            total(|run| run.scan.parsed),
+            total(|run| run.out_of_scope),
+            total(|run| run.touched),
+            runs.iter().map(|run| run.elapsed_ms).sum::<u128>()
+        );
+    }
+
     fn report_progress(&self) -> Result<()> {
         let SyncStats {
             new_sessions,
@@ -713,6 +781,7 @@ impl SyncJob {
                 print!(", {excluded_out} excluded by excluded_paths");
             }
             println!();
+            self.report_adapter_breakdown();
             println!(
                 "Settings: sources [{}], time scope [{}]",
                 self.labels


### PR DESCRIPTION
`recall sync` reported only totals, so two questions could not be answered: which adapter the time goes to, and whether a candidate was rejected **before** its transcript was read — the only rejection that saves work.

This adds that accounting. It changes no sync behaviour.

## What it adds

`SyncScanStats` now partitions every scan into `candidates`, `rejected_before_parse` and `parsed`, `SyncJob` carries per-adapter wall clock, and `--verbose` prints the breakdown:

```
Source candidates  pre-parse rej   parsed   scoped   touched       ms
CC            184            182        2        0         0        6
OC              0              0        0        0         0      340
CDX          3935           3729      206        4         0      120
PI             26             26        0        0         0        1
GRK           113            103       10        0         0        4
CUR             0              0        0      187         0     1230
total        4258           4040      218      191         0     1701
```

Adapters that scan without the shared `run_file_scan` seam report zero candidates. That is not a gap in the instrumentation — it is the finding: their work was never accounted for anywhere.

## What it already found

Measured on a real index of ~4,800 sessions, release build, warm caches. End to end: scoped sync 1.87 s, global sync 5.48 s.

- **The file-based adapters are already 95% pre-filtered.** 4,258 candidates, 4,040 rejected on mtime, 218 transcripts parsed — and only 4 of those parses were outside the project scope. Adding scope pre-filtering to that seam, which is what the scoped-sync plan proposed next, would remove about four parses and single-digit milliseconds. That work is now measured and dropped rather than assumed.
- **92% of a scoped sync is Cursor (1,230 ms) and OpenCode (340 ms)**, the two adapters that report no candidates. Cursor costs the same whether the sync is scoped or global (1,230 ms vs 1,302 ms), so scoping buys nothing there today: it materialises 187 sessions from other projects on every run and the write guard then discards them.

Both follow-ups are being handled separately; this PR is only the instrument that showed them.

## Verification

`make check` green. The numbers above are reproducible with `recall sync --verbose`; cold and warm runs differ by ~2x, so comparisons must use warm runs.