### PR TITLE
feat(adapters): open Copilot desktop sessions via ghapp

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -307,7 +307,9 @@ If the source does not support resume, exit non-zero with an actionable error.
 ### `recall session open`
 
 Open a selected session in its source app when an adapter supports app-open.
-Today this is expected to be useful for Codex desktop threads.
+Today this is expected to be useful for Codex desktop threads
+(`codex://threads/<id>`) and GitHub Copilot desktop sessions
+(`ghapp://sessions/<id>`).
 
 ```bash
 recall session open --id <id>

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -36,6 +36,10 @@ impl SourceAdapter for CopilotAdapter {
         })
     }
 
+    fn app_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(open_url_command(copilot_session_url(source_id)))
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(sessions_dir) = resolve_copilot_dir()? else {
             return Ok(vec![]);
@@ -65,6 +69,28 @@ impl SourceAdapter for CopilotAdapter {
         let result = scan_for_sync_impl(&sessions_dir, store, since_ts, include_events)?;
         Ok(Some(result))
     }
+}
+
+fn copilot_session_url(source_id: &str) -> String {
+    format!("ghapp://sessions/{source_id}")
+}
+
+#[cfg(target_os = "macos")]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand { program: "open".to_string(), args: vec![url] }
+}
+
+#[cfg(target_os = "windows")]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand {
+        program: "cmd".to_string(),
+        args: vec!["/C".to_string(), "start".to_string(), String::new(), url],
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn open_url_command(url: String) -> ResumeCommand {
+    ResumeCommand { program: "xdg-open".to_string(), args: vec![url] }
 }
 
 fn resolve_copilot_dir() -> anyhow::Result<Option<PathBuf>> {
@@ -478,6 +504,18 @@ mod tests {
             source_file_path: None,
             is_import: false,
         }
+    }
+
+    #[test]
+    fn copilot_app_command_opens_session_deeplink() {
+        let command = CopilotAdapter.app_command("7d5c993a-0966-4e3e-9622-7a39ba9576ba").unwrap();
+
+        assert!(
+            command
+                .args
+                .iter()
+                .any(|arg| arg == "ghapp://sessions/7d5c993a-0966-4e3e-9622-7a39ba9576ba")
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3430,6 +3430,35 @@ mod tests {
         assert_eq!(summary.tokens.total_tokens, 31);
     }
 
+    fn copilot_search_result() -> SearchResult {
+        let mut result = codex_search_result();
+        result.session.source = "copilot-cli".to_string();
+        result.session.source_id = "7d5c993a-0966-4e3e-9622-7a39ba9576ba".to_string();
+        result.session.title = "Copilot session".to_string();
+        result
+    }
+
+    #[test]
+    fn ctrl_o_from_search_confirms_copilot_app_open() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.results = vec![copilot_search_result()];
+
+        app.handle_search_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL), &store);
+
+        assert!(matches!(app.mode, AppMode::ConfirmResume));
+        let pending = app.pending_resume.as_ref().unwrap();
+        assert!(matches!(pending.action, PendingCommandAction::OpenApp));
+        assert!(
+            pending
+                .command
+                .args
+                .iter()
+                .any(|arg| arg == "ghapp://sessions/7d5c993a-0966-4e3e-9622-7a39ba9576ba")
+        );
+    }
+
     #[test]
     fn ctrl_o_from_search_confirms_codex_app_open() {
         crate::db::schema::register_sqlite_vec();


### PR DESCRIPTION
### What's changed?

- Add Copilot adapter `app_command` so `recall session open` and TUI Ctrl+O open the desktop app at `ghapp://sessions/<id>`.
- Cover the deeplink and TUI confirmation path with tests.
- Document the session-open URL in `docs/session.md`.

### Why

- GitHub Copilot desktop already accepts that session deep link; Recall previously only exposed CLI resume.