### PR TITLE
feat(rx): add DeepSeek Harness support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Data flow: source adapters → sync → SQLite → search → CLI/TUI.
 - `crates/rx/` — independent `rx` binary (workspace member, not an extension).
   Gateway launcher for Claude Code, Codex, OpenCode, and Pi. Does not depend on
   the `recall` crate or read `recall.db`. Install also creates `rxc` / `rxx` /
-  `rxo` / `rxp` symlinks. Bundled providers are generated from
+  `rxo` / `rxp` / `rxd` symlinks. Bundled providers are generated from
   `crates/rx/data/provider-admission.json` into `crates/rx/data/providers.json`;
   both files are committed. See `crates/rx/PROVIDERS.md`.
 - `src/extension.rs` — extension host: `recall <name>` runs the managed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tar",
  "tempfile",
  "toml",
@@ -3314,6 +3315,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4081,6 +4095,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ install: ## Install binaries to ~/.cargo/bin
 	ln -sfn rx "$(HOME)/.cargo/bin/rxx"
 	ln -sfn rx "$(HOME)/.cargo/bin/rxo"
 	ln -sfn rx "$(HOME)/.cargo/bin/rxp"
+	ln -sfn rx "$(HOME)/.cargo/bin/rxd"
 	@if [ -d "$(HOME)/.zsh/completions" ]; then \
 		"$(HOME)/.cargo/bin/recall" completions zsh > "$(HOME)/.zsh/completions/_recall"; \
 		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_recall$(RESET)\n'; \
@@ -77,7 +78,7 @@ install: ## Install binaries to ~/.cargo/bin
 uninstall: ## Remove installed binaries
 	$(CARGO) uninstall recall
 	$(CARGO) uninstall rx
-	rm -f "$(HOME)/.cargo/bin/rxc" "$(HOME)/.cargo/bin/rxx" "$(HOME)/.cargo/bin/rxo" "$(HOME)/.cargo/bin/rxp"
+	rm -f "$(HOME)/.cargo/bin/rxc" "$(HOME)/.cargo/bin/rxx" "$(HOME)/.cargo/bin/rxo" "$(HOME)/.cargo/bin/rxp" "$(HOME)/.cargo/bin/rxd"
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 

--- a/crates/rx/Cargo.toml
+++ b/crates/rx/Cargo.toml
@@ -20,6 +20,7 @@ fuzzy-matcher = "0.3"
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tar = "0.4"
 tempfile = "3"
 toml = "0.8"

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -8,6 +8,7 @@ pub(crate) enum Harness {
     Codex,
     OpenCode,
     Pi,
+    Dsh,
 }
 
 impl Harness {
@@ -17,6 +18,7 @@ impl Harness {
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
             Self::Pi => "pi",
+            Self::Dsh => "dsh",
         }
     }
 
@@ -26,6 +28,7 @@ impl Harness {
             "codex" => Some(Self::Codex),
             "opencode" => Some(Self::OpenCode),
             "pi" => Some(Self::Pi),
+            "dsh" => Some(Self::Dsh),
             _ => None,
         }
     }
@@ -83,6 +86,7 @@ pub(crate) fn argv0_harness(argv0: &str) -> Option<&'static str> {
         "rxx" => Some("codex"),
         "rxo" => Some("opencode"),
         "rxp" => Some("pi"),
+        "rxd" => Some("dsh"),
         _ => None,
     }
 }

