### PR TITLE
fix(rx): harden profile keys and release dry runs

### DIFF
--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -215,7 +215,9 @@ fn resolve_key(
             if let Some(key) = crate::config::stored_key(paths, profile_id)? {
                 return Ok(key);
             }
-            if let Some(key) = env.get(driver.env_key) {
+            if profile_id == driver.id
+                && let Some(key) = env.get(driver.env_key)
+            {
                 return Ok(key);
             }
             bail!(

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -530,6 +530,34 @@ fn missing_key_errors_before_exec() {
 }
 
 #[test]
+fn custom_profile_does_not_inherit_driver_env_key() {
+    let (_dir, paths) = temp_paths();
+    fs::write(
+        &paths.config,
+        r#"default_gateway = "tokener-dev"
+
+[gateway.tokener-dev]
+driver = "tokener"
+base_url = "https://dev.gateway.test"
+"#,
+    )
+    .unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-prod".to_string(),
+    )]));
+
+    let error = launch::plan(
+        &LaunchRequest { harness: Harness::Codex, gateway: None, passthrough: Vec::new() },
+        &paths,
+        &env,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("no API key for gateway 'tokener-dev'"), "{error}");
+}
+
+#[test]
 fn config_set_key_is_redacted_and_secret() {
     let (_dir, paths) = temp_paths();
     config::run(ConfigCommand::SetGateway { name: "openrouter".to_string() }, &paths).unwrap();

--- a/scripts/regenerate-changelog
+++ b/scripts/regenerate-changelog
@@ -26,6 +26,11 @@ case "$title" in
 esac
 
 entry="$(git-cliff --unreleased --tag "v${version}")"
+if [ "${DRY_RUN:-false}" = "true" ]; then
+	echo "regenerate-changelog: CHANGELOG.md validated for v${version} (dry run)"
+	exit 0
+fi
+
 {
 	printf '%s\n' "$title"
 	printf '%s\n' "$entry"


### PR DESCRIPTION
### What's changed?

- prevent named gateway profiles from inheriting driver-level environment credentials
- keep changelog dry runs side-effect free

### Why

- isolate credentials by profile and preserve a clean release preflight baseline
