### PR TITLE
ci(codspeed): skip benchmarks on unrelated pull requests

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,10 +1,28 @@
 name: CodSpeed
 
+# Benches measure core hot paths only. Docs, website, skills, and
+# extension PRs cannot change those measurements, so they skip this
+# job. That skip is safe while "Run benchmarks" is not a required
+# status check — if it becomes required, a skipped run stays Pending
+# and blocks merge; add a no-op success job before requiring it.
+# Force a run from the Actions tab via workflow_dispatch.
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/codspeed.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/codspeed.yml"
   # Lets CodSpeed trigger backtest runs to build the initial baseline.
   workflow_dispatch:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -188,10 +188,13 @@ Always run `make check` before pushing. If it passes locally, CI will pass.
 
 ## Benchmarks
 
-Performance is tracked on every push and pull request by
+Performance is tracked by
 [CodSpeed](https://app.codspeed.io/samzong/Recall) via
-`.github/workflows/codspeed.yml`, using CPU simulation so results do not depend
-on runner noise.
+`.github/workflows/codspeed.yml` on pushes and pull requests that touch
+`src/`, `benches/`, `Cargo.toml`, `Cargo.lock`, or the workflow itself,
+using CPU simulation so results do not depend on runner noise. Docs,
+website, skills, and extension-only changes skip the job; force a run
+with `workflow_dispatch`.
 
 `benches/recall.rs` is a single [divan](https://github.com/nvzqz/divan) target
 grouped by pipeline stage:


### PR DESCRIPTION
### What's changed?

- CodSpeed now runs on `push`/`pull_request` only when the diff touches `src/`, `benches/`, `Cargo.toml`, `Cargo.lock`, or `.github/workflows/codspeed.yml`.
- Docs, website, skills, and extension-only changes skip the job. `workflow_dispatch` still forces a run.
- `DEVELOPMENT.md` matches that trigger.

### Why

- The job has a 45-minute timeout. Docs-only PRs (and the `main` push after them) were still installing valgrind and recently hung until that limit.
- Benches measure core hot paths; those other surfaces cannot change the numbers.
- This skip is safe while "Run benchmarks" is not a required status check. If it becomes required, a skipped run stays Pending and blocks merge — add a no-op success job before requiring it.

This PR touches the workflow file, so CodSpeed will still run here. After merge, unrelated PRs will not.