--- a/crates/rx/src/dsh.rs
+++ b/crates/rx/src/dsh.rs
@@ -1,0 +1,354 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde_yaml::{Mapping, Value};
+
+use crate::catalog;
+use crate::config::Paths;
+use crate::launch::{EnvLookup, openai_base};
+use crate::provider::{Provider, Setup};
+
+pub(crate) const PROFILE: &str = "dsh-tui";
+pub(crate) const CLI_PACKAGE: &str = "@deepseek-ai/dsh";
+pub(crate) const PLUGIN_PACKAGE: &str = "@deepseek-harness-tui/dsh-tui";
+const OFFICIAL_DEEPSEEK: &str = "https://api.deepseek.com";
+const OFFICIAL_DEEPSEEK_ROUTE: &str = "deepseek-official";
+
+pub(crate) fn npm_install_cmd() -> String {
+    format!("npm install -g {CLI_PACKAGE} {PLUGIN_PACKAGE}")
+}
+
+pub(crate) fn install_hint() -> String {
+    format!("{}\n  {}", npm_install_cmd(), profile_hint())
+}
+
+pub(crate) fn profile_hint() -> String {
+    format!("dsh plugin --profile {PROFILE} add {PLUGIN_PACKAGE}")
+}
+
+pub(crate) fn home(env: &EnvLookup) -> Option<PathBuf> {
+    if let Some(dir) = env.get("DSH_HOME").filter(|value| !value.trim().is_empty()) {
+        return Some(expand_home(dir, env));
+    }
+    if env.is_real() {
+        return dirs::home_dir().map(|home| home.join(".dsh"));
+    }
+    env.get("HOME")
+        .filter(|value| !value.trim().is_empty())
+        .map(|home| PathBuf::from(home).join(".dsh"))
+}
+
+pub(crate) fn profile_ready(env: &EnvLookup) -> bool {
+    let Some(root) = home(env) else {
+        return false;
+    };
+    let path = root.join("profiles").join(PROFILE).join("package.json");
+    fs::read_to_string(path).is_ok_and(|body| body.contains(PLUGIN_PACKAGE))
+}
+
+pub(crate) fn official_deepseek(provider_id: &str) -> bool {
+    provider_id == "deepseek"
+}
+
+pub(crate) fn args(passthrough: &[String], patch: Option<&Path>) -> Vec<String> {
+    if passthrough.first().is_some_and(|arg| arg == "plugin") {
+        return passthrough.to_vec();
+    }
+    let mut args = Vec::new();
+    if passthrough.first().is_some_and(|arg| arg == "web") {
+        args.push("web".to_string());
+        push_patch(&mut args, patch);
+        args.extend(passthrough.iter().skip(1).cloned());
+        return args;
+    }
+    if !has_profile(passthrough) {
+        args.push("--profile".to_string());
+        args.push(PROFILE.to_string());
+    }
+    push_patch(&mut args, patch);
+    args.extend(passthrough.iter().cloned());
+    args
+}
+
+pub(crate) fn env_set(provider_id: &str, provider: &Provider, key: &str) -> Vec<(String, String)> {
+    let mut env_set = vec![(provider.env.clone(), key.to_string())];
+    if official_deepseek(provider_id) && provider.endpoint != OFFICIAL_DEEPSEEK {
+        env_set.push(("DEEPSEEK_BASE_URL".to_string(), provider.endpoint.clone()));
+    }
+    env_set
+}
+
+pub(crate) fn prepare(
+    provider_id: &str,
+    provider: &Provider,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<PathBuf> {
+    let model = model.filter(|value| !value.is_empty());
+    let models = if official_deepseek(provider_id) {
+        Vec::new()
+    } else {
+        load_models(provider_id, provider, base_url, key, model, paths, env)?
+    };
+    let dir = paths.dir.join("dsh");
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let settings_path = dir.join("settings.yaml");
+    write_settings_overlay(&settings_path, provider_id, provider, base_url, model, &models, env)?;
+    let patch_path = dir.join("launch.cordis.yml");
+    write_launch_patch(&patch_path, &settings_path, official_deepseek(provider_id))?;
+    Ok(patch_path)
+}
+
+fn load_models(
+    provider_id: &str,
+    provider: &Provider,
+    base_url: &str,
+    key: &str,
+    model: Option<&str>,
+    paths: &Paths,
+    env: &EnvLookup,
+) -> Result<Vec<String>> {
+    let allow_fetch = env.is_real() || provider.setup == Setup::Generated;
+    let mut models = Vec::new();
+    match catalog::load_pi_models(paths, provider_id, base_url, key, allow_fetch) {
+        Ok(values) => {
+            for value in values {
+                push_model_id(&mut models, &value);
+            }
+        }
+        Err(error) if provider.setup != Setup::Generated => {
+            eprintln!("[rx] model catalog skipped: {error:#}");
+        }
+        Err(error) => return Err(error),
+    }
+    if let Some(model) = model.filter(|id| !models.iter().any(|existing| existing == *id)) {
+        models.insert(0, model.to_string());
+    }
+    if models.is_empty() {
+        bail!(
+            "dsh could not load models for '{provider_id}'; run: rx providers models update {provider_id}"
+        );
+    }
+    Ok(models)
+}
+
+fn push_model_id(models: &mut Vec<String>, value: &serde_json::Value) {
+    let Some(id) = value.get("id").and_then(serde_json::Value::as_str).filter(|id| !id.is_empty())
+    else {
+        return;
+    };
+    if !models.iter().any(|existing| existing == id) {
+        models.push(id.to_string());
+    }
+}
+
+fn write_settings_overlay(
+    path: &Path,
+    provider_id: &str,
+    provider: &Provider,
+    base_url: &str,
+    model: Option<&str>,
+    models: &[String],
+    env: &EnvLookup,
+) -> Result<()> {
+    let mut document = load_user_settings(env)?;
+    let root = as_mapping(&mut document)?;
+    root.insert("llm-pi-ai".into(), llm_pi_ai_section(provider_id, provider, base_url, models));
+    root.insert("agent-default-model".into(), default_model_section(provider_id, model));
+    write_yaml_atomic(path, &document)
+}
+
+fn load_user_settings(env: &EnvLookup) -> Result<Value> {
+    let Some(root) = home(env) else {
+        return Ok(Value::Mapping(Mapping::new()));
+    };
+    let path = root.join("settings.yaml");
+    match fs::read_to_string(&path) {
+        Ok(body) => serde_yaml::from_str(&body)
+            .with_context(|| format!("failed to parse {}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(Value::Mapping(Mapping::new()))
+        }
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn llm_pi_ai_section(
+    provider_id: &str,
+    provider: &Provider,
+    base_url: &str,
+    models: &[String],
+) -> Value {
+    let mut providers = Mapping::new();
+    if !official_deepseek(provider_id) && !models.is_empty() {
+        let mut route = Mapping::new();
+        route.insert("apiKeyEnv".into(), Value::String(provider.env.clone()));
+        route.insert("api".into(), Value::String("openai-completions".into()));
+        route.insert("baseURL".into(), Value::String(openai_base(base_url)));
+        let entries = models
+            .iter()
+            .map(|id| {
+                let mut entry = Mapping::new();
+                entry.insert("id".into(), Value::String(id.clone()));
+                Value::Mapping(entry)
+            })
+            .collect();
+        route.insert("models".into(), Value::Sequence(entries));
+        providers.insert(Value::String(provider_id.to_string()), Value::Mapping(route));
+    }
+    let mut section = Mapping::new();
+    section.insert("providers".into(), Value::Mapping(providers));
+    Value::Mapping(section)
+}
+
+fn default_model_section(provider_id: &str, model: Option<&str>) -> Value {
+    let mut section = Mapping::new();
+    let route = if official_deepseek(provider_id) { OFFICIAL_DEEPSEEK_ROUTE } else { provider_id };
+    section.insert("provider".into(), Value::String(route.to_string()));
+    if let Some(model) = model {
+        section.insert("model".into(), Value::String(model.to_string()));
+    }
+    Value::Mapping(section)
+}
+
+fn write_launch_patch(path: &Path, settings_path: &Path, official_deepseek: bool) -> Result<()> {
+    let mut body = format!(
+        "- id: settings\n  config:\n    path: {}\n",
+        yaml_string(&settings_path.display().to_string())
+    );
+    if !official_deepseek {
+        body.push_str("- id: llm-deepseek\n  disabled: true\n");
+    }
+    write_bytes_atomic(path, body.as_bytes())
+}
+
+fn as_mapping(value: &mut Value) -> Result<&mut Mapping> {
+    if !value.is_mapping() {
+        *value = Value::Mapping(Mapping::new());
+    }
+    value.as_mapping_mut().context("dsh settings overlay is not a mapping")
+}
+
+fn write_yaml_atomic(path: &Path, document: &Value) -> Result<()> {
+    let payload =
+        serde_yaml::to_string(document).context("failed to serialize dsh settings overlay")?;
+    write_bytes_atomic(path, payload.as_bytes())
+}
+
+fn write_bytes_atomic(path: &Path, payload: &[u8]) -> Result<()> {
+    let parent = path.parent().context("dsh launch file has no parent directory")?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary {}", path.display()))?;
+    temp.write_all(payload)
+        .with_context(|| format!("failed to write temporary {}", path.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary {}", path.display()))?;
+    temp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn push_patch(args: &mut Vec<String>, patch: Option<&Path>) {
+    if let Some(path) = patch {
+        args.push("--patch".to_string());
+        args.push(path.display().to_string());
+    }
+}
+
+fn has_profile(args: &[String]) -> bool {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--" || arg == "web" || arg == "plugin" {
+            return false;
+        }
+        if arg == "--profile" || arg.starts_with("--profile=") {
+            return true;
+        }
+        if arg == "--patch" {
+            i += 2;
+            continue;
+        }
+        if arg == "--dump-config" || arg == "--dump-default-config" {
+            i += 1;
+            continue;
+        }
+        return false;
+    }
+    false
+}
+
+fn expand_home(dir: String, env: &EnvLookup) -> PathBuf {
+    let Some(rest) = dir.strip_prefix("~/") else {
+        return PathBuf::from(dir);
+    };
+    let home = if env.is_real() {
+        dirs::home_dir()
+    } else {
+        env.get("HOME").filter(|value| !value.trim().is_empty()).map(PathBuf::from)
+    };
+    match home {
+        Some(home) => home.join(rest),
+        None => PathBuf::from(dir),
+    }
+}
+
+fn yaml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_hint_uses_official_npm_then_profile() {
+        assert_eq!(
+            install_hint(),
+            format!("npm install -g {CLI_PACKAGE} {PLUGIN_PACKAGE}\n  {}", profile_hint())
+        );
+    }
+
+    #[test]
+    fn default_args_boot_tui_profile() {
+        assert_eq!(args(&[], None), vec!["--profile", PROFILE]);
+        assert_eq!(args(&["--resume".to_string()], None), vec!["--profile", PROFILE, "--resume"]);
+    }
+
+    #[test]
+    fn keeps_explicit_profile_and_web() {
+        assert_eq!(
+            args(&["--profile".to_string(), "headless".to_string(), "job".to_string()], None),
+            vec!["--profile", "headless", "job"]
+        );
+        assert_eq!(
+            args(&["web".to_string(), "--port".to_string(), "8080".to_string()], None),
+            vec!["web", "--port", "8080"]
+        );
+        assert_eq!(
+            args(&["plugin".to_string(), "--profile".to_string(), PROFILE.to_string()], None),
+            vec!["plugin", "--profile", PROFILE]
+        );
+    }
+
+    #[test]
+    fn patch_follows_web_subcommand() {
+        let patch = PathBuf::from("/tmp/rx.cordis.yml");
+        assert_eq!(
+            args(&["web".to_string()], Some(&patch)),
+            vec!["web", "--patch", "/tmp/rx.cordis.yml"]
+        );
+        assert_eq!(
+            args(&[], Some(&patch)),
+            vec!["--profile", PROFILE, "--patch", "/tmp/rx.cordis.yml"]
+        );
+    }
+}

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -1,16 +1,12 @@
 use std::ffi::{OsStr, OsString};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 #[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
-use std::process::{Command, Stdio};
-
-#[cfg(unix)]
-use anyhow::Context;
 
 use crate::args::Harness;
 use crate::launch::EnvLookup;
@@ -49,6 +45,12 @@ pub(crate) fn spec(harness: Harness) -> InstallSpec {
             url: "https://pi.dev/install.sh",
             shell: "sh",
         },
+        Harness::Dsh => InstallSpec {
+            program: "dsh",
+            display: "DeepSeek Harness",
+            url: "https://www.npmjs.com/package/@deepseek-ai/dsh",
+            shell: "sh",
+        },
     }
 }
 
@@ -57,6 +59,9 @@ pub(crate) fn command_line(spec: &InstallSpec) -> String {
 }
 
 pub(crate) fn ensure(harness: Harness, env: &EnvLookup) -> Result<PathBuf> {
+    if matches!(harness, Harness::Dsh) {
+        return ensure_dsh(env);
+    }
     if !env.is_real() {
         return Ok(PathBuf::from(harness.as_str()));
     }
@@ -65,15 +70,7 @@ pub(crate) fn ensure(harness: Harness, env: &EnvLookup) -> Result<PathBuf> {
         return Ok(path);
     }
     let cmd = command_line(&spec);
-    if env.get("RX_NO_INSTALL").is_some_and(|value| !value.is_empty() && value != "0") {
-        bail!("{} is not installed (RX_NO_INSTALL=1). Install with:\n  {cmd}", spec.display);
-    }
-    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-        bail!("{} is not installed. Install with:\n  {cmd}", spec.display);
-    }
-    if !confirm(&format!("{} is not installed. Install now?", spec.display))? {
-        bail!("install cancelled. Install with:\n  {cmd}");
-    }
+    offer_install(spec.display, &cmd, env)?;
     eprintln!("[rx] {cmd}");
     run_official_installer(&spec)?;
     lookup(spec.program).ok_or_else(|| {
@@ -174,6 +171,102 @@ fn run_official_installer(spec: &InstallSpec) -> Result<()> {
         }
         Ok(())
     }
+}
+
+fn ensure_dsh(env: &EnvLookup) -> Result<PathBuf> {
+    if !env.is_real() {
+        return Ok(PathBuf::from("dsh"));
+    }
+    if let Some(path) = lookup_program("dsh") {
+        if crate::dsh::profile_ready(env) {
+            return Ok(path);
+        }
+        offer_install("DeepSeek Harness TUI profile", &crate::dsh::profile_hint(), env)?;
+        ensure_pnpm()?;
+        install_dsh_profile(&path, env)?;
+        return Ok(path);
+    }
+    offer_install("DeepSeek Harness", &crate::dsh::install_hint(), env)?;
+    install_dsh_packages()?;
+    let path = lookup_program("dsh").ok_or_else(|| {
+        anyhow::anyhow!(
+            "DeepSeek Harness finished installing but dsh was not found. Add npm's global bin to PATH, then retry."
+        )
+    })?;
+    if !crate::dsh::profile_ready(env) {
+        install_dsh_profile(&path, env)?;
+    }
+    Ok(path)
+}
+
+fn install_dsh_packages() -> Result<()> {
+    let cmd = crate::dsh::npm_install_cmd();
+    eprintln!("[rx] {cmd}");
+    run_npm(&["install", "-g", crate::dsh::CLI_PACKAGE, crate::dsh::PLUGIN_PACKAGE], &cmd)?;
+    ensure_pnpm()
+}
+
+fn ensure_pnpm() -> Result<()> {
+    if lookup_program("pnpm").is_some() {
+        return Ok(());
+    }
+    let cmd = "npm install -g pnpm";
+    eprintln!("[rx] {cmd}");
+    run_npm(&["install", "-g", "pnpm"], cmd)
+}
+
+fn install_dsh_profile(dsh: &Path, env: &EnvLookup) -> Result<()> {
+    let cmd = crate::dsh::profile_hint();
+    eprintln!("[rx] {cmd}");
+    run_command(
+        dsh,
+        &["plugin", "--profile", crate::dsh::PROFILE, "add", crate::dsh::PLUGIN_PACKAGE],
+        "dsh plugin",
+    )?;
+    if crate::dsh::profile_ready(env) {
+        return Ok(());
+    }
+    bail!("dsh plugin finished but the dsh-tui profile is still missing. Install with:\n  {cmd}")
+}
+
+fn offer_install(display: &str, hint: &str, env: &EnvLookup) -> Result<()> {
+    if env.get("RX_NO_INSTALL").is_some_and(|value| !value.is_empty() && value != "0") {
+        bail!("{display} is not installed (RX_NO_INSTALL=1). Install with:\n  {hint}");
+    }
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        bail!("{display} is not installed. Install with:\n  {hint}");
+    }
+    if !confirm(&format!("{display} is not installed. Install now?"))? {
+        bail!("install cancelled. Install with:\n  {hint}");
+    }
+    Ok(())
+}
+
+fn lookup_program(program: &str) -> Option<PathBuf> {
+    if let Some(path) = lookup(program) {
+        return Some(path);
+    }
+    let dir = lookup("npm")?.parent()?.to_path_buf();
+    lookup_with(program, "", &[dir], executable_extensions().as_deref())
+}
+
+fn run_npm(args: &[&str], label: &str) -> Result<()> {
+    let npm = lookup_program("npm").context("npm is required to install DeepSeek Harness")?;
+    run_command(&npm, args, label)
+}
+
+fn run_command(program: &Path, args: &[&str], label: &str) -> Result<()> {
+    let status = Command::new(program)
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format!("failed to start {label}"))?;
+    if !status.success() {
+        bail!("{label} exited with {status}");
+    }
+    Ok(())
 }
 
 fn confirm(message: &str) -> Result<bool> {

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -102,7 +102,7 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
     let model = target.model.as_deref().or(match request.harness {
         Harness::Claude => target.provider.claude_default_model,
         Harness::Codex => target.provider.default_model,
-        Harness::OpenCode | Harness::Pi => None,
+        Harness::OpenCode | Harness::Pi | Harness::Dsh => None,
     });
     if matches!(request.harness, Harness::Claude) {
         let seed = if env.is_real() {
@@ -141,7 +141,10 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
 fn passthrough(request: &LaunchRequest) -> LaunchPlan {
     LaunchPlan {
         program: request.harness.as_str().to_string(),
-        args: request.passthrough.clone(),
+        args: match request.harness {
+            Harness::Dsh => crate::dsh::args(&request.passthrough, None),
+            _ => request.passthrough.clone(),
+        },
         env_set: Vec::new(),
         stderr_note: Some(format!(
             "[rx] no provider configured; launching {} as-is (configure: rx providers login)",
@@ -443,6 +446,16 @@ fn inject(
                 program: "pi".to_string(),
                 args: crate::pi::args(provider_id, model, &request.passthrough),
                 env_set: crate::pi::env_set(&provider.env, key),
+                stderr_note: None,
+            })
+        }
+        Harness::Dsh => {
+            let patch =
+                crate::dsh::prepare(provider_id, provider, base_url, key, model, paths, env)?;
+            Ok(LaunchPlan {
+                program: "dsh".to_string(),
+                args: crate::dsh::args(&request.passthrough, Some(&patch)),
+                env_set: crate::dsh::env_set(provider_id, provider, key),
                 stderr_note: None,
             })
         }

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -2,6 +2,7 @@ mod args;
 mod catalog;
 mod claude_catalog;
 mod config;
+mod dsh;
 mod install;
 mod launch;
 mod opencode;

--- a/crates/rx/src/pick.rs
+++ b/crates/rx/src/pick.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use crate::EnvLookup;
 use crate::args::Harness;
 
-const VIEWPORT_HEIGHT: u16 = 8;
+const VIEWPORT_HEIGHT: u16 = 9;
 
 struct Palette {
     accent: Color,
@@ -43,11 +43,12 @@ struct Choice {
     alias: &'static str,
 }
 
-const CHOICES: [Choice; 4] = [
+const CHOICES: [Choice; 5] = [
     Choice { harness: Harness::Claude, alias: "rxc" },
     Choice { harness: Harness::Codex, alias: "rxx" },
     Choice { harness: Harness::OpenCode, alias: "rxo" },
     Choice { harness: Harness::Pi, alias: "rxp" },
+    Choice { harness: Harness::Dsh, alias: "rxd" },
 ];
 
 struct App {

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -290,6 +290,7 @@ fn argv0_harness_resolves_aliases() {
     assert_eq!(crate::args::argv0_harness("rxx"), Some("codex"));
     assert_eq!(crate::args::argv0_harness("rxo.exe"), Some("opencode"));
     assert_eq!(crate::args::argv0_harness("rxp"), Some("pi"));
+    assert_eq!(crate::args::argv0_harness("rxd"), Some("dsh"));
     assert_eq!(crate::args::argv0_harness("/home/u/.cargo/bin/rx"), None);
 }
 
@@ -339,6 +340,32 @@ fn rxp_inserts_pi() {
             harness: Harness::Pi,
             provider: None,
             passthrough: vec!["--print".to_string(), "hi".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rxd_inserts_dsh() {
+    let command = parse_line(&["rxd", "--resume"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Dsh,
+            provider: None,
+            passthrough: vec!["--resume".to_string()],
+        })
+    );
+}
+
+#[test]
+fn rx_dsh_is_a_harness() {
+    let command = parse_line(&["rx", "dsh", "--resume"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Dsh,
+            provider: None,
+            passthrough: vec!["--resume".to_string()],
         })
     );
 }
@@ -529,6 +556,24 @@ fn unconfigured_launch_is_passthrough() {
 }
 
 #[test]
+fn unconfigured_dsh_still_boots_tui_profile() {
+    let (_dir, paths) = temp_paths();
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Dsh,
+            provider: None,
+            passthrough: vec!["--resume".to_string()],
+        },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap();
+    assert_eq!(plan.program, "dsh");
+    assert_eq!(plan.args, vec!["--profile", "dsh-tui", "--resume"]);
+    assert!(plan.env_set.is_empty());
+}
+
+#[test]
 fn claude_openrouter_uses_api_key_and_discovery_fallback_without_seed() {
     let (_dir, paths) = temp_paths();
     let env = EnvLookup::isolated(HashMap::from([(
@@ -680,6 +725,145 @@ fn opencode_non_generated_catalog_failure_degrades_to_base_config() {
     let document: serde_json::Value = serde_json::from_str(&config).unwrap();
     assert_eq!(document["provider"]["openrouter"]["options"]["baseURL"], format!("{base_url}/v1"));
     assert!(document["provider"]["openrouter"].get("models").is_none());
+}
+
+#[test]
+fn dsh_deepseek_uses_official_adapter_and_clears_pi_ai_routes() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "DEEPSEEK_API_KEY".to_string(),
+        "sk-ds-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Dsh,
+            provider: Some("deepseek".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, "dsh");
+    assert_eq!(plan.args[0], "--profile");
+    assert_eq!(plan.args[1], "dsh-tui");
+    assert_eq!(plan.args[2], "--patch");
+    assert_eq!(plan.args[3], paths.dir.join("dsh").join("launch.cordis.yml").to_string_lossy());
+    assert_eq!(plan.env_set, vec![("DEEPSEEK_API_KEY".to_string(), "sk-ds-test".to_string())]);
+    let patch = fs::read_to_string(paths.dir.join("dsh").join("launch.cordis.yml")).unwrap();
+    assert!(patch.contains("id: settings"));
+    assert!(!patch.contains("disabled: true"));
+    let settings: serde_yaml::Value = serde_yaml::from_str(
+        &fs::read_to_string(paths.dir.join("dsh").join("settings.yaml")).unwrap(),
+    )
+    .unwrap();
+    assert!(settings["llm-pi-ai"]["providers"].as_mapping().unwrap().is_empty());
+    assert_eq!(settings["agent-default-model"]["provider"], "deepseek-official");
+}
+
+#[test]
+fn dsh_tokener_injects_provider_catalog() {
+    let (_dir, paths) = temp_paths();
+    let (base_url, server) =
+        serve_openai_models(r#"{"data":[{"id":"kimi-k3"},{"id":"gpt-5.6-sol"}]}"#);
+    fs::write(&paths.config, format!("[provider.tokener]\nbase_url = \"{base_url}\"\n")).unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Dsh,
+            provider: Some("tokener".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    server.join().unwrap();
+    assert_eq!(plan.env_set, vec![("TOKENER_API_KEY".to_string(), "sk-tokener".to_string())]);
+    let settings: serde_yaml::Value = serde_yaml::from_str(
+        &fs::read_to_string(paths.dir.join("dsh").join("settings.yaml")).unwrap(),
+    )
+    .unwrap();
+    let models = settings["llm-pi-ai"]["providers"]["tokener"]["models"].as_sequence().unwrap();
+    assert_eq!(models.len(), 2);
+    assert_eq!(models[0]["id"], "kimi-k3");
+    assert_eq!(models[1]["id"], "gpt-5.6-sol");
+    assert_eq!(settings["agent-default-model"]["provider"], "tokener");
+    assert!(settings["agent-default-model"].get("model").is_none());
+}
+
+#[test]
+fn dsh_tokener_launch_owns_settings_and_catalog() {
+    let dir = tempfile::tempdir().unwrap();
+    let dsh_home = dir.path().join("dsh-home");
+    fs::create_dir_all(&dsh_home).unwrap();
+    fs::write(
+        dsh_home.join("settings.yaml"),
+        r#"
+dsh-tui:
+  lang: zh
+permission:
+  defaultPreset: danger-full-access
+llm-pi-ai:
+  providers:
+    openrouter: { apiKeyEnv: OPENROUTER_API_KEY }
+    kimi-coding: { baseURL: https://api.tokener.dev, apiKeyEnv: KIMI_CODING_API_KEY }
+agent-default-model:
+  provider: openrouter
+  model: openrouter/auto
+"#,
+    )
+    .unwrap();
+    let (_recall, paths) = temp_paths();
+    let (base_url, server) =
+        serve_openai_models(r#"{"data":[{"id":"kimi-k3"},{"id":"gpt-5.6-sol"}]}"#);
+    fs::write(
+        &paths.config,
+        format!("[provider.tokener]\nbase_url = \"{base_url}\"\nmodel = \"kimi-k3\"\n"),
+    )
+    .unwrap();
+    let env = EnvLookup::isolated(HashMap::from([
+        ("TOKENER_API_KEY".to_string(), "sk-tokener".to_string()),
+        ("DSH_HOME".to_string(), dsh_home.display().to_string()),
+    ]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Dsh,
+            provider: Some("tokener".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    server.join().unwrap();
+    assert_eq!(plan.env_set, vec![("TOKENER_API_KEY".to_string(), "sk-tokener".to_string())]);
+    let patch = fs::read_to_string(&plan.args[3]).unwrap();
+    assert!(patch.contains("id: settings"));
+    assert!(patch.contains("id: llm-deepseek"));
+    assert!(patch.contains("disabled: true"));
+    let overlay = paths.dir.join("dsh").join("settings.yaml");
+    assert!(patch.contains(&overlay.display().to_string()));
+    let settings: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(&overlay).unwrap()).unwrap();
+    assert_eq!(settings["dsh-tui"]["lang"], "zh");
+    assert_eq!(settings["permission"]["defaultPreset"], "danger-full-access");
+    let providers = settings["llm-pi-ai"]["providers"].as_mapping().unwrap();
+    assert_eq!(providers.len(), 1);
+    assert!(providers.get(serde_yaml::Value::from("kimi-coding")).is_none());
+    assert_eq!(settings["llm-pi-ai"]["providers"]["tokener"]["apiKeyEnv"], "TOKENER_API_KEY");
+    assert_eq!(settings["llm-pi-ai"]["providers"]["tokener"]["baseURL"], format!("{base_url}/v1"));
+    let models = settings["llm-pi-ai"]["providers"]["tokener"]["models"].as_sequence().unwrap();
+    assert_eq!(models.len(), 2);
+    assert_eq!(models[0]["id"], "kimi-k3");
+    assert_eq!(models[1]["id"], "gpt-5.6-sol");
+    assert_eq!(settings["agent-default-model"]["provider"], "tokener");
+    assert_eq!(settings["agent-default-model"]["model"], "kimi-k3");
+    let original = fs::read_to_string(dsh_home.join("settings.yaml")).unwrap();
+    assert!(original.contains("kimi-coding"));
 }
 
 #[test]
@@ -2162,6 +2346,10 @@ fn install_specs_use_official_urls() {
     let pi = crate::install::spec(Harness::Pi);
     assert_eq!(pi.url, "https://pi.dev/install.sh");
     assert_eq!(pi.shell, "sh");
+
+    let dsh = crate::install::spec(Harness::Dsh);
+    assert_eq!(dsh.program, "dsh");
+    assert_eq!(dsh.display, "DeepSeek Harness");
 }
 
 #[test]
@@ -2205,4 +2393,6 @@ fn install_lookup_honors_windows_executable_extensions() {
 fn isolated_env_skips_install_offer() {
     let path = crate::install::ensure(Harness::Pi, &EnvLookup::isolated(HashMap::new())).unwrap();
     assert_eq!(path, std::path::PathBuf::from("pi"));
+    let dsh = crate::install::ensure(Harness::Dsh, &EnvLookup::isolated(HashMap::new())).unwrap();
+    assert_eq!(dsh, std::path::PathBuf::from("dsh"));
 }

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -146,7 +146,7 @@ fn confirm(message: &str) -> Result<bool> {
 fn relaunch(raw_args: &[String]) -> Result<()> {
     let exe = std::env::current_exe().context("cannot resolve rx executable path")?;
     let mut command = Command::new(&exe);
-    // current_exe() resolves aliases (rxc/rxx/rxo/rxp) to the plain rx binary,
+    // current_exe() resolves aliases (rxc/rxx/rxo/rxp/rxd) to the plain rx binary,
     // so the relaunched process would lose the argv0-selected harness.
     if let Some(harness) = raw_args.first().and_then(|argv0| crate::args::argv0_harness(argv0)) {
         command.arg(harness);


### PR DESCRIPTION
### What's changed?

- Add DeepSeek Harness as an `rx` launch target with `dsh` and `rxd` routing.
- Install and launch the TUI profile with provider-specific settings and Cordis patch overlays.
- Extend the harness picker, install aliases, documentation, and regression coverage.

### Why

- Let `rx` users launch DeepSeek Harness through their configured AI provider while preserving native DSH settings.

### Validation

- `make check`
- Live `rx` to `dsh --dump-config` composition probes for official DeepSeek and a custom OpenAI-compatible provider.