### PR TITLE
fix(sync): honor excluded transcript paths

### DIFF
--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -163,6 +163,7 @@ fn parse_antigravity_session_for_entry(
     entry: FileScanEntry,
     mtime_ms: i64,
 ) -> anyhow::Result<Option<RawSession>> {
+    let source_file_path = entry.stat_target.to_str().map(str::to_string);
     let mut raw = match parse_antigravity_transcript(&entry.stat_target, &entry.session_id) {
         Ok(Some(raw)) => raw,
         Ok(None) => return Ok(None),
@@ -173,6 +174,7 @@ fn parse_antigravity_session_for_entry(
     };
     raw.directory = entry.directory;
     raw.updated_at = Some(mtime_ms);
+    raw.source_file_path = source_file_path;
     Ok(Some(raw))
 }
 
@@ -376,6 +378,10 @@ mod tests {
         );
         let mtime = file_scan::stat_mtime_ms(&transcript).unwrap();
         let store = setup_store();
+
+        let fresh = scan_for_sync_impl(&root, &store, None).unwrap();
+        assert_eq!(fresh.sessions[0].source_file_path.as_deref(), transcript.to_str());
+
         store.insert_session(&make_existing_session(conversation_id, mtime, 1)).unwrap();
 
         let result = scan_for_sync_impl(&root, &store, None).unwrap();

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -129,15 +129,18 @@ fn parse_cline_task(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<Optio
     }
 
     let directory = extract_directory(&entry.stat_target);
+    let source_file_path = entry.stat_target.to_str().map(str::to_string);
 
-    Ok(Some(RawSession::search_only(
+    let mut raw = RawSession::search_only(
         entry.session_id,
         directory,
         started_at,
         Some(mtime_ms),
         None,
         messages,
-    )))
+    );
+    raw.source_file_path = source_file_path;
+    Ok(Some(raw))
 }
 
 fn load_ui_messages(path: &Path) -> anyhow::Result<Vec<RawMessage>> {
@@ -495,6 +498,7 @@ mod tests {
         assert_eq!(raw.source_id, "1765706891317");
         assert_eq!(raw.started_at, 1765706891317);
         assert_eq!(raw.updated_at, Some(mtime));
+        assert_eq!(raw.source_file_path.as_deref(), path.to_str());
         assert_eq!(raw.messages.len(), 1);
 
         let _ = fs::remove_dir_all(&root);

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -174,6 +174,7 @@ fn parse_codex_session_for_entry(
     mtime_ms: i64,
     include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
+    let source_file_path = entry.stat_target.to_str().map(str::to_string);
     let mut raw = match parse_codex_session_with_options(&entry.stat_target, include_events) {
         Ok(Some(raw)) => raw,
         Ok(None) => return Ok(None),
@@ -184,6 +185,7 @@ fn parse_codex_session_for_entry(
     };
     raw.source_id = entry.session_id;
     raw.updated_at = Some(mtime_ms);
+    raw.source_file_path = source_file_path;
     Ok(Some(raw))
 }
 
@@ -1836,13 +1838,14 @@ mod tests {
         let root = temp_codex_root("new");
         let sessions_dir = root.join("archived_sessions");
         let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237e";
-        write_codex_rollout(&sessions_dir, uuid, "fresh");
+        let path = write_codex_rollout(&sessions_dir, uuid, "fresh");
 
         let store = setup_store();
 
         let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.sessions[0].source_file_path.as_deref(), path.to_str());
         assert_eq!(result.stats.skipped_sessions, 0);
 
         let _ = fs::remove_dir_all(&root);

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -157,6 +157,7 @@ fn parse_copilot_session_for_entry(
     mtime_ms: i64,
     include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
+    let source_file_path = entry.stat_target.to_str().map(str::to_string);
     let file = match fs::File::open(&entry.stat_target) {
         Ok(f) => f,
         Err(e) => {
@@ -181,6 +182,7 @@ fn parse_copilot_session_for_entry(
     };
     raw.source_id = entry.session_id;
     raw.updated_at = Some(mtime_ms);
+    raw.source_file_path = source_file_path;
     Ok(Some(raw))
 }
 
@@ -597,13 +599,14 @@ mod tests {
         let root = temp_copilot_root("new");
         let sessions_dir = root.join("session-state");
         let uuid = "f3eca837-818f-44d7-9158-bf242901f960";
-        write_copilot_session(&sessions_dir, "dir-1", uuid, "fresh");
+        let events_path = write_copilot_session(&sessions_dir, "dir-1", uuid, "fresh");
 
         let store = setup_store();
 
         let result = scan_for_sync_impl(&sessions_dir, &store, None, true).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
+        assert_eq!(result.sessions[0].source_file_path.as_deref(), events_path.to_str());
         assert_eq!(result.stats.skipped_sessions, 0);
 
         let _ = fs::remove_dir_all(&root);

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -95,6 +95,20 @@ impl SourceAdapter for CursorAdapter {
 
         for composer_id in composer_ids {
             let meta = load_composer_meta(&conn, &composer_id, &lookup);
+            if existing.contains_key(&composer_id)
+                && let Some(path) = transcript_paths
+                    .get(&composer_id)
+                    .and_then(|transcript| transcript.path.to_str())
+            {
+                store.update_session_fields(
+                    self.id(),
+                    &composer_id,
+                    None,
+                    None,
+                    None,
+                    Some(path),
+                )?;
+            }
             let updated_at = meta.last_updated_at.or(meta.created_at);
             if let Some(cutoff) = since_ts
                 && updated_at.is_some_and(|ts| ts < cutoff)
@@ -239,6 +253,10 @@ fn build_raw_session(
     if include_events {
         session = session.with_events(parsed.events, EVENT_PARSER_VERSION);
     }
+    session.source_file_path = transcript_paths
+        .get(composer_id)
+        .and_then(|transcript| transcript.path.to_str())
+        .map(str::to_string);
     Ok(Some(session))
 }
 
@@ -877,6 +895,7 @@ fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<O
     let mut session =
         RawSession::search_only(String::new(), None, 0, None, Some("agent".to_string()), messages)
             .with_usage(Vec::new(), USAGE_PARSER_VERSION);
+    session.source_file_path = Some(source_path);
     if include_events {
         session = session.with_events(session_events, EVENT_PARSER_VERSION);
     }
@@ -1311,6 +1330,31 @@ mod tests {
     }
 
     #[test]
+    fn build_raw_session_attaches_matching_transcript_path() {
+        let root = temp_root("composer-path");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let transcript_path = root.join(format!("{composer_id}.jsonl"));
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let meta = load_composer_meta(&conn, &composer_id, &ComposerLookup::load(&conn));
+        let transcript_paths = HashMap::from([(
+            composer_id.clone(),
+            AgentTranscriptPath {
+                session_id: composer_id.clone(),
+                path: transcript_path.clone(),
+                directory: None,
+            },
+        )]);
+
+        let raw = build_raw_session(&conn, &composer_id, &meta, &transcript_paths, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(raw.source_file_path.as_deref(), transcript_path.to_str());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn parse_composer_session_prefers_bubble_usage_over_context_breakdown() {
         let root = temp_root("bubble-usage");
         let composer_id = uuid::Uuid::new_v4().to_string();
@@ -1444,6 +1488,7 @@ mod tests {
         // every sync.
         assert_eq!(raw.usage_parser_version, Some(USAGE_PARSER_VERSION));
         assert!(raw.usage_events.is_empty());
+        assert_eq!(raw.source_file_path.as_deref(), jsonl_path.to_str());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -82,52 +82,77 @@ impl SourceAdapter for CursorAdapter {
             return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
         };
 
-        let existing = store.session_meta_map(self.id())?;
-        let usage_state = store.usage_state_meta_map(self.id())?;
-        let event_state =
-            if include_events { store.event_state_meta_map(self.id())? } else { HashMap::new() };
-        let global_mtime = global_db_mtime();
-        let lookup = ComposerLookup::load(&conn);
-        let composer_ids = discover_composer_ids(&conn)?;
         let transcript_paths = collect_agent_transcript_paths();
-        let mut sessions = Vec::new();
-        let mut stats = SyncScanStats::default();
+        Ok(Some(scan_for_sync_conn(&conn, store, since_ts, include_events, &transcript_paths)?))
+    }
+}
 
-        for composer_id in composer_ids {
-            let meta = load_composer_meta(&conn, &composer_id, &lookup);
-            let updated_at = meta.last_updated_at.or(meta.created_at);
-            if let Some(cutoff) = since_ts
-                && updated_at.is_some_and(|ts| ts < cutoff)
-            {
-                stats.filtered_sessions += 1;
-                continue;
-            }
+fn scan_for_sync_conn(
+    conn: &Connection,
+    store: &Store,
+    since_ts: Option<i64>,
+    include_events: bool,
+    transcript_paths: &HashMap<String, AgentTranscriptPath>,
+) -> anyhow::Result<SyncScanResult> {
+    let existing = store.session_meta_map("cursor")?;
+    let existing_paths = store
+        .session_paths_for_source("cursor")?
+        .into_iter()
+        .map(|path| (path.source_id, path.source_file_path))
+        .collect::<HashMap<_, _>>();
+    let usage_state = store.usage_state_meta_map("cursor")?;
+    let event_state =
+        if include_events { store.event_state_meta_map("cursor")? } else { HashMap::new() };
+    let global_mtime = global_db_mtime();
+    let lookup = ComposerLookup::load(conn);
+    let composer_ids = discover_composer_ids(conn)?;
+    let mut sessions = Vec::new();
+    let mut stats = SyncScanStats::default();
 
-            let source_updated_at = updated_at.or(global_mtime);
-            if let Some((old_updated_at, _)) = existing.get(&composer_id)
-                && *old_updated_at == source_updated_at
-                && crate::adapters::sync_state::session_state_is_current(
-                    USAGE_PARSER_VERSION,
-                    EVENT_PARSER_VERSION,
-                    usage_state.get(&composer_id).copied(),
-                    event_state.get(&composer_id).copied(),
-                    source_updated_at,
-                    include_events,
-                )
-            {
-                stats.skipped_sessions += 1;
-                continue;
-            }
-
-            if let Some(raw) =
-                build_raw_session(&conn, &composer_id, &meta, &transcript_paths, include_events)?
-            {
-                sessions.push(raw);
-            }
+    for composer_id in composer_ids {
+        let meta = load_composer_meta(conn, &composer_id, &lookup);
+        let source_path_changed = existing.contains_key(&composer_id)
+            && transcript_paths
+                .get(&composer_id)
+                .and_then(|transcript| transcript.path.to_str())
+                .is_some_and(|path| {
+                    existing_paths.get(&composer_id).and_then(|stored| stored.as_deref())
+                        != Some(path)
+                });
+        let updated_at = meta.last_updated_at.or(meta.created_at);
+        if let Some(cutoff) = since_ts
+            && updated_at.is_some_and(|ts| ts < cutoff)
+            && !source_path_changed
+        {
+            stats.filtered_sessions += 1;
+            continue;
         }
 
-        Ok(Some(SyncScanResult { sessions, stats }))
+        let source_updated_at = updated_at.or(global_mtime);
+        if let Some((old_updated_at, _)) = existing.get(&composer_id)
+            && *old_updated_at == source_updated_at
+            && crate::adapters::sync_state::session_state_is_current(
+                USAGE_PARSER_VERSION,
+                EVENT_PARSER_VERSION,
+                usage_state.get(&composer_id).copied(),
+                event_state.get(&composer_id).copied(),
+                source_updated_at,
+                include_events,
+            )
+            && !source_path_changed
+        {
+            stats.skipped_sessions += 1;
+            continue;
+        }
+
+        if let Some(raw) =
+            build_raw_session(conn, &composer_id, &meta, transcript_paths, include_events)?
+        {
+            sessions.push(raw);
+        }
     }
+
+    Ok(SyncScanResult { sessions, stats })
 }
 
 fn scan_cursor_sessions(
@@ -1178,7 +1203,8 @@ mod tests {
     use rusqlite::Connection;
 
     use super::*;
-    use crate::types::TokenSource;
+    use crate::db::schema;
+    use crate::types::{Session, TokenSource};
 
     fn temp_root(label: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
@@ -1337,6 +1363,70 @@ mod tests {
             .unwrap();
 
         assert_eq!(raw.source_file_path.as_deref(), transcript_path.to_str());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn incremental_scan_returns_current_session_when_transcript_path_needs_backfill() {
+        schema::register_sqlite_vec();
+        let root = temp_root("path-backfill");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let transcript_path = root.join(format!("{composer_id}.jsonl"));
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let store = Store::open_in_memory().unwrap();
+        let source_updated_at = 1_700_000_100_000_i64;
+        store
+            .insert_session(&Session {
+                id: uuid::Uuid::new_v4().to_string(),
+                source: "cursor".to_string(),
+                source_id: composer_id.clone(),
+                title: "Usage review".to_string(),
+                directory: Some("/Users/x/project".to_string()),
+                repo_remote: None,
+                repo_slug: None,
+                repo_name: None,
+                started_at: 1_700_000_000_000,
+                updated_at: Some(source_updated_at),
+                message_count: 1,
+                entrypoint: Some("chat".to_string()),
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: None,
+                is_import: false,
+            })
+            .unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "cursor",
+                &composer_id,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(source_updated_at),
+            )
+            .unwrap();
+        let transcript_paths = HashMap::from([(
+            composer_id.clone(),
+            AgentTranscriptPath {
+                session_id: composer_id,
+                path: transcript_path.clone(),
+                directory: None,
+            },
+        )]);
+
+        let result = scan_for_sync_conn(
+            &conn,
+            &store,
+            Some(source_updated_at + 1),
+            false,
+            &transcript_paths,
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_file_path.as_deref(), transcript_path.to_str());
+        assert_eq!(store.session_paths_for_source("cursor").unwrap()[0].source_file_path, None);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -95,20 +95,6 @@ impl SourceAdapter for CursorAdapter {
 
         for composer_id in composer_ids {
             let meta = load_composer_meta(&conn, &composer_id, &lookup);
-            if existing.contains_key(&composer_id)
-                && let Some(path) = transcript_paths
-                    .get(&composer_id)
-                    .and_then(|transcript| transcript.path.to_str())
-            {
-                store.update_session_fields(
-                    self.id(),
-                    &composer_id,
-                    None,
-                    None,
-                    None,
-                    Some(path),
-                )?;
-            }
             let updated_at = meta.last_updated_at.or(meta.created_at);
             if let Some(cutoff) = since_ts
                 && updated_at.is_some_and(|ts| ts < cutoff)

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -166,6 +166,7 @@ fn parse_gemini_session_value(
 
     let mut session =
         RawSession::search_only(session_id, None, started_at, updated_at, None, messages);
+    session.source_file_path = source_path;
     if !usage_events.is_empty() {
         session = session.with_usage(usage_events, USAGE_PARSER_VERSION);
     }
@@ -283,5 +284,20 @@ mod tests {
         assert_eq!(event.cache_read_tokens, 30);
         assert_eq!(event.reasoning_tokens, 5);
         assert_eq!(event.token_source, crate::types::TokenSource::Observed);
+    }
+
+    #[test]
+    fn parse_gemini_session_file_sets_source_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        std::fs::write(
+            &path,
+            r#"{"sessionId":"abc-123","messages":[{"type":"user","content":"hello"}]}"#,
+        )
+        .unwrap();
+
+        let session = parse_gemini_session_file(&path).unwrap().unwrap();
+
+        assert_eq!(session.source_file_path.as_deref(), path.to_str());
     }
 }

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -298,6 +298,7 @@ fn parse_grok_session_for_entry(
     .with_usage(usage_events, USAGE_PARSER_VERSION);
 
     session.updated_at = Some(mtime_ms);
+    session.source_file_path = source_path;
     Ok(Some(session))
 }
 
@@ -881,6 +882,7 @@ mod tests {
         let session = parse_grok_session_for_entry(&entry, mtime).unwrap().unwrap();
 
         assert_eq!(session.usage_parser_version, Some(USAGE_PARSER_VERSION));
+        assert_eq!(session.source_file_path.as_deref(), updates_path.to_str());
         assert_eq!(session.usage_events.len(), 1);
         assert_eq!(session.usage_events[0].model, "grok-composer-2.5-fast");
         assert_eq!(session.usage_events[0].source_path.as_deref(), updates_path.to_str());

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -261,6 +261,7 @@ fn parse_pi_session_file(
     entry: FileScanEntry,
     mtime_ms: i64,
 ) -> anyhow::Result<Option<RawSession>> {
+    let source_file_path = entry.stat_target.to_str().map(str::to_string);
     let parsed = match parse_pi_session(&entry.stat_target, mtime_ms) {
         Ok(parsed) => parsed,
         Err(err) => {
@@ -304,7 +305,7 @@ fn parse_pi_session_file(
         usage_parser_version: Some(USAGE_PARSER_VERSION),
         events: Vec::new(),
         event_parser_version: None,
-        source_file_path: None,
+        source_file_path,
         custom_title: None,
         summary: None,
         duration_minutes: None,
@@ -838,6 +839,7 @@ mod tests {
         assert_eq!(raw.directory.as_deref(), Some("/tmp/pi-project"));
         assert_eq!(raw.started_at, 1_000);
         assert_eq!(raw.updated_at, Some(mtime));
+        assert_eq!(raw.source_file_path.as_deref(), path.to_str());
         assert_eq!(raw.messages.len(), 3);
         assert_eq!(raw.messages[0].role, Role::User);
         assert_eq!(raw.messages[0].content, "hello pi");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -949,6 +949,8 @@ mod tests {
     struct StaticAdapter {
         updated_at: i64,
         messages: &'static [&'static str],
+        source_file_path: Option<&'static str>,
+        optimized: bool,
     }
 
     impl SourceAdapter for StaticAdapter {
@@ -971,14 +973,25 @@ mod tests {
                     timestamp: Some(self.updated_at + seq as i64),
                 })
                 .collect();
-            Ok(vec![RawSession::search_only(
-                "raw1",
-                None,
-                1_000,
-                Some(self.updated_at),
-                None,
-                messages,
-            )])
+            let mut raw =
+                RawSession::search_only("raw1", None, 1_000, Some(self.updated_at), None, messages);
+            raw.source_file_path = self.source_file_path.map(str::to_string);
+            Ok(vec![raw])
+        }
+
+        fn scan_for_sync(
+            &self,
+            _store: &Store,
+            _since_ts: Option<i64>,
+            _include_events: bool,
+        ) -> anyhow::Result<Option<crate::adapters::SyncScanResult>> {
+            if !self.optimized {
+                return Ok(None);
+            }
+            Ok(Some(crate::adapters::SyncScanResult {
+                sessions: self.scan()?,
+                stats: Default::default(),
+            }))
         }
 
         fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
@@ -1237,8 +1250,12 @@ mod tests {
     #[test]
     fn sync_job_refreshes_changed_session_through_adapter_seam() {
         schema::register_sqlite_vec();
-        let initial: Vec<Box<dyn SourceAdapter>> =
-            vec![Box::new(StaticAdapter { updated_at: 2_000, messages: &["first"] })];
+        let initial: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
+            updated_at: 2_000,
+            messages: &["first"],
+            source_file_path: None,
+            optimized: false,
+        })];
         let mut job = SyncJob::new(
             SyncRunOptions {
                 force: false,
@@ -1258,8 +1275,12 @@ mod tests {
         job.run(&initial).unwrap();
         assert_eq!(job.store.session_meta("test", "raw1").unwrap(), Some((Some(2_000), 1)));
 
-        let updated: Vec<Box<dyn SourceAdapter>> =
-            vec![Box::new(StaticAdapter { updated_at: 3_000, messages: &["first", "second"] })];
+        let updated: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
+            updated_at: 3_000,
+            messages: &["first", "second"],
+            source_file_path: None,
+            optimized: false,
+        })];
         job.run(&updated).unwrap();
 
         assert_eq!(job.store.session_meta("test", "raw1").unwrap(), Some((Some(3_000), 2)));
@@ -1301,5 +1322,40 @@ mod tests {
         assert_eq!(count, 1);
         assert!(deleted.contains("s1"));
         assert!(store.session_paths_for_source("claude-code").unwrap().is_empty());
+    }
+
+    #[test]
+    fn excluded_source_file_path_blocks_fresh_and_force_sync() {
+        for force in [false, true] {
+            schema::register_sqlite_vec();
+            let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
+                updated_at: 2_000,
+                messages: &[],
+                source_file_path: Some("/tmp/private-sessions/session.jsonl"),
+                optimized: true,
+            })];
+            let mut config = AppConfig::default();
+            config.excluded_paths = vec!["**/private-sessions".to_string()];
+            let mut job = SyncJob::new(
+                SyncRunOptions {
+                    force,
+                    verbose: false,
+                    emit: false,
+                    usage_only: false,
+                    backfill_events: false,
+                    sources: None,
+                    scope: ProjectScope::Global,
+                },
+                Store::open_in_memory().unwrap(),
+                config,
+                &adapters,
+            )
+            .unwrap();
+
+            job.run(&adapters).unwrap();
+
+            assert!(job.store.session_paths_for_source("test").unwrap().is_empty());
+            assert_eq!(job.stats.excluded_out, 1);
+        }
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -427,14 +427,6 @@ impl SyncJob {
         existing: &mut ExistingState,
         purged_excluded_ids: &mut HashSet<String>,
     ) -> Result<()> {
-        if let Some(cutoff) = self.since_ts {
-            let ts = raw.updated_at.unwrap_or(raw.started_at);
-            if ts < cutoff {
-                self.stats.filtered_out += 1;
-                return Ok(());
-            }
-        }
-
         let raw_source_id = raw.source_id.clone();
 
         // Runs before every write and delete below, so a scoped sync can never
@@ -463,6 +455,31 @@ impl SyncJob {
                 self.stats.excluded_out += 1;
             }
             return Ok(());
+        }
+
+        // Path evidence drives exclusions, so backfill it after scope/exclusion
+        // checks even when content falls outside the configured sync window.
+        if let Some(source_file_path) = raw.source_file_path.as_deref()
+            && let Some(stored) = existing.paths.get_mut(&raw_source_id)
+            && stored.source_file_path.as_deref() != Some(source_file_path)
+        {
+            self.store.update_session_fields(
+                source_id,
+                &raw_source_id,
+                None,
+                None,
+                None,
+                Some(source_file_path),
+            )?;
+            stored.source_file_path = Some(source_file_path.to_string());
+        }
+
+        if let Some(cutoff) = self.since_ts {
+            let ts = raw.updated_at.unwrap_or(raw.started_at);
+            if ts < cutoff {
+                self.stats.filtered_out += 1;
+                return Ok(());
+            }
         }
 
         let existing_repo_fields = existing.paths.get(&raw_source_id).filter(|old| {
@@ -1289,6 +1306,68 @@ mod tests {
         assert_eq!(
             messages.iter().map(|message| message.content.as_str()).collect::<Vec<_>>(),
             ["first", "second"]
+        );
+    }
+
+    #[test]
+    fn source_path_backfill_runs_after_scope_and_before_time_filter() {
+        schema::register_sqlite_vec();
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
+            updated_at: 2_000,
+            messages: &[],
+            source_file_path: Some("/tmp/session.jsonl"),
+            optimized: true,
+        })];
+        let mut config = AppConfig::default();
+        config.sync_window = crate::config::SyncWindow::Today;
+        let mut global_job = SyncJob::new(
+            SyncRunOptions {
+                force: false,
+                verbose: false,
+                emit: false,
+                usage_only: false,
+                backfill_events: false,
+                sources: None,
+                scope: ProjectScope::Global,
+            },
+            Store::open_in_memory().unwrap(),
+            config,
+            &adapters,
+        )
+        .unwrap();
+        global_job.store.insert_session(&session("global", "test", "raw1")).unwrap();
+
+        global_job.run(&adapters).unwrap();
+
+        assert_eq!(
+            global_job.store.session_paths_for_source("test").unwrap()[0]
+                .source_file_path
+                .as_deref(),
+            Some("/tmp/session.jsonl")
+        );
+
+        let mut scoped_job = SyncJob::new(
+            SyncRunOptions {
+                force: false,
+                verbose: false,
+                emit: false,
+                usage_only: false,
+                backfill_events: false,
+                sources: None,
+                scope: ProjectScope::Directory("/repo/root".to_string()),
+            },
+            Store::open_in_memory().unwrap(),
+            AppConfig::default(),
+            &adapters,
+        )
+        .unwrap();
+        scoped_job.store.insert_session(&session("scoped", "test", "raw1")).unwrap();
+
+        scoped_job.run(&adapters).unwrap();
+
+        assert_eq!(
+            scoped_job.store.session_paths_for_source("test").unwrap()[0].source_file_path,
+            None
         );
     }
 


### PR DESCRIPTION
## Summary

- attach backing file paths to sessions parsed from transcript files
- backfill Cursor transcript paths only after scope and exclusion checks
- keep excluded transcript paths out of fresh, incremental, and forced syncs

## Verification

- `cargo test adapters::`
- `cargo test incremental_scan_returns_current_session_when_transcript_path_needs_backfill`
- `cargo test source_path_backfill_runs_after_scope_and_before_time_filter`
- `cargo test excluded_source_file_path_blocks_fresh_and_force_sync`
- `make check`

Closes release blocker NG-03.