### PR TITLE
fix(config): fail closed on invalid settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -198,21 +198,17 @@ mod tests {
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
-    #[cfg(unix)]
     #[test]
-    fn failed_atomic_save_preserves_existing_config() {
-        use std::os::unix::fs::PermissionsExt;
-
+    fn failed_atomic_save_preserves_existing_target() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        let original = br#"{"disabled_sources":["codex"]}"#;
-        std::fs::write(&path, original).unwrap();
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o500)).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        let marker = path.join("existing");
+        std::fs::write(&marker, "keep").unwrap();
 
         let result = AppConfig::default().save_to(&path);
 
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
         assert!(result.is_err());
-        assert_eq!(std::fs::read(&path).unwrap(), original);
+        assert_eq!(std::fs::read_to_string(marker).unwrap(), "keep");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -88,25 +89,46 @@ pub(crate) struct ShareConfig {
 impl AppConfig {
     pub(crate) fn load() -> Result<Self> {
         let path = config_path()?;
-        if !path.exists() {
-            return Ok(Self::default());
-        }
-
-        let content = std::fs::read_to_string(path)?;
-        let config: Self = serde_json::from_str(&content)?;
-        Ok(config)
+        Self::load_from(&path)
     }
 
-    pub(crate) fn load_or_default() -> Self {
-        Self::load().unwrap_or_default()
+    fn load_from(path: &Path) -> Result<Self> {
+        let content = match std::fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::default());
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to read {}", path.display()));
+            }
+        };
+        serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse {}", path.display()))
     }
 
     pub(crate) fn save(&self) -> Result<()> {
         let path = config_path()?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(path, serde_json::to_string_pretty(self)?)?;
+        self.save_to(&path)
+    }
+
+    fn save_to(&self, path: &Path) -> Result<()> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("config path has no parent: {}", path.display()))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+
+        let content = serde_json::to_vec_pretty(self)?;
+        let mut temp = tempfile::NamedTempFile::new_in(parent)
+            .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+        temp.write_all(&content)
+            .with_context(|| format!("failed to write temporary config in {}", parent.display()))?;
+        temp.as_file()
+            .sync_all()
+            .with_context(|| format!("failed to sync temporary config in {}", parent.display()))?;
+        temp.persist(path)
+            .map_err(|error| error.error)
+            .with_context(|| format!("failed to replace {}", path.display()))?;
         Ok(())
     }
 
