### PR TITLE
feat(rx): add rx gateway launcher for agent harnesses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,19 +87,19 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} -p recall -p rx
 
       - name: Package (unix)
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.artifact }}.tar.gz recall
+          tar czf ../../../${{ matrix.artifact }}.tar.gz recall rx
           cd ../../..
 
       - name: Package (windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: Compress-Archive -Path target/${{ matrix.target }}/release/recall.exe -DestinationPath ${{ matrix.artifact }}.zip
+        run: Compress-Archive -Path target/${{ matrix.target }}/release/recall.exe,target/${{ matrix.target }}/release/rx.exe -DestinationPath ${{ matrix.artifact }}.zip
 
       - uses: actions/upload-artifact@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Recall is a Rust CLI/TUI application that indexes AI coding sessions from local
 tools (Claude Code, Codex, OpenCode, Cursor, ...) into one SQLite database for
 full-text/semantic search, usage tracking, JSONL export/import, session
 sharing, and resume. The repo is a Cargo workspace: the core application crate
-at the root plus official extension crates under `extensions/`. Nothing is
+at the root, the independent `rx` launcher under `crates/rx`, plus official
+extension crates under `extensions/`. Nothing is
 published to crates.io — these are application binaries, not library crates.
 
 ## Commands
@@ -30,8 +31,9 @@ cargo test integration::eval_harness  # eval harness
 
 `make check` must pass before push. CI runs exactly the same command — there is
 no CI-only logic. The gate uses `--workspace` and `--features bench`, so it
-covers extension crates and the `bench_api` shim that `benches/` compiles
-against. Build a single extension with `cargo build -p recall-<name>`.
+covers extension crates, `crates/rx`, and the `bench_api` shim that `benches/` compiles
+against. Build a single extension with `cargo build -p recall-<name>`. Build the
+launcher with `cargo build -p rx`.
 
 Core releases use cargo-release: `make release-patch` is a dry run; add
 `EXECUTE=1` to bump, commit, tag, and push. The bump is chosen by whoever cuts
@@ -70,6 +72,10 @@ Data flow: source adapters → sync → SQLite → search → CLI/TUI.
 - `src/share/` — renders sessions to HTML and publishes share assets.
 - `src/cli.rs` — clap subcommands dispatching to the modules above; unknown
   subcommands fall through to extension dispatch.
+- `crates/rx/` — independent `rx` binary (workspace member, not an extension).
+  Gateway launcher for Claude Code and Codex. Does not depend on the `recall`
+  crate or read `recall.db`. Install also creates `rxc` / `rxx` / `rxo` / `rxp`
+  symlinks.
 - `src/extension.rs` — extension host: `recall <name>` runs the managed
   `recall-<name>` binary; `recall ext install/list/remove/upgrade` manages
   official extensions from the GitHub Pages catalog.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3129,6 +3129,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rx"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "flate2",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "toml",
+ "ureq",
+ "zip",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3278,15 @@ name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -3734,6 +3759,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,14 +3790,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3760,8 +3820,14 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4490,6 +4556,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/samzong/Recall"
 publish = false
 
 [workspace]
-members = [".", "extensions/recall-probe", "extensions/recall-reflect"]
+members = [".", "crates/rx", "extensions/recall-probe", "extensions/recall-reflect"]
 default-members = ["."]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -62,15 +62,22 @@ doc: ## Generate API documentation
 
 .PHONY: install uninstall
 
-install: ## Install binary to ~/.cargo/bin
+install: ## Install binaries to ~/.cargo/bin
 	$(CARGO) install --path . --locked
+	$(CARGO) install --path crates/rx --locked
+	ln -sfn rx "$(HOME)/.cargo/bin/rxc"
+	ln -sfn rx "$(HOME)/.cargo/bin/rxx"
+	ln -sfn rx "$(HOME)/.cargo/bin/rxo"
+	ln -sfn rx "$(HOME)/.cargo/bin/rxp"
 	@if [ -d "$(HOME)/.zsh/completions" ]; then \
 		"$(HOME)/.cargo/bin/recall" completions zsh > "$(HOME)/.zsh/completions/_recall"; \
 		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_recall$(RESET)\n'; \
 	fi
 
-uninstall: ## Remove installed binary
+uninstall: ## Remove installed binaries
 	$(CARGO) uninstall recall
+	$(CARGO) uninstall rx
+	rm -f "$(HOME)/.cargo/bin/rxc" "$(HOME)/.cargo/bin/rxx" "$(HOME)/.cargo/bin/rxo" "$(HOME)/.cargo/bin/rxp"
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 

--- a/crates/rx/Cargo.toml
+++ b/crates/rx/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rx"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Launch agent harnesses through a configured API gateway"
+repository = "https://github.com/samzong/Recall"
+publish = false
+
+[package.metadata.release]
+release = false
+
+[dependencies]
+anyhow = "1"
+dirs = "6"
+flate2 = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tar = "0.4"
+tempfile = "3"
+toml = "0.8"
+ureq = "3"
+
+[target.'cfg(windows)'.dependencies]
+zip = { version = "7", default-features = false, features = ["deflate"] }

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -1,0 +1,190 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use crate::debug;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Harness {
+    Claude,
+    Codex,
+    OpenCode,
+    Pi,
+}
+
+impl Harness {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+            Self::Pi => "pi",
+        }
+    }
+
+    fn parse(name: &str) -> Option<Self> {
+        match name {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "opencode" => Some(Self::OpenCode),
+            "pi" => Some(Self::Pi),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LaunchRequest {
+    pub harness: Harness,
+    pub gateway: Option<String>,
+    pub passthrough: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ConfigCommand {
+    SetGateway { name: String },
+    SetKey { provider: String, key: String },
+    Get { name: Option<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Command {
+    Help,
+    Version,
+    Launch(LaunchRequest),
+    Config(ConfigCommand),
+    Debug { subcommand: debug::Subcommand, gateway: Option<String> },
+    Update { yes: bool },
+}
+
+pub(crate) fn rewrite_argv0(mut args: Vec<String>) -> Vec<String> {
+    let Some(argv0) = args.first() else {
+        return args;
+    };
+    let name = Path::new(argv0).file_stem().and_then(|stem| stem.to_str()).unwrap_or("");
+    let harness = match name {
+        "rxc" => "claude",
+        "rxx" => "codex",
+        "rxo" => "opencode",
+        "rxp" => "pi",
+        _ => return args,
+    };
+    args.insert(1, harness.to_string());
+    args
+}
+
+pub(crate) fn parse(args: &[String]) -> Result<Command> {
+    let rest = args.get(1..).unwrap_or(&[]);
+    let (gateway, rest) = extract_gateway(rest)?;
+    match rest.first().map(String::as_str) {
+        None => bail!("missing harness name\n\n{}", crate::help_text().trim_end()),
+        Some("-h" | "--help") => Ok(Command::Help),
+        Some("-V" | "--version") => Ok(Command::Version),
+        Some("config") => {
+            if gateway.is_some() {
+                bail!("--gateway is not valid with rx config");
+            }
+            Ok(Command::Config(parse_config(&rest[1..])?))
+        }
+        Some("debug") => Ok(Command::Debug { subcommand: debug::parse(&rest[1..])?, gateway }),
+        Some("update") => {
+            if gateway.is_some() {
+                bail!("--gateway is not valid with rx update");
+            }
+            Ok(Command::Update { yes: parse_update_args(&rest[1..])? })
+        }
+        Some(name) => {
+            let Some(harness) = Harness::parse(name) else {
+                bail!("unknown harness: {name}\n\n{}", crate::help_text().trim_end());
+            };
+            Ok(Command::Launch(LaunchRequest { harness, gateway, passthrough: rest[1..].to_vec() }))
+        }
+    }
+}
+
+fn parse_config(args: &[String]) -> Result<ConfigCommand> {
+    match args.first().map(String::as_str) {
+        Some("set") => match args.get(1).map(String::as_str) {
+            Some("gateway") => {
+                let name = args.get(2).ok_or_else(|| {
+                    anyhow::anyhow!("usage: rx config set gateway <openrouter|tokener>")
+                })?;
+                if args.len() != 3 {
+                    bail!("usage: rx config set gateway <openrouter|tokener>");
+                }
+                Ok(ConfigCommand::SetGateway { name: name.to_string() })
+            }
+            Some("key") => {
+                let provider = args.get(2).ok_or_else(|| {
+                    anyhow::anyhow!("usage: rx config set key <openrouter|tokener> <key>")
+                })?;
+                let key = args.get(3).ok_or_else(|| {
+                    anyhow::anyhow!("usage: rx config set key <openrouter|tokener> <key>")
+                })?;
+                if args.len() != 4 {
+                    bail!("usage: rx config set key <openrouter|tokener> <key>");
+                }
+                Ok(ConfigCommand::SetKey { provider: provider.to_string(), key: key.to_string() })
+            }
+            _ => bail!("usage: rx config set <gateway|key> ..."),
+        },
+        Some("get") => {
+            if args.len() > 2 {
+                bail!("usage: rx config get [name]");
+            }
+            Ok(ConfigCommand::Get { name: args.get(1).cloned() })
+        }
+        _ => bail!("usage: rx config <set|get> ..."),
+    }
+}
+
+fn extract_gateway(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
+    let mut gateway = None;
+    let mut rest = Vec::new();
+    let mut i = 0;
+    let mut raw = false;
+    while i < args.len() {
+        let arg = &args[i];
+        if !raw && arg == "--" {
+            raw = true;
+            rest.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        if !raw && arg == "--gateway" {
+            let value =
+                args.get(i + 1).ok_or_else(|| anyhow::anyhow!("--gateway requires a value"))?;
+            gateway = Some(value.clone());
+            i += 2;
+            continue;
+        }
+        if !raw && let Some(value) = arg.strip_prefix("--gateway=") {
+            if value.is_empty() {
+                bail!("--gateway requires a value");
+            }
+            gateway = Some(value.to_string());
+            i += 1;
+            continue;
+        }
+        rest.push(arg.clone());
+        i += 1;
+    }
+    Ok((gateway, rest))
+}
+
+fn parse_update_args(args: &[String]) -> Result<bool> {
+    let mut yes = false;
+    for arg in args {
+        match arg.as_str() {
+            "--yes" | "-y" => yes = true,
+            "-h" | "--help" => {
+                bail!(
+                    "usage: rx update [--yes]\n\n\
+                     Download and install the latest rx from GitHub releases."
+                );
+            }
+            other => bail!("unexpected argument: {other}\n\nusage: rx update [--yes]"),
+        }
+    }
+    Ok(yes)
+}

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -61,16 +61,23 @@ pub(crate) fn rewrite_argv0(mut args: Vec<String>) -> Vec<String> {
     let Some(argv0) = args.first() else {
         return args;
     };
-    let name = Path::new(argv0).file_stem().and_then(|stem| stem.to_str()).unwrap_or("");
-    let harness = match name {
-        "rxc" => "claude",
-        "rxx" => "codex",
-        "rxo" => "opencode",
-        "rxp" => "pi",
-        _ => return args,
+    let Some(harness) = argv0_harness(argv0) else {
+        return args;
     };
     args.insert(1, harness.to_string());
     args
+}
+
+/// Harness implied by an invoked alias such as `rxc`; `None` for plain `rx`.
+pub(crate) fn argv0_harness(argv0: &str) -> Option<&'static str> {
+    let name = Path::new(argv0).file_stem().and_then(|stem| stem.to_str()).unwrap_or("");
+    match name {
+        "rxc" => Some("claude"),
+        "rxx" => Some("codex"),
+        "rxo" => Some("opencode"),
+        "rxp" => Some("pi"),
+        _ => None,
+    }
 }
 
 pub(crate) fn parse(args: &[String]) -> Result<Command> {

--- a/crates/rx/src/catalog.rs
+++ b/crates/rx/src/catalog.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogShape {
+    OpenAi,
+    Anthropic,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ListedModel {
+    pub id: String,
+    pub label: Option<String>,
+}
+
+pub(crate) fn fetch_get(url: &str, headers: &[(&str, String)]) -> Result<String> {
+    let (status, body) = fetch(url, headers)?;
+    if !(200..300).contains(&status) {
+        bail!("HTTP {status}: {}", truncate(&body, 300));
+    }
+    Ok(body)
+}
+
+pub(crate) fn fetch(url: &str, headers: &[(&str, String)]) -> Result<(u16, String)> {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(15)))
+        .http_status_as_error(false)
+        .build()
+        .into();
+    let mut request =
+        agent.get(url).header("User-Agent", format!("rx/{}", env!("CARGO_PKG_VERSION")));
+    for (name, value) in headers {
+        request = request.header(*name, value);
+    }
+    let mut response = request.call().with_context(|| format!("GET {url}"))?;
+    let status = response.status().as_u16();
+    let body = response.body_mut().read_to_string().context("failed to read response body")?;
+    Ok((status, body))
+}
+
+pub(crate) fn parse_catalog(body: &str) -> Result<(CatalogShape, Vec<String>, Vec<ListedModel>)> {
+    let value: serde_json::Value = serde_json::from_str(body).context("response is not JSON")?;
+    let envelope =
+        value.as_object().map(|object| object.keys().cloned().collect()).unwrap_or_default();
+    let Some(data) = value.get("data").and_then(|value| value.as_array()) else {
+        bail!("JSON has no data array");
+    };
+    let models = data
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id")?.as_str()?.to_string();
+            let label = entry
+                .get("display_name")
+                .or_else(|| entry.get("name"))
+                .and_then(|value| value.as_str())
+                .map(one_line);
+            Some(ListedModel { id, label })
+        })
+        .collect::<Vec<_>>();
+    let shape = match data.first() {
+        Some(entry) if entry.get("display_name").is_some() => CatalogShape::Anthropic,
+        Some(entry) if entry.get("name").is_some() => CatalogShape::OpenAi,
+        _ => CatalogShape::Unknown,
+    };
+    Ok((shape, envelope, models))
+}
+
+pub(crate) fn truncate(value: &str, max: usize) -> String {
+    let trimmed = value.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    let cut: String = trimmed.chars().take(max).collect();
+    format!("{cut}...")
+}
+
+fn one_line(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -289,11 +289,15 @@ fn merge_seed(document: &mut Value, caches: &SeedCaches) {
             .get("cachedGrowthBookFeatures")
             .and_then(|value| value.get(TOOL_SEARCH_UNSUPPORTED_KEY)),
     );
+    // A wrong-typed cache (e.g. null) must be replaced, not unwrapped: this is
+    // best-effort seeding and a panic here would block the launch.
+    if !object.get("cachedGrowthBookFeatures").is_some_and(Value::is_object) {
+        object.insert("cachedGrowthBookFeatures".to_string(), json!({}));
+    }
     let growthbook = object
-        .entry("cachedGrowthBookFeatures")
-        .or_insert_with(|| json!({}))
-        .as_object_mut()
-        .expect("cachedGrowthBookFeatures is an object");
+        .get_mut("cachedGrowthBookFeatures")
+        .and_then(Value::as_object_mut)
+        .expect("normalized cachedGrowthBookFeatures to an object");
     let preserved = previous_gb_deny
         .into_iter()
         .filter(|entry| !previous_rx_deny.contains(entry))

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -1,0 +1,505 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use crate::launch::{EnvLookup, anthropic_base};
+
+const MIN_CONTEXT: i64 = 100_000;
+const MAX_CONTEXT: i64 = 1_000_000;
+const OPENAI_COMPACT_WINDOW: i64 = 258_000;
+const TOOL_SEARCH_UNSUPPORTED_KEY: &str = "tengu_tool_search_unsupported_models";
+const RX_SEEDED_DENYLIST_KEY: &str = "rxSeededToolSearchDenylist";
+
+const BASE_TOOL_SEARCH_DENY: &[&str] = &["claude-3-5-haiku", "claude-3-haiku"];
+
+const SETTINGS_CLEAR_ENV: &[(&str, &str)] = &[
+    ("ANTHROPIC_API_KEY", ""),
+    ("ANTHROPIC_AUTH_TOKEN", ""),
+    ("ANTHROPIC_AWS_BASE_URL", ""),
+    ("ANTHROPIC_BEDROCK_BASE_URL", ""),
+    ("ANTHROPIC_BEDROCK_MANTLE_BASE_URL", ""),
+    ("ANTHROPIC_FOUNDRY_BASE_URL", ""),
+    ("ANTHROPIC_GOOGLE_CLOUD_BASE_URL", ""),
+    ("ANTHROPIC_UNIX_SOCKET", ""),
+    ("ANTHROPIC_VERTEX_BASE_URL", ""),
+    ("CLAUDE_CODE_OAUTH_TOKEN", ""),
+    ("CLAUDE_CODE_USE_ANTHROPIC_AWS", ""),
+    ("CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD", ""),
+    ("CLAUDE_CODE_USE_BEDROCK", ""),
+    ("CLAUDE_CODE_USE_FOUNDRY", ""),
+    ("CLAUDE_CODE_USE_GATEWAY", ""),
+    ("CLAUDE_CODE_USE_MANTLE", ""),
+    ("CLAUDE_CODE_USE_VERTEX", ""),
+    ("ENABLE_TOOL_SEARCH", "false"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UserModel {
+    pub id: String,
+    pub name: Option<String>,
+    pub context_length: Option<i64>,
+    pub canonical_slug: Option<String>,
+    pub supported_efforts: Vec<String>,
+    pub pricing: Option<Pricing>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Pricing {
+    pub prompt: Option<String>,
+    pub completion: Option<String>,
+    pub input_cache_read: Option<String>,
+    pub input_cache_write: Option<String>,
+    pub web_search: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelOption {
+    pub value: String,
+    pub label: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelAccess {
+    pub api_name: String,
+    pub max_effort_level: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct SeedCaches {
+    pub additional_model_options: Vec<ModelOption>,
+    pub model_access: Vec<ModelAccess>,
+    pub tool_search_denylist: Vec<String>,
+    pub auto_compact_windows: BTreeMap<String, i64>,
+    pub additional_model_costs: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SeedOutcome {
+    Seeded { model_count: usize },
+    Fallback,
+}
+
+pub(crate) fn try_seed_openrouter(
+    base_url: &str,
+    api_key: &str,
+    env: &EnvLookup,
+) -> Result<SeedOutcome> {
+    let models = match fetch_user_catalog(base_url, api_key) {
+        Ok(models) if !models.is_empty() => models,
+        Ok(_) => return Ok(SeedOutcome::Fallback),
+        Err(_) => return Ok(SeedOutcome::Fallback),
+    };
+    let caches = build_seed(&models);
+    if caches.additional_model_options.is_empty() {
+        return Ok(SeedOutcome::Fallback);
+    }
+    let config_path = claude_config_path(env);
+    // Seeding is an optional enhancement: any local failure must degrade to
+    // Fallback instead of blocking the launch.
+    match write_seed(&config_path, &caches) {
+        Ok(()) => Ok(SeedOutcome::Seeded { model_count: caches.additional_model_options.len() }),
+        Err(error) => {
+            eprintln!("[rx] catalog seed skipped: {error:#}");
+            Ok(SeedOutcome::Fallback)
+        }
+    }
+}
+
+pub(crate) fn fetch_user_catalog(base_url: &str, api_key: &str) -> Result<Vec<UserModel>> {
+    let url = format!("{}/v1/models/user?limit=1000", anthropic_base(base_url));
+    let body = crate::catalog::fetch_get(&url, &[("Authorization", format!("Bearer {api_key}"))])?;
+    parse_user_catalog(&body)
+}
+
+pub(crate) fn parse_user_catalog(body: &str) -> Result<Vec<UserModel>> {
+    let value: Value = serde_json::from_str(body).context("catalog response is not JSON")?;
+    let Some(data) = value.get("data").and_then(Value::as_array) else {
+        bail!("catalog JSON has no data array");
+    };
+    Ok(data.iter().filter_map(parse_user_model).collect())
+}
+
+fn parse_user_model(entry: &Value) -> Option<UserModel> {
+    let id = entry.get("id")?.as_str()?.to_string();
+    let name = entry.get("name").and_then(Value::as_str).map(str::to_string);
+    let context_length = entry.get("context_length").and_then(Value::as_i64);
+    let canonical_slug = entry.get("canonical_slug").and_then(Value::as_str).map(str::to_string);
+    let supported_efforts = entry
+        .get("reasoning")
+        .and_then(|value| value.get("supported_efforts"))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items.iter().filter_map(|item| item.as_str().map(str::to_string)).collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let pricing = entry.get("pricing").map(|pricing| Pricing {
+        prompt: pricing.get("prompt").and_then(Value::as_str).map(str::to_string),
+        completion: pricing.get("completion").and_then(Value::as_str).map(str::to_string),
+        input_cache_read: pricing
+            .get("input_cache_read")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        input_cache_write: pricing
+            .get("input_cache_write")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        web_search: pricing.get("web_search").and_then(Value::as_str).map(str::to_string),
+    });
+    Some(UserModel { id, name, context_length, canonical_slug, supported_efforts, pricing })
+}
+
+pub(crate) fn build_seed(models: &[UserModel]) -> SeedCaches {
+    let mut additional_model_options = Vec::new();
+    let mut model_access = Vec::new();
+    let mut auto_compact_windows = BTreeMap::new();
+    let mut additional_model_costs = BTreeMap::new();
+    let mut tool_search_denylist = BTreeSet::new();
+
+    for model in models {
+        let Some(context) = model.context_length.filter(|value| *value >= MIN_CONTEXT) else {
+            continue;
+        };
+        let capped = context.min(MAX_CONTEXT);
+        let stripped = strip_anthropic_prefix(&model.id);
+        let picker_value = model_picker_id(model);
+        let api_names: Vec<String> = [stripped.clone(), picker_value.clone()]
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        additional_model_options.push(ModelOption {
+            value: picker_value.clone(),
+            label: model.name.clone().unwrap_or_else(|| stripped.clone()),
+            description: context_label(capped),
+        });
+        let compact_window = auto_compact_window(&stripped, capped);
+        let max_effort = max_effort_level(&model.supported_efforts);
+        for api_name in &api_names {
+            auto_compact_windows.insert(api_name.clone(), compact_window);
+            model_access.push(ModelAccess {
+                api_name: api_name.clone(),
+                max_effort_level: max_effort.clone(),
+            });
+        }
+        if let Some(costs) = model_costs(model) {
+            for key in cost_keys(&stripped, &picker_value, model.canonical_slug.as_deref()) {
+                additional_model_costs.insert(key, costs.clone());
+            }
+        }
+        if !is_claude_id(&stripped) {
+            for api_name in api_names {
+                tool_search_denylist.insert(api_name);
+            }
+        }
+    }
+
+    let mut denylist =
+        BASE_TOOL_SEARCH_DENY.iter().map(|value| (*value).to_string()).collect::<Vec<_>>();
+    denylist.extend(tool_search_denylist);
+    denylist.sort();
+    denylist.dedup();
+
+    SeedCaches {
+        additional_model_options,
+        model_access,
+        tool_search_denylist: denylist,
+        auto_compact_windows,
+        additional_model_costs,
+    }
+}
+
+pub(crate) fn claude_settings_json(base_url: &str, seeded: bool) -> String {
+    let mut env = BTreeMap::new();
+    for (key, value) in SETTINGS_CLEAR_ENV {
+        env.insert((*key).to_string(), (*value).to_string());
+    }
+    env.insert("ANTHROPIC_BASE_URL".to_string(), anthropic_base(base_url));
+    if seeded {
+        env.insert("ENABLE_TOOL_SEARCH".to_string(), "true".to_string());
+        env.insert("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "0".to_string());
+        env.insert("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(), "1".to_string());
+        env.insert("CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(), MAX_CONTEXT.to_string());
+        env.insert("DISABLE_TELEMETRY".to_string(), "1".to_string());
+        env.insert("DISABLE_GROWTHBOOK".to_string(), "0".to_string());
+        env.insert("CLAUDE_CODE_GB_DISK_CACHE_WHEN_TELEMETRY_OFF".to_string(), "1".to_string());
+    }
+    serde_json::to_string(&json!({
+        "apiKeyHelper": "printf %s \"$OPENROUTER_API_KEY\"",
+        "env": env,
+    }))
+    .expect("settings json serializes")
+}
+
+pub(crate) fn user_passes_settings(passthrough: &[String]) -> bool {
+    passthrough.iter().any(|arg| {
+        arg == "--settings"
+            || arg == "--setting-sources"
+            || arg.starts_with("--settings=")
+            || arg.starts_with("--setting-sources=")
+    })
+}
+
+fn claude_config_path(env: &EnvLookup) -> PathBuf {
+    if let Some(dir) = env.get("CLAUDE_CONFIG_DIR").filter(|value| !value.trim().is_empty()) {
+        PathBuf::from(dir).join(".claude.json")
+    } else {
+        dirs::home_dir()
+            .map(|home| home.join(".claude.json"))
+            .unwrap_or_else(|| PathBuf::from(".claude.json"))
+    }
+}
+
+fn write_seed(path: &Path, caches: &SeedCaches) -> Result<()> {
+    let mut document = read_config_document(path)?;
+    merge_seed(&mut document, caches);
+    write_config_document(path, &document)
+}
+
+#[cfg(test)]
+pub(crate) fn write_seed_for_test(path: &Path, caches: &SeedCaches) -> Result<()> {
+    write_seed(path, caches)
+}
+
+fn read_config_document(path: &Path) -> Result<Value> {
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            let value: Value = serde_json::from_str(&contents)
+                .with_context(|| format!("failed to parse {}", path.display()))?;
+            if !value.is_object() {
+                bail!("{} root is not a JSON object", path.display());
+            }
+            Ok(value)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn merge_seed(document: &mut Value, caches: &SeedCaches) {
+    let object = document.as_object_mut().expect("claude config root is an object");
+    let previous_rx_deny = string_array(object.get(RX_SEEDED_DENYLIST_KEY));
+    let previous_gb_deny = string_array(
+        object
+            .get("cachedGrowthBookFeatures")
+            .and_then(|value| value.get(TOOL_SEARCH_UNSUPPORTED_KEY)),
+    );
+    let growthbook = object
+        .entry("cachedGrowthBookFeatures")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("cachedGrowthBookFeatures is an object");
+    let preserved = previous_gb_deny
+        .into_iter()
+        .filter(|entry| !previous_rx_deny.contains(entry))
+        .collect::<Vec<_>>();
+    let mut denylist = BASE_TOOL_SEARCH_DENY
+        .iter()
+        .map(|value| (*value).to_string())
+        .chain(preserved)
+        .chain(caches.tool_search_denylist.iter().cloned())
+        .collect::<Vec<_>>();
+    denylist.sort();
+    denylist.dedup();
+
+    growthbook.insert(TOOL_SEARCH_UNSUPPORTED_KEY.to_string(), json!(denylist));
+    object.insert(
+        "cachedGrowthBookFeaturesAt".to_string(),
+        json!(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis()),
+    );
+    object.insert(RX_SEEDED_DENYLIST_KEY.to_string(), json!(caches.tool_search_denylist));
+
+    merge_model_options(object, caches);
+    merge_model_access(object, caches);
+    merge_costs(object, caches);
+    merge_compact_windows(object, caches);
+}
+
+fn merge_model_options(object: &mut serde_json::Map<String, Value>, caches: &SeedCaches) {
+    let existing = model_options(object.get("additionalModelOptionsCache"));
+    let existing_values: HashSet<String> = existing
+        .iter()
+        .filter_map(|entry| entry.get("value").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    let mut merged = existing;
+    for option in &caches.additional_model_options {
+        if existing_values.contains(&option.value) {
+            continue;
+        }
+        merged.push(json!({
+            "value": option.value,
+            "label": option.label,
+            "description": option.description,
+        }));
+    }
+    object.insert("additionalModelOptionsCache".to_string(), Value::Array(merged));
+}
+
+fn merge_model_access(object: &mut serde_json::Map<String, Value>, caches: &SeedCaches) {
+    let existing = model_access_entries(object.get("modelAccessCache"));
+    let existing_names: HashSet<String> = existing
+        .iter()
+        .filter_map(|entry| entry.get("apiName").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    let mut merged = existing;
+    for access in &caches.model_access {
+        if existing_names.contains(&access.api_name) {
+            continue;
+        }
+        let mut entry = json!({ "apiName": access.api_name, "entitled": true });
+        if let Some(level) = &access.max_effort_level {
+            entry["maxEffortLevel"] = json!(level);
+        }
+        merged.push(entry);
+    }
+    object.insert("modelAccessCache".to_string(), Value::Array(merged));
+}
+
+fn merge_costs(object: &mut serde_json::Map<String, Value>, caches: &SeedCaches) {
+    let mut merged = object
+        .get("additionalModelCostsCache")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, value) in &caches.additional_model_costs {
+        merged.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+    object.insert("additionalModelCostsCache".to_string(), Value::Object(merged));
+}
+
+fn merge_compact_windows(object: &mut serde_json::Map<String, Value>, caches: &SeedCaches) {
+    let mut merged = object
+        .get("autoCompactWindowsCache")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, value) in &caches.auto_compact_windows {
+        merged.entry(key.clone()).or_insert(json!(value));
+    }
+    object.insert("autoCompactWindowsCache".to_string(), Value::Object(merged));
+}
+
+fn model_options(value: Option<&Value>) -> Vec<Value> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter(|item| item.get("value").is_some()).cloned().collect())
+        .unwrap_or_default()
+}
+
+fn model_access_entries(value: Option<&Value>) -> Vec<Value> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter(|item| item.get("apiName").is_some()).cloned().collect())
+        .unwrap_or_default()
+}
+
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items.iter().filter_map(|item| item.as_str().map(str::to_string)).collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn write_config_document(path: &Path, document: &Value) -> Result<()> {
+    let parent =
+        path.parent().ok_or_else(|| anyhow::anyhow!("path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let contents =
+        serde_json::to_string_pretty(document).context("failed to serialize .claude.json")?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+    temp.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write temporary file in {}", parent.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary file in {}", parent.display()))?;
+    temp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn strip_anthropic_prefix(id: &str) -> String {
+    id.strip_prefix("anthropic/").unwrap_or(id).to_string()
+}
+
+fn is_claude_id(id: &str) -> bool {
+    id.starts_with("claude-")
+}
+
+fn model_picker_id(model: &UserModel) -> String {
+    let stripped = strip_anthropic_prefix(&model.id);
+    match model.context_length {
+        Some(context) if context > MAX_CONTEXT => format!("{stripped}[1m]"),
+        _ => stripped,
+    }
+}
+
+fn context_label(context: i64) -> String {
+    if context == MAX_CONTEXT {
+        "1M context".to_string()
+    } else {
+        format!("{}K context", context.div_euclid(1000))
+    }
+}
+
+fn auto_compact_window(id: &str, context: i64) -> i64 {
+    let window = if id.starts_with("openai/") { OPENAI_COMPACT_WINDOW } else { context };
+    context.min(window)
+}
+
+fn max_effort_level(supported: &[String]) -> Option<String> {
+    const LEVELS: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
+    let supported: HashSet<&str> = supported.iter().map(String::as_str).collect();
+    LEVELS.iter().rev().find(|level| supported.contains(*level)).map(|level| (*level).to_string())
+}
+
+fn cost_keys(stripped: &str, picker: &str, canonical: Option<&str>) -> Vec<String> {
+    [Some(stripped), Some(picker), canonical]
+        .into_iter()
+        .flatten()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn model_costs(model: &UserModel) -> Option<Value> {
+    let pricing = model.pricing.as_ref()?;
+    let input = token_cost(&pricing.prompt)?;
+    let output = token_cost(&pricing.completion)?;
+    let web_search = pricing
+        .web_search
+        .as_deref()
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .unwrap_or(0.0);
+    Some(json!({
+        "inputTokens": input,
+        "outputTokens": output,
+        "promptCacheWriteTokens": token_cost(&pricing.input_cache_write).unwrap_or(input),
+        "promptCacheReadTokens": token_cost(&pricing.input_cache_read).unwrap_or(input),
+        "webSearchRequests": web_search,
+    }))
+}
+
+fn token_cost(raw: &Option<String>) -> Option<f64> {
+    let value = raw.as_deref()?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let parsed = value.parse::<f64>().ok()?;
+    if !parsed.is_finite() || parsed < 0.0 {
+        return None;
+    }
+    Some(((parsed * 1_000_000.0) * 1e12).round() / 1e12)
+}

--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::args::ConfigCommand;
+
+#[derive(Debug, Clone)]
+pub struct Paths {
+    pub dir: PathBuf,
+    pub config: PathBuf,
+    pub keys: PathBuf,
+}
+
+impl Paths {
+    pub(crate) fn user() -> Result<Self> {
+        let home =
+            dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+        Ok(Self::in_dir(home.join(".recall")))
+    }
+
+    pub(crate) fn in_dir(dir: PathBuf) -> Self {
+        Self { config: dir.join("rx.toml"), keys: dir.join("rx.keys"), dir }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AuthMode {
+    #[default]
+    ApiKey,
+    Env,
+}
+
+impl AuthMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ApiKey => "api_key",
+            Self::Env => "env",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct RxConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_gateway: Option<String>,
+    #[serde(default)]
+    pub gateway: BTreeMap<String, GatewayConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct GatewayConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub auth: AuthMode,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct KeyFile {
+    #[serde(flatten)]
+    values: BTreeMap<String, String>,
+}
+
+pub(crate) fn run(command: ConfigCommand, paths: &Paths) -> Result<()> {
+    match command {
+        ConfigCommand::SetGateway { name } => {
+            let spec = crate::launch::provider(&name)?;
+            let mut config = load_or_default(paths)?;
+            config.default_gateway = Some(spec.id.to_string());
+            ensure_gateway_entry(&mut config, spec.id, spec.default_base_url);
+            save_config(paths, &config)?;
+            println!("default gateway: {}", spec.id);
+            Ok(())
+        }
+        ConfigCommand::SetKey { provider, key } => {
+            let spec = crate::launch::provider(&provider)?;
+            let mut config = load_or_default(paths)?;
+            let entry = ensure_gateway_entry(&mut config, spec.id, spec.default_base_url);
+            entry.auth = AuthMode::ApiKey;
+            save_config(paths, &config)?;
+            let mut keys = load_keys(paths)?;
+            keys.values.insert(spec.id.to_string(), key);
+            save_keys(paths, &keys)?;
+            println!("stored API key for {}", spec.id);
+            Ok(())
+        }
+        ConfigCommand::Get { name } => {
+            print!("{}", format_get(paths, name.as_deref())?);
+            Ok(())
+        }
+    }
+}
+
+pub(crate) fn load(paths: &Paths) -> Result<Option<RxConfig>> {
+    match fs::read_to_string(&paths.config) {
+        Ok(contents) => {
+            let config: RxConfig = toml::from_str(&contents)
+                .with_context(|| format!("failed to parse {}", paths.config.display()))?;
+            Ok(Some(config))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read {}", paths.config.display()))
+        }
+    }
+}
+
+pub(crate) fn stored_key(paths: &Paths, provider: &str) -> Result<Option<String>> {
+    Ok(load_keys(paths)?.values.get(provider).cloned())
+}
+
+fn load_or_default(paths: &Paths) -> Result<RxConfig> {
+    Ok(load(paths)?.unwrap_or_default())
+}
+
+fn ensure_gateway_entry<'a>(
+    config: &'a mut RxConfig,
+    id: &str,
+    default_base_url: &str,
+) -> &'a mut GatewayConfig {
+    config.gateway.entry(id.to_string()).or_insert_with(|| GatewayConfig {
+        base_url: Some(default_base_url.to_string()),
+        auth: AuthMode::ApiKey,
+        ..Default::default()
+    })
+}
+
+pub(crate) fn format_get(paths: &Paths, name: Option<&str>) -> Result<String> {
+    let config = load_or_default(paths)?;
+    let keys = load_keys(paths)?;
+    match name {
+        None => {
+            let mut out = String::new();
+            match config.default_gateway.as_deref() {
+                Some(gateway) => out.push_str(&format!("default_gateway = {gateway}\n")),
+                None => out.push_str("default_gateway = (unset)\n"),
+            }
+            for spec in crate::launch::PROVIDERS {
+                out.push('\n');
+                out.push_str(&format_provider(&config, &keys, spec.id)?);
+            }
+            Ok(out)
+        }
+        Some("gateway") => match config.default_gateway {
+            Some(gateway) => Ok(format!("{gateway}\n")),
+            None => Ok("(unset)\n".to_string()),
+        },
+        Some(name) => Ok(format_provider(&config, &keys, name)?),
+    }
+}
+
+fn format_provider(config: &RxConfig, keys: &KeyFile, name: &str) -> Result<String> {
+    let spec = crate::launch::provider(name)?;
+    let entry = config.gateway.get(spec.id);
+    let base_url =
+        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(spec.default_base_url);
+    let auth = entry.map(|entry| entry.auth).unwrap_or_default();
+    let key = if keys.values.contains_key(spec.id) { "set" } else { "unset" };
+    let model =
+        entry.and_then(|entry| entry.model.as_deref()).or(spec.default_model).unwrap_or("(unset)");
+    Ok(format!(
+        "[{}]\nbase_url = {base_url}\nmodel = {model}\nauth = {}\nkey = {key}\n",
+        spec.id,
+        auth.as_str()
+    ))
+}
+
+fn load_keys(paths: &Paths) -> Result<KeyFile> {
+    match fs::read_to_string(&paths.keys) {
+        Ok(contents) if contents.trim().is_empty() => Ok(KeyFile::default()),
+        Ok(contents) => toml::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", paths.keys.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(KeyFile::default()),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read {}", paths.keys.display()))
+        }
+    }
+}
+
+fn save_config(paths: &Paths, config: &RxConfig) -> Result<()> {
+    let contents = toml::to_string_pretty(config).context("failed to serialize rx.toml")?;
+    write_file(&paths.config, &contents, false)
+}
+
+fn save_keys(paths: &Paths, keys: &KeyFile) -> Result<()> {
+    let contents = toml::to_string_pretty(keys).context("failed to serialize rx.keys")?;
+    write_file(&paths.keys, &contents, true)
+}
+
+fn write_file(path: &Path, contents: &str, secret: bool) -> Result<()> {
+    let parent =
+        path.parent().ok_or_else(|| anyhow::anyhow!("path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("failed to chmod {}", parent.display()))?;
+    }
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+    temp.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write temporary file in {}", parent.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary file in {}", parent.display()))?;
+    if secret {
+        set_secret_mode(temp.as_file(), path)?;
+    }
+    let persist_path = path.to_path_buf();
+    temp.persist(&persist_path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", persist_path.display()))?;
+    if secret {
+        set_secret_path_mode(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_secret_mode(file: &fs::File, path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to chmod {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_secret_mode(_file: &fs::File, _path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_secret_path_mode(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to chmod {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_secret_path_mode(_path: &Path) -> Result<()> {
+    Ok(())
+}

--- a/crates/rx/src/debug/mod.rs
+++ b/crates/rx/src/debug/mod.rs
@@ -1,0 +1,56 @@
+pub(crate) mod models;
+
+use anyhow::{Result, bail};
+
+use crate::config::Paths;
+use crate::launch::EnvLookup;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Subcommand {
+    Help,
+    Models,
+}
+
+pub(crate) fn parse(args: &[String]) -> Result<Subcommand> {
+    match args.first().map(String::as_str) {
+        None | Some("-h") | Some("--help") => Ok(Subcommand::Help),
+        Some("models") => {
+            if args.len() != 1 {
+                bail!("usage: rx debug models [--gateway <openrouter|tokener>]");
+            }
+            Ok(Subcommand::Models)
+        }
+        Some(name) => bail!("unknown debug command: {name}\n\n{}", help_text()),
+    }
+}
+
+pub(crate) fn run(
+    subcommand: Subcommand,
+    gateway: Option<String>,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<()> {
+    match subcommand {
+        Subcommand::Help => {
+            print!("{}", help_text());
+            Ok(())
+        }
+        Subcommand::Models => models::run(gateway, paths, env),
+    }
+}
+
+pub(crate) fn help_text() -> &'static str {
+    "\
+rx debug — developer diagnostics (unstable; not for everyday use)
+
+Usage:
+  rx debug models [--gateway <openrouter|tokener>]
+
+Subcommands:
+  models    probe gateway /models and /v1/models catalog endpoints
+
+Options:
+  --gateway <openrouter|tokener>   select gateway (same flag as launch commands)
+  -h, --help                       show this help
+"
+}

--- a/crates/rx/src/debug/models.rs
+++ b/crates/rx/src/debug/models.rs
@@ -1,0 +1,181 @@
+use std::collections::BTreeSet;
+
+use anyhow::{Result, bail};
+
+use crate::catalog::{self, CatalogShape, ListedModel};
+use crate::config::Paths;
+use crate::launch::{self, EnvLookup};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Probe {
+    pub url: String,
+    pub headers: Vec<String>,
+    pub status: Option<u16>,
+    pub error: Option<String>,
+    pub envelope: Vec<String>,
+    pub shape: CatalogShape,
+    pub models: Vec<ListedModel>,
+}
+
+pub(crate) fn run(gateway: Option<String>, paths: &Paths, env: &EnvLookup) -> Result<()> {
+    let Some(target) = launch::configured_gateway(gateway.as_deref(), paths, env)? else {
+        bail!("no gateway configured; run: rx config set gateway <openrouter|tokener>");
+    };
+    let openai_url = format!("{}/models", launch::openai_base(&target.base_url));
+    let anthropic_url =
+        format!("{}/v1/models?limit=1000", launch::anthropic_base(&target.base_url));
+    let openai = probe(&openai_url, &[("Authorization", format!("Bearer {}", target.key))]);
+    let anthropic = probe(
+        &anthropic_url,
+        &[
+            ("Authorization", format!("Bearer {}", target.key)),
+            ("anthropic-version", "2023-06-01".to_string()),
+        ],
+    );
+    print!("{}", render(target.spec.id, &target.base_url, &openai, &anthropic));
+    Ok(())
+}
+
+fn probe(url: &str, headers: &[(&str, String)]) -> Probe {
+    let shown_headers = headers
+        .iter()
+        .map(|(name, value)| {
+            if name.eq_ignore_ascii_case("authorization") {
+                format!("{name}: Bearer")
+            } else if name.eq_ignore_ascii_case("x-api-key") {
+                format!("{name}: (set)")
+            } else {
+                format!("{name}: {value}")
+            }
+        })
+        .collect();
+    match catalog::fetch(url, headers) {
+        Ok((status, body)) => {
+            if !(200..300).contains(&status) {
+                return Probe {
+                    url: url.to_string(),
+                    headers: shown_headers,
+                    status: Some(status),
+                    error: Some(catalog::truncate(&body, 300)),
+                    envelope: Vec::new(),
+                    shape: CatalogShape::Unknown,
+                    models: Vec::new(),
+                };
+            }
+            match catalog::parse_catalog(&body) {
+                Ok((shape, envelope, models)) => Probe {
+                    url: url.to_string(),
+                    headers: shown_headers,
+                    status: Some(status),
+                    error: None,
+                    envelope,
+                    shape,
+                    models,
+                },
+                Err(error) => Probe {
+                    url: url.to_string(),
+                    headers: shown_headers,
+                    status: Some(status),
+                    error: Some(format!("{error}; body: {}", catalog::truncate(&body, 200))),
+                    envelope: Vec::new(),
+                    shape: CatalogShape::Unknown,
+                    models: Vec::new(),
+                },
+            }
+        }
+        Err(error) => Probe {
+            url: url.to_string(),
+            headers: shown_headers,
+            status: None,
+            error: Some(error.to_string()),
+            envelope: Vec::new(),
+            shape: CatalogShape::Unknown,
+            models: Vec::new(),
+        },
+    }
+}
+
+pub(crate) fn render(gateway: &str, base_url: &str, openai: &Probe, anthropic: &Probe) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("gateway: {gateway}\n"));
+    out.push_str(&format!("base_url: {base_url}\n"));
+    out.push_str("\n## OpenAI (Codex)\n");
+    write_probe(&mut out, openai);
+    out.push_str("\n## Anthropic (Claude Code)\n");
+    write_probe(&mut out, anthropic);
+    let openai_ids = ids(openai);
+    let anthropic_ids = ids(anthropic);
+    let only_openai: Vec<_> = openai_ids.difference(&anthropic_ids).cloned().collect();
+    let only_anthropic: Vec<_> = anthropic_ids.difference(&openai_ids).cloned().collect();
+    let both = openai_ids.intersection(&anthropic_ids).count();
+    out.push_str("\n## Diff (raw id)\n");
+    out.push_str(&format!(
+        "in both: {both}\nonly OpenAI: {}\nonly Anthropic: {}\n",
+        only_openai.len(),
+        only_anthropic.len()
+    ));
+    write_id_list(&mut out, "only OpenAI", &only_openai);
+    write_id_list(&mut out, "only Anthropic", &only_anthropic);
+    let kept = anthropic.models.iter().filter(|model| claude_keeps(&model.id)).count();
+    out.push_str(&format!(
+        "\nClaude filter (id contains claude|anthropic): {kept}/{}\n",
+        anthropic.models.len()
+    ));
+    out
+}
+
+fn write_probe(out: &mut String, probe: &Probe) {
+    out.push_str(&format!("GET {}\n", probe.url));
+    for header in &probe.headers {
+        out.push_str(&format!("{header}\n"));
+    }
+    match probe.status {
+        Some(status) => out.push_str(&format!("HTTP {status}\n")),
+        None => out.push_str("HTTP (request failed)\n"),
+    }
+    if let Some(error) = &probe.error {
+        out.push_str(&format!("error: {error}\n"));
+        return;
+    }
+    out.push_str(&format!(
+        "{} models, {} envelope ({})\n",
+        probe.models.len(),
+        shape_name(probe.shape),
+        probe.envelope.join(", ")
+    ));
+    for model in &probe.models {
+        match &model.label {
+            Some(label) if label != &model.id => {
+                out.push_str(&format!("  {}  {label}\n", model.id));
+            }
+            _ => out.push_str(&format!("  {}\n", model.id)),
+        }
+    }
+}
+
+fn write_id_list(out: &mut String, title: &str, ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    out.push_str(&format!("{title}:\n"));
+    for id in ids {
+        out.push_str(&format!("  {id}\n"));
+    }
+}
+
+fn ids(probe: &Probe) -> BTreeSet<String> {
+    probe.models.iter().map(|model| model.id.clone()).collect()
+}
+
+fn claude_keeps(id: &str) -> bool {
+    let lower = id.to_ascii_lowercase();
+    lower.contains("claude") || lower.contains("anthropic")
+}
+
+fn shape_name(shape: CatalogShape) -> &'static str {
+    match shape {
+        CatalogShape::OpenAi => "openai",
+        CatalogShape::Anthropic => "anthropic",
+        CatalogShape::Unknown => "unknown",
+    }
+}

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -1,0 +1,451 @@
+use std::collections::HashMap;
+use std::process::{Command, Stdio};
+
+use anyhow::{Result, bail};
+
+use crate::args::{Harness, LaunchRequest};
+use crate::claude_catalog::{self, SeedOutcome};
+use crate::config::{AuthMode, Paths};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProviderSpec {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub default_base_url: &'static str,
+    pub env_key: &'static str,
+    pub default_model: Option<&'static str>,
+    pub claude_default_model: Option<&'static str>,
+}
+
+pub(crate) const PROVIDERS: &[ProviderSpec] = &[
+    ProviderSpec {
+        id: "openrouter",
+        name: "OpenRouter",
+        default_base_url: "https://openrouter.ai/api",
+        env_key: "OPENROUTER_API_KEY",
+        default_model: Some("~openai/gpt-latest"),
+        claude_default_model: Some("~anthropic/claude-sonnet-latest"),
+    },
+    ProviderSpec {
+        id: "tokener",
+        name: "Tokener",
+        default_base_url: "https://api.tokener.dev",
+        env_key: "TOKENER_API_KEY",
+        default_model: None,
+        claude_default_model: None,
+    },
+];
+
+pub(crate) fn provider(id: &str) -> Result<&'static ProviderSpec> {
+    PROVIDERS
+        .iter()
+        .find(|provider| provider.id == id)
+        .ok_or_else(|| anyhow::anyhow!("unknown gateway: {id} (supported: openrouter, tokener)"))
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EnvLookup {
+    overrides: HashMap<String, String>,
+    real: bool,
+}
+
+impl EnvLookup {
+    pub(crate) fn real() -> Self {
+        Self { overrides: HashMap::new(), real: true }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn isolated(overrides: HashMap<String, String>) -> Self {
+        Self { overrides, real: false }
+    }
+
+    pub(crate) fn get(&self, key: &str) -> Option<String> {
+        if let Some(value) = self.overrides.get(key) {
+            return Some(value.clone());
+        }
+        if self.real { std::env::var(key).ok() } else { None }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchPlan {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env_set: Vec<(String, String)>,
+    pub stderr_note: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GatewayTarget {
+    pub spec: &'static ProviderSpec,
+    pub base_url: String,
+    pub key: String,
+    pub model: Option<String>,
+}
+
+pub(crate) fn configured_gateway(
+    override_id: Option<&str>,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<Option<GatewayTarget>> {
+    let config = crate::config::load(paths)?;
+    let gateway_id = override_id
+        .map(str::to_string)
+        .or_else(|| config.as_ref().and_then(|config| config.default_gateway.clone()));
+    let Some(gateway_id) = gateway_id else {
+        return Ok(None);
+    };
+    let spec = provider(&gateway_id)?;
+    let entry = config.as_ref().and_then(|config| config.gateway.get(spec.id));
+    let base_url =
+        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(spec.default_base_url);
+    let auth = entry.map(|entry| entry.auth).unwrap_or(AuthMode::ApiKey);
+    let key = resolve_key(spec, auth, paths, env)?;
+    let model = entry.and_then(|entry| entry.model.clone());
+    Ok(Some(GatewayTarget { spec, base_url: base_url.to_string(), key, model }))
+}
+
+pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> Result<LaunchPlan> {
+    let Some(target) = configured_gateway(request.gateway.as_deref(), paths, env)? else {
+        return Ok(passthrough(request));
+    };
+    let model = target.model.as_deref().or(match request.harness {
+        Harness::Claude => target.spec.claude_default_model,
+        Harness::Codex => target.spec.default_model,
+        Harness::OpenCode | Harness::Pi => None,
+    });
+    if matches!(request.harness, Harness::Claude) && target.spec.id == "openrouter" {
+        let seed = claude_catalog::try_seed_openrouter(&target.base_url, &target.key, env)?;
+        return Ok(inject_claude_openrouter(request, &target.base_url, &target.key, model, seed));
+    }
+    inject(request, paths, env, target.spec, &target.base_url, &target.key, model)
+}
+
+fn passthrough(request: &LaunchRequest) -> LaunchPlan {
+    LaunchPlan {
+        program: request.harness.as_str().to_string(),
+        args: request.passthrough.clone(),
+        env_set: Vec::new(),
+        stderr_note: Some(format!(
+            "[rx] no gateway configured; launching {} as-is (configure: rx config set gateway <name>)",
+            request.harness.as_str()
+        )),
+    }
+}
+
+fn resolve_key(
+    spec: &ProviderSpec,
+    auth: AuthMode,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<String> {
+    match auth {
+        AuthMode::Env => env.get(spec.env_key).ok_or_else(|| {
+            anyhow::anyhow!(
+                "gateway '{}' is set to auth = env, but ${} is not set",
+                spec.id,
+                spec.env_key
+            )
+        }),
+        AuthMode::ApiKey => {
+            if let Some(key) = crate::config::stored_key(paths, spec.id)? {
+                return Ok(key);
+            }
+            if let Some(key) = env.get(spec.env_key) {
+                return Ok(key);
+            }
+            bail!(
+                "no API key for gateway '{}'; run: rx config set key {} <key>  (or set ${} and auth = \"env\")",
+                spec.id,
+                spec.id,
+                spec.env_key
+            )
+        }
+    }
+}
+
+fn inject_claude_openrouter(
+    request: &LaunchRequest,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    seed: SeedOutcome,
+) -> LaunchPlan {
+    inject_claude_openrouter_impl(request, base_url, key, model, seed)
+}
+
+#[cfg(test)]
+pub(crate) fn inject_claude_openrouter_for_test(
+    request: &LaunchRequest,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    seed: SeedOutcome,
+) -> LaunchPlan {
+    inject_claude_openrouter_impl(request, base_url, key, model, seed)
+}
+
+fn inject_claude_openrouter_impl(
+    request: &LaunchRequest,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    seed: SeedOutcome,
+) -> LaunchPlan {
+    let seeded = matches!(seed, SeedOutcome::Seeded { .. });
+    let mut args = request.passthrough.clone();
+    if seeded && !claude_catalog::user_passes_settings(&request.passthrough) {
+        args.insert(0, claude_catalog::claude_settings_json(base_url, true));
+        args.insert(0, "--settings".to_string());
+    }
+    let stderr_note = match seed {
+        SeedOutcome::Fallback => Some(
+            "[rx] OpenRouter catalog seed failed; falling back to gateway model discovery"
+                .to_string(),
+        ),
+        SeedOutcome::Seeded { .. } => None,
+    };
+    LaunchPlan {
+        program: "claude".to_string(),
+        args,
+        env_set: claude_openrouter_env(base_url, key, model, seeded),
+        stderr_note,
+    }
+}
+
+fn claude_openrouter_env(
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    seeded: bool,
+) -> Vec<(String, String)> {
+    let mut env_set = vec![
+        ("ANTHROPIC_BASE_URL".to_string(), anthropic_base(base_url)),
+        ("ANTHROPIC_API_KEY".to_string(), key.to_string()),
+        ("ANTHROPIC_AUTH_TOKEN".to_string(), String::new()),
+        ("OPENROUTER_API_KEY".to_string(), key.to_string()),
+        ("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK".to_string(), "1".to_string()),
+        ("CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT".to_string(), "1".to_string()),
+    ];
+    if seeded {
+        env_set.extend([
+            ("ENABLE_TOOL_SEARCH".to_string(), "true".to_string()),
+            ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "0".to_string()),
+            ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(), "1".to_string()),
+            ("CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(), "1000000".to_string()),
+            ("DISABLE_TELEMETRY".to_string(), "1".to_string()),
+            ("DISABLE_GROWTHBOOK".to_string(), "0".to_string()),
+            ("CLAUDE_CODE_GB_DISK_CACHE_WHEN_TELEMETRY_OFF".to_string(), "1".to_string()),
+        ]);
+    } else {
+        env_set.push(("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "1".to_string()));
+        let sonnet = model.unwrap_or("~anthropic/claude-sonnet-latest");
+        env_set.extend([
+            (
+                "ANTHROPIC_DEFAULT_FABLE_MODEL".to_string(),
+                "~anthropic/claude-fable-latest".to_string(),
+            ),
+            (
+                "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
+                "~anthropic/claude-opus-latest".to_string(),
+            ),
+            ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(), sonnet.to_string()),
+            (
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
+                "~anthropic/claude-haiku-latest".to_string(),
+            ),
+        ]);
+    }
+    if let Some(model) = model {
+        env_set.push(("ANTHROPIC_MODEL".to_string(), model.to_string()));
+    }
+    env_set
+}
+
+fn claude_env(
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut env_set = vec![
+        ("ANTHROPIC_BASE_URL".to_string(), anthropic_base(base_url)),
+        ("ANTHROPIC_AUTH_TOKEN".to_string(), key.to_string()),
+        ("ANTHROPIC_API_KEY".to_string(), String::new()),
+        ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "1".to_string()),
+        (spec.env_key.to_string(), key.to_string()),
+    ];
+    if spec.id == "openrouter" {
+        let sonnet = model.unwrap_or("~anthropic/claude-sonnet-latest");
+        env_set.extend([
+            (
+                "ANTHROPIC_DEFAULT_FABLE_MODEL".to_string(),
+                "~anthropic/claude-fable-latest".to_string(),
+            ),
+            (
+                "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
+                "~anthropic/claude-opus-latest".to_string(),
+            ),
+            ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(), sonnet.to_string()),
+            (
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
+                "~anthropic/claude-haiku-latest".to_string(),
+            ),
+        ]);
+    }
+    if let Some(model) = model {
+        env_set.push(("ANTHROPIC_MODEL".to_string(), model.to_string()));
+    }
+    env_set
+}
+
+fn inject(
+    request: &LaunchRequest,
+    paths: &Paths,
+    env: &EnvLookup,
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+) -> Result<LaunchPlan> {
+    match request.harness {
+        Harness::Claude => Ok(LaunchPlan {
+            program: "claude".to_string(),
+            args: request.passthrough.clone(),
+            env_set: claude_env(spec, base_url, key, model),
+            stderr_note: None,
+        }),
+        Harness::Codex => {
+            let openai_base = openai_base(base_url);
+            let mut args = vec![
+                "-c".to_string(),
+                format!("model_provider=\"{}\"", spec.id),
+                "-c".to_string(),
+                codex_provider_override(spec, &openai_base),
+            ];
+            if let Some(model) = model.filter(|_| !user_sets_model(&request.passthrough)) {
+                args.push("-c".to_string());
+                args.push(format!("model=\"{model}\""));
+            }
+            args.extend(request.passthrough.iter().cloned());
+            Ok(LaunchPlan {
+                program: "codex".to_string(),
+                args,
+                env_set: vec![(spec.env_key.to_string(), key.to_string())],
+                stderr_note: None,
+            })
+        }
+        Harness::OpenCode => {
+            let env_set = vec![
+                (spec.env_key.to_string(), key.to_string()),
+                (
+                    "OPENCODE_CONFIG_CONTENT".to_string(),
+                    crate::opencode::config_content(spec, base_url, key)?,
+                ),
+            ];
+            let mut args = request.passthrough.clone();
+            if let Some(model) = model.filter(|_| !user_sets_opencode_model(&request.passthrough)) {
+                args.insert(0, crate::opencode::prefixed_model(spec.id, model));
+                args.insert(0, "-m".to_string());
+            }
+            Ok(LaunchPlan {
+                program: "opencode".to_string(),
+                args,
+                env_set,
+                stderr_note: crate::opencode::auth_conflict_note(spec, key, env),
+            })
+        }
+        Harness::Pi => {
+            crate::pi::prepare(spec, base_url, key, paths)?;
+            Ok(LaunchPlan {
+                program: "pi".to_string(),
+                args: crate::pi::args(spec, model, &request.passthrough),
+                env_set: crate::pi::env_set(spec, key),
+                stderr_note: None,
+            })
+        }
+    }
+}
+
+fn codex_provider_override(spec: &ProviderSpec, openai_base: &str) -> String {
+    format!(
+        "model_providers.{}={{name=\"{}\", base_url=\"{}\", wire_api=\"responses\", supports_websockets=false, {}}}",
+        spec.id,
+        spec.name,
+        openai_base,
+        auth_override(spec.env_key)
+    )
+}
+
+fn auth_override(env_key: &str) -> String {
+    #[cfg(unix)]
+    {
+        format!("auth={{command=\"sh\", args=[\"-c\", \"printf %s \\\"${env_key}\\\"\"]}}")
+    }
+    #[cfg(not(unix))]
+    {
+        format!(
+            "auth={{command=\"powershell\", args=[\"-NoProfile\", \"-Command\", \"Write-Output $env:{env_key}\"]}}"
+        )
+    }
+}
+
+fn user_sets_opencode_model(passthrough: &[String]) -> bool {
+    passthrough.iter().any(|arg| arg == "-m" || arg.starts_with("-m="))
+}
+
+fn user_sets_model(passthrough: &[String]) -> bool {
+    let mut i = 0;
+    while i < passthrough.len() {
+        let arg = &passthrough[i];
+        if arg == "-m" || arg == "--model" {
+            return true;
+        }
+        if arg.starts_with("--model=") {
+            return true;
+        }
+        if arg == "-c" || arg == "--config" {
+            if passthrough.get(i + 1).is_some_and(|value| value.starts_with("model=")) {
+                return true;
+            }
+            i += 1;
+        }
+        i += 1;
+    }
+    false
+}
+
+pub(crate) fn anthropic_base(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+}
+
+pub(crate) fn openai_base(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") { trimmed.to_string() } else { format!("{trimmed}/v1") }
+}
+
+pub(crate) fn exec(plan: &LaunchPlan) -> Result<()> {
+    let mut cmd = Command::new(&plan.program);
+    cmd.args(&plan.args);
+    for (key, value) in &plan.env_set {
+        cmd.env(key, value);
+    }
+    cmd.stdin(Stdio::inherit()).stdout(Stdio::inherit()).stderr(Stdio::inherit());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let error = cmd.exec();
+        Err(anyhow::Error::from(error).context(format!("failed to exec {}", plan.program)))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = cmd.status()?;
+        if !status.success() {
+            anyhow::bail!("{} exited with status {status}", plan.program);
+        }
+        Ok(())
+    }
+}

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -1,0 +1,76 @@
+mod args;
+mod catalog;
+mod claude_catalog;
+mod config;
+mod debug;
+mod launch;
+mod opencode;
+mod pi;
+mod update;
+
+use anyhow::Result;
+
+use args::{Command, parse, rewrite_argv0};
+pub use config::Paths;
+use launch::{EnvLookup, plan};
+
+pub fn run(raw_args: impl IntoIterator<Item = String>) -> Result<()> {
+    run_with(raw_args.into_iter().collect(), &Paths::user()?, &EnvLookup::real())
+}
+
+pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result<()> {
+    let args = rewrite_argv0(raw_args.clone());
+    let command = parse(&args)?;
+    if matches!(command, Command::Launch(_)) {
+        update::maybe_before_launch(paths, env, &raw_args)?;
+    }
+    match command {
+        Command::Help => {
+            print!("{}", help_text());
+            Ok(())
+        }
+        Command::Version => {
+            println!("rx {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        Command::Config(command) => config::run(command, paths),
+        Command::Debug { subcommand, gateway } => debug::run(subcommand, gateway, paths, env),
+        Command::Update { yes } => update::run(yes, paths),
+        Command::Launch(request) => {
+            let plan = plan(&request, paths, env)?;
+            if let Some(note) = &plan.stderr_note {
+                eprintln!("{note}");
+            }
+            launch::exec(&plan)
+        }
+    }
+}
+
+pub fn help_text() -> &'static str {
+    "\
+rx — launch agent harnesses through a configured API gateway
+
+Usage:
+  rx <harness> [args...]
+  rx config set gateway <openrouter|tokener>
+  rx config set key <openrouter|tokener> <key>
+  rx config get [name]
+  rx update [--yes]
+
+Options:
+  --gateway <openrouter|tokener>   select gateway for this launch
+  -h, --help                       show this help
+  -V, --version                    show version
+
+Environment:
+  RX_NO_UPDATE=1                   skip launch-time update checks
+
+Developer: rx debug --help
+
+With no gateway configured, rx execs the harness unchanged.
+Gateway flags are stripped; every other argument is passed through.
+"
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rx/src/main.rs
+++ b/crates/rx/src/main.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = rx::run(std::env::args()) {
+        eprintln!("{error:#}");
+        std::process::exit(1);
+    }
+}

--- a/crates/rx/src/opencode.rs
+++ b/crates/rx/src/opencode.rs
@@ -14,6 +14,7 @@ pub(crate) fn config_content(spec: &ProviderSpec, base_url: &str, key: &str) -> 
             "provider": {
                 "openrouter": {
                     "options": {
+                        "baseURL": openai_base(base_url),
                         "apiKey": format!("{{env:{}}}", spec.env_key)
                     }
                 }

--- a/crates/rx/src/opencode.rs
+++ b/crates/rx/src/opencode.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use crate::catalog;
+use crate::launch::{EnvLookup, ProviderSpec, openai_base};
+
+pub(crate) fn config_content(spec: &ProviderSpec, base_url: &str, key: &str) -> Result<String> {
+    let value = match spec.id {
+        "openrouter" => json!({
+            "provider": {
+                "openrouter": {
+                    "options": {
+                        "apiKey": format!("{{env:{}}}", spec.env_key)
+                    }
+                }
+            }
+        }),
+        "tokener" => {
+            let models = fetch_model_map(base_url, key)?;
+            json!({
+                "provider": {
+                    "tokener": {
+                        "npm": "@ai-sdk/openai-compatible",
+                        "name": "Tokener",
+                        "options": {
+                            "baseURL": openai_base(base_url),
+                            "apiKey": format!("{{env:{}}}", spec.env_key)
+                        },
+                        "models": models
+                    }
+                }
+            })
+        }
+        _ => json!({}),
+    };
+    serde_json::to_string(&value).context("failed to serialize OPENCODE_CONFIG_CONTENT")
+}
+
+pub(crate) fn auth_conflict_note(
+    spec: &ProviderSpec,
+    key: &str,
+    env: &EnvLookup,
+) -> Option<String> {
+    if spec.id != "openrouter" {
+        return None;
+    }
+    let path = opencode_auth_path(env).ok()?;
+    let stored = fs::read_to_string(&path).ok()?;
+    let document: Value = serde_json::from_str(&stored).ok()?;
+    let stored_key = document.get("openrouter").and_then(|entry| {
+        entry
+            .get("key")
+            .and_then(Value::as_str)
+            .or_else(|| entry.get("apiKey").and_then(Value::as_str))
+    });
+    if stored_key.is_some_and(|stored_key| stored_key != key) {
+        Some(format!(
+            "[rx] opencode stored OpenRouter credential at {} differs from rx gateway key; remove or update it to avoid auth conflicts",
+            path.display()
+        ))
+    } else {
+        None
+    }
+}
+
+pub(crate) fn prefixed_model(provider_id: &str, model: &str) -> String {
+    let prefix = format!("{provider_id}/");
+    if model.starts_with(&prefix) { model.to_string() } else { format!("{prefix}{model}") }
+}
+
+pub(crate) fn fetch_model_map(base_url: &str, key: &str) -> Result<BTreeMap<String, Value>> {
+    let url = format!("{}/models", openai_base(base_url));
+    let body = catalog::fetch_get(&url, &[("Authorization", format!("Bearer {key}"))])?;
+    let payload: Value =
+        serde_json::from_str(&body).context("tokener models response is not JSON")?;
+    let Some(rows) = payload.get("data").and_then(Value::as_array) else {
+        return Ok(BTreeMap::new());
+    };
+    Ok(rows
+        .iter()
+        .filter_map(|row| row.get("id").and_then(Value::as_str))
+        .map(|id| (id.to_string(), json!({ "name": id })))
+        .collect())
+}
+
+fn opencode_auth_path(env: &EnvLookup) -> Result<PathBuf> {
+    if let Some(dir) = env.get("XDG_DATA_HOME").filter(|value| !value.trim().is_empty()) {
+        return Ok(PathBuf::from(dir).join("opencode").join("auth.json"));
+    }
+    let home = dirs::home_dir().context("cannot determine home directory")?;
+    Ok(home.join(".local").join("share").join("opencode").join("auth.json"))
+}

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -18,6 +18,21 @@ const PI_ENV_CLEAR: &[&str] = &[
 ];
 
 pub(crate) fn global_agent_dir() -> Result<PathBuf> {
+    // PI_CODING_AGENT_DIR is authoritative for pi's configuration location
+    // (see src/adapters/pi.rs); providers must land where the launched
+    // process will actually read them.
+    if let Some(dir) = std::env::var("PI_CODING_AGENT_DIR")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        let home = dirs::home_dir().unwrap_or_default();
+        let expanded = match dir.strip_prefix("~/") {
+            Some(rest) => home.join(rest),
+            None => PathBuf::from(dir),
+        };
+        return Ok(expanded);
+    }
     let home = dirs::home_dir().context("cannot determine home directory")?;
     Ok(home.join(".pi").join("agent"))
 }

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -1,0 +1,134 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use crate::config::Paths;
+use crate::launch::{ProviderSpec, openai_base};
+use crate::opencode;
+
+const PI_ENV_CLEAR: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "OPENAI_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+];
+
+pub(crate) fn global_agent_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("cannot determine home directory")?;
+    Ok(home.join(".pi").join("agent"))
+}
+
+pub(crate) fn recall_pi_dir(paths: &Paths) -> PathBuf {
+    paths.dir.join("pi")
+}
+
+pub(crate) fn prepare(spec: &ProviderSpec, base_url: &str, key: &str, paths: &Paths) -> Result<()> {
+    if spec.id != "tokener" {
+        return Ok(());
+    }
+    let provider = tokener_provider(spec, base_url, key)?;
+    let recall_dir = recall_pi_dir(paths);
+    fs::create_dir_all(&recall_dir)
+        .with_context(|| format!("failed to create {}", recall_dir.display()))?;
+    write_json_atomic(&recall_dir.join("tokener-provider.json"), &provider)?;
+    let agent_dir = global_agent_dir()?;
+    fs::create_dir_all(&agent_dir)
+        .with_context(|| format!("failed to create {}", agent_dir.display()))?;
+    merge_provider(&agent_dir.join("models.json"), "tokener", provider)
+}
+
+pub(crate) fn env_set(spec: &ProviderSpec, key: &str) -> Vec<(String, String)> {
+    let mut env_set = vec![(spec.env_key.to_string(), key.to_string())];
+    for name in PI_ENV_CLEAR {
+        env_set.push(((*name).to_string(), String::new()));
+    }
+    env_set
+}
+
+pub(crate) fn args(
+    spec: &ProviderSpec,
+    model: Option<&str>,
+    passthrough: &[String],
+) -> Vec<String> {
+    let mut args = Vec::new();
+    if !user_sets_models_flag(passthrough) {
+        args.push("--models".to_string());
+        args.push(format!("{}/*", spec.id));
+    }
+    if let Some(model) = model.filter(|_| !user_sets_model(passthrough)) {
+        args.push("--model".to_string());
+        args.push(opencode::prefixed_model(spec.id, model));
+    } else if !user_sets_provider(passthrough) {
+        args.push("--provider".to_string());
+        args.push(spec.id.to_string());
+    }
+    args.extend(passthrough.iter().cloned());
+    args
+}
+
+fn user_sets_models_flag(passthrough: &[String]) -> bool {
+    passthrough.iter().any(|arg| arg == "--models" || arg.starts_with("--models="))
+}
+
+fn user_sets_provider(passthrough: &[String]) -> bool {
+    passthrough.iter().any(|arg| arg == "--provider" || arg.starts_with("--provider="))
+}
+
+fn tokener_provider(spec: &ProviderSpec, base_url: &str, key: &str) -> Result<Value> {
+    let models: Vec<Value> =
+        opencode::fetch_model_map(base_url, key)?.keys().map(|id| json!({ "id": id })).collect();
+    if models.is_empty() {
+        bail!("tokener returned no models from {}", openai_base(base_url));
+    }
+    Ok(json!({
+        "baseUrl": openai_base(base_url),
+        "apiKey": format!("${}", spec.env_key),
+        "api": "openai-responses",
+        "authHeader": true,
+        "models": models
+    }))
+}
+
+pub(crate) fn merge_provider(models_path: &Path, provider_id: &str, provider: Value) -> Result<()> {
+    let mut document = if models_path.is_file() {
+        let body = fs::read_to_string(models_path)
+            .with_context(|| format!("failed to read {}", models_path.display()))?;
+        serde_json::from_str(&body).with_context(|| {
+            format!("failed to parse {}; fix or remove the file and retry", models_path.display())
+        })?
+    } else {
+        json!({ "providers": {} })
+    };
+    let Some(providers) = document.get_mut("providers").and_then(Value::as_object_mut) else {
+        document["providers"] = json!({});
+        document["providers"][provider_id] = provider;
+        return write_json_atomic(models_path, &document);
+    };
+    providers.insert(provider_id.to_string(), provider);
+    write_json_atomic(models_path, &document)
+}
+
+fn write_json_atomic(path: &Path, document: &Value) -> Result<()> {
+    let parent = path.parent().context("json file has no parent directory")?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let payload = serde_json::to_string_pretty(document).context("failed to serialize json")?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary {}", path.display()))?;
+    temp.write_all(payload.as_bytes())
+        .with_context(|| format!("failed to write temporary {}", path.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary {}", path.display()))?;
+    temp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn user_sets_model(passthrough: &[String]) -> bool {
+    passthrough.iter().any(|arg| arg == "-m" || arg == "--model" || arg.starts_with("--model="))
+}

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -154,6 +154,18 @@ fn argv0_harness_resolves_aliases() {
 }
 
 #[test]
+fn claude_seed_replaces_wrong_typed_growthbook_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join(".claude.json");
+    fs::write(&config_path, r#"{"cachedGrowthBookFeatures": null}"#).unwrap();
+    let caches = crate::claude_catalog::SeedCaches::default();
+    crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap();
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert!(document["cachedGrowthBookFeatures"].is_object());
+}
+
+#[test]
 fn release_asset_name_matches_host() {
     let name = crate::update::release_asset_name().unwrap();
     assert!(name.starts_with("recall-"));

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1,0 +1,724 @@
+use std::collections::HashMap;
+use std::fs;
+
+use crate::args::{Command, ConfigCommand, Harness, LaunchRequest, parse, rewrite_argv0};
+use crate::config::{self, Paths};
+use crate::launch::{self, EnvLookup};
+
+fn args(argv: &[&str]) -> Vec<String> {
+    argv.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+fn parse_line(argv: &[&str]) -> Command {
+    parse(&rewrite_argv0(args(argv))).unwrap()
+}
+
+fn temp_paths() -> (tempfile::TempDir, Paths) {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = Paths::in_dir(dir.path().to_path_buf());
+    (dir, paths)
+}
+
+#[test]
+fn rxc_inserts_claude() {
+    let command = parse_line(&["/usr/local/bin/rxc", "fix login"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Claude,
+            gateway: None,
+            passthrough: vec!["fix login".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rxx_inserts_codex() {
+    let command = parse_line(&["rxx", "exec", "cargo test"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Codex,
+            gateway: None,
+            passthrough: vec!["exec".to_string(), "cargo test".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rxc_keeps_leading_gateway_flag() {
+    let command = parse_line(&["rxc", "--gateway", "tokener"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("tokener".to_string()),
+            passthrough: Vec::new(),
+        })
+    );
+}
+
+#[test]
+fn gateway_flag_before_or_after_harness() {
+    let before = parse_line(&["rx", "--gateway", "openrouter", "claude", "--resume", "abc"]);
+    let after = parse_line(&["rx", "claude", "--gateway=openrouter", "--resume", "abc"]);
+    let expected = Command::Launch(LaunchRequest {
+        harness: Harness::Claude,
+        gateway: Some("openrouter".to_string()),
+        passthrough: vec!["--resume".to_string(), "abc".to_string()],
+    });
+    assert_eq!(before, expected);
+    assert_eq!(after, expected);
+}
+
+#[test]
+fn gateway_after_double_dash_is_passthrough() {
+    let command = parse_line(&["rx", "claude", "--", "--gateway", "openrouter"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Claude,
+            gateway: None,
+            passthrough: vec!["--".to_string(), "--gateway".to_string(), "openrouter".to_string()],
+        })
+    );
+}
+
+#[test]
+fn claude_help_is_passthrough() {
+    let command = parse_line(&["rx", "claude", "--help"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Claude,
+            gateway: None,
+            passthrough: vec!["--help".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rx_help_and_version() {
+    assert_eq!(parse_line(&["rx", "--help"]), Command::Help);
+    assert_eq!(parse_line(&["rx", "-V"]), Command::Version);
+}
+
+#[test]
+fn update_parses_yes_flag() {
+    assert_eq!(parse_line(&["rx", "update"]), Command::Update { yes: false });
+    assert_eq!(parse_line(&["rx", "update", "--yes"]), Command::Update { yes: true });
+}
+
+#[test]
+fn version_cmp_orders_releases() {
+    use std::cmp::Ordering;
+
+    assert_eq!(crate::update::version_cmp("0.1.0", "0.5.0"), Ordering::Less);
+    assert_eq!(crate::update::version_cmp("0.5.0", "0.5.0"), Ordering::Equal);
+    assert_eq!(crate::update::version_cmp("0.6.0", "0.5.0"), Ordering::Greater);
+}
+
+#[test]
+fn release_asset_name_matches_host() {
+    let name = crate::update::release_asset_name().unwrap();
+    assert!(name.starts_with("recall-"));
+}
+
+#[test]
+fn unknown_harness_errors() {
+    let error = parse(&args(&["rx", "gemini"])).unwrap_err();
+    assert!(error.to_string().contains("unknown harness: gemini"), "{error}");
+}
+
+#[test]
+fn rxo_inserts_opencode() {
+    let command = parse_line(&["rxo", "run", "hello"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::OpenCode,
+            gateway: None,
+            passthrough: vec!["run".to_string(), "hello".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rxp_inserts_pi() {
+    let command = parse_line(&["rxp", "--print", "hi"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Pi,
+            gateway: None,
+            passthrough: vec!["--print".to_string(), "hi".to_string()],
+        })
+    );
+}
+
+#[test]
+fn missing_gateway_value_errors() {
+    let error = parse(&args(&["rx", "claude", "--gateway"])).unwrap_err();
+    assert!(error.to_string().contains("--gateway requires a value"), "{error}");
+}
+
+#[test]
+fn config_set_and_get_parse() {
+    assert_eq!(
+        parse_line(&["rx", "config", "set", "gateway", "openrouter"]),
+        Command::Config(ConfigCommand::SetGateway { name: "openrouter".to_string() })
+    );
+    assert_eq!(
+        parse_line(&["rx", "config", "set", "key", "tokener", "sk-test"]),
+        Command::Config(ConfigCommand::SetKey {
+            provider: "tokener".to_string(),
+            key: "sk-test".to_string(),
+        })
+    );
+    assert_eq!(
+        parse_line(&["rx", "config", "get"]),
+        Command::Config(ConfigCommand::Get { name: None })
+    );
+}
+
+#[test]
+fn unconfigured_launch_is_passthrough() {
+    let (_dir, paths) = temp_paths();
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: None,
+            passthrough: vec!["--resume".to_string(), "abc".to_string()],
+        },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap();
+    assert_eq!(plan.program, "claude");
+    assert_eq!(plan.args, vec!["--resume", "abc"]);
+    assert!(plan.env_set.is_empty());
+    assert!(plan.stderr_note.as_deref().unwrap().contains("no gateway configured"));
+}
+
+#[test]
+fn claude_openrouter_uses_api_key_and_discovery_fallback_without_seed() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("openrouter".to_string()),
+            passthrough: vec!["fix it".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, "claude");
+    assert_eq!(plan.args, vec!["fix it"]);
+    assert!(
+        plan.env_set
+            .iter()
+            .any(|(k, v)| k == "ANTHROPIC_BASE_URL" && v == "https://openrouter.ai/api")
+    );
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v == "sk-or-test"));
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v.is_empty()));
+    assert!(
+        plan.env_set
+            .iter()
+            .any(|(k, v)| k == "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" && v == "1")
+    );
+    assert!(plan.env_set.iter().any(|(k, v)| k == "OPENROUTER_API_KEY" && v == "sk-or-test"));
+    assert!(
+        plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_DEFAULT_SONNET_MODEL"
+            && v == "~anthropic/claude-sonnet-latest")
+    );
+    assert!(
+        plan.env_set
+            .iter()
+            .any(|(k, v)| k == "ANTHROPIC_MODEL" && v == "~anthropic/claude-sonnet-latest")
+    );
+    assert!(plan.stderr_note.as_deref().unwrap().contains("catalog seed failed"));
+}
+
+#[test]
+fn claude_injection_tokener_still_uses_auth_token() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("tokener".to_string()),
+            passthrough: vec!["fix it".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v == "sk-tokener"));
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v.is_empty()));
+}
+
+#[test]
+fn codex_openrouter_overrides_model_and_uses_command_auth() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Codex,
+            gateway: Some("openrouter".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, "codex");
+    assert_eq!(plan.args[0], "-c");
+    assert_eq!(plan.args[1], "model_provider=\"openrouter\"");
+    assert!(plan.args[3].contains("base_url=\"https://openrouter.ai/api/v1\""));
+    assert!(plan.args[3].contains("wire_api=\"responses\""));
+    assert!(plan.args[3].contains("supports_websockets=false"));
+    assert!(plan.args[3].contains("auth={command=\"sh\""));
+    assert!(!plan.args[3].contains("env_key="));
+    assert_eq!(plan.args[5], "model=\"~openai/gpt-latest\"");
+    assert_eq!(plan.env_set, vec![("OPENROUTER_API_KEY".to_string(), "sk-or-test".to_string())]);
+}
+
+#[test]
+fn opencode_openrouter_injects_config_and_model() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::OpenCode,
+            gateway: Some("openrouter".to_string()),
+            passthrough: vec!["run".to_string(), "hello".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, "opencode");
+    assert_eq!(plan.args, vec!["run".to_string(), "hello".to_string()]);
+    assert!(plan.env_set.iter().any(|(k, v)| k == "OPENROUTER_API_KEY" && v == "sk-or-test"));
+    let config = plan
+        .env_set
+        .iter()
+        .find(|(k, _)| k == "OPENCODE_CONFIG_CONTENT")
+        .map(|(_, v)| v.as_str())
+        .unwrap();
+    assert!(config.contains("openrouter"));
+    assert!(config.contains("OPENROUTER_API_KEY"));
+}
+
+#[test]
+fn pi_openrouter_injects_provider_without_extension() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Pi,
+            gateway: Some("openrouter".to_string()),
+            passthrough: vec!["--print".to_string(), "hi".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, "pi");
+    assert_eq!(plan.args[0], "--models");
+    assert_eq!(plan.args[1], "openrouter/*");
+    assert_eq!(plan.args[2], "--provider");
+    assert_eq!(plan.args[3], "openrouter");
+    assert!(!plan.args.iter().any(|arg| arg == "--extension"));
+    assert!(!plan.env_set.iter().any(|(k, _)| k == "PI_CODING_AGENT_DIR"));
+    assert!(plan.env_set.iter().any(|(k, v)| k == "OPENROUTER_API_KEY" && v == "sk-or-test"));
+}
+
+#[test]
+fn pi_tokener_merges_provider_into_models_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let models_path = dir.path().join("models.json");
+    fs::write(&models_path, r#"{"providers":{"ollama":{"baseUrl":"http://127.0.0.1:11434/v1"}}}"#)
+        .unwrap();
+    let provider = serde_json::json!({
+        "baseUrl": "https://api.tokener.dev/v1",
+        "apiKey": "$TOKENER_API_KEY",
+        "api": "openai-responses",
+        "models": [{ "id": "gpt-5.6-sol" }]
+    });
+    crate::pi::merge_provider(&models_path, "tokener", provider).unwrap();
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&models_path).unwrap()).unwrap();
+    assert!(document["providers"]["ollama"].is_object());
+    assert_eq!(document["providers"]["tokener"]["baseUrl"], "https://api.tokener.dev/v1");
+}
+
+#[test]
+fn pi_merge_provider_refuses_to_reset_corrupt_models_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let models_path = dir.path().join("models.json");
+    fs::write(&models_path, "{").unwrap();
+    let provider = serde_json::json!({ "baseUrl": "https://api.tokener.dev/v1" });
+    let error = crate::pi::merge_provider(&models_path, "tokener", provider).unwrap_err();
+    assert!(error.to_string().contains("failed to parse"));
+    // The corrupt file must be left untouched, not overwritten with an empty provider map.
+    assert_eq!(fs::read_to_string(&models_path).unwrap(), "{");
+}
+
+#[test]
+fn pi_tokener_writes_recall_cache() {
+    let (dir, paths) = temp_paths();
+    let spec = launch::provider("tokener").unwrap();
+    if crate::pi::prepare(spec, "https://api.tokener.dev", "sk-test", &paths).is_err() {
+        return;
+    }
+    let cache = dir.path().join("pi/tokener-provider.json");
+    assert!(cache.is_file());
+    let body = fs::read_to_string(cache).unwrap();
+    assert!(body.contains("\"baseUrl\": \"https://api.tokener.dev/v1\""));
+}
+
+#[test]
+fn codex_passthrough_model_flag_wins() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Codex,
+            gateway: Some("openrouter".to_string()),
+            passthrough: vec!["--model".to_string(), "anthropic/claude-sonnet-4.6".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert!(!plan.args.iter().any(|arg| arg.starts_with("model=")));
+    assert_eq!(plan.args[plan.args.len() - 2], "--model");
+    assert_eq!(plan.args[plan.args.len() - 1], "anthropic/claude-sonnet-4.6");
+}
+
+#[test]
+fn codex_tokener_does_not_invent_a_model() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Codex,
+            gateway: Some("tokener".to_string()),
+            passthrough: vec!["exec".to_string(), "cargo test".to_string()],
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.args[1], "model_provider=\"tokener\"");
+    assert!(plan.args[3].contains("base_url=\"https://api.tokener.dev/v1\""));
+    assert!(!plan.args.iter().any(|arg| arg.starts_with("model=")));
+    assert_eq!(plan.args[4..], ["exec", "cargo test"]);
+}
+
+#[test]
+fn missing_key_errors_before_exec() {
+    let (_dir, paths) = temp_paths();
+    let error = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("openrouter".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("no API key for gateway 'openrouter'"), "{error}");
+}
+
+#[test]
+fn config_set_key_is_redacted_and_secret() {
+    let (_dir, paths) = temp_paths();
+    config::run(ConfigCommand::SetGateway { name: "openrouter".to_string() }, &paths).unwrap();
+    config::run(
+        ConfigCommand::SetKey { provider: "openrouter".to_string(), key: "sk-secret".to_string() },
+        &paths,
+    )
+    .unwrap();
+
+    let listing = config::format_get(&paths, None).unwrap();
+    assert!(listing.contains("default_gateway = openrouter"));
+    assert!(listing.contains("key = set"));
+    assert!(!listing.contains("sk-secret"));
+
+    let stored = fs::read_to_string(&paths.keys).unwrap();
+    assert!(stored.contains("sk-secret"));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&paths.keys).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        let dir_mode = fs::metadata(&paths.dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700);
+    }
+
+    let env = EnvLookup::isolated(HashMap::new());
+    let plan = launch::plan(
+        &LaunchRequest { harness: Harness::Claude, gateway: None, passthrough: Vec::new() },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.env_set[1], ("ANTHROPIC_API_KEY".to_string(), "sk-secret".to_string()));
+}
+
+#[test]
+fn url_helpers_strip_or_add_v1() {
+    assert_eq!(
+        launch::anthropic_base("https://openrouter.ai/api/v1/"),
+        "https://openrouter.ai/api"
+    );
+    assert_eq!(launch::openai_base("https://api.tokener.dev"), "https://api.tokener.dev/v1");
+    assert_eq!(launch::openai_base("https://openrouter.ai/api/v1"), "https://openrouter.ai/api/v1");
+}
+
+#[test]
+fn debug_models_parses_gateway_flag() {
+    assert_eq!(
+        parse_line(&["rx", "debug", "models"]),
+        Command::Debug { subcommand: crate::debug::Subcommand::Models, gateway: None }
+    );
+    assert_eq!(
+        parse_line(&["rx", "--gateway", "tokener", "debug", "models"]),
+        Command::Debug {
+            subcommand: crate::debug::Subcommand::Models,
+            gateway: Some("tokener".to_string()),
+        }
+    );
+    assert_eq!(
+        parse_line(&["rx", "debug", "models", "--gateway=openrouter"]),
+        Command::Debug {
+            subcommand: crate::debug::Subcommand::Models,
+            gateway: Some("openrouter".to_string()),
+        }
+    );
+}
+
+#[test]
+fn debug_models_rejects_extra_args() {
+    let error = parse(&args(&["rx", "debug", "models", "extra"])).unwrap_err();
+    assert!(error.to_string().contains("usage: rx debug models"), "{error}");
+}
+
+#[test]
+fn debug_models_requires_configured_gateway() {
+    let (_dir, paths) = temp_paths();
+    let error =
+        crate::debug::models::run(None, &paths, &EnvLookup::isolated(HashMap::new())).unwrap_err();
+    assert!(error.to_string().contains("no gateway configured"), "{error}");
+}
+
+#[test]
+fn parse_catalog_detects_openai_and_anthropic_shapes() {
+    let (shape, envelope, models) = crate::catalog::parse_catalog(
+        r#"{"data":[{"id":"openai/gpt-4","name":"GPT-4"}],"total_count":1}"#,
+    )
+    .unwrap();
+    assert_eq!(shape, crate::catalog::CatalogShape::OpenAi);
+    assert_eq!(envelope, vec!["data".to_string(), "total_count".to_string()]);
+    assert_eq!(models[0].id, "openai/gpt-4");
+    assert_eq!(models[0].label.as_deref(), Some("GPT-4"));
+
+    let (shape, envelope, models) = crate::catalog::parse_catalog(
+        r#"{"data":[{"id":"anthropic/openai/gpt-4","display_name":"GPT-4"}],"has_more":false}"#,
+    )
+    .unwrap();
+    assert_eq!(shape, crate::catalog::CatalogShape::Anthropic);
+    assert!(envelope.contains(&"has_more".to_string()));
+    assert_eq!(models[0].id, "anthropic/openai/gpt-4");
+}
+
+#[test]
+fn render_splits_openai_and_anthropic_ids() {
+    let openai = crate::debug::models::Probe {
+        url: "https://example.test/v1/models".to_string(),
+        headers: vec!["Authorization: Bearer".to_string()],
+        status: Some(200),
+        error: None,
+        envelope: vec!["data".to_string()],
+        shape: crate::catalog::CatalogShape::OpenAi,
+        models: vec![
+            crate::catalog::ListedModel { id: "a".to_string(), label: None },
+            crate::catalog::ListedModel { id: "b".to_string(), label: None },
+        ],
+    };
+    let anthropic = crate::debug::models::Probe {
+        url: "https://example.test/v1/models?limit=1000".to_string(),
+        headers: vec!["Authorization: Bearer".to_string()],
+        status: Some(200),
+        error: None,
+        envelope: vec!["data".to_string()],
+        shape: crate::catalog::CatalogShape::Anthropic,
+        models: vec![crate::catalog::ListedModel {
+            id: "anthropic/b".to_string(),
+            label: Some("B".to_string()),
+        }],
+    };
+    let text =
+        crate::debug::models::render("tokener", "https://api.tokener.dev", &openai, &anthropic);
+    assert!(text.contains("## OpenAI (Codex)"));
+    assert!(text.contains("## Anthropic (Claude Code)"));
+    assert!(text.contains("only OpenAI: 2"));
+    assert!(text.contains("only Anthropic: 1"));
+    assert!(text.contains("Claude filter (id contains claude|anthropic): 1/1"));
+}
+
+#[test]
+fn openrouter_seed_builds_picker_and_denylist() {
+    let models = vec![
+        crate::claude_catalog::UserModel {
+            id: "anthropic/claude-sonnet-5".to_string(),
+            name: Some("Sonnet 5".to_string()),
+            context_length: Some(200_000),
+            canonical_slug: Some("anthropic/claude-sonnet-5".to_string()),
+            supported_efforts: vec!["high".to_string()],
+            pricing: None,
+        },
+        crate::claude_catalog::UserModel {
+            id: "openai/gpt-5.6-sol".to_string(),
+            name: Some("GPT 5.6 Sol".to_string()),
+            context_length: Some(400_000),
+            canonical_slug: None,
+            supported_efforts: vec![],
+            pricing: None,
+        },
+    ];
+    let seed = crate::claude_catalog::build_seed(&models);
+    assert_eq!(seed.additional_model_options.len(), 2);
+    assert!(seed.model_access.iter().any(|entry| entry.api_name == "claude-sonnet-5"));
+    assert!(seed.model_access.iter().any(|entry| entry.api_name == "openai/gpt-5.6-sol"));
+    assert!(seed.tool_search_denylist.iter().any(|id| id == "openai/gpt-5.6-sol"));
+    assert!(!seed.tool_search_denylist.iter().any(|id| id == "claude-sonnet-5"));
+}
+
+#[test]
+fn openrouter_seed_writes_claude_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join(".claude.json");
+    fs::write(
+        &config_path,
+        r#"{"additionalModelOptionsCache":[{"value":"keep-me","label":"Keep","description":"old"}]}"#,
+    )
+    .unwrap();
+    let caches = crate::claude_catalog::build_seed(&[crate::claude_catalog::UserModel {
+        id: "google/gemini-3.7-flash".to_string(),
+        name: Some("Gemini".to_string()),
+        context_length: Some(200_000),
+        canonical_slug: None,
+        supported_efforts: vec![],
+        pricing: None,
+    }]);
+    crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap();
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    let options = document["additionalModelOptionsCache"].as_array().unwrap();
+    assert_eq!(options.len(), 2);
+    assert!(options.iter().any(|entry| entry["value"] == "keep-me"));
+    assert!(options.iter().any(|entry| entry["value"] == "google/gemini-3.7-flash"));
+    assert!(
+        document["rxSeededToolSearchDenylist"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry == "google/gemini-3.7-flash")
+    );
+}
+
+#[test]
+fn claude_seed_errors_on_non_object_config_root_instead_of_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join(".claude.json");
+    fs::write(&config_path, r#"["not", "an", "object"]"#).unwrap();
+    let caches = crate::claude_catalog::SeedCaches::default();
+    let error = crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap_err();
+    assert!(error.to_string().contains("not a JSON object"));
+    // The original file is preserved.
+    assert_eq!(fs::read_to_string(&config_path).unwrap(), r#"["not", "an", "object"]"#);
+}
+
+#[test]
+fn openrouter_seeded_plan_injects_settings() {
+    let plan = launch::inject_claude_openrouter_for_test(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("openrouter".to_string()),
+            passthrough: vec!["fix it".to_string()],
+        },
+        "https://openrouter.ai/api",
+        "sk-or-test",
+        Some("~anthropic/claude-sonnet-latest"),
+        crate::claude_catalog::SeedOutcome::Seeded { model_count: 2 },
+    );
+    assert_eq!(plan.args[0], "--settings");
+    assert!(plan.args[1].contains("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"));
+    assert_eq!(plan.args[2], "fix it");
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v == "sk-or-test"));
+    assert!(
+        plan.env_set
+            .iter()
+            .any(|(k, v)| k == "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" && v == "0")
+    );
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ENABLE_TOOL_SEARCH" && v == "true"));
+    assert!(plan.stderr_note.is_none());
+}
+
+#[test]
+#[ignore = "live OpenRouter network + writes ~/.claude.json when HOME/CLAUDE_CONFIG_DIR aim at temp dir"]
+fn live_openrouter_seed_populates_claude_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let recall = dir.path().join(".recall");
+    fs::create_dir_all(&recall).unwrap();
+    fs::write(recall.join("rx.toml"), "default_gateway = \"openrouter\"\n\n[gateway.openrouter]\n")
+        .unwrap();
+    let key = std::env::var("OPENROUTER_API_KEY")
+        .or_else(|_| std::env::var("ORI_OPENROUTER_API_KEY"))
+        .expect("set OPENROUTER_API_KEY for live seed test");
+    fs::write(recall.join("rx.keys"), format!("openrouter = \"{key}\"\n")).unwrap();
+    let env = EnvLookup::isolated(HashMap::from([
+        ("CLAUDE_CONFIG_DIR".to_string(), dir.path().display().to_string()),
+        ("OPENROUTER_API_KEY".to_string(), key),
+    ]));
+    let outcome = crate::claude_catalog::try_seed_openrouter(
+        "https://openrouter.ai/api",
+        &env.get("OPENROUTER_API_KEY").unwrap(),
+        &env,
+    )
+    .unwrap();
+    assert!(matches!(outcome, crate::claude_catalog::SeedOutcome::Seeded { .. }));
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join(".claude.json")).unwrap())
+            .unwrap();
+    let count = document["additionalModelOptionsCache"].as_array().unwrap().len();
+    assert!(count > 100, "expected a large seeded catalog, got {count}");
+}

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -119,6 +119,41 @@ fn version_cmp_orders_releases() {
 }
 
 #[test]
+fn update_pending_uses_installed_release_not_crate_version() {
+    let release = crate::update::ReleaseInfo {
+        version: "0.5.0".to_string(),
+        asset_name: String::new(),
+        download_url: String::new(),
+    };
+    // rx's crate version stays 0.1.0 while core releases advance; once this
+    // release stream artifact is recorded as installed, it must not re-prompt.
+    assert!(!crate::update::update_pending(
+        "0.1.0",
+        &release,
+        &crate::update::state_with_installed(Some("0.5.0"))
+    ));
+    assert!(crate::update::update_pending(
+        "0.1.0",
+        &release,
+        &crate::update::state_with_installed(Some("0.4.0"))
+    ));
+    assert!(crate::update::update_pending(
+        "0.1.0",
+        &release,
+        &crate::update::state_with_installed(None)
+    ));
+}
+
+#[test]
+fn argv0_harness_resolves_aliases() {
+    assert_eq!(crate::args::argv0_harness("/usr/local/bin/rxc"), Some("claude"));
+    assert_eq!(crate::args::argv0_harness("rxx"), Some("codex"));
+    assert_eq!(crate::args::argv0_harness("rxo.exe"), Some("opencode"));
+    assert_eq!(crate::args::argv0_harness("rxp"), Some("pi"));
+    assert_eq!(crate::args::argv0_harness("/home/u/.cargo/bin/rx"), None);
+}
+
+#[test]
 fn release_asset_name_matches_host() {
     let name = crate::update::release_asset_name().unwrap();
     assert!(name.starts_with("recall-"));

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -97,7 +97,7 @@ pub(crate) fn maybe_before_launch(
     };
     state.last_check = Some(now_rfc3339());
     save_state(paths, &state)?;
-    if version_cmp(current, &release.version) != Ordering::Less {
+    if !update_pending(current, &release, &state) {
         return Ok(());
     }
     if state.auto_update {

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -22,22 +22,22 @@ pub(crate) struct ReleaseInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct UpdateState {
+pub(crate) struct UpdateState {
     #[serde(default)]
     auto_update: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_check: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_installed: Option<String>,
 }
 
-pub(crate) fn run(yes: bool, _paths: &Paths) -> Result<()> {
+pub(crate) fn run(yes: bool, paths: &Paths) -> Result<()> {
     let current = env!("CARGO_PKG_VERSION");
     let release = fetch_latest_release()?;
-    match version_cmp(current, &release.version) {
-        Ordering::Greater | Ordering::Equal => {
-            println!("rx {current} is up to date (latest: {})", release.version);
-            return Ok(());
-        }
-        Ordering::Less => {}
+    let state = load_state(paths)?;
+    if !update_pending(current, &release, &state) {
+        println!("rx {current} is up to date (latest: {})", release.version);
+        return Ok(());
     }
     if !yes && !confirm(&format!("Update rx {current} → {}?", release.version))? {
         println!("update cancelled");
@@ -45,8 +45,34 @@ pub(crate) fn run(yes: bool, _paths: &Paths) -> Result<()> {
     }
     eprintln!("Updating rx to {}...", release.version);
     install_release(&release)?;
+    record_installed(paths, &release.version)?;
     println!("Updated rx to {}", release.version);
     Ok(())
+}
+
+/// rx shares the core release stream but its own crate version does not advance,
+/// so the installed release tag — not `CARGO_PKG_VERSION` — decides whether the
+/// fetched release is already installed.
+pub(crate) fn update_pending(current: &str, release: &ReleaseInfo, state: &UpdateState) -> bool {
+    if state.last_installed.as_deref() == Some(release.version.as_str()) {
+        return false;
+    }
+    version_cmp(current, &release.version) == Ordering::Less
+}
+
+fn record_installed(paths: &Paths, version: &str) -> Result<()> {
+    let mut state = load_state(paths)?;
+    state.last_installed = Some(version.to_string());
+    save_state(paths, &state)
+}
+
+#[cfg(test)]
+pub(crate) fn state_with_installed(version: Option<&str>) -> UpdateState {
+    UpdateState {
+        auto_update: false,
+        last_check: None,
+        last_installed: version.map(str::to_string),
+    }
 }
 
 pub(crate) fn maybe_before_launch(
@@ -77,6 +103,7 @@ pub(crate) fn maybe_before_launch(
     if state.auto_update {
         eprintln!("Updating rx to {}...", release.version);
         install_release(&release)?;
+        record_installed(paths, &release.version)?;
         relaunch(raw_args)?;
     } else if !io::stderr().is_terminal() || !io::stdin().is_terminal() {
         eprintln!("rx {} is available — run `rx update`", release.version);
@@ -87,11 +114,13 @@ pub(crate) fn maybe_before_launch(
                 save_state(paths, &state)?;
                 eprintln!("Updating rx to {}...", release.version);
                 install_release(&release)?;
+                record_installed(paths, &release.version)?;
                 relaunch(raw_args)?;
             }
             PromptChoice::UpdateNow => {
                 eprintln!("Updating rx to {}...", release.version);
                 install_release(&release)?;
+                record_installed(paths, &release.version)?;
                 relaunch(raw_args)?;
             }
             PromptChoice::NotNow => {}
@@ -136,6 +165,11 @@ fn confirm(message: &str) -> Result<bool> {
 fn relaunch(raw_args: &[String]) -> Result<()> {
     let exe = std::env::current_exe().context("cannot resolve rx executable path")?;
     let mut command = Command::new(&exe);
+    // current_exe() resolves aliases (rxc/rxx/rxo/rxp) to the plain rx binary,
+    // so the relaunched process would lose the argv0-selected harness.
+    if let Some(harness) = raw_args.first().and_then(|argv0| crate::args::argv0_harness(argv0)) {
+        command.arg(harness);
+    }
     command.args(raw_args.iter().skip(1));
     #[cfg(unix)]
     {
@@ -235,8 +269,12 @@ fn replace_executable(source: &Path) -> Result<()> {
     #[cfg(windows)]
     if target.is_file() {
         // Windows locks running executables: move the old binary aside so the
-        // staged update can take its place.
+        // staged update can take its place. A leftover backup from a previous
+        // update must go first — Windows rename does not replace destinations.
         let backup = target.with_extension("old.exe");
+        if backup.exists() {
+            let _ = fs::remove_file(&backup);
+        }
         fs::rename(&target, &backup)
             .with_context(|| format!("move running executable to {}", backup.display()))?;
     }

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -1,0 +1,359 @@
+use std::cmp::Ordering;
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Paths;
+use crate::launch::EnvLookup;
+
+const GITHUB_REPO: &str = "samzong/Recall";
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReleaseInfo {
+    pub version: String,
+    pub asset_name: String,
+    pub download_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct UpdateState {
+    #[serde(default)]
+    auto_update: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_check: Option<String>,
+}
+
+pub(crate) fn run(yes: bool, _paths: &Paths) -> Result<()> {
+    let current = env!("CARGO_PKG_VERSION");
+    let release = fetch_latest_release()?;
+    match version_cmp(current, &release.version) {
+        Ordering::Greater | Ordering::Equal => {
+            println!("rx {current} is up to date (latest: {})", release.version);
+            return Ok(());
+        }
+        Ordering::Less => {}
+    }
+    if !yes && !confirm(&format!("Update rx {current} → {}?", release.version))? {
+        println!("update cancelled");
+        return Ok(());
+    }
+    eprintln!("Updating rx to {}...", release.version);
+    install_release(&release)?;
+    println!("Updated rx to {}", release.version);
+    Ok(())
+}
+
+pub(crate) fn maybe_before_launch(
+    paths: &Paths,
+    env: &EnvLookup,
+    raw_args: &[String],
+) -> Result<()> {
+    if env.get("RX_NO_UPDATE").is_some_and(|value| !value.is_empty() && value != "0") {
+        return Ok(());
+    }
+    let mut state = load_state(paths)?;
+    if !should_check(&state) {
+        return Ok(());
+    }
+    let current = env!("CARGO_PKG_VERSION");
+    let release = match fetch_latest_release() {
+        Ok(release) => release,
+        Err(error) => {
+            eprintln!("[rx] update check failed: {error:#}");
+            return Ok(());
+        }
+    };
+    state.last_check = Some(now_rfc3339());
+    save_state(paths, &state)?;
+    if version_cmp(current, &release.version) != Ordering::Less {
+        return Ok(());
+    }
+    if state.auto_update {
+        eprintln!("Updating rx to {}...", release.version);
+        install_release(&release)?;
+        relaunch(raw_args)?;
+    } else if !io::stderr().is_terminal() || !io::stdin().is_terminal() {
+        eprintln!("rx {} is available — run `rx update`", release.version);
+    } else {
+        match prompt(&release.version)? {
+            PromptChoice::Always => {
+                state.auto_update = true;
+                save_state(paths, &state)?;
+                eprintln!("Updating rx to {}...", release.version);
+                install_release(&release)?;
+                relaunch(raw_args)?;
+            }
+            PromptChoice::UpdateNow => {
+                eprintln!("Updating rx to {}...", release.version);
+                install_release(&release)?;
+                relaunch(raw_args)?;
+            }
+            PromptChoice::NotNow => {}
+        }
+    }
+    Ok(())
+}
+
+enum PromptChoice {
+    Always,
+    UpdateNow,
+    NotNow,
+}
+
+fn prompt(latest: &str) -> Result<PromptChoice> {
+    eprintln!("rx {latest} is available. Update before launching?");
+    eprintln!("  1) Always auto-update on launch");
+    eprintln!("  2) Update now");
+    eprintln!("  3) Not now");
+    eprint!("> ");
+    io::stderr().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    match line.trim() {
+        "1" | "always" => Ok(PromptChoice::Always),
+        "2" | "update" | "y" | "yes" => Ok(PromptChoice::UpdateNow),
+        _ => Ok(PromptChoice::NotNow),
+    }
+}
+
+fn confirm(message: &str) -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        bail!("refusing to update without --yes in non-interactive mode");
+    }
+    eprint!("{message} [y/N] ");
+    io::stderr().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+}
+
+fn relaunch(raw_args: &[String]) -> Result<()> {
+    let exe = std::env::current_exe().context("cannot resolve rx executable path")?;
+    let mut command = Command::new(&exe);
+    command.args(raw_args.iter().skip(1));
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        Err(command.exec()).context("failed to relaunch rx after update")
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command.status().context("failed to relaunch rx after update")?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+pub(crate) fn fetch_latest_release() -> Result<ReleaseInfo> {
+    let asset_name = release_asset_name()?;
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let body = http_get(&url, &[("Accept", "application/vnd.github+json")])?;
+    let value: serde_json::Value = serde_json::from_str(&body).context("GitHub release JSON")?;
+    let tag = value.get("tag_name").and_then(|v| v.as_str()).context("release missing tag_name")?;
+    let version = tag.trim_start_matches('v').to_string();
+    let assets =
+        value.get("assets").and_then(|v| v.as_array()).context("release missing assets")?;
+    let download_url = assets
+        .iter()
+        .find(|asset| asset.get("name").and_then(|v| v.as_str()) == Some(asset_name))
+        .and_then(|asset| asset.get("browser_download_url").and_then(|v| v.as_str()))
+        .with_context(|| format!("release asset not found: {asset_name}"))?
+        .to_string();
+    Ok(ReleaseInfo { version, asset_name: asset_name.to_string(), download_url })
+}
+
+fn install_release(release: &ReleaseInfo) -> Result<()> {
+    let temp = tempfile::tempdir().context("create temp dir for update")?;
+    let archive_path = temp.path().join(&release.asset_name);
+    let bytes = http_get_bytes(&release.download_url, &[])?;
+    fs::write(&archive_path, bytes).context("write release download")?;
+    let extracted = extract_rx_binary(&archive_path, temp.path())?;
+    replace_executable(&extracted)
+}
+
+fn extract_rx_binary(archive_path: &Path, dest: &Path) -> Result<PathBuf> {
+    let file_name = archive_path.file_name().and_then(|name| name.to_str()).unwrap_or("");
+    if file_name.ends_with(".tar.gz") {
+        extract_tar_gz(archive_path, dest)?;
+        Ok(dest.join("rx"))
+    } else if file_name.ends_with(".zip") {
+        extract_zip(archive_path, dest)?;
+        Ok(dest.join("rx.exe"))
+    } else {
+        bail!("unsupported release archive: {}", archive_path.display())
+    }
+}
+
+fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
+    let file =
+        fs::File::open(archive_path).with_context(|| format!("open {}", archive_path.display()))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    archive.unpack(dest).context("unpack release tarball")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn extract_zip(archive_path: &Path, dest: &Path) -> Result<()> {
+    let file =
+        fs::File::open(archive_path).with_context(|| format!("open {}", archive_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file).context("read release zip")?;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).context("read zip entry")?;
+        let Some(name) = entry.enclosed_name() else {
+            continue;
+        };
+        let out_path = dest.join(name);
+        if entry.is_dir() {
+            fs::create_dir_all(&out_path)?;
+        } else {
+            if let Some(parent) = out_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut outfile = fs::File::create(&out_path)?;
+            io::copy(&mut entry, &mut outfile)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn extract_zip(_archive_path: &Path, _dest: &Path) -> Result<()> {
+    bail!("zip release archives are only supported on Windows")
+}
+
+fn replace_executable(source: &Path) -> Result<()> {
+    if !source.is_file() {
+        bail!("release archive did not contain rx at {}", source.display());
+    }
+    let target = std::env::current_exe().context("cannot resolve rx executable path")?;
+    #[cfg(windows)]
+    if target.is_file() {
+        // Windows locks running executables: move the old binary aside so the
+        // staged update can take its place.
+        let backup = target.with_extension("old.exe");
+        fs::rename(&target, &backup)
+            .with_context(|| format!("move running executable to {}", backup.display()))?;
+    }
+    let staging = target.with_extension("update-staging");
+    fs::copy(source, &staging).with_context(|| format!("stage update at {}", staging.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755))?;
+    }
+    fs::rename(&staging, &target)
+        .with_context(|| format!("install update to {}", target.display()))?;
+    Ok(())
+}
+
+fn http_get(url: &str, headers: &[(&str, &str)]) -> Result<String> {
+    let bytes = http_get_bytes(url, headers)?;
+    String::from_utf8(bytes).context("response is not UTF-8")
+}
+
+fn http_get_bytes(url: &str, headers: &[(&str, &str)]) -> Result<Vec<u8>> {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(60)))
+        .http_status_as_error(false)
+        .build()
+        .into();
+    let mut request =
+        agent.get(url).header("User-Agent", format!("rx/{}", env!("CARGO_PKG_VERSION")));
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    let mut response = request.call().with_context(|| format!("GET {url}"))?;
+    let status = response.status().as_u16();
+    let body = response.body_mut().read_to_vec().context("read response body")?;
+    if !(200..300).contains(&status) {
+        bail!("HTTP {status}: {}", String::from_utf8_lossy(&body[..body.len().min(300)]));
+    }
+    Ok(body)
+}
+
+pub(crate) fn release_asset_name() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("recall-macos-aarch64.tar.gz"),
+        ("macos", "x86_64") => Ok("recall-macos-x86_64.tar.gz"),
+        ("linux", "x86_64") => Ok("recall-linux-x86_64.tar.gz"),
+        ("windows", "x86_64") => Ok("recall-windows-x86_64.zip"),
+        (os, arch) => bail!("unsupported platform for rx update: {os}-{arch}"),
+    }
+}
+
+pub(crate) fn version_cmp(left: &str, right: &str) -> Ordering {
+    let parse = |value: &str| {
+        value
+            .trim_start_matches('v')
+            .split(['.', '-'])
+            .map(|part| {
+                part.chars()
+                    .take_while(|ch| ch.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<u64>()
+                    .unwrap_or(0)
+            })
+            .collect::<Vec<_>>()
+    };
+    let left_parts = parse(left);
+    let right_parts = parse(right);
+    let len = left_parts.len().max(right_parts.len());
+    for index in 0..len {
+        match left_parts
+            .get(index)
+            .copied()
+            .unwrap_or(0)
+            .cmp(&right_parts.get(index).copied().unwrap_or(0))
+        {
+            Ordering::Equal => {}
+            other => return other,
+        }
+    }
+    Ordering::Equal
+}
+
+fn state_path(paths: &Paths) -> PathBuf {
+    paths.dir.join("rx-update.toml")
+}
+
+fn load_state(paths: &Paths) -> Result<UpdateState> {
+    let path = state_path(paths);
+    if !path.is_file() {
+        return Ok(UpdateState::default());
+    }
+    let body = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&body).with_context(|| format!("parse {}", path.display()))
+}
+
+fn save_state(paths: &Paths, state: &UpdateState) -> Result<()> {
+    fs::create_dir_all(&paths.dir).with_context(|| format!("create {}", paths.dir.display()))?;
+    let body = toml::to_string_pretty(state).context("serialize rx-update.toml")?;
+    let path = state_path(paths);
+    fs::write(&path, body).with_context(|| format!("write {}", path.display()))
+}
+
+fn should_check(state: &UpdateState) -> bool {
+    let Some(last_check) = &state.last_check else {
+        return true;
+    };
+    let Ok(parsed) = chrono_like_parse(last_check) else {
+        return true;
+    };
+    SystemTime::now().duration_since(parsed).is_ok_and(|elapsed| elapsed >= CHECK_INTERVAL)
+}
+
+fn now_rfc3339() -> String {
+    let seconds = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    format!("{seconds}")
+}
+
+fn chrono_like_parse(value: &str) -> Result<SystemTime> {
+    let seconds: u64 = value.parse().context("parse last_check timestamp")?;
+    Ok(UNIX_EPOCH + Duration::from_secs(seconds))
+}

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -1269,7 +1269,7 @@ fn f32_slice_to_bytes_roundtrip() {
     assert_eq!(bytes.len(), 16);
 
     let roundtrip: Vec<f32> =
-        bytes.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+        bytes.as_chunks::<4>().0.iter().map(|c| f32::from_le_bytes(*c)).collect();
     assert_eq!(original, roundtrip);
 }
 


### PR DESCRIPTION
### What's changed?

- Add the independent `rx` crate as a workspace member: a gateway launcher that execs claude/codex/opencode/pi through a configured API gateway (openrouter or tokener)
- Config and key storage under `~/.recall` (`rx.toml`, mode-0600 `rx.keys`); optional OpenRouter catalog seeding for Claude Code model caches, degrading to gateway model discovery on any local or network failure
- `rx config set/get`, `rx debug models` gateway probe, and self-update from GitHub releases with launch-time update prompts (24h check interval, `RX_NO_UPDATE` opt-out)
- `rxc`/`rxx`/`rxo`/`rxp` argv0 dispatch to the matching harness; `make install` creates all four symlinks
- Release workflow now builds and packages both `recall` and `rx`; AGENTS.md documents the new crate

### Why

- Route agent harnesses through a configurable API gateway without manual environment setup, while keeping the launcher fully independent of the recall core (no dependency on the `recall` crate or `recall.db`)
- Optional enhancements never block launches: catalog seed failures fall back with a stderr note, and corrupt external config (`.claude.json` non-object root, unparseable `models.json`) is reported instead of overwritten

### Verification

- `make check` (audit → fmt → clippy -D warnings → test) passes on the exact committed tree
- New regression tests cover argv0 dispatch, gateway flag parsing, per-harness injection plans, and the two corruption-guard paths