### PR TITLE
fix(rx): update help status and OpenCode model flags

### DIFF
--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -58,13 +58,19 @@ pub(crate) enum ModelsCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UpdateCommand {
+    Help,
+    Run { yes: bool },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Command {
     Help,
     Version,
     Launch(LaunchRequest),
     PickHarness { provider: Option<String> },
     Providers(ProvidersCommand),
-    Update { yes: bool },
+    Update(UpdateCommand),
 }
 
 pub(crate) fn rewrite_argv0(mut args: Vec<String>) -> Vec<String> {
@@ -108,7 +114,7 @@ pub(crate) fn parse(args: &[String]) -> Result<Command> {
             if provider.is_some() {
                 bail!("--provider is not valid with rx update");
             }
-            Ok(Command::Update { yes: parse_update_args(&rest[1..])? })
+            Ok(Command::Update(parse_update(&rest[1..])?))
         }
         Some(name) => {
             let Some(harness) = Harness::parse(name) else {
@@ -201,17 +207,18 @@ fn extract_provider(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
     Ok((provider, rest))
 }
 
+fn parse_update(args: &[String]) -> Result<UpdateCommand> {
+    match args.first().map(String::as_str) {
+        Some("-h" | "--help") if args.len() == 1 => Ok(UpdateCommand::Help),
+        _ => Ok(UpdateCommand::Run { yes: parse_update_args(args)? }),
+    }
+}
+
 fn parse_update_args(args: &[String]) -> Result<bool> {
     let mut yes = false;
     for arg in args {
         match arg.as_str() {
             "--yes" | "-y" => yes = true,
-            "-h" | "--help" => {
-                bail!(
-                    "usage: rx update [--yes]\n\n\
-                     Download and install the latest rx from GitHub releases."
-                );
-            }
             other => bail!("unexpected argument: {other}\n\nusage: rx update [--yes]"),
         }
     }

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -486,7 +486,9 @@ fn auth_override(env_key: &str) -> String {
 }
 
 fn user_sets_opencode_model(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| arg == "-m" || arg.starts_with("-m="))
+    passthrough.iter().any(|arg| {
+        arg == "-m" || arg.starts_with("-m=") || arg == "--model" || arg.starts_with("--model=")
+    })
 }
 
 fn user_sets_model(passthrough: &[String]) -> bool {

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result
             Ok(())
         }
         Command::Providers(command) => providers::run(command, paths, env),
-        Command::Update { yes } => update::run(yes),
+        Command::Update(command) => update::run(command),
         Command::PickHarness { provider } => {
             let Some(harness) = pick::harness(env)? else {
                 return Ok(());

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -7,7 +7,8 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 
 use crate::args::{
-    Command, Harness, LaunchRequest, ModelsCommand, ProvidersCommand, parse, rewrite_argv0,
+    Command, Harness, LaunchRequest, ModelsCommand, ProvidersCommand, UpdateCommand, parse,
+    rewrite_argv0,
 };
 use crate::config::{self, Paths};
 use crate::launch::{self, EnvLookup};
@@ -205,8 +206,11 @@ fn rx_help_and_version() {
 
 #[test]
 fn update_parses_yes_flag() {
-    assert_eq!(parse_line(&["rx", "update"]), Command::Update { yes: false });
-    assert_eq!(parse_line(&["rx", "update", "--yes"]), Command::Update { yes: true });
+    assert_eq!(parse_line(&["rx", "update"]), Command::Update(UpdateCommand::Run { yes: false }));
+    assert_eq!(
+        parse_line(&["rx", "update", "--yes"]),
+        Command::Update(UpdateCommand::Run { yes: true })
+    );
 }
 
 #[test]

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
+use crate::args::UpdateCommand;
 use crate::config::Paths;
 use crate::launch::EnvLookup;
 
@@ -32,7 +33,24 @@ pub(crate) struct UpdateState {
     last_check: Option<String>,
 }
 
-pub(crate) fn run(yes: bool) -> Result<()> {
+pub(crate) fn help() -> &'static str {
+    concat!(
+        "usage: rx update [--yes]\n\n",
+        "Download and install the latest rx from GitHub releases.\n",
+    )
+}
+
+pub(crate) fn run(command: UpdateCommand) -> Result<()> {
+    match command {
+        UpdateCommand::Help => {
+            print!("{}", help());
+            Ok(())
+        }
+        UpdateCommand::Run { yes } => install(yes),
+    }
+}
+
+fn install(yes: bool) -> Result<()> {
     let current = crate::RELEASE_VERSION;
     let release = fetch_latest_release()?;
     if !update_pending(current, &release) {


### PR DESCRIPTION
### What's changed?

- `rx update -h` / `--help` prints update usage and exits 0.
- OpenCode launch honors `--model` and `--model=` instead of injecting a second `-m`.

### Why

- Subcommand help was reported as a command failure.
- OpenCode's documented long-form model flags were ignored.
- `rx config set key` no longer exists; empty-key rejection is handled by `rx providers login`.

Fixes #155
Fixes #156
Fixes #160