@@ -116,11 +138,6 @@ impl AppConfig {
         self.disabled_sources.retain(|id| known_sources.iter().any(|(known, _)| known == id));
         self.disabled_sources.sort();
         self.disabled_sources.dedup();
-
-        let enabled_count = known_sources.len().saturating_sub(self.disabled_sources.len());
-        if enabled_count == 0 {
-            self.disabled_sources.clear();
-        }
     }
 
     pub(crate) fn is_source_enabled(&self, source_id: &str) -> bool {
@@ -149,4 +166,53 @@ pub(crate) fn config_path() -> Result<PathBuf> {
     let dir =
         dirs::config_dir().ok_or_else(|| anyhow::anyhow!("cannot determine config directory"))?;
     Ok(dir.join("recall").join("config.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn existing_invalid_config_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{ invalid json").unwrap();
+
+        let error = AppConfig::load_from(&path).unwrap_err();
+
+        assert!(error.to_string().contains("failed to parse"), "{error:#}");
+    }
+
+    #[test]
+    fn atomic_save_replaces_existing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, "{}").unwrap();
+        let mut config = AppConfig::default();
+        config.disabled_sources.push("codex".to_string());
+
+        config.save_to(&path).unwrap();
+
+        let reloaded = AppConfig::load_from(&path).unwrap();
+        assert_eq!(reloaded.disabled_sources, vec!["codex"]);
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_atomic_save_preserves_existing_config() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let original = br#"{"disabled_sources":["codex"]}"#;
+        std::fs::write(&path, original).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = AppConfig::default().save_to(&path);
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+    }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -23,7 +23,7 @@ struct SourceSummary {
 pub(crate) fn run(format: InfoFormat) -> Result<()> {
     let all = adapters::all_adapters();
     let labels = adapters::source_labels();
-    let mut config = AppConfig::load_or_default();
+    let mut config = AppConfig::load()?;
     config.normalize_sources(&labels);
     let store = Store::open()?;
     let progress = store.semantic_progress().unwrap_or_default();

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -1523,14 +1523,14 @@ fn config_disables_persist_across_reloads() {
 }
 
 #[test]
-fn config_drops_obsolete_disabled_entries() {
+fn config_drops_obsolete_disabled_entries_without_reenabling_known_sources() {
     let mut config = AppConfig::default();
     config.disabled_sources = vec!["ghost-adapter".to_string(), "claude-code".to_string()];
     let known = vec![("claude-code".to_string(), "CC".to_string())];
     config.normalize_sources(&known);
 
     assert!(!config.disabled_sources.iter().any(|id| id == "ghost-adapter"));
-    assert!(config.is_source_enabled("claude-code"), "cleared to avoid zero-source state");
+    assert!(!config.is_source_enabled("claude-code"), "explicit all-disabled state must survive");
 }
 
 #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -558,7 +558,7 @@ fn cmd_session_share(
     let session = resolve_session_ref(&store, &sources, id, source_filter, source_id)?;
     let messages = store.get_messages(&session.id)?;
     let usage_events = store.list_usage_events_for_session(&session.id)?;
-    let config = AppConfig::load_or_default();
+    let config = AppConfig::load()?;
     let tldr_markdown = tldr_file.and_then(read_tldr_file);
     let render_options = crate::share::ShareRenderOptions { tldr_markdown };
     let preview = crate::share::preview_session_with_options(

--- a/src/share_init.rs
+++ b/src/share_init.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use crate::config::AppConfig;
 
 pub(crate) fn run(project_name: Option<String>, publish_dir: Option<PathBuf>) -> Result<()> {
-    let mut config = AppConfig::load_or_default();
+    let mut config = AppConfig::load()?;
     let existing = config.share.clone();
     if let Some(ref share) = existing {
         println!("Share already initialized");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -197,8 +197,8 @@ impl ExistingState {
 
 pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
     let available_adapters = adapters::all_adapters();
-    SyncJob::new(options, Store::open()?, AppConfig::load_or_default(), &available_adapters)?
-        .run(&available_adapters)
+    let config = AppConfig::load()?;
+    SyncJob::new(options, Store::open()?, config, &available_adapters)?.run(&available_adapters)
 }
 
 struct SyncJob {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2364,8 +2364,7 @@ impl App {
             self.config.sync_window = self.config.sync_window.next();
         } else if let Some((source_id, _)) = self.all_sources.get(self.settings_selected - 1) {
             if self.config.is_source_enabled(source_id) {
-                let enabled_count =
-                    self.all_sources.len().saturating_sub(self.config.disabled_sources.len());
+                let enabled_count = self.enabled_sources().len();
                 if enabled_count <= 1 {
                     self.status_message = Some("At least one source must stay enabled".to_string());
                     return;
@@ -3645,11 +3644,12 @@ mod tests {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
         let mut config = AppConfig::default();
-        config.disabled_sources = vec!["codex".to_string(), "cline".to_string()];
+        config.disabled_sources = vec!["cline".to_string()];
 
-        let app = App::new(&store, vec![source("codex", "Codex")], config);
+        let app = App::new(&store, vec![source("codex", "Codex"), source("grok", "Grok")], config);
 
-        assert_eq!(app.config.disabled_sources, vec!["codex".to_string(), "cline".to_string()]);
+        assert_eq!(app.config.disabled_sources, vec!["cline".to_string()]);
+        assert_eq!(app.enabled_sources().len(), 2);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -209,10 +209,8 @@ impl App {
     pub(crate) fn new(
         store: &Store,
         all_sources: Vec<(String, String)>,
-        mut config: AppConfig,
+        config: AppConfig,
     ) -> Self {
-        config.normalize_sources(&all_sources);
-
         let (total_sessions, total_messages) = store.stats().unwrap_or((0, 0));
         let semantic_progress = store.semantic_progress().unwrap_or_default();
         let background_status = store.background_job_status("pipeline").unwrap_or_default();
@@ -3640,6 +3638,18 @@ mod tests {
         let app = App::new(&store, vec![source("codex", "Codex")], AppConfig::default());
 
         assert_eq!(app.sort_order, SortOrder::Newest);
+    }
+
+    #[test]
+    fn app_preserves_disabled_sources_outside_visible_subset() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut config = AppConfig::default();
+        config.disabled_sources = vec!["codex".to_string(), "cline".to_string()];
+
+        let app = App::new(&store, vec![source("codex", "Codex")], config);
+
+        assert_eq!(app.config.disabled_sources, vec!["codex".to_string(), "cline".to_string()]);
     }
 
     #[test]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -25,15 +25,18 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
     use crate::tui::ui;
 
     let usage_mode = usage_start.is_some();
+    let known_sources = adapters::source_labels();
+    let sources = if usage_start.is_some() {
+        adapters::dashboard_source_labels()
+    } else {
+        known_sources.clone()
+    };
+    let mut config = AppConfig::load()?;
+    config.normalize_sources(&known_sources);
     let store = Store::open()?;
     if !cfg!(debug_assertions) {
         semantic::ensure_background_worker(true)?;
     }
-    let sources = if usage_start.is_some() {
-        adapters::dashboard_source_labels()
-    } else {
-        adapters::source_labels()
-    };
 
     struct TerminalGuard;
     impl Drop for TerminalGuard {
@@ -51,9 +54,6 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
-
-    let mut config = AppConfig::load_or_default();
-    config.normalize_sources(&sources);
 
     let mut app = App::new(&store, sources, config);
     if cfg!(debug_assertions) {


### PR DESCRIPTION
## Summary

- default only when the config file is missing; propagate read and parse errors from every production caller
- persist config through a same-directory temporary file, sync it, then atomically replace the target
- preserve an explicit all-disabled source configuration, including when the usage TUI shows only a source subset

## Root cause

`AppConfig::load_or_default()` discarded every load error, while `normalize_sources()` cleared `disabled_sources` when all known sources were disabled. `save()` also wrote directly to the target file.

## Verification

- `make check`
- corrupt config: `recall info --format json` exits 1 with the config path and parse error
- unreadable config: `recall info --format json` exits 1 with permission denied
- all 12 sources disabled: `recall sync --verbose` reports `scanned=0, skipped=12`
- atomic save success and failure-preserves-old-content regression tests