### PR TITLE
fix(rx): align version identity and serialize catalog seeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,6 +3135,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "flate2",
+ "fs2",
  "serde",
  "serde_json",
  "tar",

--- a/crates/rx/Cargo.toml
+++ b/crates/rx/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "rx"
+# Distribution and update identity follows the root Recall version via build.rs.
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
@@ -10,9 +11,13 @@ publish = false
 [package.metadata.release]
 release = false
 
+[build-dependencies]
+toml = "0.8"
+
 [dependencies]
 anyhow = "1"
 dirs = "6"
+fs2 = "0.4"
 flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rx/build.rs
+++ b/crates/rx/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo"),
+    );
+    let root_manifest = manifest_dir.join("../..").join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", root_manifest.display());
+
+    let contents = fs::read_to_string(&root_manifest)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", root_manifest.display()));
+    let manifest: toml::Value =
+        toml::from_str(&contents).expect("failed to parse workspace Cargo.toml");
+    let version = manifest
+        .get("package")
+        .and_then(|package| package.get("version"))
+        .and_then(toml::Value::as_str)
+        .expect("workspace Cargo.toml is missing package.version");
+    println!("cargo:rustc-env=RX_RELEASE_VERSION={version}");
+}

--- a/crates/rx/src/catalog.rs
+++ b/crates/rx/src/catalog.rs
@@ -30,8 +30,7 @@ pub(crate) fn fetch(url: &str, headers: &[(&str, String)]) -> Result<(u16, Strin
         .http_status_as_error(false)
         .build()
         .into();
-    let mut request =
-        agent.get(url).header("User-Agent", format!("rx/{}", env!("CARGO_PKG_VERSION")));
+    let mut request = agent.get(url).header("User-Agent", format!("rx/{}", crate::RELEASE_VERSION));
     for (name, value) in headers {
         request = request.header(*name, value);
     }

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use fs2::FileExt;
 use serde_json::{Value, json};
 
 use crate::launch::{EnvLookup, anthropic_base};
@@ -14,6 +15,7 @@ const MAX_CONTEXT: i64 = 1_000_000;
 const OPENAI_COMPACT_WINDOW: i64 = 258_000;
 const TOOL_SEARCH_UNSUPPORTED_KEY: &str = "tengu_tool_search_unsupported_models";
 const RX_SEEDED_DENYLIST_KEY: &str = "rxSeededToolSearchDenylist";
+const MAX_WRITE_ATTEMPTS: usize = 4;
 
 const BASE_TOOL_SEARCH_DENY: &[&str] = &["claude-3-5-haiku", "claude-3-haiku"];
 
@@ -260,9 +262,38 @@ fn claude_config_path(env: &EnvLookup) -> PathBuf {
 }
 
 fn write_seed(path: &Path, caches: &SeedCaches) -> Result<()> {
-    let mut document = read_config_document(path)?;
-    merge_seed(&mut document, caches);
-    write_config_document(path, &document)
+    write_seed_with_hook(path, caches, |_| {})
+}
+
+fn write_seed_with_hook<F>(path: &Path, caches: &SeedCaches, mut after_read: F) -> Result<()>
+where
+    F: FnMut(usize),
+{
+    let parent =
+        path.parent().ok_or_else(|| anyhow::anyhow!("path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".rx.lock");
+    let lock_path = PathBuf::from(lock_path);
+    // The stable sidecar must outlive each lock holder. Removing it after
+    // unlock could split existing waiters and new writers across two inodes.
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    lock.lock_exclusive().with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    for attempt in 0..MAX_WRITE_ATTEMPTS {
+        let (mut document, snapshot) = read_config_document(path)?;
+        after_read(attempt);
+        merge_seed(&mut document, caches);
+        if write_config_document(path, &document, snapshot.as_deref())? {
+            return Ok(());
+        }
+    }
+    bail!("{} changed repeatedly while seeding catalog", path.display())
 }
 
 #[cfg(test)]
@@ -270,17 +301,36 @@ pub(crate) fn write_seed_for_test(path: &Path, caches: &SeedCaches) -> Result<()
     write_seed(path, caches)
 }
 
-fn read_config_document(path: &Path) -> Result<Value> {
-    match fs::read_to_string(path) {
-        Ok(contents) => {
-            let value: Value = serde_json::from_str(&contents)
+#[cfg(test)]
+pub(crate) fn write_seed_with_hook_for_test<F>(
+    path: &Path,
+    caches: &SeedCaches,
+    after_read: F,
+) -> Result<()>
+where
+    F: FnMut(usize),
+{
+    write_seed_with_hook(path, caches, after_read)
+}
+
+fn read_config_document(path: &Path) -> Result<(Value, Option<Vec<u8>>)> {
+    match read_config_bytes(path)? {
+        Some(contents) => {
+            let value: Value = serde_json::from_slice(&contents)
                 .with_context(|| format!("failed to parse {}", path.display()))?;
             if !value.is_object() {
                 bail!("{} root is not a JSON object", path.display());
             }
-            Ok(value)
+            Ok((value, Some(contents)))
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        None => Ok((json!({}), None)),
+    }
+}
+
+fn read_config_bytes(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
     }
 }
@@ -417,10 +467,9 @@ fn string_array(value: Option<&Value>) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn write_config_document(path: &Path, document: &Value) -> Result<()> {
+fn write_config_document(path: &Path, document: &Value, expected: Option<&[u8]>) -> Result<bool> {
     let parent =
         path.parent().ok_or_else(|| anyhow::anyhow!("path has no parent: {}", path.display()))?;
-    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
     let contents =
         serde_json::to_string_pretty(document).context("failed to serialize .claude.json")?;
     let mut temp = tempfile::NamedTempFile::new_in(parent)
@@ -430,10 +479,13 @@ fn write_config_document(path: &Path, document: &Value) -> Result<()> {
     temp.as_file()
         .sync_all()
         .with_context(|| format!("failed to sync temporary file in {}", parent.display()))?;
+    if read_config_bytes(path)?.as_deref() != expected {
+        return Ok(false);
+    }
     temp.persist(path)
         .map_err(|error| error.error)
         .with_context(|| format!("failed to replace {}", path.display()))?;
-    Ok(())
+    Ok(true)
 }
 
 fn strip_anthropic_prefix(id: &str) -> String {

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -15,6 +15,8 @@ use args::{Command, argv0_harness, parse, rewrite_argv0};
 pub use config::Paths;
 use launch::{EnvLookup, plan};
 
+pub(crate) const RELEASE_VERSION: &str = env!("RX_RELEASE_VERSION");
+
 pub fn run(raw_args: impl IntoIterator<Item = String>) -> Result<()> {
     run_with(raw_args.into_iter().collect(), &Paths::user()?, &EnvLookup::real())
 }
@@ -38,12 +40,12 @@ pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result
             Ok(())
         }
         Command::Version => {
-            println!("rx {}", env!("CARGO_PKG_VERSION"));
+            println!("rx {RELEASE_VERSION}");
             Ok(())
         }
         Command::Config(command) => config::run(command, paths),
         Command::Debug { subcommand, gateway } => debug::run(subcommand, gateway, paths, env),
-        Command::Update { yes } => update::run(yes, paths),
+        Command::Update { yes } => update::run(yes),
         Command::Launch(request) => {
             let program = install::ensure(request.harness, env)?;
             let mut plan = plan(&request, paths, env)?;

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpListener;
+use std::path::Path;
+use std::sync::{Arc, Barrier};
 use std::thread;
 
 use crate::args::{Command, ConfigCommand, Harness, LaunchRequest, parse, rewrite_argv0};
@@ -122,29 +124,66 @@ fn version_cmp_orders_releases() {
 }
 
 #[test]
-fn update_pending_uses_installed_release_not_crate_version() {
+fn release_version_matches_core_package() {
+    let manifest: toml::Value = toml::from_str(include_str!("../../../Cargo.toml")).unwrap();
+    assert_eq!(crate::RELEASE_VERSION, manifest["package"]["version"].as_str().unwrap());
+}
+
+#[test]
+fn update_pending_uses_release_version() {
     let release = crate::update::ReleaseInfo {
         version: "0.5.0".to_string(),
         asset_name: String::new(),
         download_url: String::new(),
     };
-    // rx's crate version stays 0.1.0 while core releases advance; once this
-    // release stream artifact is recorded as installed, it must not re-prompt.
-    assert!(!crate::update::update_pending(
-        "0.1.0",
-        &release,
-        &crate::update::state_with_installed(Some("0.5.0"))
-    ));
-    assert!(crate::update::update_pending(
-        "0.1.0",
-        &release,
-        &crate::update::state_with_installed(Some("0.4.0"))
-    ));
-    assert!(crate::update::update_pending(
-        "0.1.0",
-        &release,
-        &crate::update::state_with_installed(None)
-    ));
+    assert!(!crate::update::update_pending("0.5.0", &release));
+    assert!(crate::update::update_pending("0.4.0", &release));
+}
+
+#[test]
+fn homebrew_managed_rx_requires_brew_upgrade() {
+    for path in [
+        "/opt/homebrew/Cellar/recall/0.5.1/bin/rx",
+        "/usr/local/Cellar/recall/0.5.1/bin/rx",
+        "/home/linuxbrew/.linuxbrew/Cellar/recall/0.5.1/bin/rx",
+        "/srv/custom-brew/Cellar/recall/0.5.1/bin/rx",
+    ] {
+        assert_eq!(
+            crate::update::self_update_blocker_for_test(Path::new(path)),
+            Some(crate::update::HOMEBREW_UPDATE_HINT)
+        );
+    }
+    assert_eq!(
+        crate::update::self_update_blocker_for_test(Path::new("/Users/x/.cargo/bin/rx")),
+        None
+    );
+    assert_eq!(
+        crate::update::self_update_blocker_for_test(Path::new(
+            "/opt/homebrew/Cellar/other/0.5.1/bin/rx"
+        )),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn homebrew_managed_rx_is_detected_through_bin_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let cellar_rx = dir.path().join("Cellar/recall/0.5.1/bin/rx");
+    fs::create_dir_all(cellar_rx.parent().unwrap()).unwrap();
+    fs::write(&cellar_rx, b"rx").unwrap();
+    let linked_rx = dir.path().join("bin/rx");
+    fs::create_dir_all(linked_rx.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&cellar_rx, &linked_rx).unwrap();
+
+    assert_eq!(
+        crate::update::self_update_blocker_for_test(&linked_rx),
+        Some(crate::update::HOMEBREW_UPDATE_HINT)
+    );
+    assert_eq!(
+        crate::update::homebrew_launch_update_notice_for_test(&linked_rx, "0.6.0"),
+        Some("rx 0.6.0 is available — run `brew upgrade recall`".to_string())
+    );
 }
 
 #[test]
@@ -1007,6 +1046,83 @@ fn openrouter_seed_writes_claude_json() {
             .unwrap()
             .iter()
             .any(|entry| entry == "google/gemini-3.7-flash")
+    );
+}
+
+#[test]
+fn concurrent_claude_seed_writes_preserve_both_catalogs() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join(".claude.json");
+    fs::write(
+        &config_path,
+        serde_json::to_vec(&serde_json::json!({
+            "padding": "x".repeat(4_000_000)
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let barrier = Arc::new(Barrier::new(2));
+    let mut writers = Vec::new();
+    for id in ["anthropic/claude-race-a", "anthropic/claude-race-b"] {
+        let path = config_path.clone();
+        let barrier = Arc::clone(&barrier);
+        let caches = crate::claude_catalog::build_seed(&[crate::claude_catalog::UserModel {
+            id: id.to_string(),
+            name: Some(id.to_string()),
+            context_length: Some(200_000),
+            canonical_slug: None,
+            supported_efforts: vec![],
+            pricing: None,
+        }]);
+        writers.push(thread::spawn(move || {
+            barrier.wait();
+            crate::claude_catalog::write_seed_for_test(&path, &caches).unwrap();
+        }));
+    }
+    for writer in writers {
+        writer.join().unwrap();
+    }
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    let values = document["additionalModelOptionsCache"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|entry| entry["value"].as_str())
+        .collect::<Vec<_>>();
+    assert!(values.contains(&"claude-race-a"));
+    assert!(values.contains(&"claude-race-b"));
+}
+
+#[test]
+fn claude_seed_remerges_external_config_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join(".claude.json");
+    fs::write(&config_path, r#"{"before":true}"#).unwrap();
+    let caches = crate::claude_catalog::build_seed(&[crate::claude_catalog::UserModel {
+        id: "anthropic/claude-race-rx".to_string(),
+        name: Some("Race RX".to_string()),
+        context_length: Some(200_000),
+        canonical_slug: None,
+        supported_efforts: vec![],
+        pricing: None,
+    }]);
+    let external_path = config_path.clone();
+    crate::claude_catalog::write_seed_with_hook_for_test(&config_path, &caches, |attempt| {
+        if attempt == 0 {
+            fs::write(&external_path, r#"{"external":"keep"}"#).unwrap();
+        }
+    })
+    .unwrap();
+    let document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert_eq!(document["external"], "keep");
+    assert!(
+        document["additionalModelOptionsCache"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["value"] == "claude-race-rx")
     );
 }
 

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -13,6 +14,8 @@ use crate::launch::EnvLookup;
 
 const GITHUB_REPO: &str = "samzong/Recall";
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+pub(crate) const HOMEBREW_UPDATE_HINT: &str =
+    "rx is managed by Homebrew; run `brew upgrade recall`";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReleaseInfo {
@@ -27,52 +30,28 @@ pub(crate) struct UpdateState {
     auto_update: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_check: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    last_installed: Option<String>,
 }
 
-pub(crate) fn run(yes: bool, paths: &Paths) -> Result<()> {
-    let current = env!("CARGO_PKG_VERSION");
+pub(crate) fn run(yes: bool) -> Result<()> {
+    let current = crate::RELEASE_VERSION;
     let release = fetch_latest_release()?;
-    let state = load_state(paths)?;
-    if !update_pending(current, &release, &state) {
+    if !update_pending(current, &release) {
         println!("rx {current} is up to date (latest: {})", release.version);
         return Ok(());
     }
+    ensure_current_executable_self_update_allowed()?;
     if !yes && !confirm(&format!("Update rx {current} → {}?", release.version))? {
         println!("update cancelled");
         return Ok(());
     }
     eprintln!("Updating rx to {}...", release.version);
     install_release(&release)?;
-    record_installed(paths, &release.version)?;
     println!("Updated rx to {}", release.version);
     Ok(())
 }
 
-/// rx shares the core release stream but its own crate version does not advance,
-/// so the installed release tag — not `CARGO_PKG_VERSION` — decides whether the
-/// fetched release is already installed.
-pub(crate) fn update_pending(current: &str, release: &ReleaseInfo, state: &UpdateState) -> bool {
-    if state.last_installed.as_deref() == Some(release.version.as_str()) {
-        return false;
-    }
+pub(crate) fn update_pending(current: &str, release: &ReleaseInfo) -> bool {
     version_cmp(current, &release.version) == Ordering::Less
-}
-
-fn record_installed(paths: &Paths, version: &str) -> Result<()> {
-    let mut state = load_state(paths)?;
-    state.last_installed = Some(version.to_string());
-    save_state(paths, &state)
-}
-
-#[cfg(test)]
-pub(crate) fn state_with_installed(version: Option<&str>) -> UpdateState {
-    UpdateState {
-        auto_update: false,
-        last_check: None,
-        last_installed: version.map(str::to_string),
-    }
 }
 
 pub(crate) fn maybe_before_launch(
@@ -87,7 +66,7 @@ pub(crate) fn maybe_before_launch(
     if !should_check(&state) {
         return Ok(());
     }
-    let current = env!("CARGO_PKG_VERSION");
+    let current = crate::RELEASE_VERSION;
     let release = match fetch_latest_release() {
         Ok(release) => release,
         Err(error) => {
@@ -97,13 +76,17 @@ pub(crate) fn maybe_before_launch(
     };
     state.last_check = Some(now_unix_seconds());
     save_state(paths, &state)?;
-    if !update_pending(current, &release, &state) {
+    if !update_pending(current, &release) {
+        return Ok(());
+    }
+    let current_exe = std::env::current_exe().context("cannot resolve rx executable path")?;
+    if let Some(notice) = homebrew_launch_update_notice(&current_exe, &release.version) {
+        eprintln!("{notice}");
         return Ok(());
     }
     if state.auto_update {
         eprintln!("Updating rx to {}...", release.version);
         install_release(&release)?;
-        record_installed(paths, &release.version)?;
         relaunch(raw_args)?;
     } else if !io::stderr().is_terminal() || !io::stdin().is_terminal() {
         eprintln!("rx {} is available — run `rx update`", release.version);
@@ -114,13 +97,11 @@ pub(crate) fn maybe_before_launch(
                 save_state(paths, &state)?;
                 eprintln!("Updating rx to {}...", release.version);
                 install_release(&release)?;
-                record_installed(paths, &release.version)?;
                 relaunch(raw_args)?;
             }
             PromptChoice::UpdateNow => {
                 eprintln!("Updating rx to {}...", release.version);
                 install_release(&release)?;
-                record_installed(paths, &release.version)?;
                 relaunch(raw_args)?;
             }
             PromptChoice::NotNow => {}
@@ -266,6 +247,7 @@ fn replace_executable(source: &Path) -> Result<()> {
         bail!("release archive did not contain rx at {}", source.display());
     }
     let target = std::env::current_exe().context("cannot resolve rx executable path")?;
+    ensure_self_update_allowed(&target)?;
     #[cfg(windows)]
     if target.is_file() {
         // Windows locks running executables: move the old binary aside so the
@@ -290,6 +272,53 @@ fn replace_executable(source: &Path) -> Result<()> {
     Ok(())
 }
 
+fn ensure_current_executable_self_update_allowed() -> Result<()> {
+    let target = std::env::current_exe().context("cannot resolve rx executable path")?;
+    ensure_self_update_allowed(&target)
+}
+
+fn ensure_self_update_allowed(path: &Path) -> Result<()> {
+    if let Some(hint) = self_update_blocker(path) {
+        bail!(hint);
+    }
+    Ok(())
+}
+
+fn self_update_blocker(path: &Path) -> Option<&'static str> {
+    homebrew_update_hint(path).or_else(|| {
+        fs::canonicalize(path).ok().and_then(|resolved| homebrew_update_hint(&resolved))
+    })
+}
+
+fn homebrew_launch_update_notice(path: &Path, latest: &str) -> Option<String> {
+    self_update_blocker(path)
+        .map(|_| format!("rx {latest} is available — run `brew upgrade recall`"))
+}
+
+fn homebrew_update_hint(path: &Path) -> Option<&'static str> {
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    components
+        .windows(2)
+        .any(|pair| pair[0] == OsStr::new("Cellar") && pair[1] == OsStr::new("recall"))
+        .then_some(HOMEBREW_UPDATE_HINT)
+}
+
+#[cfg(test)]
+pub(crate) fn self_update_blocker_for_test(path: &Path) -> Option<&'static str> {
+    self_update_blocker(path)
+}
+
+#[cfg(test)]
+pub(crate) fn homebrew_launch_update_notice_for_test(path: &Path, latest: &str) -> Option<String> {
+    homebrew_launch_update_notice(path, latest)
+}
+
 fn http_get(url: &str, headers: &[(&str, &str)]) -> Result<String> {
     let bytes = http_get_bytes(url, headers)?;
     String::from_utf8(bytes).context("response is not UTF-8")
@@ -301,8 +330,7 @@ fn http_get_bytes(url: &str, headers: &[(&str, &str)]) -> Result<Vec<u8>> {
         .http_status_as_error(false)
         .build()
         .into();
-    let mut request =
-        agent.get(url).header("User-Agent", format!("rx/{}", env!("CARGO_PKG_VERSION")));
+    let mut request = agent.get(url).header("User-Agent", format!("rx/{}", crate::RELEASE_VERSION));
     for (name, value) in headers {
         request = request.header(*name, *value);
     }


### PR DESCRIPTION
### What's changed?

- Bake the workspace Recall version into `rx` so `rx -V` and update checks compare the shipped release instead of crate `0.1.0`.
- Refuse self-update when the executable is Homebrew-managed and tell users to `brew upgrade recall`.
- Serialize `.claude.json` catalog seeds with an exclusive sidecar lock plus compare-and-swap retries so concurrent launches keep both catalogs.

### Why

- The crate version is intentionally pinned, so `last_installed` was compensating for a stale identity. Homebrew self-update would replace a brew-managed binary. Concurrent seed writes could drop one catalog.