### PR TITLE
fix(rx): stabilize dsh installation

### DIFF
--- a/crates/rx/src/dsh.rs
+++ b/crates/rx/src/dsh.rs
@@ -14,11 +14,12 @@ use crate::provider::{Provider, Setup};
 pub(crate) const PROFILE: &str = "dsh-tui";
 pub(crate) const CLI_PACKAGE: &str = "@deepseek-ai/dsh";
 pub(crate) const PLUGIN_PACKAGE: &str = "@deepseek-harness-tui/dsh-tui";
+pub(crate) const PLUGIN_SPEC: &str = "@deepseek-harness-tui/dsh-tui@latest";
 const OFFICIAL_DEEPSEEK: &str = "https://api.deepseek.com";
 const OFFICIAL_DEEPSEEK_ROUTE: &str = "deepseek-official";
 
 pub(crate) fn npm_install_cmd() -> String {
-    format!("npm install -g {CLI_PACKAGE} {PLUGIN_PACKAGE}")
+    format!("npm install -g --legacy-peer-deps {CLI_PACKAGE} {PLUGIN_PACKAGE}")
 }
 
 pub(crate) fn install_hint() -> String {
@@ -26,7 +27,7 @@ pub(crate) fn install_hint() -> String {
 }
 
 pub(crate) fn profile_hint() -> String {
-    format!("dsh plugin --profile {PROFILE} add {PLUGIN_PACKAGE}")
+    format!("dsh plugin --profile {PROFILE} add -w {PLUGIN_SPEC}")
 }
 
 pub(crate) fn home(env: &EnvLookup) -> Option<PathBuf> {
@@ -319,7 +320,10 @@ mod tests {
     fn install_hint_uses_official_npm_then_profile() {
         assert_eq!(
             install_hint(),
-            format!("npm install -g {CLI_PACKAGE} {PLUGIN_PACKAGE}\n  {}", profile_hint())
+            format!(
+                "npm install -g --legacy-peer-deps {CLI_PACKAGE} {PLUGIN_PACKAGE}\n  {}",
+                profile_hint()
+            )
         );
     }
 

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -187,6 +187,7 @@ fn ensure_dsh(env: &EnvLookup) -> Result<PathBuf> {
         return Ok(path);
     }
     offer_install("DeepSeek Harness", &crate::dsh::install_hint(), env)?;
+    ensure_pnpm()?;
     install_dsh_packages()?;
     let path = lookup_program("dsh").ok_or_else(|| {
         anyhow::anyhow!(
@@ -202,8 +203,17 @@ fn ensure_dsh(env: &EnvLookup) -> Result<PathBuf> {
 fn install_dsh_packages() -> Result<()> {
     let cmd = crate::dsh::npm_install_cmd();
     eprintln!("[rx] {cmd}");
-    run_npm(&["install", "-g", crate::dsh::CLI_PACKAGE, crate::dsh::PLUGIN_PACKAGE], &cmd)?;
-    ensure_pnpm()
+    run_npm(
+        &[
+            "install",
+            "-g",
+            "--legacy-peer-deps",
+            crate::dsh::CLI_PACKAGE,
+            crate::dsh::PLUGIN_PACKAGE,
+        ],
+        &cmd,
+    )?;
+    Ok(())
 }
 
 fn ensure_pnpm() -> Result<()> {
@@ -220,7 +230,7 @@ fn install_dsh_profile(dsh: &Path, env: &EnvLookup) -> Result<()> {
     eprintln!("[rx] {cmd}");
     run_command(
         dsh,
-        &["plugin", "--profile", crate::dsh::PROFILE, "add", crate::dsh::PLUGIN_PACKAGE],
+        &["plugin", "--profile", crate::dsh::PROFILE, "add", "-w", crate::dsh::PLUGIN_SPEC],
         "dsh plugin",
     )?;
     if crate::dsh::profile_ready(env) {


### PR DESCRIPTION
### What's changed?

- Use npm legacy peer resolution for the dsh and dsh-tui global install.
- Ensure pnpm is available before installing the dsh profile.
- Install the dsh-tui profile with the workspace and latest-version flags required by current releases.

### Why

- Prevent first-time rx dsh setup failures caused by npm peer resolution and profile installation behavior.