### PR TITLE
feat(search): improve multi-term relevance

### DIFF
--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -171,11 +171,10 @@ impl<'a> SearchEngine<'a> {
         filters: &SearchFilters,
         limit: Option<usize>,
     ) -> anyhow::Result<Vec<Hit>> {
-        let escaped = fts5_escape(query);
-        if escaped.is_empty() {
+        let match_query = fts5_query(query);
+        if match_query.is_empty() {
             return Ok(vec![]);
         }
-
         let mut sql = String::from(
             "SELECT m.session_id, SUBSTR(m.content, 1, 200) AS snip,
                     MIN(messages_fts.rank) AS best_rank
@@ -185,7 +184,7 @@ impl<'a> SearchEngine<'a> {
              WHERE messages_fts MATCH ?1",
         );
 
-        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(escaped)];
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(match_query)];
         let mut param_idx = 2;
         apply_filters(&mut sql, &mut params, &mut param_idx, filters);
 
@@ -335,18 +334,66 @@ fn rrf_merge(fts_hits: &[Hit], vec_hits: &[Hit], k: u32) -> Vec<(String, f64, Ma
     results
 }
 
-fn fts5_escape(query: &str) -> String {
-    let tokens: Vec<&str> = query.split_whitespace().collect();
-    if tokens.is_empty() {
-        return String::new();
+const FTS_PREFIX_MIN_CHARS: usize = 2;
+
+fn tokenize_query(query: &str) -> Vec<String> {
+    query
+        .split_whitespace()
+        .map(|token| {
+            token
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_')
+                .collect::<String>()
+                .to_lowercase()
+        })
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn fts5_term(token: &str, prefix: bool) -> String {
+    let mut term = String::from("\"");
+    term.push_str(&token.replace('"', "\"\""));
+    term.push('"');
+    if prefix {
+        term.push('*');
     }
+    term
+}
+
+fn fts5_query(query: &str) -> String {
+    let tokens = tokenize_query(query);
+    let last = tokens.len().saturating_sub(1);
     tokens
         .iter()
-        .map(|t| {
-            let cleaned: String = t.chars().filter(|c| c.is_alphanumeric() || *c == '_').collect();
-            cleaned.to_lowercase()
+        .enumerate()
+        .map(|(index, token)| {
+            let prefix = index == last && token.chars().count() >= FTS_PREFIX_MIN_CHARS;
+            fts5_term(token, prefix)
         })
-        .filter(|t| !t.is_empty())
         .collect::<Vec<_>>()
         .join(" OR ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fts5_query, tokenize_query};
+
+    #[test]
+    fn tokenize_query_strips_punctuation_and_case() {
+        assert_eq!(
+            tokenize_query("context power café Codex "),
+            vec!["context", "power", "café", "codex"]
+        );
+        assert_eq!(tokenize_query("bug OR 1=1 --"), vec!["bug", "or", "11"]);
+    }
+
+    #[test]
+    fn fts5_query_quotes_terms_and_prefixes_last_token() {
+        assert_eq!(
+            fts5_query("context power café Codex "),
+            r#""context" OR "power" OR "café" OR "codex"*"#
+        );
+        assert_eq!(fts5_query("a"), r#""a""#);
+        assert_eq!(fts5_query("AND OR NOT"), r#""and" OR "or" OR "not"*"#);
+    }
 }

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -668,6 +668,67 @@ fn fts_search_sql_keywords_safe() {
 }
 
 #[test]
+fn fts_search_keeps_partial_matches_when_full_match_exists() {
+    let store = setup();
+    store.insert_session(&make_session("both", "test", "both", "Both")).unwrap();
+    store.insert_session(&make_session("partial", "test", "partial", "Partial")).unwrap();
+    store
+        .insert_messages(&[
+            make_message("both", Role::User, "debug tokio runtime", 0),
+            make_message("both", Role::Assistant, "look at streams backpressure", 1),
+            make_message("partial", Role::User, "tokio parser", 0),
+        ])
+        .unwrap();
+
+    let engine = SearchEngine::new(&store.conn);
+    let mut ids: Vec<_> = engine
+        .hybrid_search("tokio streams", None, &no_filters(), 10, 3)
+        .unwrap()
+        .into_iter()
+        .map(|result| result.session.id)
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec!["both".to_string(), "partial".to_string()]);
+}
+
+#[test]
+fn fts_search_matches_any_term_without_full_match() {
+    let store = setup();
+    store.insert_session(&make_session("alpha", "test", "alpha", "Alpha")).unwrap();
+    store.insert_session(&make_session("beta", "test", "beta", "Beta")).unwrap();
+    store
+        .insert_messages(&[
+            make_message("alpha", Role::User, "only tokio here", 0),
+            make_message("beta", Role::User, "only streams here", 0),
+        ])
+        .unwrap();
+
+    let engine = SearchEngine::new(&store.conn);
+    let mut ids: Vec<_> = engine
+        .hybrid_search("tokio streams", None, &no_filters(), 10, 3)
+        .unwrap()
+        .into_iter()
+        .map(|r| r.session.id)
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec!["alpha".to_string(), "beta".to_string()]);
+}
+
+#[test]
+fn fts_search_prefixes_last_token() {
+    let store = setup();
+    store.insert_session(&make_session("s1", "test", "s1", "Power")).unwrap();
+    store
+        .insert_messages(&[make_message("s1", Role::User, "enable powercontext backfill", 0)])
+        .unwrap();
+
+    let engine = SearchEngine::new(&store.conn);
+    let results = engine.hybrid_search("powercon", None, &no_filters(), 10, 3).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].session.id, "s1");
+}
+
+#[test]
 fn hybrid_search_fts_only_without_embedding() {
     let store = setup();
     let session = make_session("s1", "test", "raw1", "Debugging session");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -251,7 +251,7 @@ impl App {
             draft_source_filter_selection: Vec::new(),
             draft_scope: scope.clone(),
             draft_time_filter: TimeRange::All,
-            draft_sort_order: SortOrder::Newest,
+            draft_sort_order: SortOrder::Relevance,
             should_quit: false,
             last_keystroke: Instant::now(),
             search_pending: false,
@@ -261,7 +261,7 @@ impl App {
             search_feedback: None,
             embedding_unavailable: false,
             status_message: None,
-            sort_order: SortOrder::Newest,
+            sort_order: SortOrder::Relevance,
             export_path: String::new(),
             export_cursor: 0,
             total_sessions,
@@ -385,7 +385,11 @@ impl App {
     }
 
     pub(crate) fn sort_label(&self) -> &'static str {
-        Self::sort_order_label(self.sort_order)
+        Self::sort_order_label(self.effective_sort_order())
+    }
+
+    fn effective_sort_order(&self) -> SortOrder {
+        if self.query.trim().is_empty() { SortOrder::Newest } else { self.sort_order }
     }
 
     pub(crate) fn draft_sort_label(&self) -> &'static str {
@@ -1947,11 +1951,11 @@ impl App {
         let was_filtered = !self.draft_source_filter_selection.is_empty()
             || self.draft_scope != ProjectScope::Global
             || self.draft_time_filter != TimeRange::All
-            || self.draft_sort_order != SortOrder::Newest;
+            || self.draft_sort_order != SortOrder::Relevance;
         self.draft_source_filter_selection.clear();
         self.draft_scope = ProjectScope::Global;
         self.draft_time_filter = TimeRange::All;
-        self.draft_sort_order = SortOrder::Newest;
+        self.draft_sort_order = SortOrder::Relevance;
         self.filter_focus = FilterFocus::Source;
         if was_filtered {
             self.mark_filters_dirty();
@@ -2246,7 +2250,7 @@ impl App {
         self.source_filter_selection.clear();
         self.scope = crate::project_scope::auto_scope();
         self.time_filter = self.config.sync_window.to_time_range();
-        self.sort_order = SortOrder::Newest;
+        self.sort_order = SortOrder::Relevance;
         self.draft_source_filter_selection = self.source_filter_selection.clone();
         self.draft_scope = self.scope.clone();
         self.draft_time_filter = self.time_filter;
@@ -2717,7 +2721,7 @@ impl App {
     }
 
     fn apply_sort(&self, results: &mut [SearchResult]) {
-        if self.sort_order == SortOrder::Newest {
+        if self.effective_sort_order() == SortOrder::Newest {
             results.sort_by_key(|b| {
                 std::cmp::Reverse((
                     b.session.updated_at.unwrap_or(b.session.started_at),
@@ -2805,7 +2809,7 @@ mod tests {
             draft_source_filter_selection: Vec::new(),
             draft_scope: ProjectScope::Global,
             draft_time_filter: TimeRange::All,
-            draft_sort_order: SortOrder::Newest,
+            draft_sort_order: SortOrder::Relevance,
             should_quit: false,
             last_keystroke: Instant::now(),
             search_pending: false,
@@ -2815,7 +2819,7 @@ mod tests {
             search_feedback: None,
             embedding_unavailable: false,
             status_message: None,
-            sort_order: SortOrder::Newest,
+            sort_order: SortOrder::Relevance,
             export_path: String::new(),
             export_cursor: 0,
             total_sessions: 0,
@@ -3651,12 +3655,19 @@ mod tests {
     }
 
     #[test]
-    fn app_defaults_to_newest_sort() {
+    fn app_defaults_to_relevance_sort_and_newest_when_browsing() {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
-        let app = App::new(&store, vec![source("codex", "Codex")], AppConfig::default());
+        let mut app = App::new(&store, vec![source("codex", "Codex")], AppConfig::default());
 
-        assert_eq!(app.sort_order, SortOrder::Newest);
+        assert_eq!(app.sort_order, SortOrder::Relevance);
+        assert_eq!(app.effective_sort_order(), SortOrder::Newest);
+        assert_eq!(app.sort_label(), "Newest");
+        assert_eq!(app.draft_sort_label(), "Relevance");
+
+        app.query = "parser".to_string();
+        assert_eq!(app.effective_sort_order(), SortOrder::Relevance);
+        assert_eq!(app.sort_label(), "Relevance");
     }
 
     #[test]
@@ -3673,15 +3684,15 @@ mod tests {
     }
 
     #[test]
-    fn clear_filters_restores_newest_sort() {
+    fn clear_filters_restores_relevance_sort() {
         let mut app = app_with_sources();
-        app.sort_order = SortOrder::Relevance;
+        app.sort_order = SortOrder::Newest;
         app.open_filters();
 
         app.clear_filters();
 
-        assert_eq!(app.sort_order, SortOrder::Relevance);
-        assert_eq!(app.draft_sort_order, SortOrder::Newest);
+        assert_eq!(app.sort_order, SortOrder::Newest);
+        assert_eq!(app.draft_sort_order, SortOrder::Relevance);
         assert!(app.filters_dirty);
     }
 
@@ -3697,6 +3708,21 @@ mod tests {
 
         assert_eq!(results[0].session.source_id, "active-older-start");
         assert_eq!(results[1].session.source_id, "stale-newer-start");
+    }
+
+    #[test]
+    fn relevance_sort_keeps_engine_order_when_query_is_set() {
+        let mut app = app_with_sources();
+        app.query = "parser".to_string();
+        let mut results = vec![
+            search_result_with_times("stale-newer-start", 900, Some(900)),
+            search_result_with_times("active-older-start", 100, Some(1000)),
+        ];
+
+        app.apply_sort(&mut results);
+
+        assert_eq!(results[0].session.source_id, "stale-newer-start");
+        assert_eq!(results[1].session.source_id, "active-older-start");
     }
 
     #[test]
@@ -3780,13 +3806,13 @@ mod tests {
 
         app.handle_filters_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE), &store);
 
-        assert_eq!(app.sort_order, SortOrder::Newest);
+        assert_eq!(app.sort_order, SortOrder::Relevance);
         assert!(app.filters_dirty);
         assert!(!app.search_pending);
 
         app.handle_filters_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &store);
 
-        assert_eq!(app.sort_order, SortOrder::Relevance);
+        assert_eq!(app.sort_order, SortOrder::Newest);
         assert!(matches!(app.mode, AppMode::Search));
         assert!(app.search_pending);
         assert_eq!(app.search_feedback.as_deref(), Some("Filters queued..."));

--- a/src/tui/ui/search.rs
+++ b/src/tui/ui/search.rs
@@ -132,7 +132,7 @@ pub(super) fn render_filter_overview(f: &mut Frame, app: &App) {
         app.filter_focus == FilterFocus::Time,
     ));
     lines.push(filter_overview_line(
-        "Sort",
+        "Query Sort",
         app.draft_sort_label(),
         "←/→",
         app.filter_focus == FilterFocus::Sort,


### PR DESCRIPTION
### What's changed?

- rank non-empty TUI searches by relevance while keeping empty-query browsing newest
- add safe last-token prefix matching while preserving partial multi-term results
- clarify query-sort behavior and cover the search contract with regression tests

### Why

- improve interactive search precision without strict AND filtering or unbounded per-term scans