### PR TITLE
feat(rx): add 'none' provider to skip provider injection

### DIFF
--- a/crates/rx/PROVIDERS.md
+++ b/crates/rx/PROVIDERS.md
@@ -13,7 +13,9 @@ OpenAI roots that already end in `/vN` (Z.AI `/paas/v4`) are left as-is.
 Users manage providers with `rx providers list`, `login [provider]`,
 `logout [provider]`, `use [provider]`, and `models update [provider]`. Passing a
 provider ID skips the picker; `use` persistently selects the default provider. The one-launch form
-`rx --provider <provider> <harness>` overrides it. Custom providers are configured
+`rx --provider <provider> <harness>` overrides it. `none` skips injection for one
+launch (`rx --provider none <harness>`) or persistently (`rx providers use none`)
+and overrides the implicit OpenRouter default. Custom providers are configured
 with `default_provider` plus `[provider.<id>]` entries in `~/.recall/rx.toml`.
 Stored API keys live in `~/.recall/rx.keys`; `auth = "env"` reads the provider's
 configured environment variable instead.

--- a/crates/rx/README.md
+++ b/crates/rx/README.md
@@ -16,6 +16,7 @@ brew install samzong/tap/recall
 rx providers login
 rx codex
 rx --provider openrouter opencode
+rx --provider none claude
 ```
 
 Running `rx` without a harness opens the picker. Arguments after the harness name are passed to that harness.

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -71,11 +71,18 @@ pub(crate) enum CompletionShell {
     Fish,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderIdFilter {
+    All,
+    Configured,
+    Targets,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompletionsCommand {
     Help,
     Generate { shell: CompletionShell },
-    ListProviders { configured: bool },
+    ListProviders(ProviderIdFilter),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -277,10 +284,13 @@ fn parse_completions(args: &[OsString]) -> Result<CompletionsCommand> {
         None if args.is_empty() => Ok(CompletionsCommand::Help),
         Some("-h" | "--help" | "help") if args.len() == 1 => Ok(CompletionsCommand::Help),
         Some("--providers") if args.len() == 1 => {
-            Ok(CompletionsCommand::ListProviders { configured: false })
+            Ok(CompletionsCommand::ListProviders(ProviderIdFilter::All))
         }
         Some("--configured") if args.len() == 1 => {
-            Ok(CompletionsCommand::ListProviders { configured: true })
+            Ok(CompletionsCommand::ListProviders(ProviderIdFilter::Configured))
+        }
+        Some("--targets") if args.len() == 1 => {
+            Ok(CompletionsCommand::ListProviders(ProviderIdFilter::Targets))
         }
         Some("bash") if args.len() == 1 => {
             Ok(CompletionsCommand::Generate { shell: CompletionShell::Bash })
@@ -291,7 +301,7 @@ fn parse_completions(args: &[OsString]) -> Result<CompletionsCommand> {
         Some("fish") if args.len() == 1 => {
             Ok(CompletionsCommand::Generate { shell: CompletionShell::Fish })
         }
-        Some("bash" | "zsh" | "fish" | "--providers" | "--configured") => {
+        Some("bash" | "zsh" | "fish" | "--providers" | "--configured" | "--targets") => {
             bail!(
                 "unexpected argument: {}\n\n{}",
                 args[1].to_string_lossy(),

--- a/crates/rx/src/completions.rs
+++ b/crates/rx/src/completions.rs
@@ -67,11 +67,11 @@ _rx() {
   COMPREPLY=()
 
   if [[ $cur == --provider=* ]]; then
-    _rx_ids --configured
+    _rx_ids --targets
     return
   fi
   if [[ $prev == --provider ]]; then
-    _rx_ids --configured
+    _rx_ids --targets
     return
   fi
 
@@ -112,8 +112,11 @@ _rx() {
         login)
           ((${#pos[@]} == 2)) && _rx_ids --providers
           ;;
-        logout|use)
+        logout)
           ((${#pos[@]} == 2)) && _rx_ids --configured
+          ;;
+        use)
+          ((${#pos[@]} == 2)) && _rx_ids --targets
           ;;
         models)
           case ${pos[2]-} in
@@ -209,11 +212,11 @@ _rx() {
   local cmd=${words[1]:t}
 
   if [[ $cur == --provider=* ]]; then
-    _rx_ids --configured
+    _rx_ids --targets
     return
   fi
   if [[ $prev == --provider ]]; then
-    _rx_ids --configured
+    _rx_ids --targets
     return
   fi
 
@@ -254,8 +257,11 @@ _rx() {
         login)
           (( $#pos == 2 )) && _rx_ids --providers
           ;;
-        logout|use)
+        logout)
           (( $#pos == 2 )) && _rx_ids --configured
+          ;;
+        use)
+          (( $#pos == 2 )) && _rx_ids --targets
           ;;
         models)
           case ${pos[3]:-} in
@@ -379,12 +385,12 @@ complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'completions' -d 'Gen
 complete -c rx -n '__rx_n 0; and __rx_has_provider' -a 'claude codex opencode pi dsh'
 complete -c rx -n '__rx_n 0' -s h -l help
 complete -c rx -n '__rx_n 0' -s V -l version
-complete -c rx -n 'not __rx_has_provider; and __rx_n 0' -l provider -xa '(__rx_ids --configured)'
-complete -c rx -n 'not __rx_has_provider; and __rx_has_harness' -l provider -xa '(__rx_ids --configured)'
+complete -c rx -n 'not __rx_has_provider; and __rx_n 0' -l provider -xa '(__rx_ids --targets)'
+complete -c rx -n 'not __rx_has_provider; and __rx_has_harness' -l provider -xa '(__rx_ids --targets)'
 complete -c rx -n '__rx_is providers; and __rx_n 1' -a 'list login logout use models'
 complete -c rx -n '__rx_is providers login; and __rx_n 2' -a '(__rx_ids --providers)'
 complete -c rx -n '__rx_is providers logout; and __rx_n 2' -a '(__rx_ids --configured)'
-complete -c rx -n '__rx_is providers use; and __rx_n 2' -a '(__rx_ids --configured)'
+complete -c rx -n '__rx_is providers use; and __rx_n 2' -a '(__rx_ids --targets)'
 complete -c rx -n '__rx_is providers models; and __rx_n 2' -a 'update'
 complete -c rx -n '__rx_is providers models update; and __rx_n 3' -a '(__rx_ids --configured)'
 complete -c rx -n '__rx_is update; and __rx_n 1' -l yes -s y
@@ -392,7 +398,7 @@ complete -c rx -n '__rx_is completions; and __rx_n 1' -a 'bash zsh fish'
 
 for cmd in rxc rxx rxo rxp rxd
     complete -c $cmd -f
-    complete -c $cmd -l provider -xa '(__rx_ids --configured)'
+    complete -c $cmd -l provider -xa '(__rx_ids --targets)'
 end
 "#;
 
@@ -421,8 +427,8 @@ pub(crate) fn run(command: CompletionsCommand, paths: &Paths, env: &EnvLookup) -
             print!("{}", script(shell));
             Ok(())
         }
-        CompletionsCommand::ListProviders { configured } => {
-            for id in providers::completion_ids(paths, env, configured)? {
+        CompletionsCommand::ListProviders(filter) => {
+            for id in providers::completion_ids(paths, env, filter)? {
                 println!("{id}");
             }
             Ok(())

--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -100,6 +100,12 @@ pub(crate) fn set_default(paths: &Paths, provider: &str) -> Result<()> {
     save_config(paths, &config)
 }
 
+pub(crate) fn set_none(paths: &Paths) -> Result<()> {
+    let mut config = load_or_default(paths)?;
+    config.default_provider = Some(crate::provider::NONE.to_string());
+    save_config(paths, &config)
+}
+
 pub(crate) fn login(paths: &Paths, provider: &str, key: String) -> Result<()> {
     let mut config = load_or_default(paths)?;
     crate::provider::resolve(provider, config.provider.get(provider))?;

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -59,16 +59,29 @@ pub(crate) struct ProviderTarget {
     pub model: Option<String>,
 }
 
+#[derive(Debug)]
+pub(crate) enum ProviderResolution {
+    SkipInjection,
+    Unconfigured,
+    Target(Box<ProviderTarget>),
+}
+
 pub(crate) fn configured_provider(
     override_id: Option<&str>,
     paths: &Paths,
     env: &EnvLookup,
-) -> Result<Option<ProviderTarget>> {
+) -> Result<ProviderResolution> {
+    if override_id.is_some_and(crate::provider::is_none) {
+        return Ok(ProviderResolution::SkipInjection);
+    }
     let config = crate::config::load(paths)?;
     let configured_id = override_id
         .map(str::to_string)
         .or_else(|| config.as_ref().and_then(|config| config.default_provider.clone()));
     let provider_id = match configured_id {
+        Some(provider_id) if crate::provider::is_none(&provider_id) => {
+            return Ok(ProviderResolution::SkipInjection);
+        }
         Some(provider_id) => provider_id,
         None => {
             let entry = config.as_ref().and_then(|config| config.provider.get("openrouter"));
@@ -78,7 +91,7 @@ pub(crate) fn configured_provider(
             {
                 "openrouter".to_string()
             } else {
-                return Ok(None);
+                return Ok(ProviderResolution::Unconfigured);
             }
         }
     };
@@ -87,19 +100,34 @@ pub(crate) fn configured_provider(
     let auth = entry.map(|entry| entry.auth).unwrap_or(AuthMode::ApiKey);
     let key = resolve_key(&provider, auth, paths, env)?;
     let model = entry.and_then(|entry| entry.model.clone());
-    Ok(Some(ProviderTarget {
+    Ok(ProviderResolution::Target(Box::new(ProviderTarget {
         provider_id,
         base_url: provider.endpoint.clone(),
         claude_url: crate::provider::claude_base(&provider),
         provider,
         key,
         model,
-    }))
+    })))
 }
 
 pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> Result<LaunchPlan> {
-    let Some(target) = configured_provider(request.provider.as_deref(), paths, env)? else {
-        return Ok(passthrough(request));
+    let target = match configured_provider(request.provider.as_deref(), paths, env)? {
+        ProviderResolution::SkipInjection => {
+            return Ok(passthrough(
+                request,
+                format!("[rx] provider 'none': launching {} as-is", request.harness.as_str()),
+            ));
+        }
+        ProviderResolution::Unconfigured => {
+            return Ok(passthrough(
+                request,
+                format!(
+                    "[rx] no provider configured; launching {} as-is (configure: rx providers login)",
+                    request.harness.as_str()
+                ),
+            ));
+        }
+        ProviderResolution::Target(target) => target,
     };
     let model = target.model.as_deref().or(match request.harness {
         Harness::Claude => target.provider.claude_default_model,
@@ -222,7 +250,7 @@ fn push_note(plan: &mut LaunchPlan, note: &str) {
     });
 }
 
-fn passthrough(request: &LaunchRequest) -> LaunchPlan {
+fn passthrough(request: &LaunchRequest, note: String) -> LaunchPlan {
     LaunchPlan {
         program: PathBuf::from(request.harness.as_str()),
         args: match request.harness {
@@ -230,10 +258,7 @@ fn passthrough(request: &LaunchRequest) -> LaunchPlan {
             _ => request.passthrough.clone(),
         },
         env_set: Vec::new(),
-        stderr_note: Some(format!(
-            "[rx] no provider configured; launching {} as-is (configure: rx providers login)",
-            request.harness.as_str()
-        )),
+        stderr_note: Some(note),
     }
 }
 

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -87,6 +87,7 @@ rx — launch agent harnesses through a configured AI provider
 Usage:
   rx
   rx --provider <provider>
+  rx --provider none <harness> [args...]
   rx <harness> [args...]
   rx --provider <provider> <harness> [args...]
   rx providers <list|login|logout|use>

--- a/crates/rx/src/provider.rs
+++ b/crates/rx/src/provider.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 
 use crate::config::{ProviderConfig, RxConfig};
 
+pub(crate) const NONE: &str = "none";
+
 const SNAPSHOT: &str = include_str!("../data/providers.json");
 
 #[derive(Debug, Deserialize)]
@@ -114,7 +116,14 @@ pub(crate) fn available(config: &RxConfig) -> Result<Vec<Provider>> {
     Ok(providers)
 }
 
+pub(crate) fn is_none(id: &str) -> bool {
+    id == NONE
+}
+
 pub(crate) fn validate_id(id: &str) -> Result<()> {
+    if is_none(id) {
+        bail!("'{NONE}' is reserved; pass --provider none or run: rx providers use none");
+    }
     if !id.is_empty()
         && id.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -312,7 +312,7 @@ pub(crate) fn help() -> &'static str {
         "  rx providers list\n",
         "  rx providers login [provider]\n",
         "  rx providers logout [provider]\n",
-        "  rx providers use [provider]\n",
+        "  rx providers use [provider|none]\n",
         "  rx providers models update [provider]\n\n",
     )
 }
@@ -351,8 +351,14 @@ fn update_models(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Res
         }
     }
     for id in ids {
-        let Some(target) = launch::configured_provider(Some(&id), paths, env)? else {
-            bail!("no API key for provider '{id}'; run: rx providers login {id}");
+        let target = match launch::configured_provider(Some(&id), paths, env)? {
+            launch::ProviderResolution::Target(target) => target,
+            launch::ProviderResolution::SkipInjection => {
+                bail!("'{id}' skips provider injection; there is no catalog to update")
+            }
+            launch::ProviderResolution::Unconfigured => {
+                bail!("no API key for provider '{id}'; run: rx providers login {id}")
+            }
         };
         let count =
             catalog::update_models(paths, &target.provider_id, &target.base_url, &target.key)?;
@@ -422,6 +428,11 @@ fn logout_provider(paths: &Paths, state: &ProviderState) -> Result<()> {
 }
 
 fn use_provider(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Result<()> {
+    if requested.is_some_and(crate::provider::is_none) {
+        crate::config::set_none(paths)?;
+        println!("* none\n  launch harnesses as-is");
+        return Ok(());
+    }
     let states = provider_states(paths, env)?;
     if let Some(id) = requested {
         let index = provider_index(&states, id, true)?;
@@ -448,13 +459,22 @@ fn set_default_provider(paths: &Paths, state: &ProviderState) -> Result<()> {
 pub(crate) fn completion_ids(
     paths: &Paths,
     env: &EnvLookup,
-    configured_only: bool,
+    filter: crate::args::ProviderIdFilter,
 ) -> Result<Vec<String>> {
-    Ok(provider_states(paths, env)?
+    let mut ids = provider_states(paths, env)?
         .into_iter()
-        .filter(|state| !configured_only || state.configured())
+        .filter(|state| match filter {
+            crate::args::ProviderIdFilter::All => true,
+            crate::args::ProviderIdFilter::Configured | crate::args::ProviderIdFilter::Targets => {
+                state.configured()
+            }
+        })
         .map(|state| state.provider.id)
-        .collect())
+        .collect::<Vec<_>>();
+    if matches!(filter, crate::args::ProviderIdFilter::Targets) {
+        ids.push(crate::provider::NONE.to_string());
+    }
+    Ok(ids)
 }
 
 fn provider_index(states: &[ProviderState], id: &str, configured: bool) -> Result<usize> {

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -9,7 +9,7 @@ use std::thread;
 
 use crate::args::{
     Command, CompletionShell, CompletionsCommand, Harness, LaunchRequest, ModelsCommand,
-    ProvidersCommand, UpdateCommand, parse, rewrite_argv0,
+    ProviderIdFilter, ProvidersCommand, UpdateCommand, parse, rewrite_argv0,
 };
 use crate::config::{self, Paths};
 use crate::launch::{self, EnvLookup};
@@ -207,6 +207,7 @@ fn rx_help_and_version() {
     assert_eq!(parse_line(&["rx", "-V"]), Command::Version);
     assert!(!crate::help_text().contains("rx config"));
     assert!(crate::help_text().contains("rx --provider <provider> <harness>"));
+    assert!(crate::help_text().contains("rx --provider none <harness>"));
     assert!(crate::help_text().contains("rx providers <list|login|logout|use>"));
     assert!(crate::help_text().contains("rx providers models update [provider]"));
     assert!(crate::help_text().contains("rx completions <bash|zsh|fish>"));
@@ -232,11 +233,15 @@ fn completions_parses_shells_and_id_lists() {
     );
     assert_eq!(
         parse_line(&["rx", "completions", "--providers"]),
-        Command::Completions(CompletionsCommand::ListProviders { configured: false })
+        Command::Completions(CompletionsCommand::ListProviders(ProviderIdFilter::All))
     );
     assert_eq!(
         parse_line(&["rx", "completions", "--configured"]),
-        Command::Completions(CompletionsCommand::ListProviders { configured: true })
+        Command::Completions(CompletionsCommand::ListProviders(ProviderIdFilter::Configured))
+    );
+    assert_eq!(
+        parse_line(&["rx", "completions", "--targets"]),
+        Command::Completions(CompletionsCommand::ListProviders(ProviderIdFilter::Targets))
     );
 }
 
@@ -269,6 +274,7 @@ fn completions_scripts_cover_rx_surface() {
             "--provider",
             "--configured",
             "--providers",
+            "--targets",
             "rxc",
             "rxx",
             "rxo",
@@ -286,16 +292,27 @@ fn completions_scripts_cover_rx_surface() {
 fn completion_ids_list_configured_and_known() {
     let (_dir, paths) = temp_paths();
     let env = EnvLookup::isolated(HashMap::new());
-    let known = crate::providers::completion_ids(&paths, &env, false).unwrap();
+    let known = crate::providers::completion_ids(&paths, &env, ProviderIdFilter::All).unwrap();
     assert!(known.contains(&"openrouter".to_string()), "{known:?}");
     assert!(known.contains(&"tokener".to_string()), "{known:?}");
-    assert!(crate::providers::completion_ids(&paths, &env, true).unwrap().is_empty());
+    assert!(
+        crate::providers::completion_ids(&paths, &env, ProviderIdFilter::Configured)
+            .unwrap()
+            .is_empty()
+    );
 
     config::login(&paths, "openrouter", "sk-secret".to_string()).unwrap();
     assert_eq!(
-        crate::providers::completion_ids(&paths, &env, true).unwrap(),
+        crate::providers::completion_ids(&paths, &env, ProviderIdFilter::Configured).unwrap(),
         vec!["openrouter".to_string()]
     );
+    let mut targets =
+        crate::providers::completion_ids(&paths, &env, ProviderIdFilter::Targets).unwrap();
+    assert_eq!(targets.pop(), Some("none".to_string()));
+    assert_eq!(targets, vec!["openrouter".to_string()]);
+    for id in known {
+        assert_ne!(id, "none");
+    }
 }
 
 #[test]
@@ -725,6 +742,102 @@ fn configured_openrouter_credential_is_the_implicit_default() {
     )
     .unwrap();
     assert_eq!(plan.args[1], "model_provider=\"openrouter\"");
+}
+
+#[test]
+fn provider_none_skips_injection() {
+    let (_dir, paths) = temp_paths();
+    config::login(&paths, "openrouter", "sk-secret".to_string()).unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            provider: Some("none".to_string()),
+            passthrough: os(&["--resume", "abc"]),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.args, os(&["--resume", "abc"]));
+    assert!(plan.env_set.is_empty());
+    let note = plan.stderr_note.unwrap();
+    assert!(note.contains("'none'"), "{note}");
+    assert!(!note.contains("no provider configured"), "{note}");
+}
+
+#[test]
+fn use_none_skips_implicit_openrouter() {
+    let (_dir, paths) = temp_paths();
+    config::login(&paths, "openrouter", "sk-secret".to_string()).unwrap();
+    crate::providers::run(
+        ProvidersCommand::Use { provider: Some("none".to_string()) },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap();
+    assert_eq!(config::load(&paths).unwrap().unwrap().default_provider.as_deref(), Some("none"));
+    assert!(config::stored_providers(&paths).unwrap().contains("openrouter"));
+
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest { harness: Harness::Codex, provider: None, passthrough: Vec::new() },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert!(plan.env_set.is_empty());
+    assert!(plan.args.iter().all(|arg| arg != "model_provider=\"openrouter\""));
+    let note = plan.stderr_note.unwrap();
+    assert!(note.contains("'none'"), "{note}");
+    assert!(!note.contains("no provider configured"), "{note}");
+}
+
+#[test]
+fn models_update_rejects_none_provider() {
+    let (_dir, paths) = temp_paths();
+    let error = crate::providers::run(
+        ProvidersCommand::Models(ModelsCommand::Update { provider: Some("none".to_string()) }),
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("skips provider injection"), "{error}");
+}
+
+#[test]
+fn provider_override_wins_over_use_none() {
+    let (_dir, paths) = temp_paths();
+    config::set_none(&paths).unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Codex,
+            provider: Some("openrouter".to_string()),
+            passthrough: Vec::new(),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.args[1], "model_provider=\"openrouter\"");
+}
+
+#[test]
+fn none_is_reserved_provider_id() {
+    let error = crate::provider::validate_id("none").unwrap_err();
+    assert!(error.to_string().contains("reserved"), "{error}");
+    let error = crate::provider::resolve("none", None).unwrap_err();
+    assert!(error.to_string().contains("reserved"), "{error}");
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- Add a reserved `none` pseudo-provider: skip provider injection for one launch (`rx --provider none <harness>`) or persistently (`rx providers use none`), launching harnesses as-is and overriding the implicit OpenRouter default.
- `configured_provider` now returns a three-state `ProviderResolution`, so both callers handle skip/unconfigured explicitly: launches print an honest `[rx] provider 'none'...` note instead of the misleading no-provider-configured warning, and `rx providers models update none` gets actionable guidance instead of suggesting login.
- Shell completions gain a hidden `--targets` id-list mode (configured providers plus `none`); `--provider` value completion and `providers use` now suggest `none` while login/logout/models-update suggestions are unchanged.
- Reserve the id in `validate_id`; provider picker/help/docs/tests updated accordingly.

### Why

Users who manage provider credentials themselves (or just want a clean passthrough launch) previously had to unset their default; there was no supported way to opt out of rx's env/config injection while keeping every other rx behavior (install, yolo defaults, update checks).