### PR TITLE
feat(rx): add shell completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ install: ## Install binaries to ~/.cargo/bin
 	@if [ -d "$(HOME)/.zsh/completions" ]; then \
 		"$(HOME)/.cargo/bin/recall" completions zsh > "$(HOME)/.zsh/completions/_recall"; \
 		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_recall$(RESET)\n'; \
+		"$(HOME)/.cargo/bin/rx" completions zsh > "$(HOME)/.zsh/completions/_rx"; \
+		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_rx$(RESET)\n'; \
 	fi
 
 uninstall: ## Remove installed binaries

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -64,6 +64,20 @@ pub(crate) enum UpdateCommand {
     Run { yes: bool },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompletionsCommand {
+    Help,
+    Generate { shell: CompletionShell },
+    ListProviders { configured: bool },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Command {
     Help,
@@ -72,6 +86,7 @@ pub(crate) enum Command {
     PickHarness { provider: Option<String> },
     Providers(ProvidersCommand),
     Update(UpdateCommand),
+    Completions(CompletionsCommand),
 }
 
 pub(crate) fn rewrite_argv0(mut args: Vec<OsString>) -> Vec<OsString> {
@@ -126,6 +141,12 @@ pub(crate) fn parse(args: &[OsString]) -> Result<Command> {
                 bail!("--provider is not valid with rx update");
             }
             Ok(Command::Update(parse_update(&rest[1..])?))
+        }
+        Some("completions") => {
+            if provider.is_some() {
+                bail!("--provider is not valid with rx completions");
+            }
+            Ok(Command::Completions(parse_completions(&rest[1..])?))
         }
         Some(name) => {
             let Some(harness) = Harness::parse(name) else {
@@ -249,6 +270,45 @@ fn extract_provider(args: &[OsString]) -> Result<(Option<String>, Vec<OsString>)
         i += 1;
     }
     Ok((provider, rest))
+}
+
+fn parse_completions(args: &[OsString]) -> Result<CompletionsCommand> {
+    match args.first().and_then(|arg| arg.to_str()) {
+        None if args.is_empty() => Ok(CompletionsCommand::Help),
+        Some("-h" | "--help" | "help") if args.len() == 1 => Ok(CompletionsCommand::Help),
+        Some("--providers") if args.len() == 1 => {
+            Ok(CompletionsCommand::ListProviders { configured: false })
+        }
+        Some("--configured") if args.len() == 1 => {
+            Ok(CompletionsCommand::ListProviders { configured: true })
+        }
+        Some("bash") if args.len() == 1 => {
+            Ok(CompletionsCommand::Generate { shell: CompletionShell::Bash })
+        }
+        Some("zsh") if args.len() == 1 => {
+            Ok(CompletionsCommand::Generate { shell: CompletionShell::Zsh })
+        }
+        Some("fish") if args.len() == 1 => {
+            Ok(CompletionsCommand::Generate { shell: CompletionShell::Fish })
+        }
+        Some("bash" | "zsh" | "fish" | "--providers" | "--configured") => {
+            bail!(
+                "unexpected argument: {}\n\n{}",
+                args[1].to_string_lossy(),
+                crate::completions::help()
+            )
+        }
+        Some(command) => {
+            bail!("unknown completions command: {command}\n\n{}", crate::completions::help())
+        }
+        None => {
+            bail!(
+                "unknown completions command: {}\n\n{}",
+                args[0].to_string_lossy(),
+                crate::completions::help()
+            )
+        }
+    }
 }
 
 fn parse_update(args: &[OsString]) -> Result<UpdateCommand> {

--- a/crates/rx/src/completions.rs
+++ b/crates/rx/src/completions.rs
@@ -1,0 +1,431 @@
+use anyhow::Result;
+
+use crate::args::{CompletionShell, CompletionsCommand};
+use crate::config::Paths;
+use crate::launch::EnvLookup;
+use crate::providers;
+
+const BASH: &str = r#"_rx_bin() {
+  local invoked=${COMP_WORDS[0]}
+  local name=${invoked##*/}
+  case $name in
+    rxc|rxx|rxo|rxp|rxd)
+      if [[ $invoked == */* ]]; then
+        printf '%s' "${invoked%/*}/rx"
+      else
+        printf '%s' rx
+      fi
+      ;;
+    *) printf '%s' "$invoked" ;;
+  esac
+}
+
+_rx_ids() {
+  local ids
+  ids=$("$(_rx_bin)" completions "$1" 2>/dev/null) || return
+  if [[ $cur == --provider=* ]]; then
+    COMPREPLY=($(compgen -P --provider= -W "$ids" -- "${cur#--provider=}"))
+  else
+    COMPREPLY=($(compgen -W "$ids" -- "$cur"))
+  fi
+}
+
+_rx_has_provider() {
+  local i w
+  for ((i = 1; i < COMP_CWORD; i++)); do
+    w=${COMP_WORDS[i]}
+    [[ $w == -- ]] && return 1
+    [[ $w == --provider || $w == --provider=* ]] && return 0
+  done
+  return 1
+}
+
+_rx_positionals() {
+  local i=1 pending=0 w
+  while ((i < COMP_CWORD)); do
+    w=${COMP_WORDS[i]}
+    if [[ $w == -- ]]; then
+      break
+    elif [[ $w == --provider ]]; then
+      pending=1
+    elif [[ $w == --provider=* ]]; then
+      :
+    elif ((pending)); then
+      pending=0
+    elif [[ $w != -* ]]; then
+      printf '%s\n' "$w"
+    fi
+    i=$((i + 1))
+  done
+}
+
+_rx() {
+  local cur prev cmd
+  cmd=${COMP_WORDS[0]##*/}
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD - 1]}
+  COMPREPLY=()
+
+  if [[ $cur == --provider=* ]]; then
+    _rx_ids --configured
+    return
+  fi
+  if [[ $prev == --provider ]]; then
+    _rx_ids --configured
+    return
+  fi
+
+  local pos=()
+  local line
+  while IFS= read -r line; do
+    pos+=("$line")
+  done < <(_rx_positionals)
+
+  case $cmd in
+    rxc|rxx|rxo|rxp|rxd)
+      if [[ $cur == -* ]] && ! _rx_has_provider; then
+        COMPREPLY=($(compgen -W '--provider' -- "$cur"))
+      fi
+      return
+      ;;
+  esac
+
+  if ((${#pos[@]} == 0)); then
+    if [[ $cur == -* ]]; then
+      local flags='--help --version -h -V'
+      _rx_has_provider || flags+=' --provider'
+      COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+    elif _rx_has_provider; then
+      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh' -- "$cur"))
+    else
+      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh providers update completions' -- "$cur"))
+    fi
+    return
+  fi
+
+  case ${pos[0]} in
+    providers)
+      case ${pos[1]-} in
+        '')
+          COMPREPLY=($(compgen -W 'list login logout use models' -- "$cur"))
+          ;;
+        login)
+          ((${#pos[@]} == 2)) && _rx_ids --providers
+          ;;
+        logout|use)
+          ((${#pos[@]} == 2)) && _rx_ids --configured
+          ;;
+        models)
+          case ${pos[2]-} in
+            '')
+              COMPREPLY=($(compgen -W 'update' -- "$cur"))
+              ;;
+            update)
+              ((${#pos[@]} == 3)) && _rx_ids --configured
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+    update)
+      [[ $cur == -* ]] && COMPREPLY=($(compgen -W '--yes -y' -- "$cur"))
+      ;;
+    completions)
+      ((${#pos[@]} == 1)) && COMPREPLY=($(compgen -W 'bash zsh fish' -- "$cur"))
+      ;;
+    claude|codex|opencode|pi|dsh)
+      if [[ $cur == -* ]] && ! _rx_has_provider; then
+        COMPREPLY=($(compgen -W '--provider' -- "$cur"))
+      fi
+      ;;
+  esac
+}
+
+complete -F _rx rx rxc rxx rxo rxp rxd
+"#;
+
+const ZSH: &str = r#"#compdef rx rxc rxx rxo rxp rxd
+
+_rx_bin() {
+  local invoked=$words[1]
+  local name=${invoked:t}
+  case $name in
+    rxc|rxx|rxo|rxp|rxd)
+      if [[ $invoked == */* ]]; then
+        print -rn -- ${invoked:h}/rx
+      else
+        print -rn -- rx
+      fi
+      ;;
+    *) print -rn -- $invoked ;;
+  esac
+}
+
+_rx_ids() {
+  local -a ids
+  ids=(${(f)"$("$(_rx_bin)" completions "$1" 2>/dev/null)"})
+  (( $#ids )) || return 1
+  if [[ $PREFIX == --provider=* ]]; then
+    compset -P '--provider='
+    _describe -t providers provider ids
+    return
+  fi
+  _describe -t providers provider ids
+}
+
+_rx_has_provider() {
+  local w
+  for w in $words[2,CURRENT-1]; do
+    [[ $w == -- ]] && return 1
+    [[ $w == --provider || $w == --provider=* ]] && return 0
+  done
+  return 1
+}
+
+_rx_positionals() {
+  local -a out
+  local i=2 pending=0 w
+  while (( i < CURRENT )); do
+    w=$words[i]
+    if [[ $w == -- ]]; then
+      break
+    elif [[ $w == --provider ]]; then
+      pending=1
+    elif [[ $w == --provider=* ]]; then
+      :
+    elif (( pending )); then
+      pending=0
+    elif [[ $w != -* ]]; then
+      out+=($w)
+    fi
+    (( i++ ))
+  done
+  (( $#out )) && print -l -- $out
+}
+
+_rx() {
+  local cur=$words[CURRENT]
+  local prev=$words[CURRENT-1]
+  local cmd=${words[1]:t}
+
+  if [[ $cur == --provider=* ]]; then
+    _rx_ids --configured
+    return
+  fi
+  if [[ $prev == --provider ]]; then
+    _rx_ids --configured
+    return
+  fi
+
+  local -a pos
+  local output
+  output=$(_rx_positionals)
+  [[ -n $output ]] && pos=(${(f)output})
+
+  case $cmd in
+    rxc|rxx|rxo|rxp|rxd)
+      if [[ $cur == -* ]] && ! _rx_has_provider; then
+        compadd -- --provider
+      fi
+      return
+      ;;
+  esac
+
+  if (( $#pos == 0 )); then
+    if [[ $cur == -* ]]; then
+      local -a flags
+      flags=(--help --version -h -V)
+      _rx_has_provider || flags+=(--provider)
+      compadd -- $flags
+    elif _rx_has_provider; then
+      compadd -- claude codex opencode pi dsh
+    else
+      compadd -- claude codex opencode pi dsh providers update completions
+    fi
+    return
+  fi
+
+  case $pos[1] in
+    providers)
+      case ${pos[2]:-} in
+        '')
+          compadd -- list login logout use models
+          ;;
+        login)
+          (( $#pos == 2 )) && _rx_ids --providers
+          ;;
+        logout|use)
+          (( $#pos == 2 )) && _rx_ids --configured
+          ;;
+        models)
+          case ${pos[3]:-} in
+            '')
+              compadd -- update
+              ;;
+            update)
+              (( $#pos == 3 )) && _rx_ids --configured
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+    update)
+      [[ $cur == -* ]] && compadd -- --yes -y
+      ;;
+    completions)
+      (( $#pos == 1 )) && compadd -- bash zsh fish
+      ;;
+    claude|codex|opencode|pi|dsh)
+      if [[ $cur == -* ]] && ! _rx_has_provider; then
+        compadd -- --provider
+      fi
+      ;;
+  esac
+}
+
+compdef _rx rx rxc rxx rxo rxp rxd
+"#;
+
+const FISH: &str = r#"function __rx_bin
+    set -l invoked (commandline -opc)[1]
+    set -l name (basename $invoked)
+    switch $name
+        case rxc rxx rxo rxp rxd
+            if string match -q '*/*' -- $invoked
+                echo (dirname $invoked)/rx
+            else
+                echo rx
+            end
+        case '*'
+            echo $invoked
+    end
+end
+
+function __rx_ids
+    set -l bin (__rx_bin)
+    $bin completions $argv[1] 2>/dev/null
+end
+
+function __rx_pos
+    set -l tokens (commandline -opc)
+    set -e tokens[1]
+    set -l out
+    set -l pending 0
+    for w in $tokens
+        if test "$w" = --
+            break
+        else if test "$w" = --provider
+            set pending 1
+        else if string match -q -- '--provider=*' "$w"
+            true
+        else if test $pending -eq 1
+            set pending 0
+        else if not string match -q -- '-*' "$w"
+            set -a out $w
+        end
+    end
+    if test (count $out) -gt 0
+        printf '%s\n' $out
+    end
+end
+
+function __rx_n
+    test (count (__rx_pos)) -eq $argv[1]
+end
+
+function __rx_is
+    set -l pos (__rx_pos)
+    test (count $pos) -ge (count $argv)
+    or return 1
+    set -l i 1
+    for expected in $argv
+        test $pos[$i] = $expected
+        or return 1
+        set i (math $i + 1)
+    end
+    return 0
+end
+
+function __rx_has_provider
+    set -l tokens (commandline -opc)
+    set -e tokens[1]
+    for w in $tokens
+        if test "$w" = --
+            return 1
+        else if test "$w" = --provider
+            return 0
+        else if string match -q -- '--provider=*' "$w"
+            return 0
+        end
+    end
+    return 1
+end
+
+function __rx_has_harness
+    set -l pos (__rx_pos)
+    test (count $pos) -ge 1
+    and contains -- $pos[1] claude codex opencode pi dsh
+end
+
+complete -c rx -f
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'claude' -d 'Claude Code'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'codex' -d 'Codex'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'opencode' -d 'OpenCode'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'pi' -d 'Pi'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'dsh' -d 'DeepSeek Harness'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'providers' -d 'Manage providers'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'update' -d 'Update rx'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'completions' -d 'Generate shell completion script'
+complete -c rx -n '__rx_n 0; and __rx_has_provider' -a 'claude codex opencode pi dsh'
+complete -c rx -n '__rx_n 0' -s h -l help
+complete -c rx -n '__rx_n 0' -s V -l version
+complete -c rx -n 'not __rx_has_provider; and __rx_n 0' -l provider -xa '(__rx_ids --configured)'
+complete -c rx -n 'not __rx_has_provider; and __rx_has_harness' -l provider -xa '(__rx_ids --configured)'
+complete -c rx -n '__rx_is providers; and __rx_n 1' -a 'list login logout use models'
+complete -c rx -n '__rx_is providers login; and __rx_n 2' -a '(__rx_ids --providers)'
+complete -c rx -n '__rx_is providers logout; and __rx_n 2' -a '(__rx_ids --configured)'
+complete -c rx -n '__rx_is providers use; and __rx_n 2' -a '(__rx_ids --configured)'
+complete -c rx -n '__rx_is providers models; and __rx_n 2' -a 'update'
+complete -c rx -n '__rx_is providers models update; and __rx_n 3' -a '(__rx_ids --configured)'
+complete -c rx -n '__rx_is update; and __rx_n 1' -l yes -s y
+complete -c rx -n '__rx_is completions; and __rx_n 1' -a 'bash zsh fish'
+
+for cmd in rxc rxx rxo rxp rxd
+    complete -c $cmd -f
+    complete -c $cmd -l provider -xa '(__rx_ids --configured)'
+end
+"#;
+
+pub(crate) fn help() -> &'static str {
+    concat!(
+        "usage: rx completions <bash|zsh|fish>\n\n",
+        "Write a shell completion script to stdout.\n"
+    )
+}
+
+pub(crate) fn script(shell: CompletionShell) -> &'static str {
+    match shell {
+        CompletionShell::Bash => BASH,
+        CompletionShell::Zsh => ZSH,
+        CompletionShell::Fish => FISH,
+    }
+}
+
+pub(crate) fn run(command: CompletionsCommand, paths: &Paths, env: &EnvLookup) -> Result<()> {
+    match command {
+        CompletionsCommand::Help => {
+            print!("{}", help());
+            Ok(())
+        }
+        CompletionsCommand::Generate { shell } => {
+            print!("{}", script(shell));
+            Ok(())
+        }
+        CompletionsCommand::ListProviders { configured } => {
+            for id in providers::completion_ids(paths, env, configured)? {
+                println!("{id}");
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -1,6 +1,7 @@
 mod args;
 mod catalog;
 mod claude_catalog;
+mod completions;
 mod config;
 mod dsh;
 mod install;
@@ -43,6 +44,7 @@ pub fn run_with(raw_args: Vec<OsString>, paths: &Paths, env: &EnvLookup) -> Resu
         }
         Command::Providers(command) => providers::run(command, paths, env),
         Command::Update(command) => update::run(command),
+        Command::Completions(command) => completions::run(command, paths, env),
         Command::PickHarness { provider } => {
             let Some(harness) = pick::harness(env)? else {
                 return Ok(());
@@ -90,6 +92,7 @@ Usage:
   rx providers <list|login|logout|use>
   rx providers models update [provider]
   rx update [--yes]
+  rx completions <bash|zsh|fish>
 
 A TTY `rx` with no harness opens a picker. Scripts must pass a harness.
 

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -445,6 +445,18 @@ fn set_default_provider(paths: &Paths, state: &ProviderState) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn completion_ids(
+    paths: &Paths,
+    env: &EnvLookup,
+    configured_only: bool,
+) -> Result<Vec<String>> {
+    Ok(provider_states(paths, env)?
+        .into_iter()
+        .filter(|state| !configured_only || state.configured())
+        .map(|state| state.provider.id)
+        .collect())
+}
+
 fn provider_index(states: &[ProviderState], id: &str, configured: bool) -> Result<usize> {
     let index = states
         .iter()

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 
 use crate::args::{
-    Command, Harness, LaunchRequest, ModelsCommand, ProvidersCommand, UpdateCommand, parse,
-    rewrite_argv0,
+    Command, CompletionShell, CompletionsCommand, Harness, LaunchRequest, ModelsCommand,
+    ProvidersCommand, UpdateCommand, parse, rewrite_argv0,
 };
 use crate::config::{self, Paths};
 use crate::launch::{self, EnvLookup};
@@ -209,8 +209,93 @@ fn rx_help_and_version() {
     assert!(crate::help_text().contains("rx --provider <provider> <harness>"));
     assert!(crate::help_text().contains("rx providers <list|login|logout|use>"));
     assert!(crate::help_text().contains("rx providers models update [provider]"));
+    assert!(crate::help_text().contains("rx completions <bash|zsh|fish>"));
     assert!(!crate::help_text().contains("rx providers list\n"));
+    assert!(!crate::help_text().contains("rx completions --providers"));
     assert!(!crate::help_text().contains("rx debug"));
+}
+
+#[test]
+fn completions_parses_shells_and_id_lists() {
+    assert_eq!(parse_line(&["rx", "completions"]), Command::Completions(CompletionsCommand::Help));
+    assert_eq!(
+        parse_line(&["rx", "completions", "zsh"]),
+        Command::Completions(CompletionsCommand::Generate { shell: CompletionShell::Zsh })
+    );
+    assert_eq!(
+        parse_line(&["rx", "completions", "bash"]),
+        Command::Completions(CompletionsCommand::Generate { shell: CompletionShell::Bash })
+    );
+    assert_eq!(
+        parse_line(&["rx", "completions", "fish"]),
+        Command::Completions(CompletionsCommand::Generate { shell: CompletionShell::Fish })
+    );
+    assert_eq!(
+        parse_line(&["rx", "completions", "--providers"]),
+        Command::Completions(CompletionsCommand::ListProviders { configured: false })
+    );
+    assert_eq!(
+        parse_line(&["rx", "completions", "--configured"]),
+        Command::Completions(CompletionsCommand::ListProviders { configured: true })
+    );
+}
+
+#[test]
+fn completions_rejects_provider_flag_and_extra_args() {
+    let error =
+        parse(&args(&["rx", "--provider", "openrouter", "completions", "zsh"])).unwrap_err();
+    assert!(error.to_string().contains("--provider is not valid with rx completions"), "{error}");
+
+    let extra = parse(&args(&["rx", "completions", "zsh", "extra"])).unwrap_err();
+    assert!(extra.to_string().contains("unexpected argument: extra"), "{extra}");
+
+    let unknown = parse(&args(&["rx", "completions", "powershell"])).unwrap_err();
+    assert!(unknown.to_string().contains("unknown completions command: powershell"), "{unknown}");
+}
+
+#[test]
+fn completions_scripts_cover_rx_surface() {
+    for shell in [CompletionShell::Bash, CompletionShell::Zsh, CompletionShell::Fish] {
+        let script = crate::completions::script(shell);
+        for needle in [
+            "claude",
+            "codex",
+            "opencode",
+            "pi",
+            "dsh",
+            "providers",
+            "update",
+            "completions",
+            "--provider",
+            "--configured",
+            "--providers",
+            "rxc",
+            "rxx",
+            "rxo",
+            "rxp",
+            "rxd",
+        ] {
+            assert!(script.contains(needle), "{shell:?} missing {needle}");
+        }
+        assert!(!script.contains("search"), "{shell:?} leaked recall commands");
+    }
+    assert!(crate::completions::script(CompletionShell::Zsh).contains("#compdef rx"));
+}
+
+#[test]
+fn completion_ids_list_configured_and_known() {
+    let (_dir, paths) = temp_paths();
+    let env = EnvLookup::isolated(HashMap::new());
+    let known = crate::providers::completion_ids(&paths, &env, false).unwrap();
+    assert!(known.contains(&"openrouter".to_string()), "{known:?}");
+    assert!(known.contains(&"tokener".to_string()), "{known:?}");
+    assert!(crate::providers::completion_ids(&paths, &env, true).unwrap().is_empty());
+
+    config::login(&paths, "openrouter", "sk-secret".to_string()).unwrap();
+    assert_eq!(
+        crate::providers::completion_ids(&paths, &env, true).unwrap(),
+        vec!["openrouter".to_string()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- add `rx completions <bash|zsh|fish>` with scripts for `rx` and the `rxc` / `rxx` / `rxo` / `rxp` / `rxd` aliases
- complete harnesses, provider subcommands, and `--provider` from live known or configured provider ids
- write `_rx` from `make install` when `~/.zsh/completions` exists

### Why

- give rx the same shell-completion path recall already has, including dynamic provider ids

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p rx --all-targets -- -D warnings`
- `cargo test -p rx` (114 passed, 1 ignored)
- `bash -n` / `zsh -n` on the generated scripts
- `target/debug/rx completions {bash,zsh,--providers}` plus rejected `--provider` / unknown-shell paths
