### PR TITLE
fix(rx): preserve non-UTF-8 arguments and executable paths

### DIFF
--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -1,3 +1,4 @@
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 use anyhow::{Result, bail};
@@ -38,7 +39,7 @@ impl Harness {
 pub(crate) struct LaunchRequest {
     pub harness: Harness,
     pub provider: Option<String>,
-    pub passthrough: Vec<String>,
+    pub passthrough: Vec<OsString>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,20 +74,19 @@ pub(crate) enum Command {
     Update(UpdateCommand),
 }
 
-pub(crate) fn rewrite_argv0(mut args: Vec<String>) -> Vec<String> {
+pub(crate) fn rewrite_argv0(mut args: Vec<OsString>) -> Vec<OsString> {
     let Some(argv0) = args.first() else {
         return args;
     };
     let Some(harness) = argv0_harness(argv0) else {
         return args;
     };
-    args.insert(1, harness.to_string());
+    args.insert(1, OsString::from(harness));
     args
 }
 
-/// Harness implied by an invoked alias such as `rxc`; `None` for plain `rx`.
-pub(crate) fn argv0_harness(argv0: &str) -> Option<&'static str> {
-    let name = Path::new(argv0).file_stem().and_then(|stem| stem.to_str()).unwrap_or("");
+pub(crate) fn argv0_harness(argv0: impl AsRef<OsStr>) -> Option<&'static str> {
+    let name = Path::new(argv0.as_ref()).file_stem().and_then(|stem| stem.to_str()).unwrap_or("");
     match name {
         "rxc" => Some("claude"),
         "rxx" => Some("codex"),
@@ -97,11 +97,22 @@ pub(crate) fn argv0_harness(argv0: &str) -> Option<&'static str> {
     }
 }
 
-pub(crate) fn parse(args: &[String]) -> Result<Command> {
+pub(crate) fn os_prefix(arg: impl AsRef<OsStr>, prefix: &str) -> bool {
+    arg.as_ref().as_encoded_bytes().starts_with(prefix.as_bytes())
+}
+
+pub(crate) fn parse(args: &[OsString]) -> Result<Command> {
     let rest = args.get(1..).unwrap_or(&[]);
     let (provider, rest) = extract_provider(rest)?;
-    match rest.first().map(String::as_str) {
-        None => Ok(Command::PickHarness { provider }),
+    match rest.first().and_then(|arg| arg.to_str()) {
+        None if rest.is_empty() => Ok(Command::PickHarness { provider }),
+        None => {
+            bail!(
+                "unknown harness: {}\n\n{}",
+                rest[0].to_string_lossy(),
+                crate::help_text().trim_end()
+            )
+        }
         Some("-h" | "--help") => Ok(Command::Help),
         Some("-V" | "--version") => Ok(Command::Version),
         Some("providers") => {
@@ -129,9 +140,10 @@ pub(crate) fn parse(args: &[String]) -> Result<Command> {
     }
 }
 
-fn parse_providers(args: &[String]) -> Result<ProvidersCommand> {
-    match args.first().map(String::as_str) {
-        None | Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ProvidersCommand::Help),
+fn parse_providers(args: &[OsString]) -> Result<ProvidersCommand> {
+    match args.first().and_then(|arg| arg.to_str()) {
+        None if args.is_empty() => Ok(ProvidersCommand::Help),
+        Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ProvidersCommand::Help),
         Some("list") if args.len() == 1 => Ok(ProvidersCommand::List),
         Some("models") => Ok(ProvidersCommand::Models(parse_models(&args[1..])?)),
         Some(command @ ("login" | "logout" | "use")) => {
@@ -146,13 +158,20 @@ fn parse_providers(args: &[String]) -> Result<ProvidersCommand> {
         Some(command) => {
             bail!("unknown providers command: {command}\n\n{}", crate::providers::help())
         }
-        None => unreachable!(),
+        None => {
+            bail!(
+                "unknown providers command: {}\n\n{}",
+                args[0].to_string_lossy(),
+                crate::providers::help()
+            )
+        }
     }
 }
 
-fn parse_models(args: &[String]) -> Result<ModelsCommand> {
-    match args.first().map(String::as_str) {
-        None | Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ModelsCommand::Help),
+fn parse_models(args: &[OsString]) -> Result<ModelsCommand> {
+    match args.first().and_then(|arg| arg.to_str()) {
+        None if args.is_empty() => Ok(ModelsCommand::Help),
+        Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ModelsCommand::Help),
         Some("update") => Ok(ModelsCommand::Update {
             provider: parse_provider_argument("models update", &args[1..])?,
         }),
@@ -162,25 +181,37 @@ fn parse_models(args: &[String]) -> Result<ModelsCommand> {
                 crate::providers::models_help()
             )
         }
-        None => unreachable!(),
+        None => {
+            bail!(
+                "unknown providers models command: {}\n\n{}",
+                args[0].to_string_lossy(),
+                crate::providers::models_help()
+            )
+        }
     }
 }
 
-fn parse_provider_argument(command: &str, args: &[String]) -> Result<Option<String>> {
+fn parse_provider_argument(command: &str, args: &[OsString]) -> Result<Option<String>> {
     if args.len() > 1 {
         bail!("usage: rx providers {command} [provider]");
     }
-    Ok(args.first().cloned())
+    let Some(arg) = args.first() else {
+        return Ok(None);
+    };
+    let Some(provider) = arg.to_str() else {
+        bail!("usage: rx providers {command} [provider]");
+    };
+    Ok(Some(provider.to_string()))
 }
 
-pub(crate) fn before_double_dash(args: &[String]) -> &[String] {
+pub(crate) fn before_double_dash(args: &[OsString]) -> &[OsString] {
     match args.iter().position(|arg| arg == "--") {
         Some(index) => &args[..index],
         None => args,
     }
 }
 
-fn extract_provider(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
+fn extract_provider(args: &[OsString]) -> Result<(Option<String>, Vec<OsString>)> {
     let mut provider = None;
     let mut rest = Vec::new();
     let mut i = 0;
@@ -196,11 +227,17 @@ fn extract_provider(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
         if !raw && arg == "--provider" {
             let value =
                 args.get(i + 1).ok_or_else(|| anyhow::anyhow!("--provider requires a value"))?;
-            provider = Some(value.clone());
+            let Some(value) = value.to_str() else {
+                bail!("--provider requires a value");
+            };
+            provider = Some(value.to_string());
             i += 2;
             continue;
         }
-        if !raw && let Some(value) = arg.strip_prefix("--provider=") {
+        if !raw && os_prefix(arg, "--provider=") {
+            let Some(value) = arg.to_str().and_then(|arg| arg.strip_prefix("--provider=")) else {
+                bail!("--provider requires a value");
+            };
             if value.is_empty() {
                 bail!("--provider requires a value");
             }
@@ -214,19 +251,22 @@ fn extract_provider(args: &[String]) -> Result<(Option<String>, Vec<String>)> {
     Ok((provider, rest))
 }
 
-fn parse_update(args: &[String]) -> Result<UpdateCommand> {
-    match args.first().map(String::as_str) {
+fn parse_update(args: &[OsString]) -> Result<UpdateCommand> {
+    match args.first().and_then(|arg| arg.to_str()) {
         Some("-h" | "--help") if args.len() == 1 => Ok(UpdateCommand::Help),
         _ => Ok(UpdateCommand::Run { yes: parse_update_args(args)? }),
     }
 }
 
-fn parse_update_args(args: &[String]) -> Result<bool> {
+fn parse_update_args(args: &[OsString]) -> Result<bool> {
     let mut yes = false;
     for arg in args {
-        match arg.as_str() {
-            "--yes" | "-y" => yes = true,
-            other => bail!("unexpected argument: {other}\n\nusage: rx update [--yes]"),
+        match arg.to_str() {
+            Some("--yes" | "-y") => yes = true,
+            Some(other) => bail!("unexpected argument: {other}\n\nusage: rx update [--yes]"),
+            None => {
+                bail!("unexpected argument: {}\n\nusage: rx update [--yes]", arg.to_string_lossy())
+            }
         }
     }
     Ok(yes)

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -304,12 +304,12 @@ pub(crate) fn claude_settings_json(base_url: &str, seeded: bool, api_key_env: &s
     .expect("settings json serializes")
 }
 
-pub(crate) fn user_passes_settings(passthrough: &[String]) -> bool {
+pub(crate) fn user_passes_settings(passthrough: &[std::ffi::OsString]) -> bool {
     args::before_double_dash(passthrough).iter().any(|arg| {
         arg == "--settings"
             || arg == "--setting-sources"
-            || arg.starts_with("--settings=")
-            || arg.starts_with("--setting-sources=")
+            || args::os_prefix(arg, "--settings=")
+            || args::os_prefix(arg, "--setting-sources=")
     })
 }
 

--- a/crates/rx/src/dsh.rs
+++ b/crates/rx/src/dsh.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -52,20 +53,20 @@ pub(crate) fn official_deepseek(provider_id: &str) -> bool {
     provider_id == "deepseek"
 }
 
-pub(crate) fn args(passthrough: &[String], patch: Option<&Path>) -> Vec<String> {
+pub(crate) fn args(passthrough: &[OsString], patch: Option<&Path>) -> Vec<OsString> {
     if passthrough.first().is_some_and(|arg| arg == "plugin") {
         return passthrough.to_vec();
     }
     let mut args = Vec::new();
     if passthrough.first().is_some_and(|arg| arg == "web") {
-        args.push("web".to_string());
+        args.push(OsString::from("web"));
         push_patch(&mut args, patch);
         args.extend(passthrough.iter().skip(1).cloned());
         return args;
     }
     if !has_profile(passthrough) {
-        args.push("--profile".to_string());
-        args.push(PROFILE.to_string());
+        args.push(OsString::from("--profile"));
+        args.push(OsString::from(PROFILE));
     }
     push_patch(&mut args, patch);
     args.extend(passthrough.iter().cloned());
@@ -256,21 +257,21 @@ fn write_bytes_atomic(path: &Path, payload: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn push_patch(args: &mut Vec<String>, patch: Option<&Path>) {
+fn push_patch(args: &mut Vec<OsString>, patch: Option<&Path>) {
     if let Some(path) = patch {
-        args.push("--patch".to_string());
-        args.push(path.display().to_string());
+        args.push(OsString::from("--patch"));
+        args.push(path.as_os_str().to_os_string());
     }
 }
 
-fn has_profile(args: &[String]) -> bool {
+fn has_profile(args: &[OsString]) -> bool {
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
         if arg == "--" || arg == "web" || arg == "plugin" {
             return false;
         }
-        if arg == "--profile" || arg.starts_with("--profile=") {
+        if arg == "--profile" || crate::args::os_prefix(arg, "--profile=") {
             return true;
         }
         if arg == "--patch" {
@@ -317,25 +318,26 @@ mod tests {
         );
     }
 
+    fn os(argv: &[&str]) -> Vec<OsString> {
+        argv.iter().map(|arg| OsString::from(*arg)).collect()
+    }
+
     #[test]
     fn default_args_boot_tui_profile() {
-        assert_eq!(args(&[], None), vec!["--profile", PROFILE]);
-        assert_eq!(args(&["--resume".to_string()], None), vec!["--profile", PROFILE, "--resume"]);
+        assert_eq!(args(&[], None), os(&["--profile", PROFILE]));
+        assert_eq!(args(&os(&["--resume"]), None), os(&["--profile", PROFILE, "--resume"]));
     }
 
     #[test]
     fn keeps_explicit_profile_and_web() {
         assert_eq!(
-            args(&["--profile".to_string(), "headless".to_string(), "job".to_string()], None),
-            vec!["--profile", "headless", "job"]
+            args(&os(&["--profile", "headless", "job"]), None),
+            os(&["--profile", "headless", "job"])
         );
+        assert_eq!(args(&os(&["web", "--port", "8080"]), None), os(&["web", "--port", "8080"]));
         assert_eq!(
-            args(&["web".to_string(), "--port".to_string(), "8080".to_string()], None),
-            vec!["web", "--port", "8080"]
-        );
-        assert_eq!(
-            args(&["plugin".to_string(), "--profile".to_string(), PROFILE.to_string()], None),
-            vec!["plugin", "--profile", PROFILE]
+            args(&os(&["plugin", "--profile", PROFILE]), None),
+            os(&["plugin", "--profile", PROFILE])
         );
     }
 
@@ -343,12 +345,12 @@ mod tests {
     fn patch_follows_web_subcommand() {
         let patch = PathBuf::from("/tmp/rx.cordis.yml");
         assert_eq!(
-            args(&["web".to_string()], Some(&patch)),
-            vec!["web", "--patch", "/tmp/rx.cordis.yml"]
+            args(&os(&["web"]), Some(&patch)),
+            os(&["web", "--patch", "/tmp/rx.cordis.yml"])
         );
         assert_eq!(
             args(&[], Some(&patch)),
-            vec!["--profile", PROFILE, "--patch", "/tmp/rx.cordis.yml"]
+            os(&["--profile", PROFILE, "--patch", "/tmp/rx.cordis.yml"])
         );
     }
 }

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Result, bail};
@@ -41,8 +43,8 @@ impl EnvLookup {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchPlan {
-    pub program: String,
-    pub args: Vec<String>,
+    pub program: PathBuf,
+    pub args: Vec<OsString>,
     pub env_set: Vec<(String, String)>,
     pub stderr_note: Option<String>,
 }
@@ -140,7 +142,7 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
 
 fn passthrough(request: &LaunchRequest) -> LaunchPlan {
     LaunchPlan {
-        program: request.harness.as_str().to_string(),
+        program: PathBuf::from(request.harness.as_str()),
         args: match request.harness {
             Harness::Dsh => crate::dsh::args(&request.passthrough, None),
             _ => request.passthrough.clone(),
@@ -217,8 +219,15 @@ fn inject_claude_openrouter_impl(
     let seeded = matches!(seed, SeedOutcome::Seeded { .. });
     let mut args = request.passthrough.clone();
     if seeded && !claude_catalog::user_passes_settings(&request.passthrough) {
-        args.insert(0, claude_catalog::claude_settings_json(base_url, true, "OPENROUTER_API_KEY"));
-        args.insert(0, "--settings".to_string());
+        args.insert(
+            0,
+            OsString::from(claude_catalog::claude_settings_json(
+                base_url,
+                true,
+                "OPENROUTER_API_KEY",
+            )),
+        );
+        args.insert(0, OsString::from("--settings"));
     }
     let stderr_note = match seed {
         SeedOutcome::Fallback => Some(
@@ -228,7 +237,7 @@ fn inject_claude_openrouter_impl(
         SeedOutcome::Seeded { .. } => None,
     };
     LaunchPlan {
-        program: "claude".to_string(),
+        program: PathBuf::from("claude"),
         args,
         env_set: claude_openrouter_env(base_url, key, model, seeded),
         stderr_note,
@@ -293,11 +302,14 @@ fn inject_claude_generated_seeded(
 ) -> LaunchPlan {
     let mut args = request.passthrough.clone();
     if !claude_catalog::user_passes_settings(&request.passthrough) {
-        args.insert(0, claude_catalog::claude_settings_json(base_url, true, env_key));
-        args.insert(0, "--settings".to_string());
+        args.insert(
+            0,
+            OsString::from(claude_catalog::claude_settings_json(base_url, true, env_key)),
+        );
+        args.insert(0, OsString::from("--settings"));
     }
     LaunchPlan {
-        program: "claude".to_string(),
+        program: PathBuf::from("claude"),
         args,
         env_set: claude_generated_seeded_env(env_key, base_url, key, model),
         stderr_note: None,
@@ -374,7 +386,7 @@ fn inject(
     let key = target.key.as_str();
     match request.harness {
         Harness::Claude => Ok(LaunchPlan {
-            program: "claude".to_string(),
+            program: PathBuf::from("claude"),
             args: request.passthrough.clone(),
             env_set: claude_env(&provider.env, &target.claude_url, key, model),
             stderr_note: None,
@@ -382,16 +394,19 @@ fn inject(
         Harness::Codex => {
             let openai_base = openai_base(base_url);
             let mut args = vec![
-                "-c".to_string(),
-                format!("model_provider=\"{provider_id}\""),
-                "-c".to_string(),
-                codex_provider_override(provider_id, provider, &openai_base),
+                OsString::from("-c"),
+                OsString::from(format!("model_provider=\"{provider_id}\"")),
+                OsString::from("-c"),
+                OsString::from(codex_provider_override(provider_id, provider, &openai_base)),
             ];
             if env.is_real() {
                 match catalog::prepare_codex_catalog(paths, provider_id, base_url, key) {
                     Ok(Some(path)) => {
-                        args.push("-c".to_string());
-                        args.push(format!("model_catalog_json=\"{}\"", path.display()));
+                        args.push(OsString::from("-c"));
+                        args.push(OsString::from(format!(
+                            "model_catalog_json=\"{}\"",
+                            path.display()
+                        )));
                     }
                     Ok(None) => {}
                     Err(error) => {
@@ -400,12 +415,12 @@ fn inject(
                 }
             }
             if let Some(model) = model.filter(|_| !user_sets_model(&request.passthrough)) {
-                args.push("-c".to_string());
-                args.push(format!("model=\"{model}\""));
+                args.push(OsString::from("-c"));
+                args.push(OsString::from(format!("model=\"{model}\"")));
             }
             args.extend(request.passthrough.iter().cloned());
             Ok(LaunchPlan {
-                program: "codex".to_string(),
+                program: PathBuf::from("codex"),
                 args,
                 env_set: vec![(provider.env.clone(), key.to_string())],
                 stderr_note: None,
@@ -428,11 +443,11 @@ fn inject(
             ));
             let mut args = request.passthrough.clone();
             if let Some(model) = model.filter(|_| !user_sets_opencode_model(&request.passthrough)) {
-                args.insert(0, crate::opencode::prefixed_model(provider_id, model));
-                args.insert(0, "-m".to_string());
+                args.insert(0, OsString::from(crate::opencode::prefixed_model(provider_id, model)));
+                args.insert(0, OsString::from("-m"));
             }
             Ok(LaunchPlan {
-                program: "opencode".to_string(),
+                program: PathBuf::from("opencode"),
                 args,
                 env_set,
                 stderr_note: crate::opencode::auth_conflict_note(provider, key, env),
@@ -443,7 +458,7 @@ fn inject(
                 if provider.setup == Setup::Generated { provider_id } else { provider.id.as_str() };
             crate::pi::prepare(provider_id, provider, base_url, key, paths, env)?;
             Ok(LaunchPlan {
-                program: "pi".to_string(),
+                program: PathBuf::from("pi"),
                 args: crate::pi::args(provider_id, model, &request.passthrough),
                 env_set: crate::pi::env_set(&provider.env, key),
                 stderr_note: None,
@@ -453,7 +468,7 @@ fn inject(
             let patch =
                 crate::dsh::prepare(provider_id, provider, base_url, key, model, paths, env)?;
             Ok(LaunchPlan {
-                program: "dsh".to_string(),
+                program: PathBuf::from("dsh"),
                 args: crate::dsh::args(&request.passthrough, Some(&patch)),
                 env_set: crate::dsh::env_set(provider_id, provider, key),
                 stderr_note: None,
@@ -485,13 +500,16 @@ fn auth_override(env_key: &str) -> String {
     }
 }
 
-fn user_sets_opencode_model(passthrough: &[String]) -> bool {
+fn user_sets_opencode_model(passthrough: &[OsString]) -> bool {
     args::before_double_dash(passthrough).iter().any(|arg| {
-        arg == "-m" || arg.starts_with("-m=") || arg == "--model" || arg.starts_with("--model=")
+        arg == "-m"
+            || args::os_prefix(arg, "-m=")
+            || arg == "--model"
+            || args::os_prefix(arg, "--model=")
     })
 }
 
-fn user_sets_model(passthrough: &[String]) -> bool {
+fn user_sets_model(passthrough: &[OsString]) -> bool {
     let passthrough = args::before_double_dash(passthrough);
     let mut i = 0;
     while i < passthrough.len() {
@@ -499,11 +517,11 @@ fn user_sets_model(passthrough: &[String]) -> bool {
         if arg == "-m" || arg == "--model" {
             return true;
         }
-        if arg.starts_with("--model=") {
+        if args::os_prefix(arg, "--model=") {
             return true;
         }
         if arg == "-c" || arg == "--config" {
-            if passthrough.get(i + 1).is_some_and(|value| value.starts_with("model=")) {
+            if passthrough.get(i + 1).is_some_and(|value| args::os_prefix(value, "model=")) {
                 return true;
             }
             i += 1;
@@ -525,14 +543,15 @@ pub(crate) fn exec(plan: &LaunchPlan) -> Result<()> {
     {
         use std::os::unix::process::CommandExt;
         let error = cmd.exec();
-        Err(anyhow::Error::from(error).context(format!("failed to exec {}", plan.program)))
+        Err(anyhow::Error::from(error)
+            .context(format!("failed to exec {}", plan.program.display())))
     }
 
     #[cfg(not(unix))]
     {
         let status = cmd.status()?;
         if !status.success() {
-            anyhow::bail!("{} exited with status {status}", plan.program);
+            anyhow::bail!("{} exited with status {status}", plan.program.display());
         }
         Ok(())
     }

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -12,6 +12,8 @@ mod provider;
 mod providers;
 mod update;
 
+use std::ffi::OsString;
+
 use anyhow::Result;
 
 use args::{Command, LaunchRequest, argv0_harness, parse, rewrite_argv0};
@@ -20,11 +22,11 @@ use launch::{EnvLookup, plan};
 
 pub(crate) const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn run(raw_args: impl IntoIterator<Item = String>) -> Result<()> {
-    run_with(raw_args.into_iter().collect(), &Paths::user()?, &EnvLookup::real())
+pub fn run(raw_args: impl IntoIterator<Item = impl Into<OsString>>) -> Result<()> {
+    run_with(raw_args.into_iter().map(Into::into).collect(), &Paths::user()?, &EnvLookup::real())
 }
 
-pub fn run_with(raw_args: Vec<String>, paths: &Paths, env: &EnvLookup) -> Result<()> {
+pub fn run_with(raw_args: Vec<OsString>, paths: &Paths, env: &EnvLookup) -> Result<()> {
     let command = if raw_args.first().and_then(|argv0| argv0_harness(argv0)).is_some() {
         parse(&rewrite_argv0(raw_args.clone()))?
     } else {
@@ -60,7 +62,7 @@ fn launch_request(
     request: LaunchRequest,
     paths: &Paths,
     env: &EnvLookup,
-    raw_args: &[String],
+    raw_args: &[OsString],
 ) -> Result<()> {
     // Updating is incidental to launching: a broken state file, an
     // unwritable config dir, or a failed install must not stop the harness.
@@ -69,7 +71,7 @@ fn launch_request(
     }
     let program = install::ensure(request.harness, env)?;
     let mut plan = plan(&request, paths, env)?;
-    plan.program = program.to_string_lossy().into_owned();
+    plan.program = program;
     if let Some(note) = &plan.stderr_note {
         eprintln!("{note}");
     }

--- a/crates/rx/src/main.rs
+++ b/crates/rx/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if let Err(error) = rx::run(std::env::args()) {
+    if let Err(error) = rx::run(std::env::args_os()) {
         eprintln!("{error:#}");
         std::process::exit(1);
     }

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -89,33 +90,37 @@ pub(crate) fn env_set(env_key: &str, key: &str) -> Vec<(String, String)> {
     env_set
 }
 
-pub(crate) fn args(provider_id: &str, model: Option<&str>, passthrough: &[String]) -> Vec<String> {
+pub(crate) fn args(
+    provider_id: &str,
+    model: Option<&str>,
+    passthrough: &[OsString],
+) -> Vec<OsString> {
     let mut args = Vec::new();
     if !user_sets_models_flag(passthrough) {
-        args.push("--models".to_string());
-        args.push(format!("{provider_id}/*"));
+        args.push(OsString::from("--models"));
+        args.push(OsString::from(format!("{provider_id}/*")));
     }
     if let Some(model) = model.filter(|_| !user_sets_model(passthrough)) {
-        args.push("--model".to_string());
-        args.push(opencode::prefixed_model(provider_id, model));
+        args.push(OsString::from("--model"));
+        args.push(OsString::from(opencode::prefixed_model(provider_id, model)));
     } else if !user_sets_provider(passthrough) {
-        args.push("--provider".to_string());
-        args.push(provider_id.to_string());
+        args.push(OsString::from("--provider"));
+        args.push(OsString::from(provider_id));
     }
     args.extend(passthrough.iter().cloned());
     args
 }
 
-fn user_sets_models_flag(passthrough: &[String]) -> bool {
+fn user_sets_models_flag(passthrough: &[OsString]) -> bool {
     args::before_double_dash(passthrough)
         .iter()
-        .any(|arg| arg == "--models" || arg.starts_with("--models="))
+        .any(|arg| arg == "--models" || args::os_prefix(arg, "--models="))
 }
 
-fn user_sets_provider(passthrough: &[String]) -> bool {
+fn user_sets_provider(passthrough: &[OsString]) -> bool {
     args::before_double_dash(passthrough)
         .iter()
-        .any(|arg| arg == "--provider" || arg.starts_with("--provider="))
+        .any(|arg| arg == "--provider" || args::os_prefix(arg, "--provider="))
 }
 
 fn generated_provider(
@@ -202,8 +207,8 @@ fn write_json_atomic(path: &Path, document: &Value) -> Result<()> {
     Ok(())
 }
 
-fn user_sets_model(passthrough: &[String]) -> bool {
+fn user_sets_model(passthrough: &[OsString]) -> bool {
     args::before_double_dash(passthrough)
         .iter()
-        .any(|arg| arg == "-m" || arg == "--model" || arg.starts_with("--model="))
+        .any(|arg| arg == "-m" || arg == "--model" || args::os_prefix(arg, "--model="))
 }

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
@@ -13,8 +14,16 @@ use crate::args::{
 use crate::config::{self, Paths};
 use crate::launch::{self, EnvLookup};
 
-fn args(argv: &[&str]) -> Vec<String> {
-    argv.iter().map(|arg| (*arg).to_string()).collect()
+fn args(argv: &[&str]) -> Vec<OsString> {
+    argv.iter().map(|arg| OsString::from(*arg)).collect()
+}
+
+fn os(argv: &[&str]) -> Vec<OsString> {
+    args(argv)
+}
+
+fn arg_str(arg: &OsString) -> &str {
+    arg.to_str().expect("test args are utf-8")
 }
 
 fn parse_line(argv: &[&str]) -> Command {
@@ -105,7 +114,7 @@ fn rxc_inserts_claude() {
         Command::Launch(LaunchRequest {
             harness: Harness::Claude,
             provider: None,
-            passthrough: vec!["fix login".to_string()],
+            passthrough: os(&["fix login"]),
         })
     );
 }
@@ -118,7 +127,7 @@ fn rxx_inserts_codex() {
         Command::Launch(LaunchRequest {
             harness: Harness::Codex,
             provider: None,
-            passthrough: vec!["exec".to_string(), "cargo test".to_string()],
+            passthrough: os(&["exec", "cargo test"]),
         })
     );
 }
@@ -143,7 +152,7 @@ fn provider_flag_before_or_after_harness() {
     let expected = Command::Launch(LaunchRequest {
         harness: Harness::Claude,
         provider: Some("openrouter".to_string()),
-        passthrough: vec!["--resume".to_string(), "abc".to_string()],
+        passthrough: os(&["--resume", "abc"]),
     });
     assert_eq!(before, expected);
     assert_eq!(after, expected);
@@ -157,7 +166,7 @@ fn provider_after_double_dash_is_passthrough() {
         Command::Launch(LaunchRequest {
             harness: Harness::Claude,
             provider: None,
-            passthrough: vec!["--".to_string(), "--provider".to_string(), "openrouter".to_string()],
+            passthrough: os(&["--", "--provider", "openrouter"]),
         })
     );
 }
@@ -170,7 +179,7 @@ fn claude_help_is_passthrough() {
         Command::Launch(LaunchRequest {
             harness: Harness::Claude,
             provider: None,
-            passthrough: vec!["--help".to_string()],
+            passthrough: os(&["--help"]),
         })
     );
 }
@@ -330,7 +339,7 @@ fn rxo_inserts_opencode() {
         Command::Launch(LaunchRequest {
             harness: Harness::OpenCode,
             provider: None,
-            passthrough: vec!["run".to_string(), "hello".to_string()],
+            passthrough: os(&["run", "hello"]),
         })
     );
 }
@@ -343,7 +352,7 @@ fn rxp_inserts_pi() {
         Command::Launch(LaunchRequest {
             harness: Harness::Pi,
             provider: None,
-            passthrough: vec!["--print".to_string(), "hi".to_string()],
+            passthrough: os(&["--print", "hi"]),
         })
     );
 }
@@ -356,7 +365,7 @@ fn rxd_inserts_dsh() {
         Command::Launch(LaunchRequest {
             harness: Harness::Dsh,
             provider: None,
-            passthrough: vec!["--resume".to_string()],
+            passthrough: os(&["--resume"]),
         })
     );
 }
@@ -369,7 +378,7 @@ fn rx_dsh_is_a_harness() {
         Command::Launch(LaunchRequest {
             harness: Harness::Dsh,
             provider: None,
-            passthrough: vec!["--resume".to_string()],
+            passthrough: os(&["--resume"]),
         })
     );
 }
@@ -547,14 +556,14 @@ fn unconfigured_launch_is_passthrough() {
         &LaunchRequest {
             harness: Harness::Claude,
             provider: None,
-            passthrough: vec!["--resume".to_string(), "abc".to_string()],
+            passthrough: os(&["--resume", "abc"]),
         },
         &paths,
         &EnvLookup::isolated(HashMap::new()),
     )
     .unwrap();
-    assert_eq!(plan.program, "claude");
-    assert_eq!(plan.args, vec!["--resume", "abc"]);
+    assert_eq!(plan.program, PathBuf::from("claude"));
+    assert_eq!(plan.args, os(&["--resume", "abc"]));
     assert!(plan.env_set.is_empty());
     assert!(plan.stderr_note.as_deref().unwrap().contains("no provider configured"));
 }
@@ -563,17 +572,13 @@ fn unconfigured_launch_is_passthrough() {
 fn unconfigured_dsh_still_boots_tui_profile() {
     let (_dir, paths) = temp_paths();
     let plan = launch::plan(
-        &LaunchRequest {
-            harness: Harness::Dsh,
-            provider: None,
-            passthrough: vec!["--resume".to_string()],
-        },
+        &LaunchRequest { harness: Harness::Dsh, provider: None, passthrough: os(&["--resume"]) },
         &paths,
         &EnvLookup::isolated(HashMap::new()),
     )
     .unwrap();
-    assert_eq!(plan.program, "dsh");
-    assert_eq!(plan.args, vec!["--profile", "dsh-tui", "--resume"]);
+    assert_eq!(plan.program, PathBuf::from("dsh"));
+    assert_eq!(plan.args, os(&["--profile", "dsh-tui", "--resume"]));
     assert!(plan.env_set.is_empty());
 }
 
@@ -588,14 +593,14 @@ fn claude_openrouter_uses_api_key_and_discovery_fallback_without_seed() {
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("openrouter".to_string()),
-            passthrough: vec!["fix it".to_string()],
+            passthrough: os(&["fix it"]),
         },
         &paths,
         &env,
     )
     .unwrap();
-    assert_eq!(plan.program, "claude");
-    assert_eq!(plan.args, vec!["fix it"]);
+    assert_eq!(plan.program, PathBuf::from("claude"));
+    assert_eq!(plan.args, os(&["fix it"]));
     assert!(
         plan.env_set
             .iter()
@@ -648,7 +653,7 @@ fn claude_injection_tokener_still_uses_auth_token() {
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("tokener".to_string()),
-            passthrough: vec!["fix it".to_string()],
+            passthrough: os(&["fix it"]),
         },
         &paths,
         &env,
@@ -675,14 +680,14 @@ fn codex_openrouter_overrides_model_and_uses_command_auth() {
         &env,
     )
     .unwrap();
-    assert_eq!(plan.program, "codex");
+    assert_eq!(plan.program, PathBuf::from("codex"));
     assert_eq!(plan.args[0], "-c");
     assert_eq!(plan.args[1], "model_provider=\"openrouter\"");
-    assert!(plan.args[3].contains("base_url=\"https://openrouter.ai/api/v1\""));
-    assert!(plan.args[3].contains("wire_api=\"responses\""));
-    assert!(plan.args[3].contains("supports_websockets=false"));
-    assert!(plan.args[3].contains("auth={command=\"sh\""));
-    assert!(!plan.args[3].contains("env_key="));
+    assert!(arg_str(&plan.args[3]).contains("base_url=\"https://openrouter.ai/api/v1\""));
+    assert!(arg_str(&plan.args[3]).contains("wire_api=\"responses\""));
+    assert!(arg_str(&plan.args[3]).contains("supports_websockets=false"));
+    assert!(arg_str(&plan.args[3]).contains("auth={command=\"sh\""));
+    assert!(!arg_str(&plan.args[3]).contains("env_key="));
     assert_eq!(plan.args[5], "model=\"~openai/gpt-latest\"");
     assert_eq!(plan.env_set, vec![("OPENROUTER_API_KEY".to_string(), "sk-or-test".to_string())]);
 }
@@ -698,14 +703,14 @@ fn opencode_openrouter_injects_config_and_model() {
         &LaunchRequest {
             harness: Harness::OpenCode,
             provider: Some("openrouter".to_string()),
-            passthrough: vec!["run".to_string(), "hello".to_string()],
+            passthrough: os(&["run", "hello"]),
         },
         &paths,
         &env,
     )
     .unwrap();
-    assert_eq!(plan.program, "opencode");
-    assert_eq!(plan.args, vec!["run".to_string(), "hello".to_string()]);
+    assert_eq!(plan.program, PathBuf::from("opencode"));
+    assert_eq!(plan.args, os(&["run", "hello"]));
     assert!(plan.env_set.iter().any(|(k, v)| k == "OPENROUTER_API_KEY" && v == "sk-or-test"));
     let config = plan
         .env_set
@@ -748,11 +753,11 @@ fn dsh_deepseek_uses_official_adapter_and_clears_pi_ai_routes() {
         &env,
     )
     .unwrap();
-    assert_eq!(plan.program, "dsh");
+    assert_eq!(plan.program, PathBuf::from("dsh"));
     assert_eq!(plan.args[0], "--profile");
     assert_eq!(plan.args[1], "dsh-tui");
     assert_eq!(plan.args[2], "--patch");
-    assert_eq!(plan.args[3], paths.dir.join("dsh").join("launch.cordis.yml").to_string_lossy());
+    assert_eq!(Path::new(&plan.args[3]), paths.dir.join("dsh").join("launch.cordis.yml"));
     assert_eq!(plan.env_set, vec![("DEEPSEEK_API_KEY".to_string(), "sk-ds-test".to_string())]);
     let patch = fs::read_to_string(paths.dir.join("dsh").join("launch.cordis.yml")).unwrap();
     assert!(patch.contains("id: settings"));
@@ -845,7 +850,7 @@ agent-default-model:
     .unwrap();
     server.join().unwrap();
     assert_eq!(plan.env_set, vec![("TOKENER_API_KEY".to_string(), "sk-tokener".to_string())]);
-    let patch = fs::read_to_string(&plan.args[3]).unwrap();
+    let patch = fs::read_to_string(Path::new(&plan.args[3])).unwrap();
     assert!(patch.contains("id: settings"));
     assert!(patch.contains("id: llm-deepseek"));
     assert!(patch.contains("disabled: true"));
@@ -881,13 +886,13 @@ fn pi_openrouter_injects_provider_without_extension() {
         &LaunchRequest {
             harness: Harness::Pi,
             provider: Some("openrouter".to_string()),
-            passthrough: vec!["--print".to_string(), "hi".to_string()],
+            passthrough: os(&["--print", "hi"]),
         },
         &paths,
         &env,
     )
     .unwrap();
-    assert_eq!(plan.program, "pi");
+    assert_eq!(plan.program, PathBuf::from("pi"));
     assert_eq!(plan.args[0], "--models");
     assert_eq!(plan.args[1], "openrouter/*");
     assert_eq!(plan.args[2], "--provider");
@@ -975,13 +980,13 @@ fn codex_passthrough_model_flag_wins() {
         &LaunchRequest {
             harness: Harness::Codex,
             provider: Some("openrouter".to_string()),
-            passthrough: vec!["--model".to_string(), "anthropic/claude-sonnet-4.6".to_string()],
+            passthrough: os(&["--model", "anthropic/claude-sonnet-4.6"]),
         },
         &paths,
         &env,
     )
     .unwrap();
-    assert!(!plan.args.iter().any(|arg| arg.starts_with("model=")));
+    assert!(!plan.args.iter().any(|arg| arg_str(arg).starts_with("model=")));
     assert_eq!(plan.args[plan.args.len() - 2], "--model");
     assert_eq!(plan.args[plan.args.len() - 1], "anthropic/claude-sonnet-4.6");
 }
@@ -997,16 +1002,16 @@ fn codex_tokener_does_not_invent_a_model() {
         &LaunchRequest {
             harness: Harness::Codex,
             provider: Some("tokener".to_string()),
-            passthrough: vec!["exec".to_string(), "cargo test".to_string()],
+            passthrough: os(&["exec", "cargo test"]),
         },
         &paths,
         &env,
     )
     .unwrap();
     assert_eq!(plan.args[1], "model_provider=\"tokener\"");
-    assert!(plan.args[3].contains("base_url=\"https://api.tokener.dev/v1\""));
-    assert!(!plan.args.iter().any(|arg| arg.starts_with("model=")));
-    assert_eq!(plan.args[4..], ["exec", "cargo test"]);
+    assert!(arg_str(&plan.args[3]).contains("base_url=\"https://api.tokener.dev/v1\""));
+    assert!(!plan.args.iter().any(|arg| arg_str(arg).starts_with("model=")));
+    assert_eq!(&plan.args[4..], os(&["exec", "cargo test"]));
 }
 
 #[test]
@@ -1222,8 +1227,8 @@ model = "gpt-prod"
     )
     .unwrap();
     assert_eq!(codex.args[1], "model_provider=\"tokener-dev\"");
-    assert!(codex.args[3].contains("model_providers.tokener-dev="));
-    assert!(codex.args[3].contains(&format!("base_url=\"{dev_base_url}/v1\"")));
+    assert!(arg_str(&codex.args[3]).contains("model_providers.tokener-dev="));
+    assert!(arg_str(&codex.args[3]).contains(&format!("base_url=\"{dev_base_url}/v1\"")));
     assert_eq!(codex.env_set, vec![("TOKENER_DEV_API_KEY".to_string(), "sk-dev".to_string())]);
 
     let server = thread::spawn(move || {
@@ -1389,7 +1394,7 @@ anthropic_base = "https://api.moonshot.ai/anthropic"
         &EnvLookup::isolated(HashMap::new()),
     )
     .unwrap();
-    assert!(codex.args[3].contains("base_url=\"https://api.moonshot.ai/v1\""));
+    assert!(arg_str(&codex.args[3]).contains("base_url=\"https://api.moonshot.ai/v1\""));
 }
 
 #[test]
@@ -1483,13 +1488,13 @@ fn isolated_codex_plan_does_not_write_model_catalog_json() {
         &LaunchRequest {
             harness: Harness::Codex,
             provider: Some("tokener".to_string()),
-            passthrough: vec!["exec".to_string()],
+            passthrough: os(&["exec"]),
         },
         &paths,
         &env,
     )
     .unwrap();
-    assert!(!plan.args.iter().any(|arg| arg.contains("model_catalog_json")));
+    assert!(!plan.args.iter().any(|arg| arg_str(arg).contains("model_catalog_json")));
     assert!(!paths.dir.join("catalogs").exists());
 }
 
@@ -1729,7 +1734,7 @@ fn generated_provider_seeded_plan_uses_auth_token_and_settings() {
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("tokener".to_string()),
-            passthrough: vec!["fix it".to_string()],
+            passthrough: os(&["fix it"]),
         },
         "TOKENER_API_KEY",
         "http://localhost:8080",
@@ -1737,7 +1742,7 @@ fn generated_provider_seeded_plan_uses_auth_token_and_settings() {
         None,
     );
     assert_eq!(plan.args[0], "--settings");
-    assert!(plan.args[1].contains("TOKENER_API_KEY"));
+    assert!(arg_str(&plan.args[1]).contains("TOKENER_API_KEY"));
     assert_eq!(plan.args[2], "fix it");
     assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v == "sk-tokener"));
     assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v.is_empty()));
@@ -2273,7 +2278,7 @@ fn openrouter_seeded_plan_injects_settings() {
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("openrouter".to_string()),
-            passthrough: vec!["fix it".to_string()],
+            passthrough: os(&["fix it"]),
         },
         "https://openrouter.ai/api",
         "sk-or-test",
@@ -2281,7 +2286,7 @@ fn openrouter_seeded_plan_injects_settings() {
         crate::claude_catalog::SeedOutcome::Seeded { model_count: 2 },
     );
     assert_eq!(plan.args[0], "--settings");
-    assert!(plan.args[1].contains("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"));
+    assert!(arg_str(&plan.args[1]).contains("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"));
     assert_eq!(plan.args[2], "fix it");
     assert!(plan.env_set.iter().any(|(k, v)| k == "ANTHROPIC_API_KEY" && v == "sk-or-test"));
     assert!(

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -76,7 +76,7 @@ pub(crate) fn update_pending(current: &str, release: &ReleaseInfo) -> bool {
 pub(crate) fn maybe_before_launch(
     paths: &Paths,
     env: &EnvLookup,
-    raw_args: &[String],
+    raw_args: &[std::ffi::OsString],
 ) -> Result<()> {
     if env.get("RX_NO_UPDATE").is_some_and(|value| !value.is_empty() && value != "0") {
         return Ok(());
@@ -163,7 +163,7 @@ fn confirm(message: &str) -> Result<bool> {
     Ok(matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
 }
 
-fn relaunch(raw_args: &[String]) -> Result<()> {
+fn relaunch(raw_args: &[std::ffi::OsString]) -> Result<()> {
     let exe = std::env::current_exe().context("cannot resolve rx executable path")?;
     let mut command = Command::new(&exe);
     // current_exe() resolves aliases (rxc/rxx/rxo/rxp/rxd) to the plain rx binary,


### PR DESCRIPTION
### What's changed?

- Collect argv with `std::env::args_os()` and keep launch passthrough plus discovered harness paths as `OsString`/`PathBuf`.
- Detect rx flags by OS-string prefix so a non-UTF-8 value after `--model=` or `--provider=` is not dropped.

### Why

- On Unix, `std::env::args()` panics on non-UTF-8 argv (exit 101), and `to_string_lossy()` rewrote a valid executable path before `exec`.

Fixes #154