### PR TITLE
feat(powercontext): add recall backfill extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "recall-powercontext"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "ureq",
+ "url",
+]
+
+[[package]]
 name = "recall-probe"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/samzong/Recall"
 publish = false
 
 [workspace]
-members = [".", "crates/rx", "extensions/recall-probe", "extensions/recall-reflect"]
+members = [".", "crates/rx", "extensions/recall-probe", "extensions/recall-reflect", "extensions/recall-powercontext"]
 default-members = ["."]
 resolver = "2"
 

--- a/extensions/recall-powercontext/Cargo.toml
+++ b/extensions/recall-powercontext/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "recall-powercontext"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Backfill Recall sessions into PowerContext Content Sources"
+repository = "https://github.com/samzong/Recall"
+publish = false
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tempfile = "3"
+ureq = "3"
+url = "2"

--- a/extensions/recall-powercontext/README.md
+++ b/extensions/recall-powercontext/README.md
@@ -1,0 +1,43 @@
+# recall-powercontext
+
+Official Recall extension that writes indexed sessions to a local PowerContext
+Server as Content Sources. PowerContext still owns Memory extraction. This
+extension does not write Artifacts or inject context.
+
+Install the official extension from the Recall catalog:
+
+```bash
+recall ext install powercontext
+```
+
+Start PowerContext in one terminal:
+
+```bash
+powercontext server run
+```
+
+Then backfill the current repository from another terminal:
+
+```bash
+cd <git-repo>
+recall sync
+recall powercontext backfill
+```
+
+The command prints a compact summary by default. Use `--format json` for
+structured output.
+
+Default export is every adapter Recall indexed for the current repository,
+with no time window (`all`). Pass `--time 30d` (or `today`, `7d`, `week`,
+`month`) to limit `recall export` to recent sessions.
+Legacy sessions without a repository identity are excluded.
+
+There is no adapter allowlist. Each primary-thread user message becomes one
+Content Source (`recall:<adapter>:<session_id>:<seq>`), matching PowerContext
+host hooks. Pass `--roles user,assistant` to also capture model replies as
+separate Sources.
+
+Same `source_id` with the same body is idempotent. A later body for the same
+message is a conflict and is not overwritten.
+
+Do not treat imported Sources or extracted Memory as a secret vault.

--- a/extensions/recall-powercontext/src/backfill.rs
+++ b/extensions/recall-powercontext/src/backfill.rs
@@ -1,0 +1,110 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+
+use crate::export::{RecallClient, normalize_time_selector, visit_stdin_sessions};
+use crate::report::{BackfillReport, CountKind, CountSink};
+use crate::scope::resolve_scope;
+use crate::server::{CaptureResult, PowerContextClient, validate_server_url};
+use crate::session::{CaptureItem, ExportRecord, RoleSet, session_captures};
+
+pub struct BackfillOptions {
+    pub cwd: PathBuf,
+    pub server_url: String,
+    pub token: Option<String>,
+    pub time: Option<String>,
+    pub roles: RoleSet,
+    pub stdin: bool,
+    pub dry_run: bool,
+}
+
+pub fn run(options: BackfillOptions) -> Result<BackfillReport> {
+    let scope = resolve_scope(&options.cwd)?;
+    let time = normalize_time_selector(options.time.as_deref())?;
+    if options.stdin && time.is_some() {
+        bail!("--time cannot be combined with --stdin; filter with recall export --time");
+    }
+    let server_url = validate_server_url(&options.server_url)?;
+    let client = if options.dry_run {
+        None
+    } else {
+        Some(PowerContextClient::new(server_url.clone(), options.token.clone()))
+    };
+    let watermark = match &client {
+        Some(client) => client.journal_watermark(&scope.id)?,
+        None => 0,
+    };
+    let mut counts = CountSink::default();
+    {
+        let mut visit = |record: ExportRecord| {
+            apply_record(&record, &options, &scope.id, client.as_ref(), watermark, &mut counts)
+        };
+        if options.stdin {
+            visit_stdin_sessions(&mut visit)?;
+        } else {
+            RecallClient::from_env().visit_export_sessions(
+                &options.cwd,
+                &scope.project,
+                time.as_deref(),
+                &mut visit,
+            )?;
+        }
+    }
+    Ok(counts.finish(
+        scope.id,
+        server_url,
+        options.dry_run,
+        options.roles.as_report_value(),
+        time.unwrap_or_else(|| "all".to_string()),
+    ))
+}
+
+fn apply_record(
+    record: &ExportRecord,
+    options: &BackfillOptions,
+    scope_id: &str,
+    client: Option<&PowerContextClient>,
+    watermark: u64,
+    counts: &mut CountSink,
+) -> Result<()> {
+    let captures = session_captures(record, options.roles)
+        .with_context(|| format!("powercontext session {} failed", record.session.id))?;
+    let adapter = record.session.source.trim();
+    for item in captures {
+        apply_item(adapter, item, options, scope_id, client, watermark, counts)?;
+    }
+    Ok(())
+}
+
+fn apply_item(
+    adapter: &str,
+    item: CaptureItem,
+    options: &BackfillOptions,
+    scope_id: &str,
+    client: Option<&PowerContextClient>,
+    watermark: u64,
+    counts: &mut CountSink,
+) -> Result<()> {
+    let request = match item {
+        CaptureItem::Failed(error) => {
+            eprintln!("powercontext capture failed: {error}");
+            counts.add(adapter, CountKind::Failed);
+            return Ok(());
+        }
+        CaptureItem::Request(request) => request,
+    };
+    if options.dry_run {
+        counts.add(&request.adapter, CountKind::Imported);
+        return Ok(());
+    }
+    let client = client.expect("live backfill always builds a client");
+    match client.capture(scope_id, &request)? {
+        CaptureResult::Accepted { position } => {
+            let kind = if position > watermark { CountKind::Imported } else { CountKind::Skipped };
+            counts.add(&request.adapter, kind);
+        }
+        CaptureResult::Conflict => counts.add(&request.adapter, CountKind::Conflict),
+        CaptureResult::Failed => counts.add(&request.adapter, CountKind::Failed),
+    }
+    Ok(())
+}

