### PR TITLE
fix(tui): preserve contrast in light terminals

### DIFF
--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -41,7 +41,7 @@ pub(crate) struct Theme {
 }
 
 pub(crate) const THEME: Theme = Theme {
-    text: Color::White,
+    text: Color::Reset,
     text_muted: Color::DarkGray,
     accent: Color::Yellow,
     highlight: Color::Cyan,
@@ -52,7 +52,7 @@ pub(crate) const THEME: Theme = Theme {
     border_focus: Color::Cyan,
     border_idle: Color::DarkGray,
     background: Color::Reset,
-    popup_bg: Color::Black,
+    popup_bg: Color::Reset,
 
     selected_fg: Color::Black,
     selected_bg: Color::Cyan,

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -412,6 +412,35 @@ mod tests {
     }
 
     #[test]
+    fn render_preview_neutral_content_inherits_terminal_palette() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.results = vec![numbered_session_result(1)];
+        app.preview_messages = vec![Message {
+            session_id: "session1".to_string(),
+            role: Role::User,
+            content: "hello".to_string(),
+            timestamp: None,
+            seq: 0,
+        }];
+
+        let width = 80;
+        let height = 10;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let frame = terminal.draw(|f| render(f, &app)).unwrap();
+        let inner =
+            crate::tui::layout::search_layout(Rect::new(0, 0, width, height)).preview_inner();
+        let first_body_cell = &frame.buffer[(inner.x + 2, inner.y + 1)];
+
+        assert_eq!(first_body_cell.symbol(), "h");
+        assert_eq!(first_body_cell.fg, Color::Reset);
+        assert_eq!(first_body_cell.bg, Color::Reset);
+    }
+
+    #[test]
     fn render_viewing_shows_one_line_session_summary_below_title() {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
@@ -536,6 +565,7 @@ mod tests {
         assert!(rendered.contains("copy URL"));
         assert!(rendered.contains("[Enter/Esc]"));
         assert!(rendered.contains("close"));
+        assert_eq!(terminal.backend().buffer()[(7, 5)].bg, Color::Reset);
     }
 
     #[test]
@@ -592,6 +622,14 @@ mod tests {
         assert!(rendered.contains("OpenCode (opencode)"));
         assert!(rendered.contains("[Enter]"));
         assert!(rendered.contains("select"));
+
+        let width = 90u16.clamp(36, 56);
+        let height = (crate::handoff::TARGETS.len() as u16 + 5).max(8);
+        let rect = Rect::new((90 - width) / 2, (18 - height) / 2, width, height);
+        let selected = &terminal.backend().buffer()
+            [(rect.x + 1, rect.y + 2 + app.handoff_target_selected as u16)];
+        assert_eq!(selected.fg, THEME.selected_fg);
+        assert_eq!(selected.bg, THEME.selected_bg);
     }
 
     fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -71,7 +71,10 @@ pub(super) fn render_subagents_picker(f: &mut Frame, app: &App) {
         let selected = index == app.subagent_selected;
         let marker = if selected { ">" } else { " " };
         let style = if selected {
-            Style::default().fg(THEME.selected_fg).bg(THEME.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(THEME.selected_fg)
+                .bg(THEME.selected_bg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(THEME.text)
         };
@@ -129,7 +132,10 @@ pub(super) fn render_handoff_target_picker(f: &mut Frame, app: &App) {
         let selected = index == app.handoff_target_selected;
         let marker = if selected { ">" } else { " " };
         let style = if selected {
-            Style::default().fg(THEME.selected_fg).bg(THEME.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(THEME.selected_fg)
+                .bg(THEME.selected_bg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(THEME.text)
         };
@@ -397,7 +403,7 @@ pub(super) fn render_settings(f: &mut Frame, app: &App) {
         .style(Style::default().bg(THEME.popup_bg));
 
     let mut lines = Vec::new();
-    let selected_style = Style::default().bg(THEME.accent).fg(THEME.selected_fg);
+    let selected_style = Style::default().bg(THEME.selected_bg).fg(THEME.selected_fg);
     let normal_style = Style::default().fg(THEME.text);
 
     lines.push(Line::from(vec![


### PR DESCRIPTION
### What's changed?

- Inherit terminal foreground and background colors for neutral TUI text and popup surfaces.
- Use the shared selected-row colors across handoff, subagent, and settings popups.
- Add rendering regressions for neutral colors and popup selection.
- Verify with `cargo test tui::ui::tests --lib` and `make check`.

### Why

- Keep content and selection legible in light terminal themes without regressing dark themes.
