### PR TITLE
feat(rx): install missing harnesses and seed Claude catalogs

### DIFF
--- a/crates/rx/src/catalog.rs
+++ b/crates/rx/src/catalog.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, bail};
 pub(crate) enum CatalogShape {
     OpenAi,
     Anthropic,
+    Codex,
     Unknown,
 }
 
@@ -44,8 +45,27 @@ pub(crate) fn parse_catalog(body: &str) -> Result<(CatalogShape, Vec<String>, Ve
     let value: serde_json::Value = serde_json::from_str(body).context("response is not JSON")?;
     let envelope =
         value.as_object().map(|object| object.keys().cloned().collect()).unwrap_or_default();
+    if let Some(models) = value.get("models").and_then(|value| value.as_array()) {
+        let listed = models
+            .iter()
+            .filter_map(|entry| {
+                let id = entry
+                    .get("slug")
+                    .or_else(|| entry.get("id"))
+                    .and_then(|value| value.as_str())?
+                    .to_string();
+                let label = entry
+                    .get("display_name")
+                    .or_else(|| entry.get("name"))
+                    .and_then(|value| value.as_str())
+                    .map(one_line);
+                Some(ListedModel { id, label })
+            })
+            .collect::<Vec<_>>();
+        return Ok((CatalogShape::Codex, envelope, listed));
+    }
     let Some(data) = value.get("data").and_then(|value| value.as_array()) else {
-        bail!("JSON has no data array");
+        bail!("JSON has no data or models array");
     };
     let models = data
         .iter()

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -85,7 +85,7 @@ pub(crate) enum SeedOutcome {
     Fallback,
 }
 
-pub(crate) fn try_seed_openrouter(
+pub(crate) fn try_seed_user_catalog(
     base_url: &str,
     api_key: &str,
     env: &EnvLookup,
@@ -119,6 +119,10 @@ pub(crate) fn fetch_user_catalog(base_url: &str, api_key: &str) -> Result<Vec<Us
 
 pub(crate) fn parse_user_catalog(body: &str) -> Result<Vec<UserModel>> {
     let value: Value = serde_json::from_str(body).context("catalog response is not JSON")?;
+    parse_user_catalog_value(&value)
+}
+
+pub(crate) fn parse_user_catalog_value(value: &Value) -> Result<Vec<UserModel>> {
     let Some(data) = value.get("data").and_then(Value::as_array) else {
         bail!("catalog JSON has no data array");
     };
@@ -214,7 +218,7 @@ pub(crate) fn build_seed(models: &[UserModel]) -> SeedCaches {
     }
 }
 
-pub(crate) fn claude_settings_json(base_url: &str, seeded: bool) -> String {
+pub(crate) fn claude_settings_json(base_url: &str, seeded: bool, api_key_env: &str) -> String {
     let mut env = BTreeMap::new();
     for (key, value) in SETTINGS_CLEAR_ENV {
         env.insert((*key).to_string(), (*value).to_string());
@@ -230,7 +234,7 @@ pub(crate) fn claude_settings_json(base_url: &str, seeded: bool) -> String {
         env.insert("CLAUDE_CODE_GB_DISK_CACHE_WHEN_TELEMETRY_OFF".to_string(), "1".to_string());
     }
     serde_json::to_string(&json!({
-        "apiKeyHelper": "printf %s \"$OPENROUTER_API_KEY\"",
+        "apiKeyHelper": format!("printf %s \"${api_key_env}\""),
         "env": env,
     }))
     .expect("settings json serializes")

--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -82,12 +82,12 @@ pub(crate) fn run(command: ConfigCommand, paths: &Paths) -> Result<()> {
         ConfigCommand::SetKey { provider, key } => {
             let spec = crate::launch::provider(&provider)?;
             let mut config = load_or_default(paths)?;
+            let mut keys = load_keys(paths)?;
             let entry = ensure_gateway_entry(&mut config, spec.id, spec.default_base_url);
             entry.auth = AuthMode::ApiKey;
-            save_config(paths, &config)?;
-            let mut keys = load_keys(paths)?;
             keys.values.insert(spec.id.to_string(), key);
             save_keys(paths, &keys)?;
+            save_config(paths, &config)?;
             println!("stored API key for {}", spec.id);
             Ok(())
         }

--- a/crates/rx/src/debug/models.rs
+++ b/crates/rx/src/debug/models.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use anyhow::{Result, bail};
 
 use crate::catalog::{self, CatalogShape, ListedModel};
+use crate::claude_catalog;
 use crate::config::Paths;
 use crate::launch::{self, EnvLookup};
 
@@ -21,46 +22,35 @@ pub(crate) fn run(gateway: Option<String>, paths: &Paths, env: &EnvLookup) -> Re
     let Some(target) = launch::configured_gateway(gateway.as_deref(), paths, env)? else {
         bail!("no gateway configured; run: rx config set gateway <openrouter|tokener>");
     };
+    let auth_header = ("Authorization", format!("Bearer {}", target.key));
     let openai_url = format!("{}/models", launch::openai_base(&target.base_url));
+    let codex_url =
+        format!("{}/v1/models?client_version=0.149.0", launch::anthropic_base(&target.base_url));
     let anthropic_url =
         format!("{}/v1/models?limit=1000", launch::anthropic_base(&target.base_url));
-    let openai = probe(&openai_url, &[("Authorization", format!("Bearer {}", target.key))]);
-    let anthropic = probe(
-        &anthropic_url,
-        &[
-            ("Authorization", format!("Bearer {}", target.key)),
-            ("anthropic-version", "2023-06-01".to_string()),
-        ],
-    );
-    print!("{}", render(target.spec.id, &target.base_url, &openai, &anthropic));
+    let user_url =
+        format!("{}/v1/models/user?limit=1000", launch::anthropic_base(&target.base_url));
+    let openai = probe(&openai_url, std::slice::from_ref(&auth_header));
+    let codex_headers = [auth_header.clone(), ("User-Agent", "codex/0.149.0".to_string())];
+    let anthropic_headers = [auth_header.clone(), ("anthropic-version", "2023-06-01".to_string())];
+    let codex = probe(&codex_url, &codex_headers);
+    let anthropic = probe(&anthropic_url, &anthropic_headers);
+    let user = probe_user(&user_url, std::slice::from_ref(&auth_header));
+    print!("{}", render(target.spec.id, &target.base_url, &openai, &codex, &anthropic, &user));
     Ok(())
 }
 
 fn probe(url: &str, headers: &[(&str, String)]) -> Probe {
-    let shown_headers = headers
-        .iter()
-        .map(|(name, value)| {
-            if name.eq_ignore_ascii_case("authorization") {
-                format!("{name}: Bearer")
-            } else if name.eq_ignore_ascii_case("x-api-key") {
-                format!("{name}: (set)")
-            } else {
-                format!("{name}: {value}")
-            }
-        })
-        .collect();
+    let shown_headers = shown_headers(headers);
     match catalog::fetch(url, headers) {
         Ok((status, body)) => {
             if !(200..300).contains(&status) {
-                return Probe {
-                    url: url.to_string(),
-                    headers: shown_headers,
-                    status: Some(status),
-                    error: Some(catalog::truncate(&body, 300)),
-                    envelope: Vec::new(),
-                    shape: CatalogShape::Unknown,
-                    models: Vec::new(),
-                };
+                return failed_probe(
+                    url,
+                    shown_headers,
+                    Some(status),
+                    catalog::truncate(&body, 300),
+                );
             }
             match catalog::parse_catalog(&body) {
                 Ok((shape, envelope, models)) => Probe {
@@ -72,43 +62,127 @@ fn probe(url: &str, headers: &[(&str, String)]) -> Probe {
                     shape,
                     models,
                 },
-                Err(error) => Probe {
-                    url: url.to_string(),
-                    headers: shown_headers,
-                    status: Some(status),
-                    error: Some(format!("{error}; body: {}", catalog::truncate(&body, 200))),
-                    envelope: Vec::new(),
-                    shape: CatalogShape::Unknown,
-                    models: Vec::new(),
-                },
+                Err(error) => failed_probe(
+                    url,
+                    shown_headers,
+                    Some(status),
+                    format!("{error}; body: {}", catalog::truncate(&body, 200)),
+                ),
             }
         }
-        Err(error) => Probe {
-            url: url.to_string(),
-            headers: shown_headers,
-            status: None,
-            error: Some(error.to_string()),
-            envelope: Vec::new(),
-            shape: CatalogShape::Unknown,
-            models: Vec::new(),
-        },
+        Err(error) => failed_probe(url, shown_headers, None, error.to_string()),
     }
 }
 
-pub(crate) fn render(gateway: &str, base_url: &str, openai: &Probe, anthropic: &Probe) -> String {
+fn probe_user(url: &str, headers: &[(&str, String)]) -> Probe {
+    let shown_headers = shown_headers(headers);
+    match catalog::fetch(url, headers) {
+        Ok((status, body)) => {
+            if !(200..300).contains(&status) {
+                return failed_probe(
+                    url,
+                    shown_headers,
+                    Some(status),
+                    catalog::truncate(&body, 300),
+                );
+            }
+            let value: serde_json::Value = match serde_json::from_str(&body) {
+                Ok(value) => value,
+                Err(error) => {
+                    return failed_probe(
+                        url,
+                        shown_headers,
+                        Some(status),
+                        format!(
+                            "catalog response is not JSON: {error}; body: {}",
+                            catalog::truncate(&body, 200)
+                        ),
+                    );
+                }
+            };
+            match claude_catalog::parse_user_catalog_value(&value) {
+                Ok(models) => {
+                    let envelope = value
+                        .as_object()
+                        .map(|object| object.keys().cloned().collect())
+                        .unwrap_or_default();
+                    Probe {
+                        url: url.to_string(),
+                        headers: shown_headers,
+                        status: Some(status),
+                        error: None,
+                        envelope,
+                        shape: CatalogShape::OpenAi,
+                        models: models
+                            .into_iter()
+                            .map(|model| ListedModel { id: model.id, label: model.name })
+                            .collect(),
+                    }
+                }
+                Err(error) => failed_probe(
+                    url,
+                    shown_headers,
+                    Some(status),
+                    format!("{error}; body: {}", catalog::truncate(&body, 200)),
+                ),
+            }
+        }
+        Err(error) => failed_probe(url, shown_headers, None, error.to_string()),
+    }
+}
+
+fn shown_headers(headers: &[(&str, String)]) -> Vec<String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            if name.eq_ignore_ascii_case("authorization") {
+                format!("{name}: Bearer")
+            } else if name.eq_ignore_ascii_case("x-api-key") {
+                format!("{name}: (set)")
+            } else {
+                format!("{name}: {value}")
+            }
+        })
+        .collect()
+}
+
+fn failed_probe(url: &str, headers: Vec<String>, status: Option<u16>, error: String) -> Probe {
+    Probe {
+        url: url.to_string(),
+        headers,
+        status,
+        error: Some(error),
+        envelope: Vec::new(),
+        shape: CatalogShape::Unknown,
+        models: Vec::new(),
+    }
+}
+
+pub(crate) fn render(
+    gateway: &str,
+    base_url: &str,
+    openai: &Probe,
+    codex: &Probe,
+    anthropic: &Probe,
+    user: &Probe,
+) -> String {
     let mut out = String::new();
     out.push_str(&format!("gateway: {gateway}\n"));
     out.push_str(&format!("base_url: {base_url}\n"));
-    out.push_str("\n## OpenAI (Codex)\n");
+    out.push_str("\n## OpenAI (GET /v1/models)\n");
     write_probe(&mut out, openai);
-    out.push_str("\n## Anthropic (Claude Code)\n");
+    out.push_str("\n## Codex (GET /v1/models?client_version=...)\n");
+    write_probe(&mut out, codex);
+    out.push_str("\n## Anthropic discovery (GET /v1/models?limit=1000)\n");
     write_probe(&mut out, anthropic);
+    out.push_str("\n## Claude seed (GET /v1/models/user?limit=1000)\n");
+    write_probe(&mut out, user);
     let openai_ids = ids(openai);
     let anthropic_ids = ids(anthropic);
     let only_openai: Vec<_> = openai_ids.difference(&anthropic_ids).cloned().collect();
     let only_anthropic: Vec<_> = anthropic_ids.difference(&openai_ids).cloned().collect();
     let both = openai_ids.intersection(&anthropic_ids).count();
-    out.push_str("\n## Diff (raw id)\n");
+    out.push_str("\n## Diff OpenAI list vs Anthropic discovery (raw id)\n");
     out.push_str(&format!(
         "in both: {both}\nonly OpenAI: {}\nonly Anthropic: {}\n",
         only_openai.len(),
@@ -118,9 +192,10 @@ pub(crate) fn render(gateway: &str, base_url: &str, openai: &Probe, anthropic: &
     write_id_list(&mut out, "only Anthropic", &only_anthropic);
     let kept = anthropic.models.iter().filter(|model| claude_keeps(&model.id)).count();
     out.push_str(&format!(
-        "\nClaude filter (id contains claude|anthropic): {kept}/{}\n",
+        "\nClaude discovery filter (id contains claude|anthropic): {kept}/{}\n",
         anthropic.models.len()
     ));
+    out.push_str(&format!("Claude user catalog models: {}\n", user.models.len()));
     out
 }
 
@@ -176,6 +251,7 @@ fn shape_name(shape: CatalogShape) -> &'static str {
     match shape {
         CatalogShape::OpenAi => "openai",
         CatalogShape::Anthropic => "anthropic",
+        CatalogShape::Codex => "codex",
         CatalogShape::Unknown => "unknown",
     }
 }

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -1,0 +1,200 @@
+use std::ffi::{OsStr, OsString};
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::process::{Command, Stdio};
+
+#[cfg(unix)]
+use anyhow::Context;
+
+use crate::args::Harness;
+use crate::launch::EnvLookup;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InstallSpec {
+    pub program: &'static str,
+    pub display: &'static str,
+    pub url: &'static str,
+    pub shell: &'static str,
+}
+
+pub(crate) fn spec(harness: Harness) -> InstallSpec {
+    match harness {
+        Harness::Claude => InstallSpec {
+            program: "claude",
+            display: "Claude Code",
+            url: "https://claude.ai/install.sh",
+            shell: "bash",
+        },
+        Harness::Codex => InstallSpec {
+            program: "codex",
+            display: "Codex",
+            url: "https://chatgpt.com/codex/install.sh",
+            shell: "sh",
+        },
+        Harness::OpenCode => InstallSpec {
+            program: "opencode",
+            display: "OpenCode",
+            url: "https://opencode.ai/install",
+            shell: "bash",
+        },
+        Harness::Pi => InstallSpec {
+            program: "pi",
+            display: "Pi",
+            url: "https://pi.dev/install.sh",
+            shell: "sh",
+        },
+    }
+}
+
+pub(crate) fn command_line(spec: &InstallSpec) -> String {
+    format!("curl -fsSL {} | {}", spec.url, spec.shell)
+}
+
+pub(crate) fn ensure(harness: Harness, env: &EnvLookup) -> Result<PathBuf> {
+    if !env.is_real() {
+        return Ok(PathBuf::from(harness.as_str()));
+    }
+    let spec = spec(harness);
+    if let Some(path) = lookup(spec.program) {
+        return Ok(path);
+    }
+    let cmd = command_line(&spec);
+    if env.get("RX_NO_INSTALL").is_some_and(|value| !value.is_empty() && value != "0") {
+        bail!("{} is not installed (RX_NO_INSTALL=1). Install with:\n  {cmd}", spec.display);
+    }
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        bail!("{} is not installed. Install with:\n  {cmd}", spec.display);
+    }
+    if !confirm(&format!("{} is not installed. Install now?", spec.display))? {
+        bail!("install cancelled. Install with:\n  {cmd}");
+    }
+    eprintln!("[rx] {cmd}");
+    run_official_installer(&spec)?;
+    lookup(spec.program).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} finished installing but {} was not found. Add ~/.local/bin and ~/.opencode/bin to PATH, then retry.",
+            spec.display,
+            spec.program
+        )
+    })
+}
+
+pub(crate) fn lookup(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let extensions = executable_extensions();
+    lookup_with(program, &path, &extra_bin_dirs(), extensions.as_deref())
+}
+
+pub(crate) fn lookup_with(
+    program: &str,
+    path: impl AsRef<std::ffi::OsStr>,
+    extra: &[PathBuf],
+    extensions: Option<&OsStr>,
+) -> Option<PathBuf> {
+    let names = executable_names(program, extensions);
+    for dir in std::env::split_paths(path.as_ref()).chain(extra.iter().cloned()) {
+        for name in &names {
+            let candidate = dir.join(name);
+            if is_runnable(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn executable_names(program: &str, extensions: Option<&OsStr>) -> Vec<OsString> {
+    let mut names = vec![OsString::from(program)];
+    if Path::new(program).extension().is_some() {
+        return names;
+    }
+    let Some(extensions) = extensions else {
+        return names;
+    };
+    for extension in
+        extensions.to_string_lossy().split(';').map(str::trim).filter(|value| !value.is_empty())
+    {
+        let extension = if extension.starts_with('.') {
+            extension.to_string()
+        } else {
+            format!(".{extension}")
+        };
+        let candidate = OsString::from(format!("{program}{extension}"));
+        if !names.contains(&candidate) {
+            names.push(candidate);
+        }
+    }
+    names
+}
+
+#[cfg(windows)]
+fn executable_extensions() -> Option<OsString> {
+    Some(std::env::var_os("PATHEXT").unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD")))
+}
+
+#[cfg(not(windows))]
+fn executable_extensions() -> Option<OsString> {
+    None
+}
+
+pub(crate) fn extra_bin_dirs() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    vec![home.join(".local/bin"), home.join(".opencode/bin"), home.join(".claude/local/bin")]
+}
+
+fn run_official_installer(spec: &InstallSpec) -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        bail!(
+            "{} official installer is a Unix shell script. Install with:\n  {}",
+            spec.display,
+            command_line(spec)
+        );
+    }
+    #[cfg(unix)]
+    {
+        let status = Command::new(spec.shell)
+            .arg("-c")
+            .arg(command_line(spec))
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .with_context(|| format!("failed to start {}", spec.shell))?;
+        if !status.success() {
+            bail!("{} installer exited with {status}", spec.display);
+        }
+        Ok(())
+    }
+}
+
+fn confirm(message: &str) -> Result<bool> {
+    eprint!("{message} [y/N] ");
+    io::stderr().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+}
+
+fn is_runnable(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path).is_ok_and(|meta| meta.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -59,6 +59,10 @@ impl EnvLookup {
         Self { overrides, real: false }
     }
 
+    pub(crate) fn is_real(&self) -> bool {
+        self.real
+    }
+
     pub(crate) fn get(&self, key: &str) -> Option<String> {
         if let Some(value) = self.overrides.get(key) {
             return Some(value.clone());
@@ -114,9 +118,30 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
         Harness::Codex => target.spec.default_model,
         Harness::OpenCode | Harness::Pi => None,
     });
-    if matches!(request.harness, Harness::Claude) && target.spec.id == "openrouter" {
-        let seed = claude_catalog::try_seed_openrouter(&target.base_url, &target.key, env)?;
-        return Ok(inject_claude_openrouter(request, &target.base_url, &target.key, model, seed));
+    if matches!(request.harness, Harness::Claude) {
+        let seed = if env.is_real() {
+            claude_catalog::try_seed_user_catalog(&target.base_url, &target.key, env)?
+        } else {
+            SeedOutcome::Fallback
+        };
+        if target.spec.id == "openrouter" {
+            return Ok(inject_claude_openrouter(
+                request,
+                &target.base_url,
+                &target.key,
+                model,
+                seed,
+            ));
+        }
+        if matches!(seed, SeedOutcome::Seeded { .. }) {
+            return Ok(inject_claude_tokener_seeded(
+                request,
+                target.spec,
+                &target.base_url,
+                &target.key,
+                model,
+            ));
+        }
     }
     inject(request, paths, env, target.spec, &target.base_url, &target.key, model)
 }
@@ -195,12 +220,12 @@ fn inject_claude_openrouter_impl(
     let seeded = matches!(seed, SeedOutcome::Seeded { .. });
     let mut args = request.passthrough.clone();
     if seeded && !claude_catalog::user_passes_settings(&request.passthrough) {
-        args.insert(0, claude_catalog::claude_settings_json(base_url, true));
+        args.insert(0, claude_catalog::claude_settings_json(base_url, true, "OPENROUTER_API_KEY"));
         args.insert(0, "--settings".to_string());
     }
     let stderr_note = match seed {
         SeedOutcome::Fallback => Some(
-            "[rx] OpenRouter catalog seed failed; falling back to gateway model discovery"
+            "[rx] gateway user catalog seed failed; falling back to gateway model discovery"
                 .to_string(),
         ),
         SeedOutcome::Seeded { .. } => None,
@@ -262,6 +287,64 @@ fn claude_openrouter_env(
     env_set
 }
 
+fn inject_claude_tokener_seeded(
+    request: &LaunchRequest,
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+) -> LaunchPlan {
+    let mut args = request.passthrough.clone();
+    if !claude_catalog::user_passes_settings(&request.passthrough) {
+        args.insert(0, claude_catalog::claude_settings_json(base_url, true, spec.env_key));
+        args.insert(0, "--settings".to_string());
+    }
+    LaunchPlan {
+        program: "claude".to_string(),
+        args,
+        env_set: claude_tokener_seeded_env(spec, base_url, key, model),
+        stderr_note: None,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn inject_claude_tokener_seeded_for_test(
+    request: &LaunchRequest,
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+) -> LaunchPlan {
+    inject_claude_tokener_seeded(request, spec, base_url, key, model)
+}
+
+fn claude_tokener_seeded_env(
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut env_set = vec![
+        ("ANTHROPIC_BASE_URL".to_string(), anthropic_base(base_url)),
+        ("ANTHROPIC_AUTH_TOKEN".to_string(), key.to_string()),
+        ("ANTHROPIC_API_KEY".to_string(), String::new()),
+        (spec.env_key.to_string(), key.to_string()),
+        ("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK".to_string(), "1".to_string()),
+        ("CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT".to_string(), "1".to_string()),
+        ("ENABLE_TOOL_SEARCH".to_string(), "true".to_string()),
+        ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "0".to_string()),
+        ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(), "1".to_string()),
+        ("CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(), "1000000".to_string()),
+        ("DISABLE_TELEMETRY".to_string(), "1".to_string()),
+        ("DISABLE_GROWTHBOOK".to_string(), "0".to_string()),
+        ("CLAUDE_CODE_GB_DISK_CACHE_WHEN_TELEMETRY_OFF".to_string(), "1".to_string()),
+    ];
+    if let Some(model) = model {
+        env_set.push(("ANTHROPIC_MODEL".to_string(), model.to_string()));
+    }
+    env_set
+}
+
 fn claude_env(
     spec: &ProviderSpec,
     base_url: &str,
@@ -275,24 +358,6 @@ fn claude_env(
         ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "1".to_string()),
         (spec.env_key.to_string(), key.to_string()),
     ];
-    if spec.id == "openrouter" {
-        let sonnet = model.unwrap_or("~anthropic/claude-sonnet-latest");
-        env_set.extend([
-            (
-                "ANTHROPIC_DEFAULT_FABLE_MODEL".to_string(),
-                "~anthropic/claude-fable-latest".to_string(),
-            ),
-            (
-                "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
-                "~anthropic/claude-opus-latest".to_string(),
-            ),
-            ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(), sonnet.to_string()),
-            (
-                "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
-                "~anthropic/claude-haiku-latest".to_string(),
-            ),
-        ]);
-    }
     if let Some(model) = model {
         env_set.push(("ANTHROPIC_MODEL".to_string(), model.to_string()));
     }
@@ -356,7 +421,7 @@ fn inject(
             })
         }
         Harness::Pi => {
-            crate::pi::prepare(spec, base_url, key, paths)?;
+            crate::pi::prepare(spec, base_url, key, paths, env)?;
             Ok(LaunchPlan {
                 program: "pi".to_string(),
                 args: crate::pi::args(spec, model, &request.passthrough),

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -3,6 +3,7 @@ mod catalog;
 mod claude_catalog;
 mod config;
 mod debug;
+mod install;
 mod launch;
 mod opencode;
 mod pi;
@@ -10,7 +11,7 @@ mod update;
 
 use anyhow::Result;
 
-use args::{Command, parse, rewrite_argv0};
+use args::{Command, argv0_harness, parse, rewrite_argv0};
 pub use config::Paths;
 use launch::{EnvLookup, plan};
 
@@ -19,8 +20,11 @@ pub fn run(raw_args: impl IntoIterator<Item = String>) -> Result<()> {
 }
 
 pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result<()> {
-    let args = rewrite_argv0(raw_args.clone());
-    let command = parse(&args)?;
+    let command = if raw_args.first().and_then(|argv0| argv0_harness(argv0)).is_some() {
+        parse(&rewrite_argv0(raw_args.clone()))?
+    } else {
+        parse(&raw_args)?
+    };
     if matches!(command, Command::Launch(_)) {
         update::maybe_before_launch(paths, env, &raw_args)?;
     }
@@ -37,7 +41,9 @@ pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result
         Command::Debug { subcommand, gateway } => debug::run(subcommand, gateway, paths, env),
         Command::Update { yes } => update::run(yes, paths),
         Command::Launch(request) => {
-            let plan = plan(&request, paths, env)?;
+            let program = install::ensure(request.harness, env)?;
+            let mut plan = plan(&request, paths, env)?;
+            plan.program = program.to_string_lossy().into_owned();
             if let Some(note) = &plan.stderr_note {
                 eprintln!("{note}");
             }
@@ -64,6 +70,7 @@ Options:
 
 Environment:
   RX_NO_UPDATE=1                   skip launch-time update checks
+  RX_NO_INSTALL=1                  skip offering to install a missing harness
 
 Developer: rx debug --help
 

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
 use crate::config::Paths;
-use crate::launch::{ProviderSpec, openai_base};
+use crate::launch::{EnvLookup, ProviderSpec, openai_base};
 use crate::opencode;
 
 const PI_ENV_CLEAR: &[&str] = &[
@@ -17,21 +17,31 @@ const PI_ENV_CLEAR: &[&str] = &[
     "GEMINI_API_KEY",
 ];
 
-pub(crate) fn global_agent_dir() -> Result<PathBuf> {
+pub(crate) fn global_agent_dir(env: &EnvLookup) -> Result<PathBuf> {
     // PI_CODING_AGENT_DIR is authoritative for pi's configuration location
     // (see src/adapters/pi.rs); providers must land where the launched
     // process will actually read them.
-    if let Some(dir) = std::env::var("PI_CODING_AGENT_DIR")
-        .ok()
+    if let Some(dir) = env
+        .get("PI_CODING_AGENT_DIR")
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
     {
-        let home = dirs::home_dir().unwrap_or_default();
         let expanded = match dir.strip_prefix("~/") {
-            Some(rest) => home.join(rest),
+            Some(rest) => {
+                let home = if env.is_real() {
+                    dirs::home_dir()
+                } else {
+                    env.get("HOME").filter(|value| !value.trim().is_empty()).map(PathBuf::from)
+                }
+                .context("cannot expand PI_CODING_AGENT_DIR without a home directory")?;
+                home.join(rest)
+            }
             None => PathBuf::from(dir),
         };
         return Ok(expanded);
+    }
+    if !env.is_real() {
+        bail!("PI_CODING_AGENT_DIR is required in an isolated environment");
     }
     let home = dirs::home_dir().context("cannot determine home directory")?;
     Ok(home.join(".pi").join("agent"))
@@ -41,7 +51,13 @@ pub(crate) fn recall_pi_dir(paths: &Paths) -> PathBuf {
     paths.dir.join("pi")
 }
 
-pub(crate) fn prepare(spec: &ProviderSpec, base_url: &str, key: &str, paths: &Paths) -> Result<()> {
+pub(crate) fn prepare(
+    spec: &ProviderSpec,
+    base_url: &str,
+    key: &str,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<()> {
     if spec.id != "tokener" {
         return Ok(());
     }
@@ -50,7 +66,7 @@ pub(crate) fn prepare(spec: &ProviderSpec, base_url: &str, key: &str, paths: &Pa
     fs::create_dir_all(&recall_dir)
         .with_context(|| format!("failed to create {}", recall_dir.display()))?;
     write_json_atomic(&recall_dir.join("tokener-provider.json"), &provider)?;
-    let agent_dir = global_agent_dir()?;
+    let agent_dir = global_agent_dir(env)?;
     fs::create_dir_all(&agent_dir)
         .with_context(|| format!("failed to create {}", agent_dir.display()))?;
     merge_provider(&agent_dir.join("models.json"), "tokener", provider)

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
 
 use crate::args::{Command, ConfigCommand, Harness, LaunchRequest, parse, rewrite_argv0};
 use crate::config::{self, Paths};
@@ -288,7 +291,7 @@ fn claude_openrouter_uses_api_key_and_discovery_fallback_without_seed() {
             .iter()
             .any(|(k, v)| k == "ANTHROPIC_MODEL" && v == "~anthropic/claude-sonnet-latest")
     );
-    assert!(plan.stderr_note.as_deref().unwrap().contains("catalog seed failed"));
+    assert!(plan.stderr_note.as_deref().unwrap().contains("user catalog seed failed"));
 }
 
 #[test]
@@ -433,13 +436,36 @@ fn pi_merge_provider_refuses_to_reset_corrupt_models_json() {
 fn pi_tokener_writes_recall_cache() {
     let (dir, paths) = temp_paths();
     let spec = launch::provider("tokener").unwrap();
-    if crate::pi::prepare(spec, "https://api.tokener.dev", "sk-test", &paths).is_err() {
-        return;
-    }
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0; 1024];
+        let size = stream.read(&mut request).unwrap();
+        assert!(String::from_utf8_lossy(&request[..size]).starts_with("GET /v1/models "));
+        let body = r#"{"data":[{"id":"gpt-5.6-sol"}]}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .unwrap();
+    });
+    let agent_dir = dir.path().join("pi-agent");
+    let env = EnvLookup::isolated(HashMap::from([(
+        "PI_CODING_AGENT_DIR".to_string(),
+        agent_dir.display().to_string(),
+    )]));
+
+    crate::pi::prepare(spec, &base_url, "sk-test", &paths, &env).unwrap();
+    server.join().unwrap();
+
     let cache = dir.path().join("pi/tokener-provider.json");
     assert!(cache.is_file());
     let body = fs::read_to_string(cache).unwrap();
-    assert!(body.contains("\"baseUrl\": \"https://api.tokener.dev/v1\""));
+    assert!(body.contains(&format!("\"baseUrl\": \"{base_url}/v1\"")));
+    let models = fs::read_to_string(agent_dir.join("models.json")).unwrap();
+    assert!(models.contains("gpt-5.6-sol"));
 }
 
 #[test]
@@ -541,6 +567,32 @@ fn config_set_key_is_redacted_and_secret() {
 }
 
 #[test]
+fn config_set_key_does_not_switch_auth_when_keys_cannot_be_loaded() {
+    let (_dir, paths) = temp_paths();
+    fs::write(
+        &paths.config,
+        r#"default_gateway = "openrouter"
+
+[gateway.openrouter]
+base_url = "https://openrouter.ai/api"
+auth = "env"
+"#,
+    )
+    .unwrap();
+    fs::write(&paths.keys, "{").unwrap();
+
+    let error = config::run(
+        ConfigCommand::SetKey { provider: "openrouter".to_string(), key: "sk-secret".to_string() },
+        &paths,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("failed to parse"), "{error}");
+
+    let config = config::load(&paths).unwrap().unwrap();
+    assert_eq!(config.gateway["openrouter"].auth, config::AuthMode::Env);
+}
+
+#[test]
 fn url_helpers_strip_or_add_v1() {
     assert_eq!(
         launch::anthropic_base("https://openrouter.ai/api/v1/"),
@@ -587,7 +639,7 @@ fn debug_models_requires_configured_gateway() {
 }
 
 #[test]
-fn parse_catalog_detects_openai_and_anthropic_shapes() {
+fn parse_catalog_detects_openai_anthropic_and_codex_shapes() {
     let (shape, envelope, models) = crate::catalog::parse_catalog(
         r#"{"data":[{"id":"openai/gpt-4","name":"GPT-4"}],"total_count":1}"#,
     )
@@ -604,6 +656,15 @@ fn parse_catalog_detects_openai_and_anthropic_shapes() {
     assert_eq!(shape, crate::catalog::CatalogShape::Anthropic);
     assert!(envelope.contains(&"has_more".to_string()));
     assert_eq!(models[0].id, "anthropic/openai/gpt-4");
+
+    let (shape, envelope, models) = crate::catalog::parse_catalog(
+        r#"{"models":[{"slug":"gpt-5.6-sol","display_name":"GPT 5.6 Sol"}]}"#,
+    )
+    .unwrap();
+    assert_eq!(shape, crate::catalog::CatalogShape::Codex);
+    assert_eq!(envelope, vec!["models".to_string()]);
+    assert_eq!(models[0].id, "gpt-5.6-sol");
+    assert_eq!(models[0].label.as_deref(), Some("GPT 5.6 Sol"));
 }
 
 #[test]
@@ -632,13 +693,71 @@ fn render_splits_openai_and_anthropic_ids() {
             label: Some("B".to_string()),
         }],
     };
-    let text =
-        crate::debug::models::render("tokener", "https://api.tokener.dev", &openai, &anthropic);
-    assert!(text.contains("## OpenAI (Codex)"));
-    assert!(text.contains("## Anthropic (Claude Code)"));
+    let codex = crate::debug::models::Probe {
+        url: "https://example.test/v1/models?client_version=0.149.0".to_string(),
+        headers: vec!["Authorization: Bearer".to_string()],
+        status: Some(200),
+        error: None,
+        envelope: vec!["models".to_string()],
+        shape: crate::catalog::CatalogShape::Codex,
+        models: vec![crate::catalog::ListedModel {
+            id: "gpt-5.6-sol".to_string(),
+            label: Some("GPT 5.6 Sol".to_string()),
+        }],
+    };
+    let user = crate::debug::models::Probe {
+        url: "https://example.test/v1/models/user?limit=1000".to_string(),
+        headers: vec!["Authorization: Bearer".to_string()],
+        status: Some(200),
+        error: None,
+        envelope: vec!["data".to_string(), "total_count".to_string()],
+        shape: crate::catalog::CatalogShape::OpenAi,
+        models: vec![crate::catalog::ListedModel {
+            id: "anthropic/claude-sonnet-5".to_string(),
+            label: Some("Sonnet 5".to_string()),
+        }],
+    };
+    let text = crate::debug::models::render(
+        "tokener",
+        "https://api.tokener.dev",
+        &openai,
+        &codex,
+        &anthropic,
+        &user,
+    );
+    assert!(text.contains("## OpenAI (GET /v1/models)"));
+    assert!(text.contains("## Codex (GET /v1/models?client_version=...)"));
+    assert!(text.contains("## Claude seed (GET /v1/models/user?limit=1000)"));
     assert!(text.contains("only OpenAI: 2"));
     assert!(text.contains("only Anthropic: 1"));
-    assert!(text.contains("Claude filter (id contains claude|anthropic): 1/1"));
+    assert!(text.contains("Claude discovery filter (id contains claude|anthropic): 1/1"));
+    assert!(text.contains("Claude user catalog models: 1"));
+}
+
+#[test]
+fn tokener_seeded_plan_uses_auth_token_and_settings() {
+    let plan = launch::inject_claude_tokener_seeded_for_test(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("tokener".to_string()),
+            passthrough: vec!["fix it".to_string()],
+        },
+        launch::provider("tokener").unwrap(),
+        "http://localhost:8080",
+        "sk-tokener",
+        None,
+    );
+    assert_eq!(plan.args[0], "--settings");
+    assert!(plan.args[1].contains("TOKENER_API_KEY"));
+    assert_eq!(plan.args[2], "fix it");
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v == "sk-tokener"));
+    assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v.is_empty()));
+    assert!(
+        plan.env_set
+            .iter()
+            .any(|(k, v)| k == "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" && v == "0")
+    );
+    assert!(plan.stderr_note.is_none());
 }
 
 #[test]
@@ -756,7 +875,7 @@ fn live_openrouter_seed_populates_claude_json() {
         ("CLAUDE_CONFIG_DIR".to_string(), dir.path().display().to_string()),
         ("OPENROUTER_API_KEY".to_string(), key),
     ]));
-    let outcome = crate::claude_catalog::try_seed_openrouter(
+    let outcome = crate::claude_catalog::try_seed_user_catalog(
         "https://openrouter.ai/api",
         &env.get("OPENROUTER_API_KEY").unwrap(),
         &env,
@@ -768,4 +887,70 @@ fn live_openrouter_seed_populates_claude_json() {
             .unwrap();
     let count = document["additionalModelOptionsCache"].as_array().unwrap().len();
     assert!(count > 100, "expected a large seeded catalog, got {count}");
+}
+
+#[test]
+fn install_specs_use_official_urls() {
+    let claude = crate::install::spec(Harness::Claude);
+    assert_eq!(claude.url, "https://claude.ai/install.sh");
+    assert_eq!(claude.shell, "bash");
+    assert_eq!(
+        crate::install::command_line(&claude),
+        "curl -fsSL https://claude.ai/install.sh | bash"
+    );
+
+    let codex = crate::install::spec(Harness::Codex);
+    assert_eq!(codex.url, "https://chatgpt.com/codex/install.sh");
+    assert_eq!(codex.shell, "sh");
+
+    let opencode = crate::install::spec(Harness::OpenCode);
+    assert_eq!(opencode.url, "https://opencode.ai/install");
+    assert_eq!(opencode.shell, "bash");
+
+    let pi = crate::install::spec(Harness::Pi);
+    assert_eq!(pi.url, "https://pi.dev/install.sh");
+    assert_eq!(pi.shell, "sh");
+}
+
+#[test]
+fn install_lookup_finds_extra_dir_when_absent_from_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("pi");
+    fs::write(&bin, "#!/bin/sh\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let found = crate::install::lookup_with("pi", "", &[dir.path().to_path_buf()], None).unwrap();
+    assert_eq!(found, bin);
+    assert!(crate::install::lookup_with("pi", "", &[], None).is_none());
+}
+
+#[test]
+fn install_lookup_honors_windows_executable_extensions() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("codex.exe");
+    fs::write(&bin, "windows executable").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let found = crate::install::lookup_with(
+        "codex",
+        "",
+        &[dir.path().to_path_buf()],
+        Some(std::ffi::OsStr::new(".COM;.EXE;.exe")),
+    )
+    .unwrap();
+    assert!(found.is_file());
+    assert_eq!(found.parent(), bin.parent());
+    assert!(found.file_name().unwrap().to_string_lossy().eq_ignore_ascii_case("codex.exe"));
+}
+
+#[test]
+fn isolated_env_skips_install_offer() {
+    let path = crate::install::ensure(Harness::Pi, &EnvLookup::isolated(HashMap::new())).unwrap();
+    assert_eq!(path, std::path::PathBuf::from("pi"));
 }

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -95,7 +95,7 @@ pub(crate) fn maybe_before_launch(
             return Ok(());
         }
     };
-    state.last_check = Some(now_rfc3339());
+    state.last_check = Some(now_unix_seconds());
     save_state(paths, &state)?;
     if !update_pending(current, &release, &state) {
         return Ok(());
@@ -380,18 +380,18 @@ fn should_check(state: &UpdateState) -> bool {
     let Some(last_check) = &state.last_check else {
         return true;
     };
-    let Ok(parsed) = chrono_like_parse(last_check) else {
+    let Ok(parsed) = parse_unix_seconds(last_check) else {
         return true;
     };
     SystemTime::now().duration_since(parsed).is_ok_and(|elapsed| elapsed >= CHECK_INTERVAL)
 }
 
-fn now_rfc3339() -> String {
+fn now_unix_seconds() -> String {
     let seconds = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
     format!("{seconds}")
 }
 
-fn chrono_like_parse(value: &str) -> Result<SystemTime> {
+fn parse_unix_seconds(value: &str) -> Result<SystemTime> {
     let seconds: u64 = value.parse().context("parse last_check timestamp")?;
     Ok(UNIX_EPOCH + Duration::from_secs(seconds))
 }


### PR DESCRIPTION
### What's changed?

- Prompt to install a missing harness via the official script on an interactive TTY, or print the command when `RX_NO_INSTALL=1` or stdin/stderr is not a TTY.
- Seed Claude from the gateway `/v1/models/user` catalog for OpenRouter and Tokener, and expand `rx debug models` with Codex and user-catalog probes.
- Persist API keys before flipping gateway auth, and resolve Pi's agent dir through the launch environment.

### Why

- Launching `rx` should not fail silently when `claude`, `codex`, `opencode`, or `pi` is absent.
- Claude gateway launches need the same user-catalog seed and debug visibility on Tokener as on OpenRouter.