--- a/extensions/recall-powercontext/src/export.rs
+++ b/extensions/recall-powercontext/src/export.rs
@@ -1,0 +1,113 @@
+use std::io::{BufRead, BufReader, Read, Seek, stdin};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+
+use crate::session::{ExportRecord, parse_export_line};
+
+#[derive(Clone, Debug)]
+pub struct RecallClient {
+    bin: PathBuf,
+}
+
+impl RecallClient {
+    pub fn from_env() -> Self {
+        let bin = std::env::var_os("RECALL_BIN")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("recall"));
+        Self { bin }
+    }
+
+    pub fn visit_export_sessions(
+        &self,
+        cwd: &Path,
+        project: &str,
+        time: Option<&str>,
+        visit: &mut impl FnMut(ExportRecord) -> Result<()>,
+    ) -> Result<()> {
+        let args = export_args(project, time);
+        let mut output = tempfile::tempfile().context("failed to create Recall export buffer")?;
+        let mut errors = tempfile::tempfile().context("failed to create Recall error buffer")?;
+        let stdout = output.try_clone().context("failed to clone Recall export buffer")?;
+        let stderr = errors.try_clone().context("failed to clone Recall error buffer")?;
+        let status = Command::new(&self.bin)
+            .args(&args)
+            .current_dir(cwd)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .status()
+            .with_context(|| format!("failed to run {}", command_label(&self.bin, &args)))?;
+        errors.rewind().context("failed to rewind Recall error buffer")?;
+        let mut bytes = Vec::new();
+        errors.read_to_end(&mut bytes).context("failed to read Recall error output")?;
+        let detail = String::from_utf8_lossy(&bytes);
+        if !status.success() {
+            let detail = detail.trim();
+            let command = command_label(&self.bin, &args);
+            if detail.is_empty() {
+                bail!("Recall command failed while running `{command}`: {status}");
+            }
+            bail!("Recall command failed while running `{command}`: {status}\n{detail}");
+        }
+        for line in detail.lines() {
+            eprintln!("{line}");
+        }
+        output.rewind().context("failed to rewind Recall export buffer")?;
+        visit_export_jsonl(BufReader::new(output), visit)
+    }
+}
+
+fn export_args(project: &str, time: Option<&str>) -> Vec<String> {
+    let mut args = vec![
+        "export".to_string(),
+        "--project".to_string(),
+        project.to_string(),
+        "--limit".to_string(),
+        "0".to_string(),
+        "--include".to_string(),
+        "metadata,messages".to_string(),
+    ];
+    if let Some(time) = time {
+        args.push("--time".to_string());
+        args.push(time.to_string());
+    }
+    args
+}
+
+pub fn normalize_time_selector(time: Option<&str>) -> Result<Option<String>> {
+    match time.map(|value| value.trim().to_ascii_lowercase()).as_deref() {
+        None | Some("") | Some("all") => Ok(None),
+        Some(time) if matches!(time, "today" | "7d" | "week" | "30d" | "month") => {
+            Ok(Some(time.to_string()))
+        }
+        Some(time) => {
+            bail!("unknown time range: {time}; expected today, 7d, week, 30d, month, or all")
+        }
+    }
+}
+
+pub fn visit_stdin_sessions(visit: &mut impl FnMut(ExportRecord) -> Result<()>) -> Result<()> {
+    visit_export_jsonl(stdin().lock(), visit)
+}
+
+fn visit_export_jsonl(
+    reader: impl BufRead,
+    visit: &mut impl FnMut(ExportRecord) -> Result<()>,
+) -> Result<()> {
+    for (index, line) in reader.lines().enumerate() {
+        let line_no = index + 1;
+        let line = line.with_context(|| format!("failed to read export JSONL line {line_no}"))?;
+        if !line.trim().is_empty() {
+            visit(parse_export_line(&line, line_no)?)?;
+        }
+    }
+    Ok(())
+}
+
+fn command_label(bin: &Path, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(bin.display().to_string());
+    parts.extend(args.iter().cloned());
+    parts.join(" ")
+}

--- a/extensions/recall-powercontext/src/main.rs
+++ b/extensions/recall-powercontext/src/main.rs
@@ -1,0 +1,113 @@
+use std::process::ExitCode;
+
+use anyhow::{Result, bail};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use serde_json::{Value, json};
+
+use crate::backfill::{BackfillOptions, run};
+use crate::scope::scope_failure;
+use crate::session::RoleSet;
+
+mod backfill;
+mod export;
+mod report;
+mod scope;
+mod server;
+mod session;
+
+#[derive(Parser)]
+#[command(
+    name = "recall-powercontext",
+    version,
+    about = "Backfill Recall sessions into PowerContext Content Sources"
+)]
+struct Cli {
+    #[arg(long = "recall-extension-manifest", hide = true)]
+    recall_extension_manifest: bool,
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Backfill(BackfillArgs),
+}
+
+#[derive(Parser)]
+struct BackfillArgs {
+    #[arg(long, default_value = "http://127.0.0.1:8000")]
+    server_url: String,
+    #[arg(long)]
+    token: Option<String>,
+    #[arg(long, help = "Recall export window: today, 7d, week, 30d, month, or all")]
+    time: Option<String>,
+    #[arg(long, default_value = "user")]
+    roles: String,
+    #[arg(long)]
+    stdin: bool,
+    #[arg(long)]
+    dry_run: bool,
+    #[arg(long, value_enum, default_value = "text")]
+    format: OutputFormat,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+fn main() -> ExitCode {
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error:#}");
+            if scope_failure(&error) { ExitCode::from(2) } else { ExitCode::FAILURE }
+        }
+    }
+}
+
+fn try_main() -> Result<()> {
+    let cli = Cli::parse();
+    if cli.recall_extension_manifest {
+        println!("{}", manifest_json());
+        return Ok(());
+    }
+    let Some(Command::Backfill(args)) = cli.command else {
+        Cli::command().print_help()?;
+        eprintln!();
+        std::process::exit(2);
+    };
+    let format = args.format;
+    let roles = RoleSet::parse(&args.roles)?;
+    let token =
+        args.token.or_else(|| std::env::var("POWERCONTEXT_TOKEN").ok().filter(|v| !v.is_empty()));
+    let report = run(BackfillOptions {
+        cwd: std::env::current_dir()?,
+        time: args.time.filter(|value| !matches!(value.trim(), "" | "all")),
+        server_url: args.server_url,
+        token,
+        roles,
+        stdin: args.stdin,
+        dry_run: args.dry_run,
+    })?;
+    let failed = report.totals.failed;
+    match format {
+        OutputFormat::Text => eprintln!("{report}"),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+    }
+    if failed > 0 {
+        let noun = if failed == 1 { "source" } else { "sources" };
+        bail!("backfill failed for {failed} {noun}");
+    }
+    Ok(())
+}
+
+fn manifest_json() -> Value {
+    json!({
+        "name": "powercontext",
+        "version": env!("CARGO_PKG_VERSION"),
+        "protocol": 2,
+        "min_recall": "0.4.0"
+    })
+}

