### PR TITLE
feat(mcp): serve a read-only session index over stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -390,6 +390,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -435,7 +436,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -486,7 +487,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -777,6 +778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,7 +798,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -800,7 +811,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -811,7 +835,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -822,7 +846,18 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -871,7 +906,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -881,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -933,7 +968,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -944,7 +979,7 @@ checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -955,6 +990,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1002,7 +1043,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1146,7 +1187,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1236,7 +1277,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2006,7 +2047,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2307,7 +2348,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2567,7 +2608,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2622,6 +2663,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2687,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2912,6 +2959,7 @@ dependencies = [
  "kitup",
  "pulldown-cmark",
  "ratatui",
+ "rmcp",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2920,6 +2968,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokenizers",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "unicode-width 0.2.0",
@@ -2976,6 +3025,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3068,6 +3137,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3218,6 +3322,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,7 +3415,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3508,7 +3649,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3522,6 +3663,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3545,7 +3697,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3643,7 +3795,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3654,7 +3806,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3763,7 +3915,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3934,7 +4086,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4302,7 +4454,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4464,7 +4616,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4475,7 +4627,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4664,7 +4816,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4680,7 +4832,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4769,7 +4921,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4781,7 +4933,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4802,7 +4954,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4822,7 +4974,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4862,7 +5014,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,14 @@ version = "0.5.3"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+rmcp = { version = "3.1.4", default-features = false, features = [
+    "server",
+    "macros",
+    "schemars",
+    "transport-io",
+] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+tokio = { version = "1", features = ["rt", "macros", "io-std", "io-util", "time"] }
 sqlite-vec = "0.1"
 hf-hub = { version = "0.5", features = ["ureq"] }
 ureq = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,6 +116,11 @@ enum Commands {
         #[arg(help = "Target shell")]
         shell: Shell,
     },
+    #[command(about = "Serve a read-only MCP server over stdio")]
+    Mcp {
+        #[arg(long, help = "Read this Recall database instead of the default index")]
+        db: Option<PathBuf>,
+    },
     #[command(hide = true, name = "__background-worker")]
     BackgroundWorker {
         #[arg(long)]
@@ -259,6 +264,7 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Completions { shell }) => {
             generate(shell, &mut Cli::command(), "recall", &mut std::io::stdout());
         }
+        Some(Commands::Mcp { db }) => crate::mcp::run(db)?,
         Some(Commands::External(args)) => {
             let status = crate::extension::run_external(args)?;
             if !status.success() {
@@ -495,6 +501,24 @@ mod tests {
         assert!(compact_help.contains("extension Manage Recall extensions"));
         assert!(compact_help.contains("session Operate on indexed sessions"));
         assert!(compact_help.contains("completions Generate shell completion script"));
+        assert!(compact_help.contains("mcp Serve a read-only MCP server over stdio"));
+    }
+
+    #[test]
+    fn mcp_parses_optional_db_path() {
+        let cli = Cli::try_parse_from(["recall", "mcp"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp { db }) => assert!(db.is_none()),
+            _ => panic!("expected mcp command"),
+        }
+
+        let cli = Cli::try_parse_from(["recall", "mcp", "--db", "/tmp/recall-fixture.db"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp { db }) => {
+                assert_eq!(db.unwrap().to_string_lossy(), "/tmp/recall-fixture.db");
+            }
+            _ => panic!("expected mcp command"),
+        }
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,8 @@ enum Commands {
     Mcp {
         #[arg(long, help = "Read this Recall database instead of the default index")]
         db: Option<PathBuf>,
+        #[command(subcommand)]
+        command: Option<McpCommands>,
     },
     #[command(hide = true, name = "__background-worker")]
     BackgroundWorker {
@@ -151,6 +153,32 @@ enum ShareCommands {
         project_name: Option<String>,
         #[arg(long, help = "Local directory used for generated share pages")]
         publish_dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum McpCommands {
+    #[command(about = "Register the Recall MCP server with local agent hosts")]
+    Install {
+        #[arg(
+            long = "agent",
+            help = "Target host: claude or codex. Repeat for multiple hosts. Use '*' for all."
+        )]
+        agents: Vec<String>,
+        #[arg(long, help = "Print host commands without running them")]
+        dry_run: bool,
+        #[arg(long, help = "Recall binary to register instead of PATH `recall`")]
+        bin: Option<PathBuf>,
+    },
+    #[command(about = "Unregister the Recall MCP server from local agent hosts")]
+    Uninstall {
+        #[arg(
+            long = "agent",
+            help = "Target host: claude or codex. Repeat for multiple hosts. Use '*' for all."
+        )]
+        agents: Vec<String>,
+        #[arg(long, help = "Print host commands without running them")]
+        dry_run: bool,
     },
 }
 
@@ -264,7 +292,17 @@ pub(crate) fn run() -> Result<()> {
         Some(Commands::Completions { shell }) => {
             generate(shell, &mut Cli::command(), "recall", &mut std::io::stdout());
         }
-        Some(Commands::Mcp { db }) => crate::mcp::run(db)?,
+        Some(Commands::Mcp { db: Some(_), command: Some(_) }) => {
+            anyhow::bail!("--db is only valid when serving (`recall mcp`)");
+        }
+        Some(Commands::Mcp { db, command: None }) => crate::mcp::run(db)?,
+        Some(Commands::Mcp {
+            command: Some(McpCommands::Install { agents, dry_run, bin }),
+            ..
+        }) => crate::mcp_host::install(&agents, dry_run, bin)?,
+        Some(Commands::Mcp {
+            command: Some(McpCommands::Uninstall { agents, dry_run }), ..
+        }) => crate::mcp_host::uninstall(&agents, dry_run)?,
         Some(Commands::External(args)) => {
             let status = crate::extension::run_external(args)?;
             if !status.success() {
@@ -359,8 +397,8 @@ fn recall_skill_bundle() -> kitup::SkillBundle {
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, Commands, ExtensionCommands, ShareCommands, Shell, SkillCommands, generate,
-        insert_installed_help,
+        Cli, Commands, ExtensionCommands, McpCommands, ShareCommands, Shell, SkillCommands,
+        generate, insert_installed_help,
     };
     use crate::adapters::{
         adapter_supports_usage_dashboard, all_adapters, source_supports_event_backfill,
@@ -508,17 +546,92 @@ mod tests {
     fn mcp_parses_optional_db_path() {
         let cli = Cli::try_parse_from(["recall", "mcp"]).unwrap();
         match cli.command {
-            Some(Commands::Mcp { db }) => assert!(db.is_none()),
+            Some(Commands::Mcp { db, command }) => {
+                assert!(db.is_none());
+                assert!(command.is_none());
+            }
             _ => panic!("expected mcp command"),
         }
 
         let cli = Cli::try_parse_from(["recall", "mcp", "--db", "/tmp/recall-fixture.db"]).unwrap();
         match cli.command {
-            Some(Commands::Mcp { db }) => {
+            Some(Commands::Mcp { db, command }) => {
                 assert_eq!(db.unwrap().to_string_lossy(), "/tmp/recall-fixture.db");
+                assert!(command.is_none());
             }
             _ => panic!("expected mcp command"),
         }
+    }
+
+    #[test]
+    fn mcp_install_parses_host_flags() {
+        let cli = Cli::try_parse_from(["recall", "mcp", "install"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp {
+                db,
+                command: Some(McpCommands::Install { agents, dry_run, bin }),
+            }) => {
+                assert!(db.is_none());
+                assert!(agents.is_empty());
+                assert!(!dry_run);
+                assert!(bin.is_none());
+            }
+            _ => panic!("expected mcp install command"),
+        }
+
+        let cli = Cli::try_parse_from([
+            "recall",
+            "mcp",
+            "install",
+            "--agent",
+            "claude",
+            "--agent",
+            "codex",
+            "--dry-run",
+            "--bin",
+            "/tmp/recall",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Mcp {
+                command: Some(McpCommands::Install { agents, dry_run, bin }),
+                ..
+            }) => {
+                assert_eq!(agents, ["claude", "codex"]);
+                assert!(dry_run);
+                assert_eq!(bin.unwrap().to_string_lossy(), "/tmp/recall");
+            }
+            _ => panic!("expected mcp install command"),
+        }
+    }
+
+    #[test]
+    fn mcp_uninstall_parses() {
+        let cli = Cli::try_parse_from(["recall", "mcp", "uninstall", "--agent", "claude"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp {
+                command: Some(McpCommands::Uninstall { agents, dry_run }),
+                ..
+            }) => {
+                assert_eq!(agents, ["claude"]);
+                assert!(!dry_run);
+            }
+            _ => panic!("expected mcp uninstall command"),
+        }
+    }
+
+    #[test]
+    fn mcp_install_rejects_db_flag() {
+        assert!(Cli::try_parse_from(["recall", "mcp", "install", "--db", "/tmp/x.db"]).is_err());
+    }
+
+    #[test]
+    fn mcp_help_lists_install_and_uninstall() {
+        let mut command = Cli::command();
+        let help = command.find_subcommand_mut("mcp").unwrap().render_long_help().to_string();
+        assert!(help.contains("install"));
+        assert!(help.contains("uninstall"));
+        assert!(help.contains("--db"));
     }
 
     #[test]

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1,5 +1,7 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use crate::types::{ParentLink, Session, ThreadRole};
 
@@ -99,12 +101,18 @@ pub(crate) struct SkillAuditEventRow {
 }
 
 impl Store {
-    pub(crate) fn open() -> Result<Self> {
+    pub(crate) fn default_db_path() -> Result<PathBuf> {
         let data_dir = dirs::data_dir()
             .ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?
             .join("recall");
-        std::fs::create_dir_all(&data_dir)?;
-        let db_path = data_dir.join("recall.db");
+        Ok(data_dir.join("recall.db"))
+    }
+
+    pub(crate) fn open() -> Result<Self> {
+        let db_path = Self::default_db_path()?;
+        if let Some(data_dir) = db_path.parent() {
+            std::fs::create_dir_all(data_dir)?;
+        }
         let conn = Connection::open(&db_path)?;
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
@@ -115,10 +123,35 @@ impl Store {
         Ok(Store { conn })
     }
 
+    pub(crate) fn open_read_only_at(path: &Path) -> Result<Self> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        conn.execute_batch(
+            "PRAGMA query_only=ON;
+             PRAGMA busy_timeout=5000;
+             PRAGMA foreign_keys=ON;",
+        )?;
+        Ok(Store { conn })
+    }
+
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;")?;
+        crate::db::schema::init(&conn)?;
+        Ok(Store { conn })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_at(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA busy_timeout=5000;
+             PRAGMA foreign_keys=ON;",
+        )?;
         crate::db::schema::init(&conn)?;
         Ok(Store { conn })
     }
@@ -269,5 +302,20 @@ mod exclusion_tests {
         assert_eq!(sessions[0].custom_title.as_deref(), Some("New title"));
         assert_eq!(sessions[0].summary.as_deref(), Some("Keep summary"));
         assert_eq!(sessions[0].duration_minutes, Some(9));
+    }
+
+    #[test]
+    fn open_read_only_at_opens_path_with_uri_characters() {
+        crate::db::schema::register_sqlite_vec();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recall?.db");
+        {
+            let store = Store::open_at(&path).unwrap();
+            store.insert_session(&sess("a", None)).unwrap();
+        }
+        let store = Store::open_read_only_at(&path).unwrap();
+        let loaded = store.get_session_by_id("a").unwrap().unwrap();
+        assert_eq!(loaded.title, "t");
+        assert!(store.insert_session(&sess("b", None)).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod handoff;
 pub(crate) mod import;
 pub(crate) mod info;
 pub(crate) mod mcp;
+pub(crate) mod mcp_host;
 pub(crate) mod project_scope;
 pub(crate) mod query;
 pub(crate) mod repo_identity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod extension;
 pub(crate) mod handoff;
 pub(crate) mod import;
 pub(crate) mod info;
+pub(crate) mod mcp;
 pub(crate) mod project_scope;
 pub(crate) mod query;
 pub(crate) mod repo_identity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,14 +5,12 @@ use anyhow::Result;
 use chrono::SecondsFormat;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{
-    CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
-};
+use rmcp::model::{CallToolResult, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{
     ServerHandler, ServiceExt, schemars, tool, tool_handler, tool_router, transport::stdio,
 };
-use serde::Deserialize;
 use serde::de::{self, Deserializer};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::adapters;
@@ -39,29 +37,44 @@ const SESSION_NOT_FOUND: &str = "Session not found.";
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct SearchSessionsArgs {
+    /// Required free-text query.
     query: String,
+    /// Optional absolute indexed directory path, or a repo name/owner-repo
+    /// slug/remote URL derived from git identity. A worktree's own directory
+    /// name alone (e.g. "myrepo--feature") does not match.
     #[serde(default)]
     project: Option<String>,
+    /// Optional tool id or label such as claude-code or CUR.
     #[serde(default)]
     source: Option<String>,
+    /// Maximum hits to return. Defaults to 10, capped at 50.
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    #[schemars(range(min = 1, max = 50))]
     limit: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct GetSessionArgs {
+    /// Recall session id from search_sessions or list_recent_sessions.
     session_id: String,
+    /// Maximum messages to return from the start of the session. Defaults to 50.
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
     max_messages: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ListRecentSessionsArgs {
+    /// Optional absolute indexed directory path, or a repo name/owner-repo
+    /// slug/remote URL derived from git identity. A worktree's own directory
+    /// name alone (e.g. "myrepo--feature") does not match.
     #[serde(default)]
     project: Option<String>,
+    /// Optional tool id or label such as claude-code or CUR.
     #[serde(default)]
     source: Option<String>,
+    /// Maximum hits to return. Defaults to 10, capped at 50.
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    #[schemars(range(min = 1, max = 50))]
     limit: Option<u32>,
 }
 
@@ -168,7 +181,13 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "Search past AI coding sessions across Claude Code, Codex, OpenCode, Cursor, and other indexed tools. Use when the user asks whether they have seen an error, made a decision, or solved a similar problem before. query is required free text. project is an optional project path or name as stored in the index. source is an optional tool id or label such as claude-code or CUR. limit defaults to 10 and is capped at 50. Returns session id, source, project, title, matched excerpt, and ISO-8601 timestamp."
+        description = "Search past AI coding sessions across Claude Code, Codex, OpenCode, Cursor, and other indexed tools. Use when the user asks whether they have seen an error, made a decision, or solved a similar problem before. Returns session id, source, project, title, matched excerpt, and ISO-8601 timestamp.",
+        annotations(
+            title = "Search sessions",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     fn search_sessions(
         &self,
@@ -178,17 +197,32 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. max_messages defaults to 50 and counts from the start of the session. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Returns metadata plus messages as plain text in sequence order."
+        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Returns metadata plus messages as plain text in sequence order.",
+        annotations(
+            title = "Get session",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     fn get_session(
         &self,
         Parameters(args): Parameters<GetSessionArgs>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        Ok(json_result(get_session(&lock_index(&self.index), &args)))
+        Ok(json_result(
+            get_session(&lock_index(&self.index), &args)
+                .map_err(|message| empty_detail(Some(message))),
+        ))
     }
 
     #[tool(
-        description = "List the most recently active indexed sessions, newest first. Use to browse what the user has been working on when there is no search query. project is an optional project path or name as stored in the index. source is an optional tool id or label. limit defaults to 10 and is capped at 50. Each hit has the same shape as search_sessions: session id, source, project, title, excerpt (summary when present), and ISO-8601 timestamp."
+        description = "List the most recently active indexed sessions, newest first. Use to browse what the user has been working on when there is no search query. Each hit has the same shape as search_sessions: session id, source, project, title, excerpt (summary when present), and ISO-8601 timestamp.",
+        annotations(
+            title = "List recent sessions",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     fn list_recent_sessions(
         &self,
@@ -203,7 +237,6 @@ impl ServerHandler for RecallMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
-            .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_instructions(
                 "Read-only memory over the local Recall session index. Search or list past coding sessions, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
             )
@@ -216,24 +249,28 @@ fn lock_index(index: &Mutex<IndexState>) -> std::sync::MutexGuard<'_, IndexState
     guard
 }
 
-fn json_result(value: Value) -> CallToolResult {
-    let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
-    let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
-    result.structured_content = Some(value);
-    result
+fn json_result(result: std::result::Result<impl Serialize, impl Serialize>) -> CallToolResult {
+    match result {
+        Ok(value) => CallToolResult::structured(to_json(value)),
+        Err(value) => CallToolResult::structured_error(to_json(value)),
+    }
 }
 
-fn search_sessions(index: &IndexState, args: &SearchSessionsArgs) -> Value {
+fn to_json(value: impl Serialize) -> Value {
+    serde_json::to_value(value).unwrap_or(Value::Null)
+}
+
+fn empty_hits(message: impl Into<String>) -> HitList {
+    HitList { message: Some(message.into()), hits: Vec::new() }
+}
+
+fn search_sessions(
+    index: &IndexState,
+    args: &SearchSessionsArgs,
+) -> std::result::Result<HitList, HitList> {
     match index {
-        IndexState::Unavailable { message, .. } => {
-            serde_json::to_value(HitList { message: Some(message.clone()), hits: Vec::new() })
-                .unwrap_or(Value::Null)
-        }
-        IndexState::Ready(store) => match search_ready(store, args) {
-            Ok(list) => serde_json::to_value(list).unwrap_or(Value::Null),
-            Err(error) => serde_json::to_value(HitList { message: Some(error), hits: Vec::new() })
-                .unwrap_or(Value::Null),
-        },
+        IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
+        IndexState::Ready(store) => search_ready(store, args).map_err(empty_hits),
     }
 }
 
@@ -261,17 +298,13 @@ fn search_ready(store: &Store, args: &SearchSessionsArgs) -> std::result::Result
     })
 }
 
-fn list_recent_sessions(index: &IndexState, args: &ListRecentSessionsArgs) -> Value {
+fn list_recent_sessions(
+    index: &IndexState,
+    args: &ListRecentSessionsArgs,
+) -> std::result::Result<HitList, HitList> {
     match index {
-        IndexState::Unavailable { message, .. } => {
-            serde_json::to_value(HitList { message: Some(message.clone()), hits: Vec::new() })
-                .unwrap_or(Value::Null)
-        }
-        IndexState::Ready(store) => match list_ready(store, args) {
-            Ok(list) => serde_json::to_value(list).unwrap_or(Value::Null),
-            Err(error) => serde_json::to_value(HitList { message: Some(error), hits: Vec::new() })
-                .unwrap_or(Value::Null),
-        },
+        IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
+        IndexState::Ready(store) => list_ready(store, args).map_err(empty_hits),
     }
 }
 
@@ -301,15 +334,13 @@ fn list_ready(
     })
 }
 
-fn get_session(index: &IndexState, args: &GetSessionArgs) -> Value {
+fn get_session(
+    index: &IndexState,
+    args: &GetSessionArgs,
+) -> std::result::Result<SessionDetail, String> {
     match index {
-        IndexState::Unavailable { message, .. } => {
-            serde_json::to_value(empty_detail(Some(message.clone()))).unwrap_or(Value::Null)
-        }
-        IndexState::Ready(store) => match get_ready(store, args) {
-            Ok(detail) => serde_json::to_value(detail).unwrap_or(Value::Null),
-            Err(error) => serde_json::to_value(empty_detail(Some(error))).unwrap_or(Value::Null),
-        },
+        IndexState::Unavailable { message, .. } => Err(message.clone()),
+        IndexState::Ready(store) => get_ready(store, args),
     }
 }
 
@@ -322,7 +353,7 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
         } else {
             format!("{SESSION_NOT_FOUND} {}", args.session_id)
         };
-        return Ok(empty_detail(Some(message)));
+        return Err(message);
     };
     let max_messages = clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, u32::MAX);
     let messages = store.get_messages(&session.id).map_err(|error| error.to_string())?;
@@ -537,41 +568,36 @@ mod tests {
     }
 
     #[test]
-    fn missing_index_returns_empty_hits_with_message() {
+    fn missing_index_is_a_tool_error() {
         let index = IndexState::Unavailable { path: None, message: MISSING_INDEX.to_string() };
-        let value = search_sessions(
-            &index,
-            &SearchSessionsArgs { query: "error".into(), project: None, source: None, limit: None },
-        );
-        let list: HitList = serde_json::from_value(value).unwrap();
+        let args =
+            SearchSessionsArgs { query: "error".into(), project: None, source: None, limit: None };
+        let list = search_sessions(&index, &args).expect_err("missing index");
         assert!(list.hits.is_empty());
         assert_eq!(list.message.as_deref(), Some(MISSING_INDEX));
+        assert_eq!(json_result(search_sessions(&index, &args)).is_error, Some(true));
     }
 
     #[test]
     fn empty_index_search_and_list_explain_the_gap() {
         let store = setup();
         let index = ready(store);
-        let search = search_sessions(
-            &index,
-            &SearchSessionsArgs {
-                query: "anything".into(),
-                project: None,
-                source: None,
-                limit: None,
-            },
-        );
-        let search: HitList = serde_json::from_value(search).unwrap();
+        let search_args = SearchSessionsArgs {
+            query: "anything".into(),
+            project: None,
+            source: None,
+            limit: None,
+        };
+        let search = search_sessions(&index, &search_args).unwrap();
         assert!(search.hits.is_empty());
         assert_eq!(search.message.as_deref(), Some(EMPTY_INDEX));
+        assert_eq!(json_result(search_sessions(&index, &search_args)).is_error, Some(false));
 
-        let listed = list_recent_sessions(
-            &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: None },
-        );
-        let listed: HitList = serde_json::from_value(listed).unwrap();
+        let list_args = ListRecentSessionsArgs { project: None, source: None, limit: None };
+        let listed = list_recent_sessions(&index, &list_args).unwrap();
         assert!(listed.hits.is_empty());
         assert_eq!(listed.message.as_deref(), Some(EMPTY_INDEX));
+        assert_eq!(json_result(list_recent_sessions(&index, &list_args)).is_error, Some(false));
     }
 
     #[test]
@@ -583,7 +609,7 @@ mod tests {
             .unwrap();
         let index = ready(store);
 
-        let value = search_sessions(
+        let list = search_sessions(
             &index,
             &SearchSessionsArgs {
                 query: "iterators".into(),
@@ -591,8 +617,8 @@ mod tests {
                 source: None,
                 limit: Some(80),
             },
-        );
-        let list: HitList = serde_json::from_value(value).unwrap();
+        )
+        .unwrap();
         assert_eq!(list.hits.len(), 1);
         assert_eq!(list.hits[0].session_id, "s1");
         assert_eq!(list.hits[0].source, "codex");
@@ -610,11 +636,11 @@ mod tests {
         store.insert_session(&session("new", "claude-code", "newer", 9_000)).unwrap();
         let index = ready(store);
 
-        let value = list_recent_sessions(
+        let list = list_recent_sessions(
             &index,
             &ListRecentSessionsArgs { project: None, source: None, limit: Some(10) },
-        );
-        let list: HitList = serde_json::from_value(value).unwrap();
+        )
+        .unwrap();
         assert_eq!(list.hits.len(), 2);
         assert_eq!(list.hits[0].session_id, "new");
         assert_eq!(list.hits[0].excerpt.as_deref(), Some("newer summary"));
@@ -627,18 +653,16 @@ mod tests {
         store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
         store.insert_messages(&[message("s1", Role::User, "hello", 0)]).unwrap();
         let index = ready(store);
-        let value = search_sessions(
-            &index,
-            &SearchSessionsArgs {
-                query: "hello".into(),
-                project: None,
-                source: Some("not-a-source".into()),
-                limit: None,
-            },
-        );
-        let list: HitList = serde_json::from_value(value).unwrap();
+        let args = SearchSessionsArgs {
+            query: "hello".into(),
+            project: None,
+            source: Some("not-a-source".into()),
+            limit: None,
+        };
+        let list = search_sessions(&index, &args).expect_err("unknown source");
         assert!(list.hits.is_empty());
         assert!(list.message.unwrap().contains("unknown source"));
+        assert_eq!(json_result(search_sessions(&index, &args)).is_error, Some(true));
     }
 
     #[test]
@@ -656,9 +680,9 @@ mod tests {
             .unwrap();
         let index = ready(store);
 
-        let value =
-            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1) });
-        let detail: SessionDetail = serde_json::from_value(value).unwrap();
+        let detail =
+            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1) })
+                .unwrap();
         assert_eq!(detail.session_id.as_deref(), Some("s1"));
         assert_eq!(detail.returned_messages, 1);
         assert!(detail.truncated);
@@ -671,17 +695,18 @@ mod tests {
     }
 
     #[test]
-    fn get_session_missing_id_is_empty_with_message() {
+    fn get_session_missing_id_is_a_tool_error() {
         let store = setup();
         store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
         let index = ready(store);
-        let value = get_session(
-            &index,
-            &GetSessionArgs { session_id: "missing".into(), max_messages: None },
+        let args = GetSessionArgs { session_id: "missing".into(), max_messages: None };
+        let error = get_session(&index, &args).expect_err("missing session");
+        assert!(error.contains(SESSION_NOT_FOUND));
+        assert_eq!(
+            json_result(get_session(&index, &args).map_err(|message| empty_detail(Some(message))))
+                .is_error,
+            Some(true)
         );
-        let detail: SessionDetail = serde_json::from_value(value).unwrap();
-        assert!(detail.session_id.is_none());
-        assert!(detail.message.unwrap().contains(SESSION_NOT_FOUND));
     }
 
     #[test]
@@ -736,8 +761,8 @@ mod tests {
         let listed = list_recent_sessions(
             &index,
             &ListRecentSessionsArgs { project: None, source: None, limit: None },
-        );
-        let listed: HitList = serde_json::from_value(listed).unwrap();
+        )
+        .unwrap();
         assert_eq!(listed.hits.len(), 1);
         assert_eq!(listed.hits[0].session_id, "s1");
         assert!(listed.message.is_none());
@@ -750,11 +775,11 @@ mod tests {
         long.summary = Some("y".repeat(EXCERPT_CHAR_CAP + 40));
         store.insert_session(&long).unwrap();
         let index = ready(store);
-        let value = list_recent_sessions(
+        let list = list_recent_sessions(
             &index,
             &ListRecentSessionsArgs { project: None, source: None, limit: None },
-        );
-        let list: HitList = serde_json::from_value(value).unwrap();
+        )
+        .unwrap();
         let excerpt = list.hits[0].excerpt.as_deref().unwrap();
         assert_eq!(excerpt.chars().count(), EXCERPT_CHAR_CAP);
         assert!(excerpt.ends_with('…'));
@@ -769,9 +794,9 @@ mod tests {
         let content = "x".repeat(GET_MESSAGE_CHAR_CAP + 1);
         store.insert_messages(&[message("s1", Role::User, &content, 0)]).unwrap();
         let index = ready(store);
-        let value =
-            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: None });
-        let detail: SessionDetail = serde_json::from_value(value).unwrap();
+        let detail =
+            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: None })
+                .unwrap();
         assert!(detail.truncated);
         assert!(detail.messages.ends_with('…'));
         assert_eq!(
@@ -787,5 +812,13 @@ mod tests {
         assert_eq!(args.limit, Some(12));
         assert_eq!(clamp_limit(Some(80), 10, 50), 50);
         assert_eq!(clamp_limit(None, 10, 50), 10);
+    }
+
+    #[test]
+    fn tools_advertise_read_only_closed_world() {
+        let notes = RecallMcp::search_sessions_tool_attr().annotations.unwrap();
+        assert_eq!(notes.read_only_hint, Some(true));
+        assert_eq!(notes.idempotent_hint, Some(true));
+        assert_eq!(notes.open_world_hint, Some(false));
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,791 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use chrono::SecondsFormat;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{
+    CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+};
+use rmcp::{
+    ServerHandler, ServiceExt, schemars, tool, tool_handler, tool_router, transport::stdio,
+};
+use serde::Deserialize;
+use serde::de::{self, Deserializer};
+use serde_json::Value;
+
+use crate::adapters;
+use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
+use crate::db::store::Store;
+use crate::project_scope::ProjectScope;
+use crate::query::{query_embedding, resolve_source_filter};
+use crate::types::{Message, Role, Session};
+
+const SEARCH_LIMIT_DEFAULT: u32 = 10;
+const SEARCH_LIMIT_MAX: u32 = 50;
+const LIST_LIMIT_DEFAULT: u32 = 10;
+const LIST_LIMIT_MAX: u32 = 50;
+const GET_MAX_MESSAGES_DEFAULT: u32 = 50;
+const GET_MESSAGE_CHAR_CAP: usize = 2_000;
+const GET_RESPONSE_CHAR_CAP: usize = 32_000;
+const EXCERPT_CHAR_CAP: usize = 200;
+
+const MISSING_INDEX: &str =
+    "Recall index not found. Run `recall sync` in a terminal to create it, then retry.";
+const EMPTY_INDEX: &str = "No sessions in the Recall index. Run `recall sync` in a terminal after using a supported coding agent.";
+const SEARCH_EMPTY: &str = "No matching sessions.";
+const SESSION_NOT_FOUND: &str = "Session not found.";
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SearchSessionsArgs {
+    query: String,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GetSessionArgs {
+    session_id: String,
+    #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    max_messages: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListRecentSessionsArgs {
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct SessionHit {
+    session_id: String,
+    source: String,
+    project: Option<String>,
+    title: String,
+    excerpt: Option<String>,
+    timestamp: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct HitList {
+    message: Option<String>,
+    hits: Vec<SessionHit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct SessionDetail {
+    message: Option<String>,
+    session_id: Option<String>,
+    source: Option<String>,
+    project: Option<String>,
+    title: Option<String>,
+    summary: Option<String>,
+    timestamp: Option<String>,
+    message_count: Option<u32>,
+    returned_messages: usize,
+    truncated: bool,
+    messages: String,
+}
+
+enum IndexState {
+    Ready(Store),
+    Unavailable { path: Option<PathBuf>, message: String },
+}
+
+#[derive(Clone)]
+struct RecallMcp {
+    index: Arc<Mutex<IndexState>>,
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Self>,
+}
+
+impl IndexState {
+    fn open(db: Option<&Path>) -> Self {
+        let path = match db {
+            Some(path) => path.to_path_buf(),
+            None => match Store::default_db_path() {
+                Ok(path) => path,
+                Err(error) => {
+                    return Self::Unavailable { path: None, message: error.to_string() };
+                }
+            },
+        };
+        Self::open_path(path)
+    }
+
+    fn open_path(path: PathBuf) -> Self {
+        if !path.exists() {
+            let message = format!("{MISSING_INDEX} ({})", path.display());
+            return Self::Unavailable { path: Some(path), message };
+        }
+        match Store::open_read_only_at(&path) {
+            Ok(store) => Self::Ready(store),
+            Err(error) => {
+                let message = format!("Cannot open Recall index at {}: {error}", path.display());
+                Self::Unavailable { path: Some(path), message }
+            }
+        }
+    }
+
+    fn ensure_open(&mut self) {
+        let path = match self {
+            Self::Ready(_) => return,
+            Self::Unavailable { path: Some(path), .. } => path.clone(),
+            Self::Unavailable { path: None, .. } => {
+                *self = Self::open(None);
+                return;
+            }
+        };
+        *self = Self::open_path(path);
+    }
+}
+
+pub(crate) fn run(db: Option<PathBuf>) -> Result<()> {
+    let runtime =
+        tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build()?;
+    runtime.block_on(serve(db))
+}
+
+async fn serve(db: Option<PathBuf>) -> Result<()> {
+    let service = RecallMcp::new(db.as_deref()).serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[tool_router]
+impl RecallMcp {
+    fn new(db: Option<&Path>) -> Self {
+        Self { index: Arc::new(Mutex::new(IndexState::open(db))), tool_router: Self::tool_router() }
+    }
+
+    #[tool(
+        description = "Search past AI coding sessions across Claude Code, Codex, OpenCode, Cursor, and other indexed tools. Use when the user asks whether they have seen an error, made a decision, or solved a similar problem before. query is required free text. project is an optional project path or name as stored in the index. source is an optional tool id or label such as claude-code or CUR. limit defaults to 10 and is capped at 50. Returns session id, source, project, title, matched excerpt, and ISO-8601 timestamp."
+    )]
+    fn search_sessions(
+        &self,
+        Parameters(args): Parameters<SearchSessionsArgs>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(json_result(search_sessions(&lock_index(&self.index), &args)))
+    }
+
+    #[tool(
+        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. max_messages defaults to 50 and counts from the start of the session. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Returns metadata plus messages as plain text in sequence order."
+    )]
+    fn get_session(
+        &self,
+        Parameters(args): Parameters<GetSessionArgs>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(json_result(get_session(&lock_index(&self.index), &args)))
+    }
+
+    #[tool(
+        description = "List the most recently active indexed sessions, newest first. Use to browse what the user has been working on when there is no search query. project is an optional project path or name as stored in the index. source is an optional tool id or label. limit defaults to 10 and is capped at 50. Each hit has the same shape as search_sessions: session id, source, project, title, excerpt (summary when present), and ISO-8601 timestamp."
+    )]
+    fn list_recent_sessions(
+        &self,
+        Parameters(args): Parameters<ListRecentSessionsArgs>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(json_result(list_recent_sessions(&lock_index(&self.index), &args)))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for RecallMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions(
+                "Read-only memory over the local Recall session index. Search or list past coding sessions, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
+            )
+    }
+}
+
+fn lock_index(index: &Mutex<IndexState>) -> std::sync::MutexGuard<'_, IndexState> {
+    let mut guard = index.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.ensure_open();
+    guard
+}
+
+fn json_result(value: Value) -> CallToolResult {
+    let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
+    result.structured_content = Some(value);
+    result
+}
+
+fn search_sessions(index: &IndexState, args: &SearchSessionsArgs) -> Value {
+    match index {
+        IndexState::Unavailable { message, .. } => {
+            serde_json::to_value(HitList { message: Some(message.clone()), hits: Vec::new() })
+                .unwrap_or(Value::Null)
+        }
+        IndexState::Ready(store) => match search_ready(store, args) {
+            Ok(list) => serde_json::to_value(list).unwrap_or(Value::Null),
+            Err(error) => serde_json::to_value(HitList { message: Some(error), hits: Vec::new() })
+                .unwrap_or(Value::Null),
+        },
+    }
+}
+
+fn search_ready(store: &Store, args: &SearchSessionsArgs) -> std::result::Result<HitList, String> {
+    let (scope, sources) = resolve_filters(store, args.project.as_deref(), args.source.as_deref())?;
+    let limit = clamp_limit(args.limit, SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX);
+    let embedding = query_embedding(store, &args.query, |message| {
+        tracing::info!("{message}");
+    })
+    .map_err(|error| error.to_string())?;
+    let filters = SearchFilters { sources, time_range: TimeRange::All, scope, thread_role: None };
+    let results = SearchEngine::new(&store.conn)
+        .hybrid_search(&args.query, embedding.as_deref(), &filters, limit, 3)
+        .map_err(|error| error.to_string())?;
+    if results.is_empty() {
+        let message = if store_is_empty(store) { EMPTY_INDEX } else { SEARCH_EMPTY };
+        return Ok(HitList { message: Some(message.to_string()), hits: Vec::new() });
+    }
+    Ok(HitList {
+        message: None,
+        hits: results
+            .into_iter()
+            .map(|result| session_hit(&result.session, result.snippet))
+            .collect(),
+    })
+}
+
+fn list_recent_sessions(index: &IndexState, args: &ListRecentSessionsArgs) -> Value {
+    match index {
+        IndexState::Unavailable { message, .. } => {
+            serde_json::to_value(HitList { message: Some(message.clone()), hits: Vec::new() })
+                .unwrap_or(Value::Null)
+        }
+        IndexState::Ready(store) => match list_ready(store, args) {
+            Ok(list) => serde_json::to_value(list).unwrap_or(Value::Null),
+            Err(error) => serde_json::to_value(HitList { message: Some(error), hits: Vec::new() })
+                .unwrap_or(Value::Null),
+        },
+    }
+}
+
+fn list_ready(
+    store: &Store,
+    args: &ListRecentSessionsArgs,
+) -> std::result::Result<HitList, String> {
+    let (scope, sources) = resolve_filters(store, args.project.as_deref(), args.source.as_deref())?;
+    let limit = clamp_limit(args.limit, LIST_LIMIT_DEFAULT, LIST_LIMIT_MAX);
+    let sessions = store
+        .list_recent_sessions_for_search_scope(sources.as_deref(), TimeRange::All, &scope, limit)
+        .map_err(|error| error.to_string())?;
+    if sessions.is_empty() {
+        let message = if store_is_empty(store) { EMPTY_INDEX } else { SEARCH_EMPTY };
+        return Ok(HitList { message: Some(message.to_string()), hits: Vec::new() });
+    }
+    Ok(HitList {
+        message: None,
+        hits: sessions
+            .into_iter()
+            .map(|session| {
+                let excerpt =
+                    session.summary.as_deref().map(|text| truncate_chars(text, EXCERPT_CHAR_CAP).0);
+                session_hit(&session, excerpt)
+            })
+            .collect(),
+    })
+}
+
+fn get_session(index: &IndexState, args: &GetSessionArgs) -> Value {
+    match index {
+        IndexState::Unavailable { message, .. } => {
+            serde_json::to_value(empty_detail(Some(message.clone()))).unwrap_or(Value::Null)
+        }
+        IndexState::Ready(store) => match get_ready(store, args) {
+            Ok(detail) => serde_json::to_value(detail).unwrap_or(Value::Null),
+            Err(error) => serde_json::to_value(empty_detail(Some(error))).unwrap_or(Value::Null),
+        },
+    }
+}
+
+fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<SessionDetail, String> {
+    let Some(session) =
+        store.get_session_by_id(&args.session_id).map_err(|error| error.to_string())?
+    else {
+        let message = if store_is_empty(store) {
+            EMPTY_INDEX.to_string()
+        } else {
+            format!("{SESSION_NOT_FOUND} {}", args.session_id)
+        };
+        return Ok(empty_detail(Some(message)));
+    };
+    let max_messages = clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, u32::MAX);
+    let messages = store.get_messages(&session.id).map_err(|error| error.to_string())?;
+    let (text, returned, truncated) = render_messages(&messages, max_messages);
+    Ok(SessionDetail {
+        message: None,
+        session_id: Some(session.id.clone()),
+        source: Some(session.source.clone()),
+        project: session.directory.clone(),
+        title: Some(session_title(&session)),
+        summary: session.summary.clone(),
+        timestamp: Some(iso8601(session.started_at)),
+        message_count: Some(session.message_count),
+        returned_messages: returned,
+        truncated,
+        messages: text,
+    })
+}
+
+fn empty_detail(message: Option<String>) -> SessionDetail {
+    SessionDetail {
+        message,
+        session_id: None,
+        source: None,
+        project: None,
+        title: None,
+        summary: None,
+        timestamp: None,
+        message_count: None,
+        returned_messages: 0,
+        truncated: false,
+        messages: String::new(),
+    }
+}
+
+fn resolve_filters(
+    store: &Store,
+    project: Option<&str>,
+    source: Option<&str>,
+) -> std::result::Result<(ProjectScope, Option<Vec<String>>), String> {
+    let scope = match project.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(project) => {
+            store.resolve_project_selector(project).map_err(|error| error.to_string())?
+        }
+        None => ProjectScope::Global,
+    };
+    let sources = resolve_source_filter(source, &adapters::source_labels())
+        .map_err(|error| error.to_string())?;
+    Ok((scope, sources))
+}
+
+fn store_is_empty(store: &Store) -> bool {
+    store.stats().ok().is_some_and(|(sessions, _)| sessions == 0)
+}
+
+fn session_hit(session: &Session, excerpt: Option<String>) -> SessionHit {
+    SessionHit {
+        session_id: session.id.clone(),
+        source: session.source.clone(),
+        project: session.directory.clone(),
+        title: session_title(session),
+        excerpt,
+        timestamp: iso8601(session.started_at),
+    }
+}
+
+fn session_title(session: &Session) -> String {
+    session
+        .custom_title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .unwrap_or(session.title.as_str())
+        .to_string()
+}
+
+fn iso8601(millis: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(millis)
+        .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Millis, true))
+        .unwrap_or_else(|| "1970-01-01T00:00:00.000Z".to_string())
+}
+
+fn clamp_limit(limit: Option<u32>, default: u32, max: u32) -> usize {
+    usize::try_from(limit.unwrap_or(default).clamp(1, max)).unwrap_or(max as usize)
+}
+
+fn render_messages(messages: &[Message], max_messages: usize) -> (String, usize, bool) {
+    let mut text = String::new();
+    let mut returned = 0;
+    let mut truncated = messages.len() > max_messages;
+    for message in messages.iter().take(max_messages) {
+        let (body, cut) = truncate_chars(&message.content, GET_MESSAGE_CHAR_CAP);
+        if cut {
+            truncated = true;
+        }
+        let block = format!("[{}] {body}", role_label(&message.role));
+        let extra = if text.is_empty() { block.len() } else { block.len() + 2 };
+        if !text.is_empty() && text.len() + extra > GET_RESPONSE_CHAR_CAP {
+            truncated = true;
+            break;
+        }
+        if !text.is_empty() {
+            text.push_str("\n\n");
+        }
+        if text.len() + block.len() > GET_RESPONSE_CHAR_CAP {
+            let remaining = GET_RESPONSE_CHAR_CAP.saturating_sub(text.len());
+            text.push_str(&truncate_chars(&block, remaining).0);
+            truncated = true;
+            returned += 1;
+            break;
+        }
+        text.push_str(&block);
+        returned += 1;
+    }
+    (text, returned, truncated)
+}
+
+fn role_label(role: &Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> (String, bool) {
+    if max_chars == 0 {
+        return (String::new(), !text.is_empty());
+    }
+    let mut chars = text.chars();
+    let kept: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_none() {
+        (kept, false)
+    } else if max_chars == 1 {
+        ("…".to_string(), true)
+    } else {
+        let mut trimmed: String = kept.chars().take(max_chars - 1).collect();
+        trimmed.push('…');
+        (trimmed, true)
+    }
+}
+
+fn deserialize_opt_u32<'de, D>(deserializer: D) -> std::result::Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumberOrString {
+        U(u32),
+        I(i64),
+        S(String),
+        Null,
+    }
+
+    match Option::<NumberOrString>::deserialize(deserializer)? {
+        None | Some(NumberOrString::Null) => Ok(None),
+        Some(NumberOrString::U(value)) => Ok(Some(value)),
+        Some(NumberOrString::I(value)) if value >= 0 => {
+            u32::try_from(value).map(Some).map_err(de::Error::custom)
+        }
+        Some(NumberOrString::S(value)) if value.trim().is_empty() => Ok(None),
+        Some(NumberOrString::S(value)) => value.parse().map(Some).map_err(de::Error::custom),
+        Some(NumberOrString::I(_)) => Err(de::Error::custom("expected a non-negative integer")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema;
+    use crate::types::Session;
+
+    fn setup() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn session(id: &str, source: &str, title: &str, started_at: i64) -> Session {
+        Session {
+            id: id.to_string(),
+            source: source.to_string(),
+            source_id: format!("src-{id}"),
+            title: title.to_string(),
+            directory: Some("/tmp/demo".to_string()),
+            repo_remote: None,
+            repo_slug: None,
+            repo_name: None,
+            started_at,
+            updated_at: Some(started_at),
+            message_count: 1,
+            entrypoint: None,
+            custom_title: None,
+            summary: Some(format!("{title} summary")),
+            duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
+        }
+    }
+
+    fn message(session_id: &str, role: Role, content: &str, seq: u32) -> Message {
+        Message {
+            session_id: session_id.to_string(),
+            role,
+            content: content.to_string(),
+            timestamp: Some(1_700_000_000_000),
+            seq,
+        }
+    }
+
+    fn ready(store: Store) -> IndexState {
+        IndexState::Ready(store)
+    }
+
+    #[test]
+    fn missing_index_returns_empty_hits_with_message() {
+        let index = IndexState::Unavailable { path: None, message: MISSING_INDEX.to_string() };
+        let value = search_sessions(
+            &index,
+            &SearchSessionsArgs { query: "error".into(), project: None, source: None, limit: None },
+        );
+        let list: HitList = serde_json::from_value(value).unwrap();
+        assert!(list.hits.is_empty());
+        assert_eq!(list.message.as_deref(), Some(MISSING_INDEX));
+    }
+
+    #[test]
+    fn empty_index_search_and_list_explain_the_gap() {
+        let store = setup();
+        let index = ready(store);
+        let search = search_sessions(
+            &index,
+            &SearchSessionsArgs {
+                query: "anything".into(),
+                project: None,
+                source: None,
+                limit: None,
+            },
+        );
+        let search: HitList = serde_json::from_value(search).unwrap();
+        assert!(search.hits.is_empty());
+        assert_eq!(search.message.as_deref(), Some(EMPTY_INDEX));
+
+        let listed = list_recent_sessions(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: None },
+        );
+        let listed: HitList = serde_json::from_value(listed).unwrap();
+        assert!(listed.hits.is_empty());
+        assert_eq!(listed.message.as_deref(), Some(EMPTY_INDEX));
+    }
+
+    #[test]
+    fn search_reuses_hybrid_search_and_clamps_limit() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "iterator panic", 2_000)).unwrap();
+        store
+            .insert_messages(&[message("s1", Role::User, "how do I use iterators in Rust", 0)])
+            .unwrap();
+        let index = ready(store);
+
+        let value = search_sessions(
+            &index,
+            &SearchSessionsArgs {
+                query: "iterators".into(),
+                project: None,
+                source: None,
+                limit: Some(80),
+            },
+        );
+        let list: HitList = serde_json::from_value(value).unwrap();
+        assert_eq!(list.hits.len(), 1);
+        assert_eq!(list.hits[0].session_id, "s1");
+        assert_eq!(list.hits[0].source, "codex");
+        assert_eq!(list.hits[0].project.as_deref(), Some("/tmp/demo"));
+        assert_eq!(list.hits[0].title, "iterator panic");
+        assert!(list.hits[0].excerpt.as_deref().unwrap().contains("iterators"));
+        assert_eq!(list.hits[0].timestamp, iso8601(2_000));
+        assert!(list.message.is_none());
+    }
+
+    #[test]
+    fn list_recent_is_newest_first_and_matches_search_shape() {
+        let store = setup();
+        store.insert_session(&session("old", "codex", "older", 1_000)).unwrap();
+        store.insert_session(&session("new", "claude-code", "newer", 9_000)).unwrap();
+        let index = ready(store);
+
+        let value = list_recent_sessions(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: Some(10) },
+        );
+        let list: HitList = serde_json::from_value(value).unwrap();
+        assert_eq!(list.hits.len(), 2);
+        assert_eq!(list.hits[0].session_id, "new");
+        assert_eq!(list.hits[0].excerpt.as_deref(), Some("newer summary"));
+        assert_eq!(list.hits[1].session_id, "old");
+    }
+
+    #[test]
+    fn unknown_source_is_empty_not_a_crash() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
+        store.insert_messages(&[message("s1", Role::User, "hello", 0)]).unwrap();
+        let index = ready(store);
+        let value = search_sessions(
+            &index,
+            &SearchSessionsArgs {
+                query: "hello".into(),
+                project: None,
+                source: Some("not-a-source".into()),
+                limit: None,
+            },
+        );
+        let list: HitList = serde_json::from_value(value).unwrap();
+        assert!(list.hits.is_empty());
+        assert!(list.message.unwrap().contains("unknown source"));
+    }
+
+    #[test]
+    fn get_session_returns_plain_text_and_caps_long_messages() {
+        let store = setup();
+        let mut long = session("s1", "codex", "long", 1_000);
+        long.message_count = 2;
+        store.insert_session(&long).unwrap();
+        let huge = "x".repeat(GET_MESSAGE_CHAR_CAP + 20);
+        store
+            .insert_messages(&[
+                message("s1", Role::User, &huge, 0),
+                message("s1", Role::Assistant, "done", 1),
+            ])
+            .unwrap();
+        let index = ready(store);
+
+        let value =
+            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1) });
+        let detail: SessionDetail = serde_json::from_value(value).unwrap();
+        assert_eq!(detail.session_id.as_deref(), Some("s1"));
+        assert_eq!(detail.returned_messages, 1);
+        assert!(detail.truncated);
+        assert!(detail.messages.starts_with("[user] "));
+        assert!(detail.messages.ends_with('…'));
+        assert!(!detail.messages.contains("[assistant]"));
+        assert!(
+            detail.messages.chars().count() <= "[user] ".chars().count() + GET_MESSAGE_CHAR_CAP
+        );
+    }
+
+    #[test]
+    fn get_session_missing_id_is_empty_with_message() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
+        let index = ready(store);
+        let value = get_session(
+            &index,
+            &GetSessionArgs { session_id: "missing".into(), max_messages: None },
+        );
+        let detail: SessionDetail = serde_json::from_value(value).unwrap();
+        assert!(detail.session_id.is_none());
+        assert!(detail.message.unwrap().contains(SESSION_NOT_FOUND));
+    }
+
+    #[test]
+    fn open_read_only_rejects_writes() {
+        schema::register_sqlite_vec();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recall.db");
+        {
+            let store = Store::open_at(&path).unwrap();
+            store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
+        }
+        let store = Store::open_read_only_at(&path).unwrap();
+        let loaded = store.get_session_by_id("s1").unwrap().unwrap();
+        assert_eq!(loaded.title, "title");
+        assert!(store.insert_session(&session("s2", "codex", "nope", 2_000)).is_err());
+    }
+
+    #[test]
+    fn missing_db_path_does_not_create_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing").join("recall.db");
+        let index = IndexState::open(Some(&path));
+        match index {
+            IndexState::Unavailable { message, path: kept } => {
+                assert!(message.contains("not found"));
+                assert_eq!(kept.as_deref(), Some(path.as_path()));
+                assert!(!path.exists());
+            }
+            IndexState::Ready(_) => panic!("missing database should stay unavailable"),
+        }
+    }
+
+    #[test]
+    fn missing_index_opens_after_the_file_appears() {
+        schema::register_sqlite_vec();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recall.db");
+        let mut index = IndexState::open(Some(&path));
+        match &index {
+            IndexState::Unavailable { message, path: kept } => {
+                assert!(message.contains("not found"));
+                assert_eq!(kept.as_deref(), Some(path.as_path()));
+            }
+            IndexState::Ready(_) => panic!("missing database should stay unavailable"),
+        }
+        {
+            let store = Store::open_at(&path).unwrap();
+            store.insert_session(&session("s1", "codex", "later", 1_000)).unwrap();
+            store.insert_messages(&[message("s1", Role::User, "hello later", 0)]).unwrap();
+        }
+        index.ensure_open();
+        let listed = list_recent_sessions(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: None },
+        );
+        let listed: HitList = serde_json::from_value(listed).unwrap();
+        assert_eq!(listed.hits.len(), 1);
+        assert_eq!(listed.hits[0].session_id, "s1");
+        assert!(listed.message.is_none());
+    }
+
+    #[test]
+    fn list_recent_bounds_summary_excerpt() {
+        let store = setup();
+        let mut long = session("s1", "codex", "long", 1_000);
+        long.summary = Some("y".repeat(EXCERPT_CHAR_CAP + 40));
+        store.insert_session(&long).unwrap();
+        let index = ready(store);
+        let value = list_recent_sessions(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: None },
+        );
+        let list: HitList = serde_json::from_value(value).unwrap();
+        let excerpt = list.hits[0].excerpt.as_deref().unwrap();
+        assert_eq!(excerpt.chars().count(), EXCERPT_CHAR_CAP);
+        assert!(excerpt.ends_with('…'));
+    }
+
+    #[test]
+    fn get_session_flags_truncated_when_one_char_over_cap() {
+        let store = setup();
+        let mut long = session("s1", "codex", "edge", 1_000);
+        long.message_count = 1;
+        store.insert_session(&long).unwrap();
+        let content = "x".repeat(GET_MESSAGE_CHAR_CAP + 1);
+        store.insert_messages(&[message("s1", Role::User, &content, 0)]).unwrap();
+        let index = ready(store);
+        let value =
+            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: None });
+        let detail: SessionDetail = serde_json::from_value(value).unwrap();
+        assert!(detail.truncated);
+        assert!(detail.messages.ends_with('…'));
+        assert_eq!(
+            detail.messages.chars().count(),
+            "[user] ".chars().count() + GET_MESSAGE_CHAR_CAP
+        );
+    }
+
+    #[test]
+    fn limit_deserializer_accepts_string_numbers() {
+        let args: SearchSessionsArgs =
+            serde_json::from_value(serde_json::json!({"query": "q", "limit": "12"})).unwrap();
+        assert_eq!(args.limit, Some(12));
+        assert_eq!(clamp_limit(Some(80), 10, 50), 50);
+        assert_eq!(clamp_limit(None, 10, 50), 10);
+    }
+}

