### PR TITLE
fix(deps): close known RustSec vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-audit --locked --version 0.22.2
       - uses: actions/cache@v5
         with:
           path: ~/.cache/ort.pyke.io

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ published to crates.io — these are application binaries, not library crates.
 ## Commands
 
 ```bash
-make check                            # full gate: fmt --check → clippy -D warnings → test
+make check                            # full gate: audit → fmt --check → clippy -D warnings → test
 make build                            # debug build
 make run                              # launch TUI
 make sync                             # cargo run -- sync (FORCE=1 reprocesses all)
@@ -45,7 +45,8 @@ PR is the release intent — after merge, a workflow creates the
 `recall-<name>-v<version>` tag, builds binaries, and regenerates the catalog.
 
 One-time setup: `git config core.hooksPath .githooks` enables the DCO signoff
-hook, and `brew install git-cliff` is required to cut a release.
+hook. Install `cargo-audit 0.22.2` for `make check`; `brew install git-cliff`
+is also required to cut a release.
 
 ## Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2222,9 +2222,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -233,6 +233,7 @@ current application release boundary, not a package metadata bug.
 
 ```bash
 cargo install cargo-release
+cargo install cargo-audit --locked --version 0.22.2
 git config core.hooksPath .githooks   # enables auto DCO signoff
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,20 @@ release: ## Release build (LTO + strip)
 
 # ── Quality ──────────────────────────────────────────────────────────────────
 
-.PHONY: check test lint fmt
+.PHONY: check audit test lint fmt
 
-check: ## Full quality gate — format, lint, test
-	@printf '\n$(BOLD)[1/3] Checking format$(RESET)\n'
+check: audit ## Full quality gate — dependency audit, format, lint, test
+	@printf '\n$(BOLD)[2/4] Checking format$(RESET)\n'
 	$(CARGO) fmt --all -- --check
-	@printf '\n$(BOLD)[2/3] Running clippy$(RESET)\n'
+	@printf '\n$(BOLD)[3/4] Running clippy$(RESET)\n'
 	$(CARGO) clippy --workspace --all-targets --features bench -- -D warnings
-	@printf '\n$(BOLD)[3/3] Running tests$(RESET)\n'
+	@printf '\n$(BOLD)[4/4] Running tests$(RESET)\n'
 	$(CARGO) test --workspace
 	@printf '\n$(GREEN)  ✓ All checks passed$(RESET)\n\n'
+
+audit: ## Check locked Rust dependencies for known vulnerabilities
+	@printf '\n$(BOLD)[1/4] Auditing dependencies$(RESET)\n'
+	$(CARGO) audit --file Cargo.lock
 
 test: ## Run tests
 	$(CARGO) test --workspace


### PR DESCRIPTION
## Summary

- upgrade crossbeam-epoch, anyhow, and memmap2 to their patched compatible releases
- add cargo audit to the canonical make check gate
- install the pinned audit tool in CI and document local setup

## Verification

- PATH="$PWD/.local/tools/cargo-audit/bin:$PATH" make check
- actionlint .github/workflows/ci.yml
- cargo metadata --locked --no-deps --format-version 1

cargo audit now reports zero vulnerabilities. The remaining informational warnings are bounded to lru methods not called by Ratatui in this dependency version, plus the build-time-only unmaintained paste macro.