### PR TITLE
feat(rx): allow named gateway profiles over shared drivers

### DIFF
--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -43,7 +43,7 @@ pub(crate) struct LaunchRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ConfigCommand {
     SetGateway { name: String },
-    SetKey { provider: String, key: String },
+    SetKey { profile: String, key: String },
     Get { name: Option<String> },
 }
 
@@ -113,25 +113,25 @@ fn parse_config(args: &[String]) -> Result<ConfigCommand> {
     match args.first().map(String::as_str) {
         Some("set") => match args.get(1).map(String::as_str) {
             Some("gateway") => {
-                let name = args.get(2).ok_or_else(|| {
-                    anyhow::anyhow!("usage: rx config set gateway <openrouter|tokener>")
-                })?;
+                let name = args
+                    .get(2)
+                    .ok_or_else(|| anyhow::anyhow!("usage: rx config set gateway <profile>"))?;
                 if args.len() != 3 {
-                    bail!("usage: rx config set gateway <openrouter|tokener>");
+                    bail!("usage: rx config set gateway <profile>");
                 }
                 Ok(ConfigCommand::SetGateway { name: name.to_string() })
             }
             Some("key") => {
-                let provider = args.get(2).ok_or_else(|| {
-                    anyhow::anyhow!("usage: rx config set key <openrouter|tokener> <key>")
-                })?;
-                let key = args.get(3).ok_or_else(|| {
-                    anyhow::anyhow!("usage: rx config set key <openrouter|tokener> <key>")
-                })?;
+                let profile = args
+                    .get(2)
+                    .ok_or_else(|| anyhow::anyhow!("usage: rx config set key <profile> <key>"))?;
+                let key = args
+                    .get(3)
+                    .ok_or_else(|| anyhow::anyhow!("usage: rx config set key <profile> <key>"))?;
                 if args.len() != 4 {
-                    bail!("usage: rx config set key <openrouter|tokener> <key>");
+                    bail!("usage: rx config set key <profile> <key>");
                 }
-                Ok(ConfigCommand::SetKey { provider: provider.to_string(), key: key.to_string() })
+                Ok(ConfigCommand::SetKey { profile: profile.to_string(), key: key.to_string() })
             }
             _ => bail!("usage: rx config set <gateway|key> ..."),
         },

--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -55,6 +55,8 @@ pub(crate) struct RxConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct GatewayConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -71,24 +73,24 @@ struct KeyFile {
 pub(crate) fn run(command: ConfigCommand, paths: &Paths) -> Result<()> {
     match command {
         ConfigCommand::SetGateway { name } => {
-            let spec = crate::launch::provider(&name)?;
             let mut config = load_or_default(paths)?;
-            config.default_gateway = Some(spec.id.to_string());
-            ensure_gateway_entry(&mut config, spec.id, spec.default_base_url);
+            let driver = crate::launch::profile_driver(&name, config.gateway.get(&name))?;
+            config.default_gateway = Some(name.clone());
+            ensure_gateway_entry(&mut config, &name, driver);
             save_config(paths, &config)?;
-            println!("default gateway: {}", spec.id);
+            println!("default gateway: {name}");
             Ok(())
         }
-        ConfigCommand::SetKey { provider, key } => {
-            let spec = crate::launch::provider(&provider)?;
+        ConfigCommand::SetKey { profile, key } => {
             let mut config = load_or_default(paths)?;
+            let driver = crate::launch::profile_driver(&profile, config.gateway.get(&profile))?;
             let mut keys = load_keys(paths)?;
-            let entry = ensure_gateway_entry(&mut config, spec.id, spec.default_base_url);
+            let entry = ensure_gateway_entry(&mut config, &profile, driver);
             entry.auth = AuthMode::ApiKey;
-            keys.values.insert(spec.id.to_string(), key);
+            keys.values.insert(profile.clone(), key);
             save_keys(paths, &keys)?;
             save_config(paths, &config)?;
-            println!("stored API key for {}", spec.id);
+            println!("stored API key for {profile}");
             Ok(())
         }
         ConfigCommand::Get { name } => {
@@ -112,8 +114,8 @@ pub(crate) fn load(paths: &Paths) -> Result<Option<RxConfig>> {
     }
 }
 
-pub(crate) fn stored_key(paths: &Paths, provider: &str) -> Result<Option<String>> {
-    Ok(load_keys(paths)?.values.get(provider).cloned())
+pub(crate) fn stored_key(paths: &Paths, profile: &str) -> Result<Option<String>> {
+    Ok(load_keys(paths)?.values.get(profile).cloned())
 }
 
 fn load_or_default(paths: &Paths) -> Result<RxConfig> {
@@ -123,10 +125,10 @@ fn load_or_default(paths: &Paths) -> Result<RxConfig> {
 fn ensure_gateway_entry<'a>(
     config: &'a mut RxConfig,
     id: &str,
-    default_base_url: &str,
+    driver: &crate::launch::DriverSpec,
 ) -> &'a mut GatewayConfig {
     config.gateway.entry(id.to_string()).or_insert_with(|| GatewayConfig {
-        base_url: Some(default_base_url.to_string()),
+        base_url: Some(driver.default_base_url.to_string()),
         auth: AuthMode::ApiKey,
         ..Default::default()
     })
@@ -142,9 +144,14 @@ pub(crate) fn format_get(paths: &Paths, name: Option<&str>) -> Result<String> {
                 Some(gateway) => out.push_str(&format!("default_gateway = {gateway}\n")),
                 None => out.push_str("default_gateway = (unset)\n"),
             }
-            for spec in crate::launch::PROVIDERS {
+            let profiles: BTreeSet<String> = crate::launch::DRIVERS
+                .iter()
+                .map(|driver| driver.id.to_string())
+                .chain(config.gateway.keys().cloned())
+                .collect();
+            for profile in profiles {
                 out.push('\n');
-                out.push_str(&format_provider(&config, &keys, spec.id)?);
+                out.push_str(&format_provider(&config, &keys, &profile)?);
             }
             Ok(out)
         }
@@ -157,17 +164,19 @@ pub(crate) fn format_get(paths: &Paths, name: Option<&str>) -> Result<String> {
 }
 
 fn format_provider(config: &RxConfig, keys: &KeyFile, name: &str) -> Result<String> {
-    let spec = crate::launch::provider(name)?;
-    let entry = config.gateway.get(spec.id);
+    let entry = config.gateway.get(name);
+    let driver = crate::launch::profile_driver(name, entry)?;
     let base_url =
-        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(spec.default_base_url);
+        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(driver.default_base_url);
     let auth = entry.map(|entry| entry.auth).unwrap_or_default();
-    let key = if keys.values.contains_key(spec.id) { "set" } else { "unset" };
-    let model =
-        entry.and_then(|entry| entry.model.as_deref()).or(spec.default_model).unwrap_or("(unset)");
+    let key = if keys.values.contains_key(name) { "set" } else { "unset" };
+    let model = entry
+        .and_then(|entry| entry.model.as_deref())
+        .or(driver.default_model)
+        .unwrap_or("(unset)");
     Ok(format!(
-        "[{}]\nbase_url = {base_url}\nmodel = {model}\nauth = {}\nkey = {key}\n",
-        spec.id,
+        "[{name}]\ndriver = {}\nbase_url = {base_url}\nmodel = {model}\nauth = {}\nkey = {key}\n",
+        driver.id,
         auth.as_str()
     ))
 }

--- a/crates/rx/src/debug/mod.rs
+++ b/crates/rx/src/debug/mod.rs
@@ -44,13 +44,9 @@ pub(crate) fn help_text() -> &'static str {
 rx debug — developer diagnostics (unstable; not for everyday use)
 
 Usage:
-  rx debug models [--gateway <profile>]
+  rx debug <subcommand> [--gateway <profile>]
 
 Subcommands:
   models    probe gateway /models and /v1/models catalog endpoints
-
-Options:
-  --gateway <profile>   select gateway (same flag as launch commands)
-  -h, --help                       show this help
 "
 }

--- a/crates/rx/src/debug/mod.rs
+++ b/crates/rx/src/debug/mod.rs
@@ -16,7 +16,7 @@ pub(crate) fn parse(args: &[String]) -> Result<Subcommand> {
         None | Some("-h") | Some("--help") => Ok(Subcommand::Help),
         Some("models") => {
             if args.len() != 1 {
-                bail!("usage: rx debug models [--gateway <openrouter|tokener>]");
+                bail!("usage: rx debug models [--gateway <profile>]");
             }
             Ok(Subcommand::Models)
         }
@@ -44,13 +44,13 @@ pub(crate) fn help_text() -> &'static str {
 rx debug — developer diagnostics (unstable; not for everyday use)
 
 Usage:
-  rx debug models [--gateway <openrouter|tokener>]
+  rx debug models [--gateway <profile>]
 
 Subcommands:
   models    probe gateway /models and /v1/models catalog endpoints
 
 Options:
-  --gateway <openrouter|tokener>   select gateway (same flag as launch commands)
+  --gateway <profile>   select gateway (same flag as launch commands)
   -h, --help                       show this help
 "
 }

--- a/crates/rx/src/debug/models.rs
+++ b/crates/rx/src/debug/models.rs
@@ -20,7 +20,7 @@ pub(crate) struct Probe {
 
 pub(crate) fn run(gateway: Option<String>, paths: &Paths, env: &EnvLookup) -> Result<()> {
     let Some(target) = launch::configured_gateway(gateway.as_deref(), paths, env)? else {
-        bail!("no gateway configured; run: rx config set gateway <openrouter|tokener>");
+        bail!("no gateway configured; run: rx config set gateway <profile>");
     };
     let auth_header = ("Authorization", format!("Bearer {}", target.key));
     let openai_url = format!("{}/models", launch::openai_base(&target.base_url));
@@ -36,7 +36,7 @@ pub(crate) fn run(gateway: Option<String>, paths: &Paths, env: &EnvLookup) -> Re
     let codex = probe(&codex_url, &codex_headers);
     let anthropic = probe(&anthropic_url, &anthropic_headers);
     let user = probe_user(&user_url, std::slice::from_ref(&auth_header));
-    print!("{}", render(target.spec.id, &target.base_url, &openai, &codex, &anthropic, &user));
+    print!("{}", render(&target.profile_id, &target.base_url, &openai, &codex, &anthropic, &user));
     Ok(())
 }
 

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -190,7 +190,7 @@ fn passthrough(request: &LaunchRequest) -> LaunchPlan {
         args: request.passthrough.clone(),
         env_set: Vec::new(),
         stderr_note: Some(format!(
-            "[rx] no gateway configured; launching {} as-is (configure: rx config set gateway <name>)",
+            "[rx] no gateway configured; launching {} as-is (configure: rx config set gateway <profile>)",
             request.harness.as_str()
         )),
     }

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -5,10 +5,10 @@ use anyhow::{Result, bail};
 
 use crate::args::{Harness, LaunchRequest};
 use crate::claude_catalog::{self, SeedOutcome};
-use crate::config::{AuthMode, Paths};
+use crate::config::{AuthMode, GatewayConfig, Paths};
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ProviderSpec {
+pub(crate) struct DriverSpec {
     pub id: &'static str,
     pub name: &'static str,
     pub default_base_url: &'static str,
@@ -17,8 +17,8 @@ pub(crate) struct ProviderSpec {
     pub claude_default_model: Option<&'static str>,
 }
 
-pub(crate) const PROVIDERS: &[ProviderSpec] = &[
-    ProviderSpec {
+pub(crate) const DRIVERS: &[DriverSpec] = &[
+    DriverSpec {
         id: "openrouter",
         name: "OpenRouter",
         default_base_url: "https://openrouter.ai/api",
@@ -26,7 +26,7 @@ pub(crate) const PROVIDERS: &[ProviderSpec] = &[
         default_model: Some("~openai/gpt-latest"),
         claude_default_model: Some("~anthropic/claude-sonnet-latest"),
     },
-    ProviderSpec {
+    DriverSpec {
         id: "tokener",
         name: "Tokener",
         default_base_url: "https://api.tokener.dev",
@@ -36,11 +36,42 @@ pub(crate) const PROVIDERS: &[ProviderSpec] = &[
     },
 ];
 
-pub(crate) fn provider(id: &str) -> Result<&'static ProviderSpec> {
-    PROVIDERS
-        .iter()
-        .find(|provider| provider.id == id)
-        .ok_or_else(|| anyhow::anyhow!("unknown gateway: {id} (supported: openrouter, tokener)"))
+pub(crate) fn driver(id: &str) -> Result<&'static DriverSpec> {
+    DRIVERS.iter().find(|driver| driver.id == id).ok_or_else(|| {
+        anyhow::anyhow!("unknown gateway driver: {id} (supported: openrouter, tokener)")
+    })
+}
+
+pub(crate) fn profile_driver(
+    profile_id: &str,
+    entry: Option<&GatewayConfig>,
+) -> Result<&'static DriverSpec> {
+    validate_profile_id(profile_id)?;
+    if let Some(driver_id) = entry.and_then(|entry| entry.driver.as_deref()) {
+        return driver(driver_id).map_err(|_| {
+            anyhow::anyhow!(
+                "gateway profile '{profile_id}' has unknown driver '{driver_id}' (supported: openrouter, tokener)"
+            )
+        });
+    }
+    if let Ok(driver) = driver(profile_id) {
+        return Ok(driver);
+    }
+    if entry.is_some() {
+        bail!(
+            "gateway profile '{profile_id}' must set driver = \"openrouter\" or driver = \"tokener\""
+        );
+    }
+    bail!("unknown gateway profile: {profile_id} (define it in rx.toml or use openrouter/tokener)")
+}
+
+fn validate_profile_id(id: &str) -> Result<()> {
+    if !id.is_empty()
+        && id.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Ok(());
+    }
+    bail!("invalid gateway profile name '{id}'; use only letters, numbers, '-' and '_'")
 }
 
 #[derive(Debug, Clone, Default)]
@@ -81,7 +112,8 @@ pub struct LaunchPlan {
 
 #[derive(Debug, Clone)]
 pub(crate) struct GatewayTarget {
-    pub spec: &'static ProviderSpec,
+    pub profile_id: String,
+    pub driver: &'static DriverSpec,
     pub base_url: String,
     pub key: String,
     pub model: Option<String>,
@@ -99,14 +131,20 @@ pub(crate) fn configured_gateway(
     let Some(gateway_id) = gateway_id else {
         return Ok(None);
     };
-    let spec = provider(&gateway_id)?;
-    let entry = config.as_ref().and_then(|config| config.gateway.get(spec.id));
+    let entry = config.as_ref().and_then(|config| config.gateway.get(&gateway_id));
+    let driver = profile_driver(&gateway_id, entry)?;
     let base_url =
-        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(spec.default_base_url);
+        entry.and_then(|entry| entry.base_url.as_deref()).unwrap_or(driver.default_base_url);
     let auth = entry.map(|entry| entry.auth).unwrap_or(AuthMode::ApiKey);
-    let key = resolve_key(spec, auth, paths, env)?;
+    let key = resolve_key(&gateway_id, driver, auth, paths, env)?;
     let model = entry.and_then(|entry| entry.model.clone());
-    Ok(Some(GatewayTarget { spec, base_url: base_url.to_string(), key, model }))
+    Ok(Some(GatewayTarget {
+        profile_id: gateway_id,
+        driver,
+        base_url: base_url.to_string(),
+        key,
+        model,
+    }))
 }
 
 pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> Result<LaunchPlan> {
@@ -114,8 +152,8 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
         return Ok(passthrough(request));
     };
     let model = target.model.as_deref().or(match request.harness {
-        Harness::Claude => target.spec.claude_default_model,
-        Harness::Codex => target.spec.default_model,
+        Harness::Claude => target.driver.claude_default_model,
+        Harness::Codex => target.driver.default_model,
         Harness::OpenCode | Harness::Pi => None,
     });
     if matches!(request.harness, Harness::Claude) {
@@ -124,7 +162,7 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
         } else {
             SeedOutcome::Fallback
         };
-        if target.spec.id == "openrouter" {
+        if target.driver.id == "openrouter" {
             return Ok(inject_claude_openrouter(
                 request,
                 &target.base_url,
@@ -136,14 +174,14 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
         if matches!(seed, SeedOutcome::Seeded { .. }) {
             return Ok(inject_claude_tokener_seeded(
                 request,
-                target.spec,
+                target.driver,
                 &target.base_url,
                 &target.key,
                 model,
             ));
         }
     }
-    inject(request, paths, env, target.spec, &target.base_url, &target.key, model)
+    inject(request, paths, env, &target, model)
 }
 
 fn passthrough(request: &LaunchRequest) -> LaunchPlan {
@@ -159,31 +197,32 @@ fn passthrough(request: &LaunchRequest) -> LaunchPlan {
 }
 
 fn resolve_key(
-    spec: &ProviderSpec,
+    profile_id: &str,
+    driver: &DriverSpec,
     auth: AuthMode,
     paths: &Paths,
     env: &EnvLookup,
 ) -> Result<String> {
     match auth {
-        AuthMode::Env => env.get(spec.env_key).ok_or_else(|| {
+        AuthMode::Env => env.get(driver.env_key).ok_or_else(|| {
             anyhow::anyhow!(
                 "gateway '{}' is set to auth = env, but ${} is not set",
-                spec.id,
-                spec.env_key
+                profile_id,
+                driver.env_key
             )
         }),
         AuthMode::ApiKey => {
-            if let Some(key) = crate::config::stored_key(paths, spec.id)? {
+            if let Some(key) = crate::config::stored_key(paths, profile_id)? {
                 return Ok(key);
             }
-            if let Some(key) = env.get(spec.env_key) {
+            if let Some(key) = env.get(driver.env_key) {
                 return Ok(key);
             }
             bail!(
                 "no API key for gateway '{}'; run: rx config set key {} <key>  (or set ${} and auth = \"env\")",
-                spec.id,
-                spec.id,
-                spec.env_key
+                profile_id,
+                profile_id,
+                driver.env_key
             )
         }
     }
@@ -289,20 +328,20 @@ fn claude_openrouter_env(
 
 fn inject_claude_tokener_seeded(
     request: &LaunchRequest,
-    spec: &ProviderSpec,
+    driver: &DriverSpec,
     base_url: &str,
     key: &str,
     model: Option<&str>,
 ) -> LaunchPlan {
     let mut args = request.passthrough.clone();
     if !claude_catalog::user_passes_settings(&request.passthrough) {
-        args.insert(0, claude_catalog::claude_settings_json(base_url, true, spec.env_key));
+        args.insert(0, claude_catalog::claude_settings_json(base_url, true, driver.env_key));
         args.insert(0, "--settings".to_string());
     }
     LaunchPlan {
         program: "claude".to_string(),
         args,
-        env_set: claude_tokener_seeded_env(spec, base_url, key, model),
+        env_set: claude_tokener_seeded_env(driver, base_url, key, model),
         stderr_note: None,
     }
 }
@@ -310,16 +349,16 @@ fn inject_claude_tokener_seeded(
 #[cfg(test)]
 pub(crate) fn inject_claude_tokener_seeded_for_test(
     request: &LaunchRequest,
-    spec: &ProviderSpec,
+    driver: &DriverSpec,
     base_url: &str,
     key: &str,
     model: Option<&str>,
 ) -> LaunchPlan {
-    inject_claude_tokener_seeded(request, spec, base_url, key, model)
+    inject_claude_tokener_seeded(request, driver, base_url, key, model)
 }
 
 fn claude_tokener_seeded_env(
-    spec: &ProviderSpec,
+    driver: &DriverSpec,
     base_url: &str,
     key: &str,
     model: Option<&str>,
@@ -328,7 +367,7 @@ fn claude_tokener_seeded_env(
         ("ANTHROPIC_BASE_URL".to_string(), anthropic_base(base_url)),
         ("ANTHROPIC_AUTH_TOKEN".to_string(), key.to_string()),
         ("ANTHROPIC_API_KEY".to_string(), String::new()),
-        (spec.env_key.to_string(), key.to_string()),
+        (driver.env_key.to_string(), key.to_string()),
         ("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK".to_string(), "1".to_string()),
         ("CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT".to_string(), "1".to_string()),
         ("ENABLE_TOOL_SEARCH".to_string(), "true".to_string()),
@@ -346,7 +385,7 @@ fn claude_tokener_seeded_env(
 }
 
 fn claude_env(
-    spec: &ProviderSpec,
+    driver: &DriverSpec,
     base_url: &str,
     key: &str,
     model: Option<&str>,
@@ -356,7 +395,7 @@ fn claude_env(
         ("ANTHROPIC_AUTH_TOKEN".to_string(), key.to_string()),
         ("ANTHROPIC_API_KEY".to_string(), String::new()),
         ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(), "1".to_string()),
-        (spec.env_key.to_string(), key.to_string()),
+        (driver.env_key.to_string(), key.to_string()),
     ];
     if let Some(model) = model {
         env_set.push(("ANTHROPIC_MODEL".to_string(), model.to_string()));
@@ -368,25 +407,27 @@ fn inject(
     request: &LaunchRequest,
     paths: &Paths,
     env: &EnvLookup,
-    spec: &ProviderSpec,
-    base_url: &str,
-    key: &str,
+    target: &GatewayTarget,
     model: Option<&str>,
 ) -> Result<LaunchPlan> {
+    let profile_id = target.profile_id.as_str();
+    let driver = target.driver;
+    let base_url = target.base_url.as_str();
+    let key = target.key.as_str();
     match request.harness {
         Harness::Claude => Ok(LaunchPlan {
             program: "claude".to_string(),
             args: request.passthrough.clone(),
-            env_set: claude_env(spec, base_url, key, model),
+            env_set: claude_env(driver, base_url, key, model),
             stderr_note: None,
         }),
         Harness::Codex => {
             let openai_base = openai_base(base_url);
             let mut args = vec![
                 "-c".to_string(),
-                format!("model_provider=\"{}\"", spec.id),
+                format!("model_provider=\"{profile_id}\""),
                 "-c".to_string(),
-                codex_provider_override(spec, &openai_base),
+                codex_provider_override(profile_id, driver, &openai_base),
             ];
             if let Some(model) = model.filter(|_| !user_sets_model(&request.passthrough)) {
                 args.push("-c".to_string());
@@ -396,49 +437,51 @@ fn inject(
             Ok(LaunchPlan {
                 program: "codex".to_string(),
                 args,
-                env_set: vec![(spec.env_key.to_string(), key.to_string())],
+                env_set: vec![(driver.env_key.to_string(), key.to_string())],
                 stderr_note: None,
             })
         }
         Harness::OpenCode => {
+            let provider_id = if driver.id == "tokener" { profile_id } else { driver.id };
             let env_set = vec![
-                (spec.env_key.to_string(), key.to_string()),
+                (driver.env_key.to_string(), key.to_string()),
                 (
                     "OPENCODE_CONFIG_CONTENT".to_string(),
-                    crate::opencode::config_content(spec, base_url, key)?,
+                    crate::opencode::config_content(provider_id, driver, base_url, key)?,
                 ),
             ];
             let mut args = request.passthrough.clone();
             if let Some(model) = model.filter(|_| !user_sets_opencode_model(&request.passthrough)) {
-                args.insert(0, crate::opencode::prefixed_model(spec.id, model));
+                args.insert(0, crate::opencode::prefixed_model(provider_id, model));
                 args.insert(0, "-m".to_string());
             }
             Ok(LaunchPlan {
                 program: "opencode".to_string(),
                 args,
                 env_set,
-                stderr_note: crate::opencode::auth_conflict_note(spec, key, env),
+                stderr_note: crate::opencode::auth_conflict_note(driver, key, env),
             })
         }
         Harness::Pi => {
-            crate::pi::prepare(spec, base_url, key, paths, env)?;
+            let provider_id = if driver.id == "tokener" { profile_id } else { driver.id };
+            crate::pi::prepare(provider_id, driver, base_url, key, paths, env)?;
             Ok(LaunchPlan {
                 program: "pi".to_string(),
-                args: crate::pi::args(spec, model, &request.passthrough),
-                env_set: crate::pi::env_set(spec, key),
+                args: crate::pi::args(provider_id, model, &request.passthrough),
+                env_set: crate::pi::env_set(driver, key),
                 stderr_note: None,
             })
         }
     }
 }
 
-fn codex_provider_override(spec: &ProviderSpec, openai_base: &str) -> String {
+fn codex_provider_override(profile_id: &str, driver: &DriverSpec, openai_base: &str) -> String {
     format!(
         "model_providers.{}={{name=\"{}\", base_url=\"{}\", wire_api=\"responses\", supports_websockets=false, {}}}",
-        spec.id,
-        spec.name,
+        profile_id,
+        driver.name,
         openai_base,
-        auth_override(spec.env_key)
+        auth_override(driver.env_key)
     )
 }
 

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -62,24 +62,19 @@ rx — launch agent harnesses through a configured API gateway
 
 Usage:
   rx <harness> [args...]
+  rx --gateway <profile> <harness> [args...]
   rx config set gateway <profile>
   rx config set key <profile> <key>
   rx config get [name]
   rx update [--yes]
-
-Options:
-  --gateway <profile>              select gateway for this launch
-  -h, --help                       show this help
-  -V, --version                    show version
+  rx debug --help
 
 Environment:
-  RX_NO_UPDATE=1                   skip launch-time update checks
-  RX_NO_INSTALL=1                  skip offering to install a missing harness
+  RX_NO_UPDATE=1     skip launch-time update checks
+  RX_NO_INSTALL=1    skip offering to install a missing harness
 
-Developer: rx debug --help
-
-With no gateway configured, rx execs the harness unchanged.
-Gateway flags are stripped; every other argument is passed through.
+Unconfigured, rx execs the harness unchanged; gateway flags are stripped
+and every other argument passes through.
 "
 }
 

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -72,9 +72,6 @@ Usage:
 Environment:
   RX_NO_UPDATE=1     skip launch-time update checks
   RX_NO_INSTALL=1    skip offering to install a missing harness
-
-Unconfigured, rx execs the harness unchanged; gateway flags are stripped
-and every other argument passes through.
 "
 }
 

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -58,13 +58,13 @@ rx — launch agent harnesses through a configured API gateway
 
 Usage:
   rx <harness> [args...]
-  rx config set gateway <openrouter|tokener>
-  rx config set key <openrouter|tokener> <key>
+  rx config set gateway <profile>
+  rx config set key <profile> <key>
   rx config get [name]
   rx update [--yes]
 
 Options:
-  --gateway <openrouter|tokener>   select gateway for this launch
+  --gateway <profile>              select gateway for this launch
   -h, --help                       show this help
   -V, --version                    show version
 

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -26,7 +26,11 @@ pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result
         parse(&raw_args)?
     };
     if matches!(command, Command::Launch(_)) {
-        update::maybe_before_launch(paths, env, &raw_args)?;
+        // Updating is incidental to launching: a broken state file, an
+        // unwritable config dir, or a failed install must not stop the harness.
+        if let Err(error) = update::maybe_before_launch(paths, env, &raw_args) {
+            eprintln!("[rx] update skipped: {error:#}");
+        }
     }
     match command {
         Command::Help => {

--- a/crates/rx/src/opencode.rs
+++ b/crates/rx/src/opencode.rs
@@ -6,16 +6,21 @@ use anyhow::{Context, Result};
 use serde_json::{Value, json};
 
 use crate::catalog;
-use crate::launch::{EnvLookup, ProviderSpec, openai_base};
+use crate::launch::{DriverSpec, EnvLookup, openai_base};
 
-pub(crate) fn config_content(spec: &ProviderSpec, base_url: &str, key: &str) -> Result<String> {
-    let value = match spec.id {
+pub(crate) fn config_content(
+    provider_id: &str,
+    driver: &DriverSpec,
+    base_url: &str,
+    key: &str,
+) -> Result<String> {
+    let value = match driver.id {
         "openrouter" => json!({
             "provider": {
-                "openrouter": {
+                provider_id: {
                     "options": {
                         "baseURL": openai_base(base_url),
-                        "apiKey": format!("{{env:{}}}", spec.env_key)
+                        "apiKey": format!("{{env:{}}}", driver.env_key)
                     }
                 }
             }
@@ -24,12 +29,12 @@ pub(crate) fn config_content(spec: &ProviderSpec, base_url: &str, key: &str) -> 
             let models = fetch_model_map(base_url, key)?;
             json!({
                 "provider": {
-                    "tokener": {
+                    provider_id: {
                         "npm": "@ai-sdk/openai-compatible",
                         "name": "Tokener",
                         "options": {
                             "baseURL": openai_base(base_url),
-                            "apiKey": format!("{{env:{}}}", spec.env_key)
+                            "apiKey": format!("{{env:{}}}", driver.env_key)
                         },
                         "models": models
                     }
@@ -42,11 +47,11 @@ pub(crate) fn config_content(spec: &ProviderSpec, base_url: &str, key: &str) -> 
 }
 
 pub(crate) fn auth_conflict_note(
-    spec: &ProviderSpec,
+    driver: &DriverSpec,
     key: &str,
     env: &EnvLookup,
 ) -> Option<String> {
-    if spec.id != "openrouter" {
+    if driver.id != "openrouter" {
         return None;
     }
     let path = opencode_auth_path(env).ok()?;

--- a/crates/rx/src/opencode.rs
+++ b/crates/rx/src/opencode.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
 use crate::catalog;
@@ -96,6 +96,9 @@ pub(crate) fn fetch_model_map(base_url: &str, key: &str) -> Result<BTreeMap<Stri
 fn opencode_auth_path(env: &EnvLookup) -> Result<PathBuf> {
     if let Some(dir) = env.get("XDG_DATA_HOME").filter(|value| !value.trim().is_empty()) {
         return Ok(PathBuf::from(dir).join("opencode").join("auth.json"));
+    }
+    if !env.is_real() {
+        bail!("XDG_DATA_HOME is required in an isolated environment");
     }
     let home = dirs::home_dir().context("cannot determine home directory")?;
     Ok(home.join(".local").join("share").join("opencode").join("auth.json"))

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
 use crate::config::Paths;
-use crate::launch::{EnvLookup, ProviderSpec, openai_base};
+use crate::launch::{DriverSpec, EnvLookup, openai_base};
 use crate::opencode;
 
 const PI_ENV_CLEAR: &[&str] = &[
@@ -52,50 +52,47 @@ pub(crate) fn recall_pi_dir(paths: &Paths) -> PathBuf {
 }
 
 pub(crate) fn prepare(
-    spec: &ProviderSpec,
+    provider_id: &str,
+    driver: &DriverSpec,
     base_url: &str,
     key: &str,
     paths: &Paths,
     env: &EnvLookup,
 ) -> Result<()> {
-    if spec.id != "tokener" {
+    if driver.id != "tokener" {
         return Ok(());
     }
-    let provider = tokener_provider(spec, base_url, key)?;
+    let provider = tokener_provider(driver, base_url, key)?;
     let recall_dir = recall_pi_dir(paths);
     fs::create_dir_all(&recall_dir)
         .with_context(|| format!("failed to create {}", recall_dir.display()))?;
-    write_json_atomic(&recall_dir.join("tokener-provider.json"), &provider)?;
+    write_json_atomic(&recall_dir.join(format!("{provider_id}-provider.json")), &provider)?;
     let agent_dir = global_agent_dir(env)?;
     fs::create_dir_all(&agent_dir)
         .with_context(|| format!("failed to create {}", agent_dir.display()))?;
-    merge_provider(&agent_dir.join("models.json"), "tokener", provider)
+    merge_provider(&agent_dir.join("models.json"), provider_id, provider)
 }
 
-pub(crate) fn env_set(spec: &ProviderSpec, key: &str) -> Vec<(String, String)> {
-    let mut env_set = vec![(spec.env_key.to_string(), key.to_string())];
+pub(crate) fn env_set(driver: &DriverSpec, key: &str) -> Vec<(String, String)> {
+    let mut env_set = vec![(driver.env_key.to_string(), key.to_string())];
     for name in PI_ENV_CLEAR {
         env_set.push(((*name).to_string(), String::new()));
     }
     env_set
 }
 
-pub(crate) fn args(
-    spec: &ProviderSpec,
-    model: Option<&str>,
-    passthrough: &[String],
-) -> Vec<String> {
+pub(crate) fn args(provider_id: &str, model: Option<&str>, passthrough: &[String]) -> Vec<String> {
     let mut args = Vec::new();
     if !user_sets_models_flag(passthrough) {
         args.push("--models".to_string());
-        args.push(format!("{}/*", spec.id));
+        args.push(format!("{provider_id}/*"));
     }
     if let Some(model) = model.filter(|_| !user_sets_model(passthrough)) {
         args.push("--model".to_string());
-        args.push(opencode::prefixed_model(spec.id, model));
+        args.push(opencode::prefixed_model(provider_id, model));
     } else if !user_sets_provider(passthrough) {
         args.push("--provider".to_string());
-        args.push(spec.id.to_string());
+        args.push(provider_id.to_string());
     }
     args.extend(passthrough.iter().cloned());
     args
@@ -109,7 +106,7 @@ fn user_sets_provider(passthrough: &[String]) -> bool {
     passthrough.iter().any(|arg| arg == "--provider" || arg.starts_with("--provider="))
 }
 
-fn tokener_provider(spec: &ProviderSpec, base_url: &str, key: &str) -> Result<Value> {
+fn tokener_provider(driver: &DriverSpec, base_url: &str, key: &str) -> Result<Value> {
     let models: Vec<Value> =
         opencode::fetch_model_map(base_url, key)?.keys().map(|id| json!({ "id": id })).collect();
     if models.is_empty() {
@@ -117,7 +114,7 @@ fn tokener_provider(spec: &ProviderSpec, base_url: &str, key: &str) -> Result<Va
     }
     Ok(json!({
         "baseUrl": openai_base(base_url),
-        "apiKey": format!("${}", spec.env_key),
+        "apiKey": format!("${}", driver.env_key),
         "api": "openai-responses",
         "authHeader": true,
         "models": models

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -221,7 +221,7 @@ fn config_set_and_get_parse() {
     assert_eq!(
         parse_line(&["rx", "config", "set", "key", "tokener", "sk-test"]),
         Command::Config(ConfigCommand::SetKey {
-            provider: "tokener".to_string(),
+            profile: "tokener".to_string(),
             key: "sk-test".to_string(),
         })
     );
@@ -435,7 +435,7 @@ fn pi_merge_provider_refuses_to_reset_corrupt_models_json() {
 #[test]
 fn pi_tokener_writes_recall_cache() {
     let (dir, paths) = temp_paths();
-    let spec = launch::provider("tokener").unwrap();
+    let driver = launch::driver("tokener").unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     let server = thread::spawn(move || {
@@ -457,7 +457,7 @@ fn pi_tokener_writes_recall_cache() {
         agent_dir.display().to_string(),
     )]));
 
-    crate::pi::prepare(spec, &base_url, "sk-test", &paths, &env).unwrap();
+    crate::pi::prepare("tokener", driver, &base_url, "sk-test", &paths, &env).unwrap();
     server.join().unwrap();
 
     let cache = dir.path().join("pi/tokener-provider.json");
@@ -534,7 +534,7 @@ fn config_set_key_is_redacted_and_secret() {
     let (_dir, paths) = temp_paths();
     config::run(ConfigCommand::SetGateway { name: "openrouter".to_string() }, &paths).unwrap();
     config::run(
-        ConfigCommand::SetKey { provider: "openrouter".to_string(), key: "sk-secret".to_string() },
+        ConfigCommand::SetKey { profile: "openrouter".to_string(), key: "sk-secret".to_string() },
         &paths,
     )
     .unwrap();
@@ -582,7 +582,7 @@ auth = "env"
     fs::write(&paths.keys, "{").unwrap();
 
     let error = config::run(
-        ConfigCommand::SetKey { provider: "openrouter".to_string(), key: "sk-secret".to_string() },
+        ConfigCommand::SetKey { profile: "openrouter".to_string(), key: "sk-secret".to_string() },
         &paths,
     )
     .unwrap_err();
@@ -590,6 +590,167 @@ auth = "env"
 
     let config = config::load(&paths).unwrap().unwrap();
     assert_eq!(config.gateway["openrouter"].auth, config::AuthMode::Env);
+}
+
+#[test]
+fn custom_gateway_profiles_keep_independent_keys_and_driver_behavior() {
+    let (dir, paths) = temp_paths();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let dev_base_url = format!("http://{}", listener.local_addr().unwrap());
+    fs::write(
+        &paths.config,
+        format!(
+            r#"default_gateway = "tokener-dev"
+
+[gateway.tokener-dev]
+driver = "tokener"
+base_url = "{dev_base_url}"
+model = "gpt-dev"
+
+[gateway.tokener-prod]
+driver = "tokener"
+base_url = "https://prod.gateway.test"
+model = "gpt-prod"
+"#
+        ),
+    )
+    .unwrap();
+
+    config::run(
+        ConfigCommand::SetKey { profile: "tokener-dev".to_string(), key: "sk-dev".to_string() },
+        &paths,
+    )
+    .unwrap();
+    config::run(
+        ConfigCommand::SetKey { profile: "tokener-prod".to_string(), key: "sk-prod".to_string() },
+        &paths,
+    )
+    .unwrap();
+    config::run(ConfigCommand::SetGateway { name: "tokener-prod".to_string() }, &paths).unwrap();
+
+    let listing = config::format_get(&paths, None).unwrap();
+    assert!(listing.contains("default_gateway = tokener-prod"));
+    assert!(listing.contains("[tokener-dev]\ndriver = tokener"));
+    assert!(listing.contains("[tokener-prod]\ndriver = tokener"));
+
+    let agent_dir = dir.path().join("pi-agent");
+    let env = EnvLookup::isolated(HashMap::from([(
+        "PI_CODING_AGENT_DIR".to_string(),
+        agent_dir.display().to_string(),
+    )]));
+    let codex = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Codex,
+            gateway: Some("tokener-dev".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(codex.args[1], "model_provider=\"tokener-dev\"");
+    assert!(codex.args[3].contains("model_providers.tokener-dev="));
+    assert!(codex.args[3].contains(&format!("base_url=\"{dev_base_url}/v1\"")));
+    assert_eq!(codex.env_set, vec![("TOKENER_API_KEY".to_string(), "sk-dev".to_string())]);
+
+    let server = thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let size = stream.read(&mut request).unwrap();
+            assert!(String::from_utf8_lossy(&request[..size]).starts_with("GET /v1/models "));
+            let body = r#"{"data":[{"id":"gpt-dev"}]}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+        }
+    });
+
+    let opencode = launch::plan(
+        &LaunchRequest {
+            harness: Harness::OpenCode,
+            gateway: Some("tokener-dev".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(opencode.args, ["-m", "tokener-dev/gpt-dev"]);
+    let opencode_config = opencode
+        .env_set
+        .iter()
+        .find(|(name, _)| name == "OPENCODE_CONFIG_CONTENT")
+        .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+        .unwrap();
+    assert!(opencode_config["provider"]["tokener-dev"].is_object());
+    assert!(opencode_config["provider"]["tokener"].is_null());
+
+    let pi = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Pi,
+            gateway: Some("tokener-dev".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(pi.args, ["--models", "tokener-dev/*", "--model", "tokener-dev/gpt-dev"]);
+    assert!(dir.path().join("pi/tokener-dev-provider.json").is_file());
+    let pi_models: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(agent_dir.join("models.json")).unwrap()).unwrap();
+    assert!(pi_models["providers"]["tokener-dev"].is_object());
+    assert!(pi_models["providers"]["tokener"].is_null());
+    server.join().unwrap();
+
+    let claude = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            gateway: Some("tokener-prod".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert!(
+        claude
+            .env_set
+            .iter()
+            .any(|(key, value)| key == "ANTHROPIC_BASE_URL" && value == "https://prod.gateway.test")
+    );
+    assert!(
+        claude
+            .env_set
+            .iter()
+            .any(|(key, value)| key == "ANTHROPIC_AUTH_TOKEN" && value == "sk-prod")
+    );
+}
+
+#[test]
+fn gateway_profile_names_cannot_escape_generated_config_boundaries() {
+    let (_dir, paths) = temp_paths();
+    fs::write(
+        &paths.config,
+        r#"default_gateway = "../prod"
+
+[gateway."../prod"]
+driver = "tokener"
+"#,
+    )
+    .unwrap();
+
+    let error = launch::plan(
+        &LaunchRequest { harness: Harness::Pi, gateway: None, passthrough: Vec::new() },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("invalid gateway profile name '../prod'"), "{error}");
 }
 
 #[test]
@@ -742,7 +903,7 @@ fn tokener_seeded_plan_uses_auth_token_and_settings() {
             gateway: Some("tokener".to_string()),
             passthrough: vec!["fix it".to_string()],
         },
-        launch::provider("tokener").unwrap(),
+        launch::driver("tokener").unwrap(),
         "http://localhost:8080",
         "sk-tokener",
         None,


### PR DESCRIPTION
## What

Gateway config keys had to equal a built-in provider id, so one machine could hold only one endpoint and one key per provider. This splits the concept in two:

- a **profile** is any user-chosen name under `[gateway.<name>]`
- `driver = "openrouter" | "tokener"` selects the built-in behavior it runs on

```toml
default_gateway = "tokener-dev"

[gateway.tokener-dev]
driver = "tokener"
base_url = "https://dev.example.com"
model = "gpt-dev"

[gateway.tokener-prod]
driver = "tokener"
base_url = "https://prod.example.com"
```

```
rx config set key tokener-dev  sk-dev
rx config set key tokener-prod sk-prod
rx --gateway tokener-dev codex
```

Profiles are defined by hand in `~/.recall/rx.toml`; `rx config set` then manages their key and default selection. A profile with no `driver` falls back to matching its own name, so **existing configs keep working untouched**.

The profile id, not the driver id, now flows into every generated harness config: codex `model_provider`, the OpenCode provider block, and pi's provider file and model prefix. OpenRouter keeps the built-in provider id in OpenCode and pi because those tools ship it themselves.

Profile names are restricted to `[A-Za-z0-9_-]`, which keeps them safe both as path components in pi's provider file and as bare TOML keys in codex `-c` overrides.

## Known limitation

A profile with no stored key still falls back to the driver-level env var. With `TOKENER_API_KEY` set and no key stored for `tokener-dev`, that profile resolves to the prod key while keeping the dev `base_url`:

```
profile=tokener-dev base_url=https://dev.example.com key=sk-PROD
```

Storing a key per profile avoids it. Fixing it properly means per-profile env vars, which is a product decision left out of this PR.

## Also in this branch

Two unrelated bugs found while auditing, kept as separate commits:

- `maybe_before_launch` swallowed a failed release fetch but propagated everything else, so a corrupt `rx-update.toml` or an unwritable config dir aborted the launch. Updating is incidental to launching and now gets no veto.
- `opencode_auth_path` fell back to `dirs::home_dir()` without checking `EnvLookup::is_real`, so isolated tests read the developer's real `auth.json`.

Plus two help-text trims.

## Verification

- `make check` (audit + fmt + clippy `-D warnings` + workspace tests) green on the final diff
- new test covers two profiles on one driver keeping independent keys across codex / OpenCode / pi / claude injection, plus profile-name escaping
- end-to-end in a temp `HOME`: hand-written profile survives `rx config set` rewrites; `rx config get` reports each profile's driver, base_url and key state
- corrupt `rx-update.toml` now prints `[rx] update skipped: ...` and launches instead of aborting