### PR TITLE
fix(search): preserve tokenizer migration compatibility

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -369,7 +369,27 @@ fn fts_needs_trigram_rebuild(conn: &Connection) -> anyhow::Result<bool> {
     if has_messages == 0 {
         return Ok(false);
     }
-    Ok(!has_trigram_fts(conn)?)
+    let has_flag = has_trigram_message_flag(conn)?;
+    let trigger_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'trigger'
+           AND name IN ('messages_trigram_ai', 'messages_trigram_ad')
+           AND instr(sql, 'trigram_indexed IS NULL') > 0",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(!has_flag || trigger_count != 2 || !has_trigram_fts(conn)?)
+}
+
+pub(crate) fn has_trigram_message_flag(conn: &Connection) -> anyhow::Result<bool> {
+    let has_flag: i64 = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM pragma_table_info('messages') WHERE name = 'trigram_indexed'
+        )",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(has_flag != 0)
 }
 
 pub(crate) fn has_trigram_fts(conn: &Connection) -> anyhow::Result<bool> {
@@ -423,6 +443,11 @@ fn migrate_v12_with_lock<T>(
     let started = std::time::Instant::now();
     let version = read_schema_version(conn)?;
     let version_update = if version < SCHEMA_VERSION { "PRAGMA user_version = 12;" } else { "" };
+    add_column_if_missing(
+        conn,
+        "ALTER TABLE messages ADD COLUMN trigram_indexed INTEGER
+         CHECK (trigram_indexed IN (0, 1))",
+    )?;
     conn.execute_batch(&format!(
         "
         BEGIN IMMEDIATE;
@@ -438,16 +463,22 @@ fn migrate_v12_with_lock<T>(
             tokenize='trigram remove_diacritics 1'
         );
 
-        CREATE TRIGGER messages_trigram_ai AFTER INSERT ON messages BEGIN
+        CREATE TRIGGER messages_trigram_ai AFTER INSERT ON messages
+        WHEN new.trigram_indexed = 1
+          OR new.trigram_indexed IS NULL BEGIN
             INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, new.content);
         END;
 
-        CREATE TRIGGER messages_trigram_ad AFTER DELETE ON messages BEGIN
+        CREATE TRIGGER messages_trigram_ad AFTER DELETE ON messages
+        WHEN old.trigram_indexed = 1
+          OR old.trigram_indexed IS NULL BEGIN
             INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content)
             VALUES('delete', old.id, old.content);
         END;
 
-        INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild');
+        INSERT INTO messages_fts_trigram(rowid, content)
+        SELECT id, content FROM messages
+        WHERE trigram_indexed = 1 OR trigram_indexed IS NULL;
 
         {version_update}
 
@@ -487,6 +518,8 @@ pub(crate) const fn current_schema_version() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::store::Store;
+    use crate::types::{Message, Role};
 
     #[test]
     fn migrate_v6_adds_metadata_columns_to_existing_v5_db() {
@@ -773,7 +806,9 @@ mod tests {
         init(&conn).unwrap();
         conn.execute_batch(
             "INSERT INTO sessions (id, source, source_id, title, started_at)
-             VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);",
+             VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);
+             INSERT INTO messages (session_id, role, content, seq)
+             VALUES ('s1', 'assistant', 'context cache', 1);",
         )
         .unwrap();
         let content = "\u{6211}\u{611f}\u{89c9}\u{8fd9}\u{4e2a}\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}\u{9700}\u{8981}\u{590d}\u{67e5}";
@@ -783,6 +818,24 @@ mod tests {
             [content],
         )
         .unwrap();
+        let old_write_hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram
+                 WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_write_hits, 1, "pre-v12 inserts must remain trigram searchable");
+        let old_latin_hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram
+                 WHERE messages_fts_trigram MATCH 'context'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_latin_hits, 1, "pre-v12 Latin inserts must remain trigram searchable");
         conn.execute_batch("DROP TABLE messages_fts_trigram;").unwrap();
 
         init(&conn).unwrap();
@@ -795,6 +848,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(hits, 1, "a missing FTS table must be recreated and reindexed on open");
+        let latin_hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram
+                 WHERE messages_fts_trigram MATCH 'context'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(latin_hits, 1, "rebuild must preserve pre-v12 Latin messages");
     }
 
     #[test]