--- a/src/mcp_host.rs
+++ b/src/mcp_host.rs
@@ -1,0 +1,411 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+const SERVER_NAME: &str = "recall";
+const DEFAULT_BIN: &str = "recall";
+const SERVER_ARG: &str = "mcp";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Host {
+    Claude,
+    Codex,
+}
+
+impl Host {
+    const ALL: [Self; 2] = [Self::Claude, Self::Codex];
+
+    fn id(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+
+    fn binary(self) -> &'static str {
+        self.id()
+    }
+
+    fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "claude" | "claude-code" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            other => bail!("unknown MCP host '{other}'; supported hosts: claude, codex"),
+        }
+    }
+}
+
+enum HostAction {
+    Install { bin: String },
+    Uninstall,
+}
+
+pub(crate) fn install(agents: &[String], dry_run: bool, bin: Option<PathBuf>) -> Result<()> {
+    let hosts = resolve_hosts(agents)?;
+    let bin = resolve_bin(bin)?;
+    run_hosts(hosts, dry_run, HostAction::Install { bin })
+}
+
+pub(crate) fn uninstall(agents: &[String], dry_run: bool) -> Result<()> {
+    run_hosts(resolve_hosts(agents)?, dry_run, HostAction::Uninstall)
+}
+
+fn resolve_hosts(agents: &[String]) -> Result<Vec<Host>> {
+    if agents.is_empty() || agents.iter().any(|agent| agent.trim() == "*") {
+        return Ok(Host::ALL.to_vec());
+    }
+
+    let mut hosts = Vec::new();
+    for agent in agents {
+        let host = Host::parse(agent)?;
+        if !hosts.contains(&host) {
+            hosts.push(host);
+        }
+    }
+    Ok(hosts)
+}
+
+fn resolve_bin(bin: Option<PathBuf>) -> Result<String> {
+    let Some(path) = bin else {
+        return Ok(DEFAULT_BIN.to_string());
+    };
+    if path.as_os_str().is_empty() {
+        bail!("--bin must not be empty");
+    }
+    if path.is_absolute() {
+        ensure_bin_file(&path)?;
+        return Ok(path.to_string_lossy().into_owned());
+    }
+    if path.components().count() == 1 {
+        return Ok(path.to_string_lossy().into_owned());
+    }
+
+    let absolute = std::env::current_dir()
+        .context("failed to resolve current directory for --bin")?
+        .join(path);
+    ensure_bin_file(&absolute)?;
+    Ok(absolute.to_string_lossy().into_owned())
+}
+
+fn ensure_bin_file(path: &Path) -> Result<()> {
+    if path.is_file() {
+        return Ok(());
+    }
+    bail!("--bin {} is not a file", path.display());
+}
+
+fn add_args(host: Host, bin: &str) -> Vec<String> {
+    match host {
+        Host::Claude => vec![
+            "mcp".into(),
+            "add".into(),
+            "--scope".into(),
+            "user".into(),
+            SERVER_NAME.into(),
+            "--".into(),
+            bin.into(),
+            SERVER_ARG.into(),
+        ],
+        Host::Codex => {
+            vec![
+                "mcp".into(),
+                "add".into(),
+                SERVER_NAME.into(),
+                "--".into(),
+                bin.into(),
+                SERVER_ARG.into(),
+            ]
+        }
+    }
+}
+
+fn remove_args(host: Host) -> Vec<String> {
+    match host {
+        Host::Claude => {
+            vec!["mcp".into(), "remove".into(), SERVER_NAME.into(), "-s".into(), "user".into()]
+        }
+        Host::Codex => vec!["mcp".into(), "remove".into(), SERVER_NAME.into()],
+    }
+}
+
+fn run_hosts(hosts: Vec<Host>, dry_run: bool, action: HostAction) -> Result<()> {
+    let mut changed = 0usize;
+    let mut errors = Vec::new();
+
+    for host in hosts {
+        if !binary_on_path(host.binary()) {
+            eprintln!("skipped {}: `{}` is not on PATH", host.id(), host.binary());
+            continue;
+        }
+        match apply_host(host, dry_run, &action) {
+            Ok(()) => changed += 1,
+            Err(error) => errors.push(error),
+        }
+    }
+
+    if changed == 0 && errors.is_empty() {
+        bail!("no supported MCP hosts found on PATH (claude, codex)");
+    }
+    if !errors.is_empty() {
+        let detail = errors.iter().map(ToString::to_string).collect::<Vec<_>>().join("; ");
+        if changed == 0 {
+            bail!("failed to update Recall MCP: {detail}");
+        }
+        bail!("updated some hosts, but failed: {detail}");
+    }
+    Ok(())
+}
+
+fn apply_host(host: Host, dry_run: bool, action: &HostAction) -> Result<()> {
+    match action {
+        HostAction::Install { bin } => {
+            let args = add_args(host, bin);
+            if dry_run {
+                println!("{}", display_command(host.binary(), &args));
+                return Ok(());
+            }
+            install_host(host, bin)
+        }
+        HostAction::Uninstall => {
+            let args = remove_args(host);
+            if dry_run {
+                println!("{}", display_command(host.binary(), &args));
+                return Ok(());
+            }
+            uninstall_host(host)
+        }
+    }
+}
+
+fn install_host(host: Host, bin: &str) -> Result<()> {
+    let args = add_args(host, bin);
+    let add = run_host(host.binary(), &args)?;
+    if add.success {
+        println!("installed {}", host.id());
+        return Ok(());
+    }
+    if !looks_like_already_exists(&add.combined()) {
+        bail!("{}: {}", display_command(host.binary(), &args), add.summary());
+    }
+
+    remove_host(host)?;
+    let retry = run_host(host.binary(), &args)?;
+    if retry.success {
+        println!("installed {}", host.id());
+        return Ok(());
+    }
+    bail!("{}: {}", display_command(host.binary(), &args), retry.summary())
+}
+
+fn uninstall_host(host: Host) -> Result<()> {
+    remove_host(host)?;
+    println!("uninstalled {}", host.id());
+    Ok(())
+}
+
+fn remove_host(host: Host) -> Result<()> {
+    let args = remove_args(host);
+    let output = run_host(host.binary(), &args)?;
+    if output.success || looks_like_not_found(&output.combined()) {
+        return Ok(());
+    }
+    bail!("{}: {}", display_command(host.binary(), &args), output.summary())
+}
+
+struct HostOutput {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+impl HostOutput {
+    fn combined(&self) -> String {
+        format!("{}\n{}", self.stdout, self.stderr)
+    }
+
+    fn summary(&self) -> String {
+        let stderr = self.stderr.trim();
+        if !stderr.is_empty() {
+            return stderr.to_string();
+        }
+        let stdout = self.stdout.trim();
+        if stdout.is_empty() { "host command failed".to_string() } else { stdout.to_string() }
+    }
+}
+
+fn run_host(program: &str, args: &[String]) -> Result<HostOutput> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run {program}"))?;
+    let result = HostOutput {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    };
+    if !result.stdout.is_empty() {
+        print!("{}", result.stdout);
+        if !result.stdout.ends_with('\n') {
+            println!();
+        }
+    }
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr);
+        if !result.stderr.ends_with('\n') {
+            eprintln!();
+        }
+    }
+    Ok(result)
+}
+
+fn looks_like_already_exists(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("duplicate")
+        || (lower.contains("already")
+            && (lower.contains("exist") || lower.contains("registered") || lower.contains("added")))
+}
+
+fn looks_like_not_found(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("not found")
+        || lower.contains("does not exist")
+        || lower.contains("not registered")
+        || lower.contains("not configured")
+        || lower.contains("no mcp server")
+}
+
+fn display_command(program: &str, args: &[String]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().map(String::as_str))
+        .map(quote_arg)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_arg(arg: &str) -> String {
+    if arg.bytes().any(|b| b.is_ascii_whitespace() || b == b'\'') {
+        format!("'{}'", arg.replace('\'', "'\\''"))
+    } else {
+        arg.to_string()
+    }
+}
+
+fn binary_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| host_binary_in(&dir, name))
+}
+
+#[cfg(unix)]
+fn host_binary_in(dir: &Path, name: &str) -> bool {
+    is_unix_executable(&dir.join(name))
+}
+
+#[cfg(windows)]
+fn host_binary_in(dir: &Path, name: &str) -> bool {
+    dir.join(name).is_file() || dir.join(format!("{name}.exe")).is_file()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn host_binary_in(dir: &Path, name: &str) -> bool {
+    dir.join(name).is_file()
+}
+
+#[cfg(unix)]
+fn is_unix_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.is_file()
+        && path.metadata().ok().is_some_and(|meta| meta.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Host, add_args, display_command, looks_like_already_exists, looks_like_not_found,
+        quote_arg, remove_args, resolve_bin, resolve_hosts,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn resolve_hosts_defaults_to_all() {
+        assert_eq!(resolve_hosts(&[]).unwrap(), Host::ALL.to_vec());
+        assert_eq!(resolve_hosts(&["*".into()]).unwrap(), Host::ALL.to_vec());
+    }
+
+    #[test]
+    fn resolve_hosts_accepts_aliases_and_dedups() {
+        assert_eq!(
+            resolve_hosts(&["claude-code".into(), "CLAUDE".into(), "codex".into()]).unwrap(),
+            vec![Host::Claude, Host::Codex]
+        );
+    }
+
+    #[test]
+    fn resolve_hosts_rejects_unknown() {
+        let error = resolve_hosts(&["cursor".into()]).unwrap_err().to_string();
+        assert!(error.contains("unknown MCP host 'cursor'"));
+    }
+
+    #[test]
+    fn add_args_match_host_clis() {
+        assert_eq!(
+            add_args(Host::Claude, "recall"),
+            ["mcp", "add", "--scope", "user", "recall", "--", "recall", "mcp"]
+        );
+        assert_eq!(
+            add_args(Host::Codex, "recall"),
+            ["mcp", "add", "recall", "--", "recall", "mcp"]
+        );
+        assert_eq!(
+            add_args(Host::Claude, "/tmp/recall"),
+            ["mcp", "add", "--scope", "user", "recall", "--", "/tmp/recall", "mcp"]
+        );
+    }
+
+    #[test]
+    fn remove_args_match_host_clis() {
+        assert_eq!(remove_args(Host::Claude), ["mcp", "remove", "recall", "-s", "user"]);
+        assert_eq!(remove_args(Host::Codex), ["mcp", "remove", "recall"]);
+    }
+
+    #[test]
+    fn resolve_bin_defaults_to_path_name() {
+        assert_eq!(resolve_bin(None).unwrap(), "recall");
+        assert_eq!(resolve_bin(Some(PathBuf::from("recall"))).unwrap(), "recall");
+    }
+
+    #[test]
+    fn resolve_bin_rejects_missing_absolute_file() {
+        let error = resolve_bin(Some(PathBuf::from("/definitely-missing-recall-bin"))).unwrap_err();
+        assert!(error.to_string().contains("is not a file"));
+    }
+
+    #[test]
+    fn resolve_bin_keeps_existing_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("recall");
+        fs::write(&bin, "").unwrap();
+        assert_eq!(resolve_bin(Some(bin.clone())).unwrap(), bin.to_string_lossy());
+    }
+
+    #[test]
+    fn display_command_quotes_whitespace() {
+        assert_eq!(
+            display_command("claude", &add_args(Host::Claude, "/tmp/My Recall/recall")),
+            "claude mcp add --scope user recall -- '/tmp/My Recall/recall' mcp"
+        );
+        assert_eq!(quote_arg("plain"), "plain");
+    }
+
+    #[test]
+    fn host_error_text_classifies_upsert_and_missing() {
+        assert!(looks_like_already_exists("MCP server recall already exists"));
+        assert!(looks_like_already_exists("duplicate server name"));
+        assert!(!looks_like_already_exists("permission denied"));
+        assert!(looks_like_not_found("MCP server recall not found"));
+        assert!(!looks_like_not_found("connection refused"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `recall mcp` as a stdio MCP server with `search_sessions`, `list_recent_sessions`, and `get_session`.
- Open the local index read-only (`SQLITE_OPEN_READ_ONLY` + `query_only`) and refuse to create a missing database.
- Reuse the existing hybrid search and project/source filters; keep MCP logs on stderr so the protocol stays clean.

This PR is oversized (~1063 insertions) because the server, CLI wiring, read-only store path, and tests are one shippable story.

Register with Claude Code or Codex after install:

```bash
claude mcp add --scope user recall -- recall mcp
codex mcp add recall -- recall mcp
```

## Test plan

- [x] `cargo test --lib` (438 passed)
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo audit --file Cargo.lock`
- [ ] `recall mcp` against a real index, then call `search_sessions` / `list_recent_sessions` / `get_session` from Claude Code
- [ ] Confirm a missing `--db` path does not create files
- [ ] Confirm `recall search --format json` still keeps logs off stdout when `RUST_LOG` is set