### PR TITLE
fix(rx): ignore option detectors after --

### DIFF
--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -173,6 +173,13 @@ fn parse_provider_argument(command: &str, args: &[String]) -> Result<Option<Stri
     Ok(args.first().cloned())
 }
 
+pub(crate) fn before_double_dash(args: &[String]) -> &[String] {
+    match args.iter().position(|arg| arg == "--") {
+        Some(index) => &args[..index],
+        None => args,
+    }
+}
+
 fn extract_provider(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
     let mut provider = None;
     let mut rest = Vec::new();

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -9,6 +9,7 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::args;
 use crate::catalog::{self, ListedModel};
 use crate::config::Paths;
 use crate::launch::EnvLookup;
@@ -304,7 +305,7 @@ pub(crate) fn claude_settings_json(base_url: &str, seeded: bool, api_key_env: &s
 }
 
 pub(crate) fn user_passes_settings(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| {
+    args::before_double_dash(passthrough).iter().any(|arg| {
         arg == "--settings"
             || arg == "--setting-sources"
             || arg.starts_with("--settings=")

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Result, bail};
 
-use crate::args::{Harness, LaunchRequest};
+use crate::args::{self, Harness, LaunchRequest};
 use crate::catalog;
 use crate::claude_catalog::{self, SeedOutcome};
 use crate::config::{AuthMode, Paths};
@@ -486,12 +486,13 @@ fn auth_override(env_key: &str) -> String {
 }
 
 fn user_sets_opencode_model(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| {
+    args::before_double_dash(passthrough).iter().any(|arg| {
         arg == "-m" || arg.starts_with("-m=") || arg == "--model" || arg.starts_with("--model=")
     })
 }
 
 fn user_sets_model(passthrough: &[String]) -> bool {
+    let passthrough = args::before_double_dash(passthrough);
     let mut i = 0;
     while i < passthrough.len() {
         let arg = &passthrough[i];

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
+use crate::args;
 use crate::catalog;
 use crate::config::Paths;
 use crate::launch::{EnvLookup, openai_base};
@@ -105,11 +106,15 @@ pub(crate) fn args(provider_id: &str, model: Option<&str>, passthrough: &[String
 }
 
 fn user_sets_models_flag(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| arg == "--models" || arg.starts_with("--models="))
+    args::before_double_dash(passthrough)
+        .iter()
+        .any(|arg| arg == "--models" || arg.starts_with("--models="))
 }
 
 fn user_sets_provider(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| arg == "--provider" || arg.starts_with("--provider="))
+    args::before_double_dash(passthrough)
+        .iter()
+        .any(|arg| arg == "--provider" || arg.starts_with("--provider="))
 }
 
 fn generated_provider(
@@ -179,5 +184,7 @@ fn write_json_atomic(path: &Path, document: &Value) -> Result<()> {
 }
 
 fn user_sets_model(passthrough: &[String]) -> bool {
-    passthrough.iter().any(|arg| arg == "-m" || arg == "--model" || arg.starts_with("--model="))
+    args::before_double_dash(passthrough)
+        .iter()
+        .any(|arg| arg == "-m" || arg == "--model" || arg.starts_with("--model="))
 }


### PR DESCRIPTION
### What's changed?

- Model, settings, `--models`, and `--provider` detectors now ignore arguments after `--`.

### Why

- A value after `--` belongs to the child harness. Treating it as an rx option suppressed model or settings injection.

Fixes #161