### PR TITLE
fix(sync): skip command envelopes when deriving session titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,6 @@ jobs:
         with:
           merge-multiple: true
 
-      # release-please already created the tag and the GitHub release with its
-      # changelog entry; this job only attaches the built binaries to it.
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -157,11 +157,28 @@ pub(crate) fn title_from_user_messages(user_contents: &[&str]) -> String {
     }
 }
 
+/// Openers written by the agent harness rather than by the user: slash-command
+/// envelopes, skill preambles, resumed-session banners, tool errors, and
+/// interruption markers.
+///
+/// Claude Code emits the envelope as `<command-name>` followed by
+/// `<command-message>`, so matching only the latter never fires on a real
+/// transcript.
+const NOISE_FIRST_MESSAGE_PREFIXES: &[&str] = &[
+    "<command-name>",
+    "<command-message>",
+    "<local-command-caveat>",
+    "<system-reminder>",
+    "<tool_use_error>",
+    "[Request interrupted",
+    "# New session -",
+    "Base directory for this skill:",
+    "This session is being continued from",
+];
+
 fn is_noise_first_message(content: &str) -> bool {
     let trimmed = content.trim_start();
-    trimmed.starts_with("<command-message>")
-        || trimmed.starts_with("<local-command-caveat>")
-        || trimmed.starts_with("# New session -")
+    NOISE_FIRST_MESSAGE_PREFIXES.iter().any(|prefix| trimmed.starts_with(prefix))
 }
 
 #[cfg(test)]
@@ -253,6 +270,24 @@ mod tests {
             "actually implement the feature",
         ];
         assert_eq!(title_from_user_messages(&msgs), "actually implement the feature");
+    }
+
+    #[test]
+    fn title_skips_command_envelope_led_by_command_name() {
+        let msgs = [
+            "<command-name>/clear</command-name>\n<command-message>clear</command-message>",
+            "review the sync regression",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "review the sync regression");
+    }
+
+    #[test]
+    fn title_skips_skill_preamble() {
+        let msgs = [
+            "Base directory for this skill: /Users/x/.claude/skills/recall",
+            "find the session about migrations",
+        ];
+        assert_eq!(title_from_user_messages(&msgs), "find the session about migrations");
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- `is_noise_first_message` now tests one list of harness-written openers instead of three hard-coded `starts_with` calls, and covers the prefixes that actually appear in transcripts: `<command-name>`, `<system-reminder>`, `<tool_use_error>`, `[Request interrupted`, skill preambles, and resumed-session banners.
- Two regression tests: a `<command-name>`-led command envelope, and a skill preamble.
- `Cargo.lock`: h2 0.4.14 -> 0.4.16 for RUSTSEC-2026-0258.
- `.github/workflows/release.yml`: drop a stale comment about release-please creating the tag, which no longer applies after dad8eba.

### Why

- The filter only matched `<command-message>`, but Claude Code writes `<command-name>` first, so `starts_with` never fired and the raw slash-command envelope became the session title. The existing test asserted the reverse tag order, which is why the gap never surfaced.
- Measured against a local index of 6,953 sessions: 359 titles were harness noise rather than intent — 255 from `<command-name>` envelopes and 104 from skill preambles. Those sessions are effectively unfindable by title in both search results and the TUI list.
- Sessions whose user messages are all noise still fall back to the first message, so none of them regress to `Untitled`.
- h2 ships in the same branch because the `audit` stage of `make check` fails without it (advisory published 2026-08-17), so this branch could not go green on its own. `Cargo.lock` was edited in place rather than via `cargo update`, which would also have reshuffled nine `windows-sys` references unrelated to this fix.

### Verification

- `make check` -> `All checks passed` (fmt --check, clippy -D warnings, cargo audit, full workspace test suite: 437 passed / 0 failed).
- Re-synced one project with `sync --force`: among sessions whose source files still exist, noise titles went 10 -> 1. The remaining one is a session whose only user message is `/clear`, where falling back to the first message is the intended behavior. Sessions whose source transcripts were deleted from disk cannot be backfilled, since titles are derived at sync time.