### PR TITLE
fix(release): scope release-please to the root package and pre-1.0 bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ against. Build a single extension with `cargo build -p recall-<name>`.
 
 Core releases run through release-please: every merge to `main` updates a
 release PR that carries the next version, the `CHANGELOG.md` entries derived
-from the conventional commits, and the `Cargo.toml`/`Cargo.lock` bump. Merging
+from the conventional commits, and the root `Cargo.toml` bump. It deliberately does not use the `rust` release type: that rewrites every workspace member to the released version, which would republish the independently versioned extensions. `Cargo.lock` is therefore not updated by the release PR and self-heals on the next build. Merging
 that PR is what cuts the release — it creates the `v*` tag and the GitHub
 release, and then calls `release.yml` to build and attach the binaries.
 `release.yml` is not triggered by the tag push, because whether such an event

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,10 +2,18 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
       "package-name": "recall",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.package.version"
+        }
+      ],
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
The first release PR (#124) came out wrong in two independent ways. Both were named as things to verify in #123 and both landed.

## 1. It proposed 1.0.0

release-please bumps the **major** on a breaking change unless it is told the project is pre-1.0, so #118's `feat!` took `0.3.0` straight to `1.0.0`. The schema option is documented as:

> `bump-minor-pre-major`: Breaking changes only bump semver minor if version < 1.0.0

The next version has to be **0.4.0** — `recall-reflect` 0.2.0 already declares `min_recall: 0.4.0`, and a core at 1.0.0 would satisfy it by accident while skipping an entire version line for no reason.

## 2. It rewrote both extension crates

```
extensions/recall-probe/Cargo.toml    +1 -1   → version = "1.0.0"
extensions/recall-reflect/Cargo.toml  +1 -1   → version = "1.0.0"
```

The `rust` release type rewrites every member of a Cargo workspace to the released version. These crates version independently, and per `extensions/AGENTS.md` **a version bump in their manifest is exactly what their release workflow reads as release intent** — merging #124 would have published `recall-probe` and `recall-reflect` at 1.0.0 off the core's version line, and broken reflect's `min_recall` contract in the catalog.

`release-type: simple` with an `extra-files` updater targeting `$.package.version` touches the root manifest only.

## Known consequence

`Cargo.lock` is no longer updated by the release PR, so it keeps the old version for the root package until the next build regenerates it. Nothing in CI builds with `--locked`, so this does not fail anything; it is recorded in AGENTS.md rather than left to be rediscovered.

## Verification

`make check` green. The real verification is the next release PR: release-please recomputes its branch when the config changes, so after this merges, #124 must show **0.4.0** and touch **no file under `extensions/`**. If either is still wrong, do not merge it.