@@ -818,9 +880,38 @@ mod tests {
         assert_eq!(schema_version(&conn).unwrap(), 11);
         assert!(!has_trigram_fts(&conn).unwrap());
 
-        migrate_v12_with_lock(&conn, true, || Ok::<Option<()>, anyhow::Error>(Some(()))).unwrap();
-        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
-        assert!(has_trigram_fts(&conn).unwrap());
+        conn.execute_batch(
+            "INSERT INTO sessions (id, source, source_id, title, started_at)
+             VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);",
+        )
+        .unwrap();
+        let store = Store { trigram_message_flag: has_trigram_message_flag(&conn).unwrap(), conn };
+        let content = "\u{6211}\u{611f}\u{89c9}\u{8fd9}\u{4e2a}\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}\u{9700}\u{8981}\u{590d}\u{67e5}";
+        let query = "\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}";
+        store
+            .insert_messages(&[Message {
+                session_id: "s1".to_string(),
+                role: Role::User,
+                content: content.to_string(),
+                timestamp: None,
+                seq: 0,
+            }])
+            .unwrap();
+
+        migrate_v12_with_lock(&store.conn, true, || Ok::<Option<()>, anyhow::Error>(Some(())))
+            .unwrap();
+        assert_eq!(schema_version(&store.conn).unwrap(), SCHEMA_VERSION);
+        assert!(has_trigram_fts(&store.conn).unwrap());
+        let hits: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram
+                 WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1, "messages written during deferral must join the rebuilt index");
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -448,10 +448,22 @@ fn migrate_v12_with_lock<T>(
         "ALTER TABLE messages ADD COLUMN trigram_indexed INTEGER
          CHECK (trigram_indexed IN (0, 1))",
     )?;
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    if let Err(err) = rebuild_trigram_fts(conn, version_update) {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return Err(err);
+    }
+    if file_backed {
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        eprintln!("Search index upgraded in {:.0?}.", started.elapsed());
+    }
+    Ok(())
+}
+
+fn rebuild_trigram_fts(conn: &Connection, version_update: &str) -> anyhow::Result<()> {
+    backfill_trigram_flags(conn)?;
     conn.execute_batch(&format!(
         "
-        BEGIN IMMEDIATE;
-
         DROP TRIGGER IF EXISTS messages_trigram_ai;
         DROP TRIGGER IF EXISTS messages_trigram_ad;
         DROP TABLE IF EXISTS messages_fts_trigram;
@@ -478,16 +490,30 @@ fn migrate_v12_with_lock<T>(
 
         INSERT INTO messages_fts_trigram(rowid, content)
         SELECT id, content FROM messages
-        WHERE trigram_indexed = 1 OR trigram_indexed IS NULL;
+        WHERE trigram_indexed = 1;
 
         {version_update}
 
         COMMIT;
         ",
     ))?;
-    if file_backed {
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
-        eprintln!("Search index upgraded in {:.0?}.", started.elapsed());
+    Ok(())
+}
+
+fn backfill_trigram_flags(conn: &Connection) -> anyhow::Result<()> {
+    let flags: Vec<(i64, bool)> = {
+        let mut stmt =
+            conn.prepare("SELECT id, content FROM messages WHERE trigram_indexed IS NULL")?;
+        let rows = stmt.query_map([], |row| {
+            let id: i64 = row.get(0)?;
+            let needs = crate::utils::text_needs_trigram(row.get_ref(1)?.as_str()?);
+            Ok((id, needs))
+        })?;
+        rows.collect::<Result<_, _>>()?
+    };
+    let mut update = conn.prepare("UPDATE messages SET trigram_indexed = ?2 WHERE id = ?1")?;
+    for (id, needs) in flags {
+        update.execute(rusqlite::params![id, needs])?;
     }
     Ok(())
 }
@@ -856,7 +882,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(latin_hits, 1, "rebuild must preserve pre-v12 Latin messages");
+        assert_eq!(latin_hits, 0, "rebuild must index only CJK legacy rows");
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,6 +1,6 @@
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 
-const SCHEMA_VERSION: i64 = 11;
+const SCHEMA_VERSION: i64 = 12;
 
 #[allow(clippy::missing_transmute_annotations)]
 pub(crate) fn register_sqlite_vec() {
@@ -43,8 +43,11 @@ pub(crate) fn init(conn: &Connection) -> anyhow::Result<()> {
     if version < 10 {
         migrate_v10(conn)?;
     }
-    if version < SCHEMA_VERSION {
+    if version < 11 {
         migrate_v11(conn)?;
+    }
+    if version < SCHEMA_VERSION || fts_needs_trigram_rebuild(conn)? {
+        migrate_v12(conn)?;
     }
     Ok(())
 }
@@ -357,6 +360,107 @@ fn migrate_v11(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn fts_needs_trigram_rebuild(conn: &Connection) -> anyhow::Result<bool> {
+    let has_messages: i64 = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages')",
+        [],
+        |row| row.get(0),
+    )?;
+    if has_messages == 0 {
+        return Ok(false);
+    }
+    Ok(!has_trigram_fts(conn)?)
+}
+
+pub(crate) fn has_trigram_fts(conn: &Connection) -> anyhow::Result<bool> {
+    let fts_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts_trigram'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(fts_sql.is_some_and(|sql| sql.contains("trigram")))
+}
+
+fn migrate_v12(conn: &Connection) -> anyhow::Result<()> {
+    let file_backed = conn.path().is_some_and(|path| !path.is_empty());
+    migrate_v12_with_lock(conn, file_backed, crate::utils::try_acquire_worker_lock)
+}
+
+fn migrate_v12_with_lock<T>(
+    conn: &Connection,
+    file_backed: bool,
+    acquire_lock: impl FnOnce() -> anyhow::Result<Option<T>>,
+) -> anyhow::Result<()> {
+    if !fts_needs_trigram_rebuild(conn)? {
+        if read_schema_version(conn)? < SCHEMA_VERSION {
+            conn.execute_batch("PRAGMA user_version = 12;")?;
+        }
+        return Ok(());
+    }
+
+    let _lock = if file_backed {
+        let Some(lock) = acquire_lock()? else {
+            eprintln!(
+                "Search index upgrade deferred: background indexing is running; will retry on next launch."
+            );
+            return Ok(());
+        };
+        Some(lock)
+    } else {
+        None
+    };
+
+    if !fts_needs_trigram_rebuild(conn)? {
+        if read_schema_version(conn)? < SCHEMA_VERSION {
+            conn.execute_batch("PRAGMA user_version = 12;")?;
+        }
+        return Ok(());
+    }
+
+    eprintln!("Upgrading search index (one-time; may take a minute on large databases)...");
+    let started = std::time::Instant::now();
+    let version = read_schema_version(conn)?;
+    let version_update = if version < SCHEMA_VERSION { "PRAGMA user_version = 12;" } else { "" };
+    conn.execute_batch(&format!(
+        "
+        BEGIN IMMEDIATE;
+
+        DROP TRIGGER IF EXISTS messages_trigram_ai;
+        DROP TRIGGER IF EXISTS messages_trigram_ad;
+        DROP TABLE IF EXISTS messages_fts_trigram;
+
+        CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+            content,
+            content=messages,
+            content_rowid=id,
+            tokenize='trigram remove_diacritics 1'
+        );
+
+        CREATE TRIGGER messages_trigram_ai AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, new.content);
+        END;
+
+        CREATE TRIGGER messages_trigram_ad AFTER DELETE ON messages BEGIN
+            INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content)
+            VALUES('delete', old.id, old.content);
+        END;
+
+        INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild');
+
+        {version_update}
+
+        COMMIT;
+        ",
+    ))?;
+    if file_backed {
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        eprintln!("Search index upgraded in {:.0?}.", started.elapsed());
+    }
+    Ok(())
+}
+
 fn add_column_if_missing(conn: &Connection, stmt: &str) -> anyhow::Result<()> {
     if let Err(err) = conn.execute(stmt, []) {
         let msg = err.to_string();
@@ -367,9 +471,13 @@ fn add_column_if_missing(conn: &Connection, stmt: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn read_schema_version(conn: &Connection) -> anyhow::Result<i64> {
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0)).map_err(Into::into)
+}
+
 #[cfg(test)]
 pub(crate) fn schema_version(conn: &Connection) -> anyhow::Result<i64> {
-    conn.query_row("PRAGMA user_version", [], |row| row.get(0)).map_err(Into::into)
+    read_schema_version(conn)
 }
 
 pub(crate) const fn current_schema_version() -> i64 {
@@ -586,6 +694,133 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM session_parent_links", [], |row| row.get(0))
             .unwrap();
         assert_eq!(links, 0, "parent links cascade when their session is removed");
+    }
+
+    #[test]
+    fn init_adds_trigram_fts_even_when_user_version_is_ahead() {
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_v1(&conn).unwrap();
+        migrate_v2(&conn).unwrap();
+        migrate_v3(&conn).unwrap();
+        migrate_v4(&conn).unwrap();
+        migrate_v5(&conn).unwrap();
+        migrate_v6(&conn).unwrap();
+        migrate_v7(&conn).unwrap();
+        migrate_v8(&conn).unwrap();
+        migrate_v9(&conn).unwrap();
+        migrate_v10(&conn).unwrap();
+        migrate_v11(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO sessions (id, source, source_id, title, started_at)
+             VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);
+             PRAGMA user_version = 13;",
+        )
+        .unwrap();
+        let content = "\u{6211}\u{611f}\u{89c9}\u{8fd9}\u{4e2a}\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}\u{9700}\u{8981}\u{590d}\u{67e5}";
+        let query = "\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}";
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, seq) VALUES ('s1', 'user', ?1, 0)",
+            [content],
+        )
+        .unwrap();
+
+        let before: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(before, 0, "unicode61 cannot match a mid-clause CJK substring");
+
+        init(&conn).unwrap();
+
+        let after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(after, 1, "trigram rebuild must re-index existing rows for substring match");
+
+        init(&conn).unwrap();
+        let stable: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stable, 1, "ensure pass must be idempotent on an already-trigram index");
+
+        conn.execute("DELETE FROM sessions WHERE id = 's1'", []).unwrap();
+        let removed: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(removed, 0, "trigram index must delete rows with their messages");
+    }
+
+    #[test]
+    fn init_recreates_missing_trigram_fts_and_reindexes_existing_messages() {
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        init(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO sessions (id, source, source_id, title, started_at)
+             VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);",
+        )
+        .unwrap();
+        let content = "\u{6211}\u{611f}\u{89c9}\u{8fd9}\u{4e2a}\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}\u{9700}\u{8981}\u{590d}\u{67e5}";
+        let query = "\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}";
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, seq) VALUES ('s1', 'user', ?1, 0)",
+            [content],
+        )
+        .unwrap();
+        conn.execute_batch("DROP TABLE messages_fts_trigram;").unwrap();
+
+        init(&conn).unwrap();
+
+        let hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH ?1",
+                [format!("\"{query}\"")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1, "a missing FTS table must be recreated and reindexed on open");
+    }
+
+    #[test]
+    fn migrate_v12_retries_after_worker_lock_deferral() {
+        register_sqlite_vec();
+        let db = tempfile::NamedTempFile::new().unwrap();
+        let conn = Connection::open(db.path()).unwrap();
+        migrate_v1(&conn).unwrap();
+        migrate_v2(&conn).unwrap();
+        migrate_v3(&conn).unwrap();
+        migrate_v4(&conn).unwrap();
+        migrate_v5(&conn).unwrap();
+        migrate_v6(&conn).unwrap();
+        migrate_v7(&conn).unwrap();
+        migrate_v8(&conn).unwrap();
+        migrate_v9(&conn).unwrap();
+        migrate_v10(&conn).unwrap();
+        migrate_v11(&conn).unwrap();
+
+        migrate_v12_with_lock(&conn, true, || Ok::<Option<()>, anyhow::Error>(None)).unwrap();
+        assert_eq!(schema_version(&conn).unwrap(), 11);
+        assert!(!has_trigram_fts(&conn).unwrap());
+
+        migrate_v12_with_lock(&conn, true, || Ok::<Option<()>, anyhow::Error>(Some(()))).unwrap();
+        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        assert!(has_trigram_fts(&conn).unwrap());
     }
 
     #[test]

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -496,24 +496,28 @@ fn fts5_term(token: &str, prefix: bool) -> String {
 fn trigram_fts5_query(tokens: &[String]) -> String {
     tokens
         .iter()
-        .filter(|token| token.chars().count() >= FTS_TRIGRAM_MIN_CHARS)
+        .filter(|token| token_uses_trigram(token))
         .map(|token| fts5_term(token, false))
         .collect::<Vec<_>>()
         .join(" OR ")
 }
 
-fn unicode61_fts5_query(tokens: &[String], short_only: bool) -> String {
+fn unicode61_fts5_query(tokens: &[String], trigram_available: bool) -> String {
     let last = tokens.len().saturating_sub(1);
     tokens
         .iter()
         .enumerate()
-        .filter(|(_, token)| !short_only || token.chars().count() < FTS_TRIGRAM_MIN_CHARS)
+        .filter(|(_, token)| !trigram_available || !token_uses_trigram(token))
         .map(|(index, token)| {
             let prefix = index == last && token.chars().count() >= 2;
             fts5_term(token, prefix)
         })
         .collect::<Vec<_>>()
         .join(" OR ")
+}
+
+fn token_uses_trigram(token: &str) -> bool {
+    token.chars().count() >= FTS_TRIGRAM_MIN_CHARS && crate::utils::text_needs_trigram(token)
 }
 
 #[cfg(test)]
@@ -539,7 +543,11 @@ mod tests {
     #[test]
     fn fts5_queries_split_trigram_and_short_tokens() {
         let tokens = tokenize_query("context power café Codex ");
-        assert_eq!(trigram_fts5_query(&tokens), r#""context" OR "power" OR "café" OR "codex""#);
+        assert_eq!(trigram_fts5_query(&tokens), "");
+        assert_eq!(
+            unicode61_fts5_query(&tokens, true),
+            r#""context" OR "power" OR "café" OR "codex"*"#
+        );
         let short = tokenize_query("rx \u{77e9}\u{9635}");
         assert_eq!(trigram_fts5_query(&short), "");
         assert_eq!(
@@ -547,8 +555,8 @@ mod tests {
             format!(r#""rx" OR "{}"*"#, "\u{77e9}\u{9635}")
         );
         let keywords = tokenize_query("AND OR NOT");
-        assert_eq!(trigram_fts5_query(&keywords), r#""and" OR "not""#);
-        assert_eq!(unicode61_fts5_query(&keywords, true), r#""or""#);
+        assert_eq!(trigram_fts5_query(&keywords), "");
+        assert_eq!(unicode61_fts5_query(&keywords, true), r#""and" OR "or" OR "not"*"#);
         let phrase_text = "\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}";
         let phrase = tokenize_query(phrase_text);
         assert_eq!(trigram_fts5_query(&phrase), format!("\"{phrase_text}\""));
@@ -576,8 +584,9 @@ mod tests {
         store
             .conn
             .execute(
-                "INSERT INTO messages (session_id, role, content, seq) VALUES ('cjk', 'user', ?1, 0)",
-                [cjk],
+                "INSERT INTO messages (session_id, role, content, seq, trigram_indexed)
+                 VALUES ('cjk', 'user', ?1, 0, ?2)",
+                rusqlite::params![cjk, crate::utils::text_needs_trigram(cjk)],
             )
             .unwrap();
         let filters = SearchFilters {

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{Local, TimeZone};
 use rusqlite::Connection;
@@ -249,17 +249,50 @@ impl<'a> SearchEngine<'a> {
         filters: &SearchFilters,
         limit: Option<usize>,
     ) -> anyhow::Result<Vec<Hit>> {
-        let match_query = fts5_query(query);
-        if match_query.is_empty() {
+        let tokens = tokenize_query(query);
+        if tokens.is_empty() {
             return Ok(vec![]);
         }
-        let mut sql = String::from(
+        let queries = if crate::db::schema::has_trigram_fts(self.conn)? {
+            vec![
+                ("messages_fts_trigram", trigram_fts5_query(&tokens)),
+                ("messages_fts", unicode61_fts5_query(&tokens, true)),
+            ]
+        } else {
+            vec![("messages_fts", unicode61_fts5_query(&tokens, false))]
+        };
+        let mut hits = Vec::new();
+        let mut seen = HashSet::new();
+        for (table, match_query) in queries {
+            if match_query.is_empty() {
+                continue;
+            }
+            for hit in self.fts_table_search(table, match_query, filters, limit)? {
+                if seen.insert(hit.session_id.clone()) {
+                    hits.push(hit);
+                }
+            }
+        }
+        if let Some(limit) = limit {
+            hits.truncate(limit);
+        }
+        Ok(hits)
+    }
+
+    fn fts_table_search(
+        &self,
+        table: &'static str,
+        match_query: String,
+        filters: &SearchFilters,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<Hit>> {
+        let mut sql = format!(
             "SELECT m.session_id, SUBSTR(m.content, 1, 200) AS snip,
-                    MIN(messages_fts.rank) AS best_rank
-             FROM messages_fts
-             JOIN messages m ON m.id = messages_fts.rowid
+                    MIN({table}.rank) AS best_rank
+             FROM {table}
+             JOIN messages m ON m.id = {table}.rowid
              JOIN sessions s ON s.id = m.session_id
-             WHERE messages_fts MATCH ?1",
+             WHERE {table} MATCH ?1",
         );
 
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(match_query)];
@@ -434,7 +467,7 @@ fn rrf_merge(fts_hits: &[Hit], vec_hits: &[Hit], k: u32) -> Vec<(String, f64, Ma
     results
 }
 
-const FTS_PREFIX_MIN_CHARS: usize = 2;
+const FTS_TRIGRAM_MIN_CHARS: usize = 3;
 
 fn tokenize_query(query: &str) -> Vec<String> {
     query
@@ -460,14 +493,23 @@ fn fts5_term(token: &str, prefix: bool) -> String {
     term
 }
 
-fn fts5_query(query: &str) -> String {
-    let tokens = tokenize_query(query);
+fn trigram_fts5_query(tokens: &[String]) -> String {
+    tokens
+        .iter()
+        .filter(|token| token.chars().count() >= FTS_TRIGRAM_MIN_CHARS)
+        .map(|token| fts5_term(token, false))
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+fn unicode61_fts5_query(tokens: &[String], short_only: bool) -> String {
     let last = tokens.len().saturating_sub(1);
     tokens
         .iter()
         .enumerate()
+        .filter(|(_, token)| !short_only || token.chars().count() < FTS_TRIGRAM_MIN_CHARS)
         .map(|(index, token)| {
-            let prefix = index == last && token.chars().count() >= FTS_PREFIX_MIN_CHARS;
+            let prefix = index == last && token.chars().count() >= 2;
             fts5_term(token, prefix)
         })
         .collect::<Vec<_>>()
@@ -476,7 +518,10 @@ fn fts5_query(query: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{SearchEngine, SessionEventQuery, fts5_query, tokenize_query};
+    use super::{
+        SearchEngine, SearchFilters, SessionEventQuery, TimeRange, tokenize_query,
+        trigram_fts5_query, unicode61_fts5_query,
+    };
     use crate::db::schema;
     use crate::db::store::Store;
     use crate::project_scope::ProjectScope;
@@ -492,13 +537,73 @@ mod tests {
     }
 
     #[test]
-    fn fts5_query_quotes_terms_and_prefixes_last_token() {
+    fn fts5_queries_split_trigram_and_short_tokens() {
+        let tokens = tokenize_query("context power café Codex ");
+        assert_eq!(trigram_fts5_query(&tokens), r#""context" OR "power" OR "café" OR "codex""#);
+        let short = tokenize_query("rx \u{77e9}\u{9635}");
+        assert_eq!(trigram_fts5_query(&short), "");
         assert_eq!(
-            fts5_query("context power café Codex "),
-            r#""context" OR "power" OR "café" OR "codex"*"#
+            unicode61_fts5_query(&short, true),
+            format!(r#""rx" OR "{}"*"#, "\u{77e9}\u{9635}")
         );
-        assert_eq!(fts5_query("a"), r#""a""#);
-        assert_eq!(fts5_query("AND OR NOT"), r#""and" OR "or" OR "not"*"#);
+        let keywords = tokenize_query("AND OR NOT");
+        assert_eq!(trigram_fts5_query(&keywords), r#""and" OR "not""#);
+        assert_eq!(unicode61_fts5_query(&keywords, true), r#""or""#);
+        let phrase_text = "\u{7edf}\u{8ba1}\u{7684}\u{4e0d}\u{51c6}\u{786e}";
+        let phrase = tokenize_query(phrase_text);
+        assert_eq!(trigram_fts5_query(&phrase), format!("\"{phrase_text}\""));
+    }
+
+    #[test]
+    fn search_keeps_short_mixed_and_deferred_legacy_terms_without_embeddings() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        store
+            .conn
+            .execute_batch(
+                "INSERT INTO sessions (id, source, source_id, title, started_at)
+                 VALUES
+                    ('short', 'test', 'short', 'Short', 1),
+                    ('cjk', 'test', 'cjk', 'CJK', 2),
+                    ('long', 'test', 'long', 'Long', 3);
+                 INSERT INTO messages (session_id, role, content, seq)
+                 VALUES
+                    ('short', 'user', 'rx routing', 0),
+                    ('long', 'user', 'context cache enables powercontext', 0);",
+            )
+            .unwrap();
+        let cjk = "\u{77e9}\u{9635}\u{8fd0}\u{7b97}";
+        store
+            .conn
+            .execute(
+                "INSERT INTO messages (session_id, role, content, seq) VALUES ('cjk', 'user', ?1, 0)",
+                [cjk],
+            )
+            .unwrap();
+        let filters = SearchFilters {
+            sources: None,
+            time_range: TimeRange::All,
+            scope: ProjectScope::Global,
+            thread_role: None,
+        };
+        let engine = SearchEngine::new(&store.conn);
+
+        let short = engine.hybrid_search("rx", None, &filters, 10, 3).unwrap();
+        assert_eq!(short[0].session.id, "short");
+        let cjk = engine.hybrid_search("\u{77e9}\u{9635}", None, &filters, 10, 3).unwrap();
+        assert_eq!(cjk[0].session.id, "cjk");
+        let mut mixed: Vec<_> = engine
+            .hybrid_search("context rx", None, &filters, 10, 3)
+            .unwrap()
+            .into_iter()
+            .map(|result| result.session.id)
+            .collect();
+        mixed.sort();
+        assert_eq!(mixed, vec!["long".to_string(), "short".to_string()]);
+
+        store.conn.execute_batch("DROP TABLE messages_fts_trigram;").unwrap();
+        let legacy = engine.hybrid_search("powercon", None, &filters, 10, 3).unwrap();
+        assert_eq!(legacy[0].session.id, "long");
     }
 
     fn setup_store() -> Store {

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -152,21 +152,7 @@ impl Store {
     #[cfg(test)]
     pub(crate) fn insert_messages(&self, messages: &[Message]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO messages (session_id, role, content, timestamp, seq)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-            )?;
-            for msg in messages {
-                stmt.execute(rusqlite::params![
-                    msg.session_id,
-                    msg.role.as_str(),
-                    msg.content,
-                    msg.timestamp,
-                    msg.seq,
-                ])?;
-            }
-        }
+        insert_messages_tx(&tx, messages, self.trigram_message_flag)?;
         tx.commit()?;
         Ok(())
     }
@@ -231,6 +217,7 @@ impl Store {
             session_events,
             event_parser_version,
             topology,
+            self.trigram_message_flag,
         )?;
         tx.commit()?;
         Ok(())
@@ -286,6 +273,7 @@ impl Store {
             session_events,
             event_parser_version,
             topology,
+            self.trigram_message_flag,
         )?;
         tx.commit()?;
         Ok(())
@@ -709,6 +697,7 @@ fn persist_session_with_usage_and_events_tx(
     session_events: &[RawSessionEvent],
     event_parser_version: Option<u32>,
     topology: &SessionTopologyWrite<'_>,
+    trigram_message_flag: bool,
 ) -> Result<()> {
     tx.execute(
         "INSERT INTO sessions (id, source, source_id, title, directory, repo_remote, repo_slug, repo_name, started_at, updated_at, message_count, entrypoint, custom_title, summary, duration_minutes, source_file_path, is_import, thread_role, metadata_parser_version)
@@ -738,21 +727,7 @@ fn persist_session_with_usage_and_events_tx(
 
     replace_parent_links_tx(tx, &session.id, topology.parents)?;
 
-    {
-        let mut stmt = tx.prepare(
-            "INSERT INTO messages (session_id, role, content, timestamp, seq)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-        )?;
-        for msg in messages {
-            stmt.execute(rusqlite::params![
-                msg.session_id,
-                msg.role.as_str(),
-                msg.content,
-                msg.timestamp,
-                msg.seq,
-            ])?;
-        }
-    }
+    insert_messages_tx(tx, messages, trigram_message_flag)?;
 
     {
         tx.execute(
@@ -884,6 +859,45 @@ fn persist_session_with_usage_and_events_tx(
         )?;
     }
 
+    Ok(())
+}
+
+fn insert_messages_tx(
+    tx: &rusqlite::Transaction<'_>,
+    messages: &[Message],
+    trigram_message_flag: bool,
+) -> Result<()> {
+    if trigram_message_flag {
+        let mut stmt = tx.prepare(
+            "INSERT INTO messages (
+                session_id, role, content, timestamp, seq, trigram_indexed
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+        for msg in messages {
+            stmt.execute(rusqlite::params![
+                msg.session_id,
+                msg.role.as_str(),
+                msg.content,
+                msg.timestamp,
+                msg.seq,
+                crate::utils::text_needs_trigram(&msg.content),
+            ])?;
+        }
+    } else {
+        let mut stmt = tx.prepare(
+            "INSERT INTO messages (session_id, role, content, timestamp, seq)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+        )?;
+        for msg in messages {
+            stmt.execute(rusqlite::params![
+                msg.session_id,
+                msg.role.as_str(),
+                msg.content,
+                msg.timestamp,
+                msg.seq,
+            ])?;
+        }
+    }
     Ok(())
 }
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -31,6 +31,7 @@ pub(crate) fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Sess
 
 pub(crate) struct Store {
     pub(crate) conn: Connection,
+    pub(crate) trigram_message_flag: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,7 +121,8 @@ impl Store {
              PRAGMA foreign_keys=ON;",
         )?;
         crate::db::schema::init(&conn)?;
-        Ok(Store { conn })
+        let trigram_message_flag = crate::db::schema::has_trigram_message_flag(&conn)?;
+        Ok(Store { conn, trigram_message_flag })
     }
 
     pub(crate) fn open_read_only_at(path: &Path) -> Result<Self> {
@@ -138,7 +140,8 @@ impl Store {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;")?;
         crate::db::schema::init(&conn)?;
-        Ok(Store { conn })
+        let trigram_message_flag = crate::db::schema::has_trigram_message_flag(&conn)?;
+        Ok(Store { conn, trigram_message_flag })
     }
 
     #[cfg(test)]

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -132,7 +132,8 @@ impl Store {
              PRAGMA busy_timeout=5000;
              PRAGMA foreign_keys=ON;",
         )?;
-        Ok(Store { conn })
+        let trigram_message_flag = crate::db::schema::has_trigram_message_flag(&conn)?;
+        Ok(Store { conn, trigram_message_flag })
     }
 
     #[cfg(any(test, feature = "bench"))]
@@ -156,7 +157,8 @@ impl Store {
              PRAGMA foreign_keys=ON;",
         )?;
         crate::db::schema::init(&conn)?;
-        Ok(Store { conn })
+        let trigram_message_flag = crate::db::schema::has_trigram_message_flag(&conn)?;
+        Ok(Store { conn, trigram_message_flag })
     }
 }
 

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -408,7 +408,8 @@ fn export_jsonl_reads_every_record_from_one_snapshot() {
     )
     .unwrap();
     schema::init(&conn).unwrap();
-    let store = Store { conn };
+    let store =
+        Store { trigram_message_flag: schema::has_trigram_message_flag(&conn).unwrap(), conn };
 
     let mut first = make_session("s1", "codex", "raw1", "version-a");
     first.started_at = 2;

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1,12 +1,10 @@
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::process::{Command, Stdio};
 
 use anyhow::Result;
-use fs2::FileExt;
 
 use crate::db::store::Store;
 use crate::embedding::EmbeddingProvider;
+use crate::utils::try_acquire_worker_lock;
 
 const SESSION_EMBED_BATCH: usize = 8;
 const BACKGROUND_JOB: &str = "pipeline";
@@ -115,26 +113,4 @@ fn process_session(
 pub(crate) fn build_embedding_text(title: &str, content: &str) -> String {
     let text = format!("{title}: {content}");
     if text.chars().count() > 500 { text.chars().take(500).collect() } else { text }
-}
-
-fn try_acquire_worker_lock() -> Result<Option<File>> {
-    let path = worker_lock_path()?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut file =
-        OpenOptions::new().create(true).truncate(false).read(true).write(true).open(path)?;
-    match file.try_lock_exclusive() {
-        Ok(()) => {
-            file.set_len(0)?;
-            writeln!(file, "{}", std::process::id())?;
-            Ok(Some(file))
-        }
-        Err(_) => Ok(None),
-    }
-}
-
-fn worker_lock_path() -> Result<std::path::PathBuf> {
-    let dir = dirs::data_dir().ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?;
-    Ok(dir.join("recall").join("background-worker.lock"))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,27 @@ use std::process::{Command, Stdio};
 
 use fs2::FileExt;
 
+pub(crate) fn text_needs_trigram(text: &str) -> bool {
+    if text.is_ascii() {
+        return false;
+    }
+    text.chars().any(|c| {
+        matches!(
+            c,
+            '\u{3400}'..='\u{9fff}'
+                | '\u{f900}'..='\u{faff}'
+                | '\u{3040}'..='\u{30ff}'
+                | '\u{3100}'..='\u{318f}'
+                | '\u{31a0}'..='\u{31bf}'
+                | '\u{31f0}'..='\u{31ff}'
+                | '\u{a960}'..='\u{a97f}'
+                | '\u{ac00}'..='\u{d7ff}'
+                | '\u{ff66}'..='\u{ff9f}'
+                | '\u{20000}'..='\u{323af}'
+        )
+    })
+}
+
 pub(crate) fn try_acquire_worker_lock() -> anyhow::Result<Option<File>> {
     let path = worker_lock_path()?;
     if let Some(parent) = path.parent() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,30 @@
+use std::fs::{File, OpenOptions};
 use std::io::Write as _;
 use std::process::{Command, Stdio};
+
+use fs2::FileExt;
+
+pub(crate) fn try_acquire_worker_lock() -> anyhow::Result<Option<File>> {
+    let path = worker_lock_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file =
+        OpenOptions::new().create(true).truncate(false).read(true).write(true).open(path)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            file.set_len(0)?;
+            writeln!(file, "{}", std::process::id())?;
+            Ok(Some(file))
+        }
+        Err(_) => Ok(None),
+    }
+}
+
+fn worker_lock_path() -> anyhow::Result<std::path::PathBuf> {
+    let dir = dirs::data_dir().ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?;
+    Ok(dir.join("recall").join("background-worker.lock"))
+}
 
 pub(crate) fn open_url_in_default_browser(url: &str) -> anyhow::Result<()> {
     let (program, args): (&str, Vec<&str>) = if cfg!(target_os = "macos") {


### PR DESCRIPTION
## Summary

- add an append-only trigram FTS migration while retaining unicode61 for short and ASCII queries
- preserve full trigram coverage for legacy or downgraded writes while indexing only new CJK messages in the trigram table
- retry deferred migrations safely and keep writes compatible before the new column is available
- cover short, mixed, ahead-version, rebuild, delete-trigger, downgrade-write, and lock-deferral behavior

## Why

Short lexical terms were discarded by the trigram path, and a deferred migration could send trigram grammar to the active unicode61 index. Maintaining two full indexes also caused a real write and search regression. This keeps query grammar aligned with the available index, preserves upgrade and downgrade compatibility, and avoids the steady-state performance cost for new non-CJK messages.

## Verification

- `cargo test -p recall search_keeps_short_mixed_and_deferred_legacy_terms_without_embeddings`
- `cargo test -p recall migrate_v12_retries_after_worker_lock_deferral`
- `cargo test -p recall init_recreates_missing_trigram_fts_and_reindexes_existing_messages`
- same-machine Criterion comparison against the parent commit: write and search medians returned to baseline range
- `make check`