--- a/extensions/recall-powercontext/src/report.rs
+++ b/extensions/recall-powercontext/src/report.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+use std::fmt::{self, Display, Write};
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct Counts {
+    pub imported: u64,
+    pub skipped: u64,
+    pub conflicts: u64,
+    pub failed: u64,
+}
+
+impl Counts {
+    pub fn add(&mut self, kind: CountKind) {
+        match kind {
+            CountKind::Imported => self.imported += 1,
+            CountKind::Skipped => self.skipped += 1,
+            CountKind::Conflict => self.conflicts += 1,
+            CountKind::Failed => self.failed += 1,
+        }
+    }
+
+    fn total(self) -> u64 {
+        self.imported + self.skipped + self.conflicts + self.failed
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CountKind {
+    Imported,
+    Skipped,
+    Conflict,
+    Failed,
+}
+
+impl CountKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Imported => "Imported",
+            Self::Skipped => "Skipped",
+            Self::Conflict => "Conflicts",
+            Self::Failed => "Failed",
+        }
+    }
+
+    fn value(self, counts: Counts) -> u64 {
+        match self {
+            Self::Imported => counts.imported,
+            Self::Skipped => counts.skipped,
+            Self::Conflict => counts.conflicts,
+            Self::Failed => counts.failed,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BackfillReport {
+    pub scope_id: String,
+    pub server_url: String,
+    pub dry_run: bool,
+    pub time: String,
+    pub roles: String,
+    pub totals: Counts,
+    pub by_adapter: Vec<AdapterCounts>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AdapterCounts {
+    pub adapter: String,
+    #[serde(flatten)]
+    pub counts: Counts,
+}
+
+impl Display for BackfillReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let total = self.totals.total();
+        let noun = if total == 1 { "source" } else { "sources" };
+        if self.dry_run {
+            writeln!(f, "Dry run: {total} {noun} selected")?;
+        } else if total == 0 {
+            writeln!(f, "Backfill complete: no matching sources")?;
+        } else if self.totals.failed > 0 {
+            writeln!(f, "Backfill finished: {total} {noun} processed")?;
+        } else if total == self.totals.imported {
+            writeln!(f, "Backfill complete: {total} {noun} imported")?;
+        } else {
+            writeln!(f, "Backfill complete: {total} {noun} processed")?;
+        }
+        writeln!(f, "Scope: {}", self.scope_id.strip_prefix("git:").unwrap_or(&self.scope_id))?;
+
+        if self.by_adapter.is_empty() {
+            return Ok(());
+        }
+
+        let mut columns = vec![CountKind::Imported];
+        for kind in [CountKind::Skipped, CountKind::Conflict, CountKind::Failed] {
+            if kind.value(self.totals) > 0 {
+                columns.push(kind);
+            }
+        }
+        let adapter_width = self
+            .by_adapter
+            .iter()
+            .map(|row| row.adapter.chars().count())
+            .max()
+            .unwrap_or(0)
+            .max("Adapter".len())
+            + 2;
+
+        f.write_char('\n')?;
+        write!(f, "{:<adapter_width$}", "Adapter")?;
+        for kind in &columns {
+            write!(f, "{:>11}", kind.label())?;
+        }
+        f.write_char('\n')?;
+        for row in &self.by_adapter {
+            write!(f, "{:<adapter_width$}", row.adapter)?;
+            for kind in &columns {
+                write!(f, "{:>11}", kind.value(row.counts))?;
+            }
+            f.write_char('\n')?;
+        }
+        write!(f, "{:<adapter_width$}", "Total")?;
+        for kind in columns {
+            write!(f, "{:>11}", kind.value(self.totals))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct CountSink {
+    totals: Counts,
+    by_adapter: BTreeMap<String, Counts>,
+}
+
+impl CountSink {
+    pub fn add(&mut self, adapter: &str, kind: CountKind) {
+        self.totals.add(kind);
+        self.by_adapter.entry(adapter.to_string()).or_default().add(kind);
+    }
+
+    pub fn finish(
+        self,
+        scope_id: String,
+        server_url: String,
+        dry_run: bool,
+        roles: String,
+        time: String,
+    ) -> BackfillReport {
+        let by_adapter = self
+            .by_adapter
+            .into_iter()
+            .map(|(adapter, counts)| AdapterCounts { adapter, counts })
+            .collect();
+        BackfillReport {
+            scope_id,
+            server_url,
+            dry_run,
+            time,
+            roles,
+            totals: self.totals,
+            by_adapter,
+        }
+    }
+}

--- a/extensions/recall-powercontext/src/scope.rs
+++ b/extensions/recall-powercontext/src/scope.rs
@@ -1,0 +1,182 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+const MAX_SCOPE_LENGTH: usize = 256;
+const WORKSPACE_STATE_SCHEMA: &str = "powercontext.codex-workspace.v1";
+
+#[derive(Debug)]
+pub struct ScopeError(pub String);
+
+impl std::fmt::Display for ScopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ScopeError {}
+
+pub struct ResolvedScope {
+    pub id: String,
+    pub project: String,
+}
+
+pub fn resolve_scope(cwd: &Path) -> Result<ResolvedScope> {
+    let git_dir = git_value(cwd, &["rev-parse", "--absolute-git-dir"])?
+        .ok_or_else(|| ScopeError("not a git repository; run from a repo with origin".into()))?;
+    let root = git_value(cwd, &["rev-parse", "--show-toplevel"])?
+        .ok_or_else(|| ScopeError("not a git repository; run from a repo with origin".into()))?;
+    let remote = git_value(Path::new(&root), &["config", "--get", "remote.origin.url"])?
+        .ok_or_else(|| {
+            ScopeError("git remote origin is missing; refusing local:sha256 scope".into())
+        })?;
+    let project = normalize_git_remote(&remote)
+        .ok_or_else(|| ScopeError(format!("git remote origin is not a network URL: {remote}")))?;
+    let id =
+        read_bound_scope_id(Path::new(&git_dir)).unwrap_or_else(|| bounded_scope("git", &project));
+    Ok(ResolvedScope { id, project })
+}
+
+fn read_bound_scope_id(git_dir: &Path) -> Option<String> {
+    #[derive(Deserialize)]
+    struct WorkspaceState {
+        schema: String,
+        scope_id: String,
+    }
+
+    let bytes = fs::read(git_dir.join("powercontext/codex-workspace.json")).ok()?;
+    let state: WorkspaceState = serde_json::from_slice(&bytes).ok()?;
+    if state.schema != WORKSPACE_STATE_SCHEMA
+        || state.scope_id.is_empty()
+        || state.scope_id.trim() != state.scope_id
+        || state.scope_id.chars().count() > MAX_SCOPE_LENGTH
+    {
+        return None;
+    }
+    Some(state.scope_id)
+}
+
+pub fn normalize_git_remote(remote: &str) -> Option<String> {
+    let value = remote.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if !value.contains("://") {
+        return normalize_scp_remote(value);
+    }
+    let (scheme, rest) = value.split_once("://")?;
+    if !matches!(scheme, "http" | "https" | "ssh" | "git") {
+        return None;
+    }
+    let rest = rest.trim_start_matches('/');
+    let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+    let authority = authority.rsplit('@').next()?.trim();
+    if authority.is_empty() {
+        return None;
+    }
+    let host = authority.to_ascii_lowercase();
+    let path = normalize_path(path);
+    if path.is_empty() {
+        return None;
+    }
+    Some(format!("{host}/{path}"))
+}
+
+fn normalize_scp_remote(value: &str) -> Option<String> {
+    let rest = match value.split_once('@') {
+        Some((user, rest)) if !user.is_empty() && !user.contains('/') => rest,
+        None => value,
+        Some(_) => return None,
+    };
+    let (host, path) = rest.split_once(':')?;
+    if host.is_empty() || host.contains('/') {
+        return None;
+    }
+    let path = normalize_path(path);
+    if path.is_empty() {
+        return None;
+    }
+    Some(format!("{}/{path}", host.to_ascii_lowercase()))
+}
+
+fn normalize_path(path: &str) -> String {
+    let mut normalized = path
+        .replace('\\', "/")
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("/");
+    if let Some(stripped) = normalized.strip_suffix(".git") {
+        normalized = stripped.to_string();
+    }
+    normalized.trim_end_matches('/').to_string()
+}
+
+fn bounded_scope(prefix: &str, value: &str) -> String {
+    let candidate = format!("{prefix}:{value}");
+    if candidate.chars().count() <= MAX_SCOPE_LENGTH {
+        return candidate;
+    }
+    format!("{prefix}:sha256:{:x}", Sha256::digest(value.as_bytes()))
+}
+
+fn git_value(cwd: &Path, args: &[&str]) -> Result<Option<String>> {
+    let output =
+        Command::new("git").args(args).current_dir(cwd).output().context("failed to run git")?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let value = String::from_utf8(output.stdout)
+        .context("git output was not valid UTF-8")?
+        .trim()
+        .to_string();
+    if value.is_empty() { Ok(None) } else { Ok(Some(value)) }
+}
+
+pub fn scope_failure(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<ScopeError>().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bounded_scope, normalize_git_remote};
+
+    #[test]
+    fn normalizes_scp_and_https_remotes() {
+        assert_eq!(
+            normalize_git_remote("git@github.com:samzong/Recall.git").as_deref(),
+            Some("github.com/samzong/Recall")
+        );
+        assert_eq!(
+            normalize_git_remote("https://USER:token@GitHub.com/samzong/Recall.git").as_deref(),
+            Some("github.com/samzong/Recall")
+        );
+        assert_eq!(
+            normalize_git_remote("ssh://git@github.com/samzong/Recall.git").as_deref(),
+            Some("github.com/samzong/Recall")
+        );
+        assert_eq!(
+            normalize_git_remote("https://github.com:443/samzong/Recall.git").as_deref(),
+            Some("github.com:443/samzong/Recall")
+        );
+    }
+
+    #[test]
+    fn rejects_file_and_empty_remotes() {
+        assert_eq!(normalize_git_remote("file:///tmp/repo.git"), None);
+        assert_eq!(normalize_git_remote(""), None);
+        assert_eq!(normalize_git_remote("   "), None);
+    }
+
+    #[test]
+    fn hashes_overlong_scope_ids() {
+        let long = "x".repeat(300);
+        let scope = bounded_scope("git", &long);
+        assert!(scope.starts_with("git:sha256:"));
+        assert!(scope.len() < 256);
+    }
+}

--- a/extensions/recall-powercontext/src/server.rs
+++ b/extensions/recall-powercontext/src/server.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use ureq::Agent;
+use url::{Host, Url};
+
+use crate::session::CaptureRequest;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureResult {
+    Accepted { position: u64 },
+    Conflict,
+    Failed,
+}
+
+pub struct PowerContextClient {
+    agent: Agent,
+    base: String,
+    token: Option<String>,
+}
+
+impl PowerContextClient {
+    pub fn new(base: String, token: Option<String>) -> Self {
+        let config = Agent::config_builder()
+            .http_status_as_error(false)
+            .max_redirects(0)
+            .timeout_global(Some(REQUEST_TIMEOUT))
+            .build();
+        Self { agent: config.into(), base, token }
+    }
+
+    pub fn journal_watermark(&self, scope_id: &str) -> Result<u64> {
+        let url = format!("{}/v1/stats", self.base);
+        let mut request = self.agent.get(&url).query("scope_id", scope_id);
+        if let Some(token) = &self.token {
+            request = request.header("Authorization", format!("Bearer {token}"));
+        }
+        let mut response = match request.call() {
+            Ok(response) => response,
+            Err(error) => return map_transport(error),
+        };
+        let status = response.status().as_u16();
+        let body = response.body_mut().read_to_string().context("failed to read /v1/stats")?;
+        if status != 200 {
+            bail!("PowerContext /v1/stats failed with HTTP {status}");
+        }
+        parse_watermark(&body).context("invalid PowerContext /v1/stats response")
+    }
+
+    pub fn capture(&self, scope_id: &str, request: &CaptureRequest) -> Result<CaptureResult> {
+        let url = format!("{}/v1/sources/content", self.base);
+        let mut metadata = json!({
+            "kind": "recall-session",
+            "adapter": request.adapter,
+            "session_id": request.session_id,
+            "seq": request.seq,
+        });
+        if let Some(started_at) = &request.started_at {
+            metadata["started_at"] = Value::String(started_at.clone());
+        }
+        let payload = json!({
+            "scope_id": scope_id,
+            "source_id": request.source_id,
+            "content": request.content,
+            "metadata": metadata,
+        });
+        let mut http_request = self.agent.post(&url).header("Content-Type", "application/json");
+        if let Some(token) = &self.token {
+            http_request = http_request.header("Authorization", format!("Bearer {token}"));
+        }
+        let mut response = match http_request.send(payload.to_string()) {
+            Ok(response) => response,
+            Err(error) => return map_transport(error),
+        };
+        let status = response.status().as_u16();
+        let body =
+            response.body_mut().read_to_string().context("failed to read /v1/sources/content")?;
+        match status {
+            202 => Ok(CaptureResult::Accepted {
+                position: parse_capture_response(&body, &request.source_id)
+                    .context("invalid PowerContext /v1/sources/content response")?,
+            }),
+            409 if is_source_conflict(&body) => Ok(CaptureResult::Conflict),
+            _ => {
+                eprintln!("powercontext capture failed for {}: HTTP {status}", request.source_id);
+                Ok(CaptureResult::Failed)
+            }
+        }
+    }
+}
+
+fn map_transport<T>(error: ureq::Error) -> Result<T> {
+    if is_unreachable(&error) {
+        bail!("PowerContext Server is unreachable: {error}");
+    }
+    Err(anyhow!(error))
+}
+
+fn is_unreachable(error: &ureq::Error) -> bool {
+    matches!(
+        error,
+        ureq::Error::Io(_)
+            | ureq::Error::ConnectionFailed
+            | ureq::Error::HostNotFound
+            | ureq::Error::Timeout(_)
+    )
+}
+
+pub fn validate_server_url(raw: &str) -> Result<String> {
+    let value = raw.trim();
+    let url = Url::parse(value).context("invalid server URL")?;
+    if !matches!(url.scheme(), "http" | "https") {
+        bail!("server URL must be http:// or https://");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        bail!("server URL must not include userinfo");
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        bail!("server URL must not include a query or fragment");
+    }
+    let loopback = match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(host)) => host.is_loopback(),
+        Some(Host::Ipv6(host)) => host.is_loopback(),
+        None => false,
+    };
+    if !loopback {
+        bail!("refusing non-loopback server URL: {value}");
+    }
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
+fn parse_watermark(body: &str) -> Result<u64> {
+    #[derive(Deserialize)]
+    struct Stats {
+        inventory: Inventory,
+    }
+    #[derive(Deserialize)]
+    struct Inventory {
+        sources: Sources,
+    }
+    #[derive(Deserialize)]
+    struct Sources {
+        total: u64,
+    }
+    Ok(serde_json::from_str::<Stats>(body)?.inventory.sources.total)
+}
+
+fn parse_capture_response(body: &str, expected_source_id: &str) -> Result<u64> {
+    #[derive(Deserialize)]
+    struct Capture {
+        status: String,
+        source: Source,
+        position: u64,
+    }
+    #[derive(Deserialize)]
+    struct Source {
+        name: String,
+        source_id: String,
+    }
+    let capture: Capture = serde_json::from_str(body)?;
+    if capture.status != "accepted"
+        || capture.source.name != "content"
+        || capture.source.source_id != expected_source_id
+        || capture.position == 0
+    {
+        bail!("capture response does not match the request");
+    }
+    Ok(capture.position)
+}
+
+fn is_source_conflict(body: &str) -> bool {
+    #[derive(Deserialize)]
+    struct Envelope {
+        error: ErrorBody,
+    }
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        code: String,
+    }
+    serde_json::from_str::<Envelope>(body)
+        .map(|envelope| envelope.error.code == "source_conflict")
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_source_conflict, parse_watermark, validate_server_url};
+
+    #[test]
+    fn accepts_loopback_http_and_rejects_lan() {
+        assert!(validate_server_url("http://127.0.0.1:8000/").is_ok());
+        assert!(validate_server_url("http://[::1]:8000").is_ok());
+        assert!(validate_server_url("https://localhost").is_ok());
+        let error = validate_server_url("http://192.168.1.9:8000").unwrap_err().to_string();
+        assert!(error.contains("non-loopback"), "{error}");
+    }
+
+    #[test]
+    fn detects_payload_conflict_and_stats_watermark() {
+        assert!(is_source_conflict(
+            r#"{"error":{"code":"source_conflict","message":"x","details":null}}"#
+        ));
+        assert!(!is_source_conflict(r#"{"error":{"code":"revision_conflict"}}"#));
+        assert_eq!(parse_watermark(r#"{"inventory":{"sources":{"total":7}}}"#).unwrap(), 7);
+    }
+}

--- a/extensions/recall-powercontext/src/session.rs
+++ b/extensions/recall-powercontext/src/session.rs
@@ -1,0 +1,290 @@
+use anyhow::{Result, bail};
+use serde::Deserialize;
+
+pub const RECORD_SCHEMA_VERSION: u32 = 5;
+pub const MAX_SOURCE_ID_LENGTH: usize = 256;
+pub const MAX_CONTENT_LENGTH: usize = 200_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RoleSet {
+    user: bool,
+    assistant: bool,
+}
+
+impl RoleSet {
+    pub fn parse(value: &str) -> Result<Self> {
+        let mut roles = Self { user: false, assistant: false };
+        for part in value.split(',') {
+            match part.trim().to_ascii_lowercase().as_str() {
+                "" => {}
+                "user" => roles.user = true,
+                "assistant" => roles.assistant = true,
+                other => bail!("unsupported role '{other}'; expected user and/or assistant"),
+            }
+        }
+        if !roles.user && !roles.assistant {
+            bail!("--roles must include user and/or assistant");
+        }
+        Ok(roles)
+    }
+
+    pub fn contains(self, role: &str) -> bool {
+        match role {
+            "user" => self.user,
+            "assistant" => self.assistant,
+            _ => false,
+        }
+    }
+
+    pub fn as_report_value(self) -> String {
+        match (self.user, self.assistant) {
+            (true, true) => "user,assistant",
+            (true, false) => "user",
+            (false, true) => "assistant",
+            (false, false) => unreachable!(),
+        }
+        .to_string()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExportRecord {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub record_type: String,
+    pub session: ExportSession,
+    #[serde(default)]
+    pub messages: Vec<ExportMessage>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExportSession {
+    pub id: String,
+    pub source: String,
+    #[serde(default)]
+    pub started_at: i64,
+    #[serde(default)]
+    pub topology: Option<ExportTopology>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExportTopology {
+    #[serde(default)]
+    pub thread_role: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExportMessage {
+    pub seq: u32,
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct CaptureRequest {
+    pub adapter: String,
+    pub session_id: String,
+    pub seq: u32,
+    pub source_id: String,
+    pub content: String,
+    pub started_at: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CaptureItem {
+    Request(CaptureRequest),
+    Failed(String),
+}
+
+pub fn parse_export_line(line: &str, line_no: usize) -> Result<ExportRecord> {
+    let record: ExportRecord = serde_json::from_str(line)
+        .map_err(|error| anyhow::anyhow!("failed to parse export JSONL line {line_no}: {error}"))?;
+    if record.schema_version != RECORD_SCHEMA_VERSION {
+        bail!(
+            "unsupported export schema_version {} on line {line_no}; expected {RECORD_SCHEMA_VERSION}",
+            record.schema_version
+        );
+    }
+    if record.record_type != "session" {
+        bail!(
+            "unsupported export record_type '{}' on line {line_no}; expected session",
+            record.record_type
+        );
+    }
+    Ok(record)
+}
+
+pub fn session_captures(record: &ExportRecord, roles: RoleSet) -> Result<Vec<CaptureItem>> {
+    if record.session.topology.as_ref().and_then(|topology| topology.thread_role.as_deref())
+        == Some("subagent")
+    {
+        return Ok(Vec::new());
+    }
+    let adapter = record.session.source.trim();
+    let session_id = record.session.id.trim();
+    if adapter.is_empty() || session_id.is_empty() {
+        bail!("export session is missing source or id");
+    }
+    let started_at = if record.session.started_at > 0 {
+        Some(record.session.started_at.to_string())
+    } else {
+        None
+    };
+    let mut messages: Vec<&ExportMessage> = record
+        .messages
+        .iter()
+        .filter(|message| roles.contains(&message.role) && !message.content.trim().is_empty())
+        .collect();
+    messages.sort_by_key(|message| message.seq);
+    let mut items = Vec::new();
+    for message in messages {
+        items.push(capture_item(adapter, session_id, started_at.clone(), message)?);
+    }
+    Ok(items)
+}
+
+fn capture_item(
+    adapter: &str,
+    session_id: &str,
+    started_at: Option<String>,
+    message: &ExportMessage,
+) -> Result<CaptureItem> {
+    let content = message.content.trim();
+    if content.chars().count() > MAX_CONTENT_LENGTH {
+        return Ok(CaptureItem::Failed(format!(
+            "message {session_id}#{} exceeds {MAX_CONTENT_LENGTH} characters",
+            message.seq
+        )));
+    }
+    let source_id = format!("recall:{adapter}:{session_id}:{}", message.seq);
+    if source_id.chars().count() > MAX_SOURCE_ID_LENGTH {
+        bail!("source_id exceeds {MAX_SOURCE_ID_LENGTH} characters: {source_id}");
+    }
+    Ok(CaptureItem::Request(CaptureRequest {
+        adapter: adapter.to_string(),
+        session_id: session_id.to_string(),
+        seq: message.seq,
+        source_id,
+        content: content.to_string(),
+        started_at,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RoleSet;
+    use super::{
+        CaptureItem, MAX_CONTENT_LENGTH, RECORD_SCHEMA_VERSION, parse_export_line, session_captures,
+    };
+
+    fn record(source: &str, id: &str, role: &str, messages: &str) -> String {
+        format!(
+            r#"{{"schema_version":{RECORD_SCHEMA_VERSION},"record_type":"session","session":{{"id":"{id}","source":"{source}","started_at":1000,"topology":{{"thread_role":"{role}","parents":[]}}}},"messages":{messages}}}"#
+        )
+    }
+
+    fn requests(record: &str, roles: RoleSet) -> Vec<super::CaptureRequest> {
+        session_captures(&parse_export_line(record, 1).unwrap(), roles)
+            .unwrap()
+            .into_iter()
+            .filter_map(|item| match item {
+                CaptureItem::Request(request) => Some(request),
+                CaptureItem::Failed(_) => None,
+            })
+            .collect()
+    }
+
+    fn user_only() -> RoleSet {
+        RoleSet::parse("user").unwrap()
+    }
+
+    #[test]
+    fn rejects_schema_other_than_five() {
+        let line = r#"{"schema_version":4,"record_type":"session","session":{"id":"s","source":"codex"},"messages":[]}"#;
+        let error = parse_export_line(line, 1).unwrap_err().to_string();
+        assert!(error.contains("schema_version 4"), "{error}");
+    }
+
+    #[test]
+    fn skips_subagent_and_empty_user_bodies() {
+        let jsonl = [
+            record("cursor", "s1", "subagent", r#"[{"seq":0,"role":"user","content":"hi"}]"#),
+            record("cursor", "s2", "primary", r#"[{"seq":0,"role":"assistant","content":"no"}]"#),
+        ]
+        .join("\n");
+        let records: Vec<_> = jsonl
+            .lines()
+            .enumerate()
+            .map(|(index, line)| parse_export_line(line, index + 1).unwrap())
+            .collect();
+        assert!(session_captures(&records[0], user_only()).unwrap().is_empty());
+        assert!(session_captures(&records[1], user_only()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn posts_one_source_per_user_message() {
+        let line = format!(
+            r#"{{"schema_version":{RECORD_SCHEMA_VERSION},"record_type":"session","session":{{"id":"s1","source":"gemini-cli","started_at":9}},"messages":[{{"seq":1,"role":"assistant","content":"no"}},{{"seq":0,"role":"user","content":" one "}},{{"seq":2,"role":"user","content":"two"}}]}}"#
+        );
+        let captured = requests(&line, user_only());
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].source_id, "recall:gemini-cli:s1:0");
+        assert_eq!(captured[0].content, "one");
+        assert_eq!(captured[0].seq, 0);
+        assert_eq!(captured[1].source_id, "recall:gemini-cli:s1:2");
+        assert_eq!(captured[1].content, "two");
+        assert_eq!(captured[1].started_at.as_deref(), Some("9"));
+    }
+
+    #[test]
+    fn assistant_roles_are_opt_in_as_separate_sources() {
+        let line = record(
+            "codex",
+            "s1",
+            "primary",
+            r#"[{"seq":0,"role":"user","content":"q"},{"seq":1,"role":"assistant","content":"a"}]"#,
+        );
+        let user = requests(&line, user_only());
+        assert_eq!(user.len(), 1);
+        assert_eq!(user[0].source_id, "recall:codex:s1:0");
+        let both = requests(&line, RoleSet::parse("user,assistant").unwrap());
+        assert_eq!(both.len(), 2);
+        assert_eq!(both[1].source_id, "recall:codex:s1:1");
+        assert_eq!(both[1].content, "a");
+    }
+
+    #[test]
+    fn oversized_message_fails_alone() {
+        let huge = "x".repeat(MAX_CONTENT_LENGTH + 1);
+        let line = format!(
+            r#"{{"schema_version":{RECORD_SCHEMA_VERSION},"record_type":"session","session":{{"id":"s1","source":"codex","started_at":1,"topology":{{"thread_role":"primary","parents":[]}}}},"messages":[{{"seq":0,"role":"user","content":"{huge}"}},{{"seq":1,"role":"user","content":"ok"}}]}}"#
+        );
+        let items = session_captures(&parse_export_line(&line, 1).unwrap(), user_only()).unwrap();
+        assert!(matches!(items[0], CaptureItem::Failed(_)));
+        let CaptureItem::Request(request) = &items[1] else {
+            panic!("expected request");
+        };
+        assert_eq!(request.source_id, "recall:codex:s1:1");
+    }
+
+    #[test]
+    fn source_id_limit_counts_characters() {
+        let session_id = "é".repeat(150);
+        let line = record(
+            "codex",
+            &session_id,
+            "primary",
+            r#"[{"seq":0,"role":"user","content":"hello"}]"#,
+        );
+        let captured = requests(&line, user_only());
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].source_id.chars().count() <= super::MAX_SOURCE_ID_LENGTH);
+        assert!(captured[0].source_id.len() > super::MAX_SOURCE_ID_LENGTH);
+    }
+
+    #[test]
+    fn rejects_unknown_roles() {
+        let error = RoleSet::parse("user,tool").unwrap_err().to_string();
+        assert!(error.contains("tool"), "{error}");
+    }
+}

--- a/extensions/recall-powercontext/tests/backfill_cli.rs
+++ b/extensions/recall-powercontext/tests/backfill_cli.rs
@@ -1,0 +1,517 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+
+use tempfile::TempDir;
+
+fn adapter_jsonl() -> String {
+    ["codex", "future-harness"]
+        .iter()
+        .enumerate()
+        .map(|(idx, adapter)| {
+            format!(
+                r#"{{"schema_version":5,"record_type":"session","session":{{"id":"s{idx}","source":"{adapter}","source_id":"raw-{idx}","title":"{adapter}","started_at":1000,"updated_at":1100,"message_count":1,"topology":{{"thread_role":"primary","parents":[]}}}},"messages":[{{"seq":0,"role":"user","content":"prompt from {adapter}"}}]}}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn manifest_is_protocol_two() {
+    let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .arg("--recall-extension-manifest")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "powercontext");
+    assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["protocol"], 2);
+    assert_eq!(json["min_recall"], "0.4.0");
+}
+
+#[test]
+fn dry_run_reports_bound_scope_and_unknown_adapters() {
+    let fake = FakeRecall::new(&adapter_jsonl(), 0, "export warning");
+    let repo = temp_dir("recall-pc-repo");
+    init_git_repo(repo.path(), "https://USER:token@GitHub.com/samzong/Recall.git");
+    bind_workstream_scope(repo.path(), "workstream:bound");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .env("RECALL_BIN", fake.script_path())
+        .current_dir(repo.path())
+        .args(["backfill", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.stdout.is_empty());
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(text.contains("Dry run: 2 sources selected"), "{text}");
+    assert!(text.contains("Scope: workstream:bound"), "{text}");
+    assert!(text.contains("codex"), "{text}");
+    assert!(text.contains("future-harness"), "{text}");
+    assert!(text.contains("Total"), "{text}");
+    assert!(!text.contains("Skipped"), "{text}");
+    assert!(!text.contains("Conflicts"), "{text}");
+    assert!(!text.contains("Failed"), "{text}");
+    assert!(text.contains("export warning"), "{text}");
+    let calls = fake.calls();
+    assert_eq!(
+        calls,
+        ["export --project github.com/samzong/Recall --limit 0 --include metadata,messages"]
+    );
+}
+
+#[test]
+fn dry_run_forwards_time_window_to_export() {
+    let fake = FakeRecall::new(&adapter_jsonl(), 0, "");
+    let repo = temp_dir("recall-pc-time");
+    init_git_repo(repo.path(), "git@github.com:samzong/Recall.git");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .env("RECALL_BIN", fake.script_path())
+        .current_dir(repo.path())
+        .args(["backfill", "--dry-run", "--time", "30d", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["time"], "30d");
+    assert_eq!(
+        fake.calls(),
+        [
+            "export --project github.com/samzong/Recall --limit 0 --include metadata,messages --time 30d"
+        ]
+    );
+}
+
+#[test]
+fn recall_export_failures_are_reported() {
+    let repo = temp_dir("recall-pc-export-failure");
+    init_git_repo(repo.path(), "https://github.com/example/repo.git");
+    let server = MockServer::start();
+    let jsonl = r#"{"schema_version":5,"record_type":"session","session":{"id":"new","source":"cursor","started_at":1},"messages":[{"seq":0,"role":"user","content":"fresh"}]}"#;
+
+    for (stdout, exit_code, stderr, expected) in
+        [(jsonl, 23, "boom", "boom"), ("not-json", 0, "", "line 1")]
+    {
+        let fake = FakeRecall::new(stdout, exit_code, stderr);
+        let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+            .env("RECALL_BIN", fake.script_path())
+            .current_dir(repo.path())
+            .args(["backfill", "--server-url", &server.url()])
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(expected), "{stderr}");
+        assert!(server.posted_ids().is_empty());
+    }
+}
+
+#[test]
+fn rejects_unknown_time_and_time_with_stdin() {
+    let repo = temp_dir("recall-pc-time-bad");
+    init_git_repo(repo.path(), "git@github.com:samzong/Recall.git");
+
+    let unknown = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .current_dir(repo.path())
+        .args(["backfill", "--dry-run", "--time", "yesterday"])
+        .output()
+        .unwrap();
+    assert!(!unknown.status.success());
+    let stderr = String::from_utf8_lossy(&unknown.stderr);
+    assert!(stderr.contains("yesterday"), "{stderr}");
+
+    let stdin = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .current_dir(repo.path())
+        .args(["backfill", "--stdin", "--time", "30d"])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!stdin.status.success());
+    let stderr = String::from_utf8_lossy(&stdin.stderr);
+    assert!(stderr.contains("--stdin"), "{stderr}");
+}
+
+#[test]
+fn stdin_backfill_posts_and_classifies_skip_conflict_and_import() {
+    let repo = temp_dir("recall-pc-http");
+    init_git_repo(repo.path(), "https://github.com/samzong/Recall.git");
+    let server = MockServer::start();
+    let jsonl = r#"{"schema_version":5,"record_type":"session","session":{"id":"new","source":"cursor","started_at":1,"topology":{"thread_role":"primary","parents":[]}},"messages":[{"seq":0,"role":"user","content":"fresh"}]}
+{"schema_version":5,"record_type":"session","session":{"id":"old","source":"codex","started_at":1,"topology":{"thread_role":"primary","parents":[]}},"messages":[{"seq":0,"role":"user","content":"same"}]}
+{"schema_version":5,"record_type":"session","session":{"id":"changed","source":"opencode","started_at":1,"topology":{"thread_role":"primary","parents":[]}},"messages":[{"seq":0,"role":"user","content":"changed"}]}
+{"schema_version":5,"record_type":"session","session":{"id":"child","source":"gemini-cli","started_at":1,"topology":{"thread_role":"subagent","parents":[]}},"messages":[{"seq":0,"role":"user","content":"nested"}]}"#;
+
+    let output = run_stdin_backfill(repo.path(), &server.url(), jsonl);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["totals"]["imported"], 1, "{json}");
+    assert_eq!(json["totals"]["skipped"], 1);
+    assert_eq!(json["totals"]["conflicts"], 1);
+    assert_eq!(json["totals"]["failed"], 0);
+    assert!(server.posted_ids().contains(&"recall:cursor:new:0".to_string()));
+    assert!(!server.posted_ids().iter().any(|id| id.contains("gemini-cli")));
+}
+
+#[test]
+fn missing_origin_exits_two_without_export() {
+    let fake = FakeRecall::new("", 0, "");
+    let repo = temp_dir("recall-pc-noorigin");
+    init_git_repo(repo.path(), "");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .env("RECALL_BIN", fake.script_path())
+        .current_dir(repo.path())
+        .args(["backfill", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("origin"), "{stderr}");
+    assert!(fake.calls().is_empty());
+}
+
+#[test]
+fn unreachable_server_stops_the_run() {
+    let repo = temp_dir("recall-pc-down");
+    init_git_repo(repo.path(), "git@github.com:samzong/Recall.git");
+    let jsonl = r#"{"schema_version":5,"record_type":"session","session":{"id":"s1","source":"cursor","started_at":1},"messages":[{"seq":0,"role":"user","content":"hi"}]}"#;
+
+    let output = run_stdin_backfill(repo.path(), "http://127.0.0.1:1", jsonl);
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unreachable") || stderr.contains("Connection"), "{stderr}");
+}
+
+#[test]
+fn rejects_non_loopback_http_and_redirects() {
+    for server_url in ["http://192.168.1.9:8000", "http://localhost:8000@evil.example"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+            .args(["backfill", "--dry-run", "--stdin", "--server-url", server_url])
+            .output()
+            .unwrap();
+        assert!(!output.status.success(), "accepted {server_url}");
+    }
+
+    let repo = temp_dir("recall-pc-redirect");
+    init_git_repo(repo.path(), "https://github.com/example/repo.git");
+    let target = MockServer::start();
+    let redirect = MockServer::start_redirect(&format!("{}/v1/stats", target.url()));
+    let output = run_stdin_backfill(repo.path(), &redirect.url(), "");
+    assert!(
+        !output.status.success(),
+        "followed redirect: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn malformed_and_failed_captures_return_nonzero() {
+    let repo = temp_dir("recall-pc-server-errors");
+    init_git_repo(repo.path(), "git@github.com:samzong/Recall.git");
+    let server = MockServer::start();
+
+    for session_id in ["badresponse", "servererror"] {
+        let jsonl = format!(
+            r#"{{"schema_version":5,"record_type":"session","session":{{"id":"{session_id}","source":"codex","started_at":1}},"messages":[{{"seq":0,"role":"user","content":"hello"}}]}}"#
+        );
+        let output = run_stdin_backfill(repo.path(), &server.url(), &jsonl);
+        assert!(
+            !output.status.success(),
+            "{session_id}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+}
+
+#[test]
+fn invalid_stats_response_stops_before_capture() {
+    let repo = temp_dir("recall-pc-bad-stats");
+    init_git_repo(repo.path(), "git@github.com:samzong/Recall.git");
+    let jsonl = r#"{"schema_version":5,"record_type":"session","session":{"id":"new","source":"cursor","started_at":1},"messages":[{"seq":0,"role":"user","content":"hello"}]}"#;
+
+    for (status, body) in [(200, "{}"), (500, r#"{"error":{"code":"boom"}}"#)] {
+        let server = MockServer::start_with_stats(status, body);
+        let output = run_stdin_backfill(repo.path(), &server.url(), jsonl);
+        assert!(
+            !output.status.success(),
+            "HTTP {status}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(server.posted_ids().is_empty());
+    }
+}
+
+fn run_stdin_backfill(repo: &Path, server_url: &str, jsonl: &str) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_recall-powercontext"))
+        .current_dir(repo)
+        .args(["backfill", "--stdin", "--server-url", server_url, "--format", "json"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.as_mut().unwrap().write_all(jsonl.as_bytes()).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+struct FakeRecall {
+    _dir: TempDir,
+    script: PathBuf,
+    calls: PathBuf,
+}
+
+impl FakeRecall {
+    fn new(export_stdout: &str, export_exit_code: i32, export_stderr: &str) -> Self {
+        let dir = temp_dir("recall-pc-fake");
+        let script = dir.path().join("recall-fake.sh");
+        let calls = dir.path().join("calls.txt");
+        let stdout_path = dir.path().join("export.jsonl");
+        let stderr_path = dir.path().join("export.stderr");
+        fs::write(&stdout_path, export_stdout).unwrap();
+        fs::write(&stderr_path, export_stderr).unwrap();
+        fs::write(&calls, "").unwrap();
+        let script_body = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "{calls}"
+if [ "$1" = "export" ]; then
+  cat "{stderr_path}" >&2
+  cat "{stdout_path}"
+  exit {export_exit_code}
+fi
+echo "unexpected command: $*" >&2
+exit 99
+"#,
+            calls = calls.display(),
+            stdout_path = stdout_path.display(),
+            stderr_path = stderr_path.display(),
+            export_exit_code = export_exit_code,
+        );
+        fs::write(&script, script_body).unwrap();
+        make_executable(&script);
+        Self { _dir: dir, script, calls }
+    }
+
+    fn script_path(&self) -> &Path {
+        &self.script
+    }
+
+    fn calls(&self) -> Vec<String> {
+        fs::read_to_string(&self.calls).unwrap().lines().map(str::to_string).collect()
+    }
+}
+
+struct MockServer {
+    url: String,
+    posted: PathBuf,
+    _dir: TempDir,
+}
+
+impl MockServer {
+    fn start() -> Self {
+        Self::start_with_stats(
+            200,
+            r#"{"scope_id":"git:github.com/samzong/Recall","inventory":{"sources":{"total":5}}}"#,
+        )
+    }
+
+    fn start_with_stats(stats_status: u16, stats_body: &str) -> Self {
+        Self::start_with_stats_response(stats_status, stats_body, None)
+    }
+
+    fn start_redirect(location: &str) -> Self {
+        Self::start_with_stats_response(302, "", Some(location))
+    }
+
+    fn start_with_stats_response(
+        stats_status: u16,
+        stats_body: &str,
+        stats_location: Option<&str>,
+    ) -> Self {
+        let dir = temp_dir("recall-pc-http");
+        let posted = dir.path().join("posted.txt");
+        fs::write(&posted, "").unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let posted_for_thread = posted.clone();
+        let stats_body = stats_body.to_string();
+        let stats_location = stats_location.map(str::to_string);
+        thread::spawn(move || {
+            for incoming in listener.incoming() {
+                let Ok(mut stream) = incoming else {
+                    continue;
+                };
+                let Ok(request) = read_http_request(&mut stream) else {
+                    continue;
+                };
+                let is_stats = request.starts_with("GET /v1/stats");
+                let (status, body) = if is_stats {
+                    (stats_status, stats_body.clone())
+                } else if request.starts_with("POST /v1/sources/content") {
+                    let source_id = request
+                        .split("\"source_id\":\"")
+                        .nth(1)
+                        .and_then(|rest| rest.split('"').next())
+                        .unwrap_or("")
+                        .to_string();
+                    let mut file =
+                        fs::OpenOptions::new().append(true).open(&posted_for_thread).unwrap();
+                    writeln!(file, "{source_id}").unwrap();
+                    match source_id.as_str() {
+                        "recall:cursor:new:0" => (
+                            202,
+                            r#"{"status":"accepted","source":{"name":"content","source_id":"recall:cursor:new:0"},"position":6}"#.to_string(),
+                        ),
+                        "recall:codex:old:0" => (
+                            202,
+                            r#"{"status":"accepted","source":{"name":"content","source_id":"recall:codex:old:0"},"position":3}"#.to_string(),
+                        ),
+                        "recall:opencode:changed:0" => (
+                            409,
+                            r#"{"error":{"code":"source_conflict","message":"The Source identity has different content.","details":null}}"#.to_string(),
+                        ),
+                        "recall:codex:badresponse:0" => (202, "{}".to_string()),
+                        "recall:codex:servererror:0" => (
+                            500,
+                            r#"{"error":{"code":"boom","message":"server error"}}"#.to_string(),
+                        ),
+                        other => (
+                            500,
+                            format!(r#"{{"error":{{"code":"unexpected","message":"{other}"}}}}"#),
+                        ),
+                    }
+                } else {
+                    (404, r#"{"error":{"code":"not_found"}}"#.to_string())
+                };
+                let headers = if is_stats {
+                    stats_location
+                        .as_ref()
+                        .map(|location| format!("Location: {location}\r\n"))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        Self { url: format!("http://127.0.0.1:{}", addr.port()), posted, _dir: dir }
+    }
+
+    fn url(&self) -> String {
+        self.url.clone()
+    }
+
+    fn posted_ids(&self) -> Vec<String> {
+        fs::read_to_string(&self.posted).unwrap().lines().map(str::to_string).collect()
+    }
+}
+
+fn bind_workstream_scope(path: &Path, scope_id: &str) {
+    let state_dir = path.join(".git/powercontext");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("codex-workspace.json"),
+        format!(r#"{{"schema":"powercontext.codex-workspace.v1","scope_id":"{scope_id}"}}"#),
+    )
+    .unwrap();
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> std::io::Result<String> {
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(2)))?;
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 2048];
+    loop {
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(header_end) = find_double_crlf(&buf) {
+            let content_len = content_length(&buf[..header_end]).unwrap_or(0);
+            if buf.len() >= header_end + content_len {
+                break;
+            }
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|window| window == b"\r\n\r\n").map(|idx| idx + 4)
+}
+
+fn content_length(headers: &[u8]) -> Option<usize> {
+    let headers = std::str::from_utf8(headers).ok()?;
+    headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        if name.eq_ignore_ascii_case("content-length") { value.trim().parse().ok() } else { None }
+    })
+}
+
+fn temp_dir(prefix: &str) -> TempDir {
+    tempfile::Builder::new().prefix(prefix).tempdir().unwrap()
+}
+
+fn init_git_repo(path: &Path, origin: &str) {
+    let output = Command::new("git")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .args(["init", "--quiet"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git init stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if origin.is_empty() {
+        return;
+    }
+    let output = Command::new("git")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .args(["remote", "add", "origin", origin])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git remote stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}


### PR DESCRIPTION
### What's changed?

- Add the official `recall-powercontext` extension for backfilling Recall sessions into PowerContext Content Sources.
- Derive project scope from sanitized Git remote identities while keeping PowerContext workstream bindings separate.
- Provide human-readable and JSON reports with imported, skipped, conflict, and failure accounting.

### Why

- Make PowerContext backfill available through Recall's managed extension model.
- Keep Recall access on the stable CLI JSONL protocol with an explicit project selector.

### Verification

- `make check`
- Real `recall-powercontext backfill --dry-run` against local Recall data