### PR TITLE
feat(rx): add Kimi Code launch path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,9 +3269,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tar",
  "tempfile",
  "toml",
+ "toml_edit 0.22.27",
  "ureq",
  "zip",
 ]

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ install: ## Install binaries to ~/.cargo/bin
 	ln -sfn rx "$(HOME)/.cargo/bin/rxo"
 	ln -sfn rx "$(HOME)/.cargo/bin/rxp"
 	ln -sfn rx "$(HOME)/.cargo/bin/rxd"
+	ln -sfn rx "$(HOME)/.cargo/bin/rxk"
 	@if [ -d "$(HOME)/.zsh/completions" ]; then \
 		"$(HOME)/.cargo/bin/recall" completions zsh > "$(HOME)/.zsh/completions/_recall"; \
 		printf '$(GREEN)  ✓ Updated ~/.zsh/completions/_recall$(RESET)\n'; \
@@ -80,7 +81,7 @@ install: ## Install binaries to ~/.cargo/bin
 uninstall: ## Remove installed binaries
 	$(CARGO) uninstall recall
 	$(CARGO) uninstall rx
-	rm -f "$(HOME)/.cargo/bin/rxc" "$(HOME)/.cargo/bin/rxx" "$(HOME)/.cargo/bin/rxo" "$(HOME)/.cargo/bin/rxp" "$(HOME)/.cargo/bin/rxd"
+	rm -f "$(HOME)/.cargo/bin/rxc" "$(HOME)/.cargo/bin/rxx" "$(HOME)/.cargo/bin/rxo" "$(HOME)/.cargo/bin/rxp" "$(HOME)/.cargo/bin/rxd" "$(HOME)/.cargo/bin/rxk"
 
 # ── Run ──────────────────────────────────────────────────────────────────────
 

--- a/crates/rx/Cargo.toml
+++ b/crates/rx/Cargo.toml
@@ -21,9 +21,11 @@ ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
 toml = "0.8"
+toml_edit = "0.22"
 ureq = "3"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/rx/README.md
+++ b/crates/rx/README.md
@@ -1,6 +1,6 @@
 # rx
 
-`rx` launches Claude Code, Codex, OpenCode, Pi, and DeepSeek Harness with one provider configuration. It prepares each harness and runs its native CLI.
+`rx` launches Claude Code, Codex, OpenCode, Pi, DeepSeek Harness, and Kimi Code with one provider configuration. It prepares each harness and runs its native CLI.
 
 [![rx architecture](assets/rx-architecture.png)](assets/rx-architecture.png)
 
@@ -17,9 +17,12 @@ rx providers login
 rx codex
 rx --provider openrouter opencode
 rx --provider none claude
+rx dsh web
+rx kimi
 ```
 
 Running `rx` without a harness opens the picker. Arguments after the harness name are passed to that harness.
+For Kimi Code, `rx` seeds the selected provider and its cached models as `rx-<provider>/<model>` aliases in Kimi's native catalog. `--model <id>` selects one of those models. Without it or a provider-level `model` in `rx.toml`, `rx` uses the first cached provider model and reports that choice on stderr. RX-owned entries are refreshed only while their payload remains unchanged; native and user-edited entries are preserved. Kimi requires catalog credentials in its config, so the selected provider key is also stored in Kimi's local `config.toml` with secret-only file permissions.
 
 | Harness | Commands |
 | --- | --- |
@@ -28,6 +31,7 @@ Running `rx` without a harness opens the picker. Arguments after the harness nam
 | OpenCode | `rx opencode`, `rxo` |
 | Pi | `rx pi`, `rxp` |
 | DeepSeek Harness | `rx dsh`, `rxd` |
+| Kimi Code | `rx kimi`, `rxk` |
 
 Provider commands:
 

--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -10,6 +10,7 @@ pub(crate) enum Harness {
     OpenCode,
     Pi,
     Dsh,
+    Kimi,
 }
 
 impl Harness {
@@ -20,6 +21,7 @@ impl Harness {
             Self::OpenCode => "opencode",
             Self::Pi => "pi",
             Self::Dsh => "dsh",
+            Self::Kimi => "kimi",
         }
     }
 
@@ -30,6 +32,7 @@ impl Harness {
             "opencode" => Some(Self::OpenCode),
             "pi" => Some(Self::Pi),
             "dsh" => Some(Self::Dsh),
+            "kimi" => Some(Self::Kimi),
             _ => None,
         }
     }
@@ -115,6 +118,7 @@ pub(crate) fn argv0_harness(argv0: impl AsRef<OsStr>) -> Option<&'static str> {
         "rxo" => Some("opencode"),
         "rxp" => Some("pi"),
         "rxd" => Some("dsh"),
+        "rxk" => Some("kimi"),
         _ => None,
     }
 }

--- a/crates/rx/src/catalog.rs
+++ b/crates/rx/src/catalog.rs
@@ -135,6 +135,37 @@ pub(crate) fn load_pi_models(
     read_json_array(artifact_path(paths, provider_id, "pi.json"))
 }
 
+pub(crate) fn load_listed_models(
+    paths: &Paths,
+    provider_id: &str,
+    base_url: &str,
+    key: &str,
+    allow_fetch: bool,
+) -> Result<Vec<ListedModel>> {
+    ensure(paths, provider_id, base_url, key, allow_fetch)?;
+    let path = artifact_path(paths, provider_id, "json");
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let body =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let document: Value = serde_json::from_str(&body)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(document
+        .get("models")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|model| {
+            Some(ListedModel {
+                id: model.get("slug")?.as_str()?.to_string(),
+                name: model.get("display_name").and_then(Value::as_str).map(str::to_string),
+                context_length: model.get("context_window").and_then(Value::as_i64),
+            })
+        })
+        .collect())
+}
+
 pub(crate) fn load_claude_seed(
     paths: &Paths,
     provider_id: &str,

--- a/crates/rx/src/completions.rs
+++ b/crates/rx/src/completions.rs
@@ -9,7 +9,7 @@ const BASH: &str = r#"_rx_bin() {
   local invoked=${COMP_WORDS[0]}
   local name=${invoked##*/}
   case $name in
-    rxc|rxx|rxo|rxp|rxd)
+    rxc|rxx|rxo|rxp|rxd|rxk)
       if [[ $invoked == */* ]]; then
         printf '%s' "${invoked%/*}/rx"
       else
@@ -82,7 +82,7 @@ _rx() {
   done < <(_rx_positionals)
 
   case $cmd in
-    rxc|rxx|rxo|rxp|rxd)
+    rxc|rxx|rxo|rxp|rxd|rxk)
       if [[ $cur == -* ]] && ! _rx_has_provider; then
         COMPREPLY=($(compgen -W '--provider' -- "$cur"))
       fi
@@ -96,9 +96,9 @@ _rx() {
       _rx_has_provider || flags+=' --provider'
       COMPREPLY=($(compgen -W "$flags" -- "$cur"))
     elif _rx_has_provider; then
-      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh' -- "$cur"))
+      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh kimi' -- "$cur"))
     else
-      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh providers update completions' -- "$cur"))
+      COMPREPLY=($(compgen -W 'claude codex opencode pi dsh kimi providers update completions' -- "$cur"))
     fi
     return
   fi
@@ -136,7 +136,7 @@ _rx() {
     completions)
       ((${#pos[@]} == 1)) && COMPREPLY=($(compgen -W 'bash zsh fish' -- "$cur"))
       ;;
-    claude|codex|opencode|pi|dsh)
+    claude|codex|opencode|pi|dsh|kimi)
       if [[ $cur == -* ]] && ! _rx_has_provider; then
         COMPREPLY=($(compgen -W '--provider' -- "$cur"))
       fi
@@ -144,16 +144,16 @@ _rx() {
   esac
 }
 
-complete -F _rx rx rxc rxx rxo rxp rxd
+complete -F _rx rx rxc rxx rxo rxp rxd rxk
 "#;
 
-const ZSH: &str = r#"#compdef rx rxc rxx rxo rxp rxd
+const ZSH: &str = r#"#compdef rx rxc rxx rxo rxp rxd rxk
 
 _rx_bin() {
   local invoked=$words[1]
   local name=${invoked:t}
   case $name in
-    rxc|rxx|rxo|rxp|rxd)
+    rxc|rxx|rxo|rxp|rxd|rxk)
       if [[ $invoked == */* ]]; then
         print -rn -- ${invoked:h}/rx
       else
@@ -226,7 +226,7 @@ _rx() {
   [[ -n $output ]] && pos=(${(f)output})
 
   case $cmd in
-    rxc|rxx|rxo|rxp|rxd)
+    rxc|rxx|rxo|rxp|rxd|rxk)
       if [[ $cur == -* ]] && ! _rx_has_provider; then
         compadd -- --provider
       fi
@@ -241,9 +241,9 @@ _rx() {
       _rx_has_provider || flags+=(--provider)
       compadd -- $flags
     elif _rx_has_provider; then
-      compadd -- claude codex opencode pi dsh
+      compadd -- claude codex opencode pi dsh kimi
     else
-      compadd -- claude codex opencode pi dsh providers update completions
+      compadd -- claude codex opencode pi dsh kimi providers update completions
     fi
     return
   fi
@@ -281,7 +281,7 @@ _rx() {
     completions)
       (( $#pos == 1 )) && compadd -- bash zsh fish
       ;;
-    claude|codex|opencode|pi|dsh)
+    claude|codex|opencode|pi|dsh|kimi)
       if [[ $cur == -* ]] && ! _rx_has_provider; then
         compadd -- --provider
       fi
@@ -289,14 +289,14 @@ _rx() {
   esac
 }
 
-compdef _rx rx rxc rxx rxo rxp rxd
+compdef _rx rx rxc rxx rxo rxp rxd rxk
 "#;
 
 const FISH: &str = r#"function __rx_bin
     set -l invoked (commandline -opc)[1]
     set -l name (basename $invoked)
     switch $name
-        case rxc rxx rxo rxp rxd
+        case rxc rxx rxo rxp rxd rxk
             if string match -q '*/*' -- $invoked
                 echo (dirname $invoked)/rx
             else
@@ -370,7 +370,7 @@ end
 function __rx_has_harness
     set -l pos (__rx_pos)
     test (count $pos) -ge 1
-    and contains -- $pos[1] claude codex opencode pi dsh
+    and contains -- $pos[1] claude codex opencode pi dsh kimi
 end
 
 complete -c rx -f
@@ -379,10 +379,11 @@ complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'codex' -d 'Codex'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'opencode' -d 'OpenCode'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'pi' -d 'Pi'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'dsh' -d 'DeepSeek Harness'
+complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'kimi' -d 'Kimi Code'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'providers' -d 'Manage providers'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'update' -d 'Update rx'
 complete -c rx -n '__rx_n 0; and not __rx_has_provider' -a 'completions' -d 'Generate shell completion script'
-complete -c rx -n '__rx_n 0; and __rx_has_provider' -a 'claude codex opencode pi dsh'
+complete -c rx -n '__rx_n 0; and __rx_has_provider' -a 'claude codex opencode pi dsh kimi'
 complete -c rx -n '__rx_n 0' -s h -l help
 complete -c rx -n '__rx_n 0' -s V -l version
 complete -c rx -n 'not __rx_has_provider; and __rx_n 0' -l provider -xa '(__rx_ids --targets)'
@@ -396,7 +397,7 @@ complete -c rx -n '__rx_is providers models update; and __rx_n 3' -a '(__rx_ids 
 complete -c rx -n '__rx_is update; and __rx_n 1' -l yes -s y
 complete -c rx -n '__rx_is completions; and __rx_n 1' -a 'bash zsh fish'
 
-for cmd in rxc rxx rxo rxp rxd
+for cmd in rxc rxx rxo rxp rxd rxk
     complete -c $cmd -f
     complete -c $cmd -l provider -xa '(__rx_ids --targets)'
 end

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -51,6 +51,12 @@ pub(crate) fn spec(harness: Harness) -> InstallSpec {
             url: "https://www.npmjs.com/package/@deepseek-ai/dsh",
             shell: "sh",
         },
+        Harness::Kimi => InstallSpec {
+            program: "kimi",
+            display: "Kimi Code",
+            url: "https://code.kimi.com/kimi-code/install.sh",
+            shell: "bash",
+        },
     }
 }
 
@@ -144,7 +150,12 @@ pub(crate) fn extra_bin_dirs() -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
-    vec![home.join(".local/bin"), home.join(".opencode/bin"), home.join(".claude/local/bin")]
+    vec![
+        home.join(".local/bin"),
+        home.join(".opencode/bin"),
+        home.join(".claude/local/bin"),
+        home.join(".kimi-code/bin"),
+    ]
 }
 
 fn run_official_installer(spec: &InstallSpec) -> Result<()> {

--- a/crates/rx/src/kimi.rs
+++ b/crates/rx/src/kimi.rs
@@ -1,0 +1,542 @@
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use toml_edit::{DocumentMut, Item, Table, value};
+
+use crate::args;
+use crate::catalog::{self, ListedModel};
+use crate::config::Paths;
+use crate::launch::{EnvLookup, LaunchPlan, ProviderTarget};
+
+const MARKER_VERSION: u32 = 1;
+const MAX_WRITE_ATTEMPTS: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct OwnedCatalog {
+    version: u32,
+    provider: OwnedProvider,
+    models: BTreeMap<String, OwnedModel>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct OwnedProvider {
+    alias: String,
+    base_url: String,
+    api_key_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct OwnedModel {
+    provider: String,
+    model: String,
+    max_context_size: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+}
+
+pub(crate) fn prepare(
+    target: &ProviderTarget,
+    configured_model: Option<&str>,
+    paths: &Paths,
+    env: &EnvLookup,
+    passthrough: &[OsString],
+) -> Result<LaunchPlan> {
+    let provider_id = target.provider_id.as_str();
+    let provider_alias = format!("rx-{provider_id}");
+    let model_prefix = format!("{provider_alias}/");
+    let (requested_model, mut args) = take_model(passthrough)?;
+    let preferred_model = requested_model
+        .or_else(|| configured_model.map(str::to_string))
+        .map(|model| model.strip_prefix(&model_prefix).unwrap_or(&model).to_string());
+    let allow_fetch = env.is_real() || target.provider.setup == crate::provider::Setup::Generated;
+    let mut notes = Vec::new();
+    let mut models = match catalog::load_listed_models(
+        paths,
+        provider_id,
+        &target.base_url,
+        &target.key,
+        allow_fetch,
+    ) {
+        Ok(models) => models,
+        Err(error) if preferred_model.is_some() => {
+            notes.push(format!(
+                "[rx] kimi: provider catalog unavailable; seeding only the selected model: {error:#}"
+            ));
+            Vec::new()
+        }
+        Err(error) => return Err(error),
+    };
+    let selected_model = match preferred_model {
+        Some(model) => model,
+        None => {
+            let model = models.first().map(|model| model.id.clone()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "kimi needs a model for provider '{provider_id}'; pass --model <id> or set [provider.{provider_id}] model in rx.toml"
+                )
+            })?;
+            notes.push(format!(
+                "[rx] kimi: no model selected; using first provider model '{model}' (set [provider.{provider_id}] model to choose)"
+            ));
+            model
+        }
+    };
+    if !models.iter().any(|model| model.id == selected_model) {
+        models.push(ListedModel {
+            id: selected_model.clone(),
+            name: None,
+            context_length: Some(
+                target.provider.default_context.unwrap_or(catalog::DEFAULT_CONTEXT_WINDOW),
+            ),
+        });
+    }
+    let config_path = kimi_config_path(paths, env)?;
+    seed_catalog(&config_path, &provider_alias, target, &models)?;
+    args.insert(0, OsString::from(format!("{provider_alias}/{selected_model}")));
+    args.insert(0, OsString::from("--model"));
+    Ok(LaunchPlan {
+        program: PathBuf::from("kimi"),
+        args,
+        env_set: vec![("KIMI_MODEL_NAME".to_string(), String::new())],
+        stderr_note: (!notes.is_empty()).then(|| notes.join("\n")),
+    })
+}
+
+fn kimi_config_path(paths: &Paths, env: &EnvLookup) -> Result<PathBuf> {
+    if let Some(home) = env.get("KIMI_CODE_HOME").filter(|value| !value.trim().is_empty()) {
+        return Ok(PathBuf::from(home).join("config.toml"));
+    }
+    if !env.is_real() {
+        return Ok(paths.dir.join("kimi-code").join("config.toml"));
+    }
+    let home = dirs::home_dir().context("cannot determine home directory")?;
+    Ok(home.join(".kimi-code").join("config.toml"))
+}
+
+fn seed_catalog(
+    config_path: &Path,
+    provider_alias: &str,
+    target: &ProviderTarget,
+    models: &[ListedModel],
+) -> Result<()> {
+    let parent = config_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("path has no parent: {}", config_path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let lock_path = appended_path(config_path, ".rx.lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    lock.lock_exclusive().with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    let marker_path = appended_path(config_path, ".rx-catalog.json");
+    let desired = desired_catalog(provider_alias, target, models);
+    for _ in 0..MAX_WRITE_ATTEMPTS {
+        let snapshot = read_bytes(config_path)?;
+        let mut document = read_document(config_path, snapshot.as_deref())?;
+        let previous = read_marker(&marker_path)?;
+        reconcile(&mut document, previous.as_ref(), &desired, &target.key)?;
+        let staged_config = stage_secret(config_path, document.to_string().as_bytes())?;
+        let marker =
+            serde_json::to_vec_pretty(&desired).context("failed to serialize Kimi marker")?;
+        let staged_marker = stage_secret(&marker_path, &marker)?;
+        if read_bytes(config_path)?.as_deref() != snapshot.as_deref() {
+            continue;
+        }
+        persist_secret(staged_config, config_path)?;
+        persist_secret(staged_marker, &marker_path)?;
+        return Ok(());
+    }
+    bail!("{} changed repeatedly while seeding Kimi catalog", config_path.display())
+}
+
+fn desired_catalog(
+    provider_alias: &str,
+    target: &ProviderTarget,
+    models: &[ListedModel],
+) -> OwnedCatalog {
+    let provider = OwnedProvider {
+        alias: provider_alias.to_string(),
+        base_url: catalog::openai_base(&target.base_url),
+        api_key_sha256: key_hash(&target.key),
+    };
+    let models = models
+        .iter()
+        .map(|model| {
+            let alias = format!("{provider_alias}/{}", model.id);
+            let entry = OwnedModel {
+                provider: provider_alias.to_string(),
+                model: model.id.clone(),
+                max_context_size: model
+                    .context_length
+                    .unwrap_or_else(|| catalog::fallback_context(&target.provider_id)),
+                display_name: model.name.clone(),
+            };
+            (alias, entry)
+        })
+        .collect();
+    OwnedCatalog { version: MARKER_VERSION, provider, models }
+}
+
+fn reconcile(
+    document: &mut DocumentMut,
+    previous: Option<&OwnedCatalog>,
+    desired: &OwnedCatalog,
+    key: &str,
+) -> Result<()> {
+    if let Some(previous) = previous {
+        if previous.version != MARKER_VERSION {
+            bail!("unsupported Kimi catalog marker version {}", previous.version);
+        }
+        if let Some(models) = table_mut(document, "models")? {
+            for (alias, owned) in &previous.models {
+                if models.get(alias).is_some_and(|item| model_matches(item, owned)) {
+                    models.remove(alias);
+                }
+            }
+        }
+        let provider_referenced = table(document, "models")?.is_some_and(|models| {
+            models.iter().any(|(_, item)| {
+                item.as_table().and_then(|table| string_field(table, "provider"))
+                    == Some(&previous.provider.alias)
+            })
+        });
+        let reusable = previous.provider == desired.provider;
+        if !provider_referenced
+            && !reusable
+            && let Some(providers) = table_mut(document, "providers")?
+            && providers
+                .get(&previous.provider.alias)
+                .is_some_and(|item| provider_matches(item, &previous.provider))
+        {
+            providers.remove(&previous.provider.alias);
+        }
+    }
+
+    let provider_exists = table(document, "providers")?
+        .is_some_and(|providers| providers.contains_key(&desired.provider.alias));
+    let provider_reusable = if let Some(previous) = previous {
+        previous.provider == desired.provider
+            && table(document, "providers")?
+                .and_then(|providers| providers.get(&desired.provider.alias))
+                .is_some_and(|item| provider_matches(item, &desired.provider))
+    } else {
+        false
+    };
+    if provider_exists && !provider_reusable {
+        bail!(
+            "Kimi provider alias '{}' already exists outside rx ownership",
+            desired.provider.alias
+        );
+    }
+    if let Some(models) = table(document, "models")?
+        && let Some(alias) = desired.models.keys().find(|alias| models.contains_key(alias))
+    {
+        bail!("Kimi model alias '{alias}' already exists outside rx ownership");
+    }
+
+    if !provider_reusable {
+        let mut provider = Table::new();
+        provider["type"] = value("openai");
+        provider["base_url"] = value(&desired.provider.base_url);
+        provider["api_key"] = value(key);
+        let providers = ensure_table(document, "providers")?;
+        providers.insert(&desired.provider.alias, Item::Table(provider));
+    }
+    let models = ensure_table(document, "models")?;
+    for (alias, model) in &desired.models {
+        let mut entry = Table::new();
+        entry["provider"] = value(&model.provider);
+        entry["model"] = value(&model.model);
+        entry["max_context_size"] = value(model.max_context_size);
+        if let Some(display_name) = &model.display_name {
+            entry["display_name"] = value(display_name);
+        }
+        models.insert(alias, Item::Table(entry));
+    }
+    Ok(())
+}
+
+fn provider_matches(item: &Item, owned: &OwnedProvider) -> bool {
+    let Some(table) = item.as_table() else {
+        return false;
+    };
+    table.len() == 3
+        && string_field(table, "type") == Some("openai")
+        && string_field(table, "base_url") == Some(owned.base_url.as_str())
+        && string_field(table, "api_key").is_some_and(|key| key_hash(key) == owned.api_key_sha256)
+}
+
+fn model_matches(item: &Item, owned: &OwnedModel) -> bool {
+    let Some(table) = item.as_table() else {
+        return false;
+    };
+    let expected_len = if owned.display_name.is_some() { 4 } else { 3 };
+    table.len() == expected_len
+        && string_field(table, "provider") == Some(owned.provider.as_str())
+        && string_field(table, "model") == Some(owned.model.as_str())
+        && table
+            .get("max_context_size")
+            .and_then(Item::as_value)
+            .and_then(|value| value.as_integer())
+            == Some(owned.max_context_size)
+        && match &owned.display_name {
+            Some(display_name) => {
+                string_field(table, "display_name") == Some(display_name.as_str())
+            }
+            None => !table.contains_key("display_name"),
+        }
+}
+
+fn string_field<'a>(table: &'a Table, key: &str) -> Option<&'a str> {
+    table.get(key)?.as_value()?.as_str()
+}
+
+fn table<'a>(document: &'a DocumentMut, key: &str) -> Result<Option<&'a Table>> {
+    match document.get(key) {
+        Some(item) => item
+            .as_table()
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("Kimi config '{key}' is not a table")),
+        None => Ok(None),
+    }
+}
+
+fn table_mut<'a>(document: &'a mut DocumentMut, key: &str) -> Result<Option<&'a mut Table>> {
+    match document.get_mut(key) {
+        Some(item) => item
+            .as_table_mut()
+            .map(Some)
+            .ok_or_else(|| anyhow::anyhow!("Kimi config '{key}' is not a table")),
+        None => Ok(None),
+    }
+}
+
+fn ensure_table<'a>(document: &'a mut DocumentMut, key: &str) -> Result<&'a mut Table> {
+    if document.get(key).is_none() {
+        document[key] = Item::Table(Table::new());
+    }
+    document[key]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("Kimi config '{key}' is not a table"))
+}
+
+fn read_document(path: &Path, contents: Option<&[u8]>) -> Result<DocumentMut> {
+    let Some(contents) = contents else {
+        return Ok(DocumentMut::new());
+    };
+    let body = std::str::from_utf8(contents)
+        .with_context(|| format!("{} is not UTF-8", path.display()))?;
+    body.parse().with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn read_marker(path: &Path) -> Result<Option<OwnedCatalog>> {
+    match fs::read(path) {
+        Ok(contents) => serde_json::from_slice(&contents)
+            .with_context(|| format!("failed to parse {}", path.display()))
+            .map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn read_bytes(path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn stage_secret(path: &Path, contents: &[u8]) -> Result<tempfile::NamedTempFile> {
+    let parent =
+        path.parent().ok_or_else(|| anyhow::anyhow!("path has no parent: {}", path.display()))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+    temp.write_all(contents)
+        .with_context(|| format!("failed to write temporary file for {}", path.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary file for {}", path.display()))?;
+    set_secret_mode(temp.as_file(), path)?;
+    Ok(temp)
+}
+
+fn persist_secret(temp: tempfile::NamedTempFile, path: &Path) -> Result<()> {
+    temp.persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+fn appended_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
+}
+
+fn key_hash(key: &str) -> String {
+    format!("{:x}", Sha256::digest(key.as_bytes()))
+}
+
+#[cfg(unix)]
+fn set_secret_mode(file: &fs::File, path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to chmod {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_secret_mode(_file: &fs::File, _path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn take_model(passthrough: &[OsString]) -> Result<(Option<String>, Vec<OsString>)> {
+    let limit = args::before_double_dash(passthrough).len();
+    let mut model = None;
+    let mut kept = Vec::with_capacity(passthrough.len());
+    let mut i = 0;
+    while i < passthrough.len() {
+        let arg = &passthrough[i];
+        if i < limit && (arg == "-m" || arg == "--model") {
+            let value = passthrough
+                .get(i + 1)
+                .filter(|_| i + 1 < limit)
+                .ok_or_else(|| anyhow::anyhow!("{} requires a model id", arg.to_string_lossy()))?;
+            let value = value.to_str().filter(|value| !value.is_empty()).ok_or_else(|| {
+                anyhow::anyhow!("{} requires a UTF-8 model id", arg.to_string_lossy())
+            })?;
+            model = Some(value.to_string());
+            i += 2;
+            continue;
+        }
+        let text = if i < limit { arg.to_str() } else { None };
+        if let Some(value) =
+            text.and_then(|text| text.strip_prefix("--model=").or_else(|| text.strip_prefix("-m=")))
+        {
+            if value.is_empty() {
+                bail!("{} requires a model id", arg.to_string_lossy());
+            }
+            model = Some(value.to_string());
+            i += 1;
+            continue;
+        }
+        kept.push(arg.clone());
+        i += 1;
+    }
+    Ok((model, kept))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(key: &str) -> ProviderTarget {
+        let provider = crate::provider::find("tokener").unwrap().clone();
+        ProviderTarget {
+            provider_id: "tokener".to_string(),
+            base_url: "https://provider.test".to_string(),
+            claude_url: "https://provider.test".to_string(),
+            provider,
+            key: key.to_string(),
+            model: None,
+        }
+    }
+
+    fn listed(id: &str, name: &str, context: i64) -> ListedModel {
+        ListedModel {
+            id: id.to_string(),
+            name: Some(name.to_string()),
+            context_length: Some(context),
+        }
+    }
+
+    fn os(argv: &[&str]) -> Vec<OsString> {
+        argv.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn model_flag_selects_catalog_model_and_preserves_literal_arguments() {
+        assert_eq!(
+            take_model(&os(&["--plan", "-m", "kimi-k3", "--", "--model", "literal"])).unwrap(),
+            (Some("kimi-k3".to_string()), os(&["--plan", "--", "--model", "literal"]))
+        );
+        assert_eq!(
+            take_model(&os(&["--model=glm-5", "-m=deepseek-v4"])).unwrap(),
+            (Some("deepseek-v4".to_string()), Vec::new())
+        );
+    }
+
+    #[test]
+    fn catalog_refresh_preserves_user_config_and_replaces_owned_models() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "default_model = \"native/model\"\n\n[providers.native]\n# keep this\ntype = \"openai\"\nbase_url = \"https://native.test/v1\"\napi_key = \"native-key\"\n\n[models.\"native/model\"]\nprovider = \"native\"\nmodel = \"native-model\"\nmax_context_size = 100000\n",
+        )
+        .unwrap();
+        seed_catalog(
+            &path,
+            "rx-tokener",
+            &target("rx-secret"),
+            &[listed("model-a", "Model A", 200_000), listed("model-b", "Model B", 300_000)],
+        )
+        .unwrap();
+        seed_catalog(
+            &path,
+            "rx-tokener",
+            &target("rx-secret"),
+            &[listed("model-b", "Model B", 300_000), listed("model-c", "Model C", 400_000)],
+        )
+        .unwrap();
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(body.contains("# keep this"));
+        let document: toml::Value = toml::from_str(&body).unwrap();
+        assert_eq!(document["default_model"].as_str(), Some("native/model"));
+        assert_eq!(document["providers"]["native"]["api_key"].as_str(), Some("native-key"));
+        assert!(document["models"].get("native/model").is_some());
+        assert!(document["models"].get("rx-tokener/model-a").is_none());
+        assert!(document["models"].get("rx-tokener/model-b").is_some());
+        assert!(document["models"].get("rx-tokener/model-c").is_some());
+        let marker = fs::read_to_string(appended_path(&path, ".rx-catalog.json")).unwrap();
+        assert!(!marker.contains("rx-secret"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+            assert_eq!(
+                fs::metadata(appended_path(&path, ".rx-catalog.json"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn modified_owned_model_is_preserved_and_blocks_reclaim() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let models = [listed("model-a", "Model A", 200_000)];
+        seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models).unwrap();
+        let mut document = fs::read_to_string(&path).unwrap().parse::<DocumentMut>().unwrap();
+        document["models"]["rx-tokener/model-a"]["model"] = value("user-model");
+        fs::write(&path, document.to_string()).unwrap();
+        let error = seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models).unwrap_err();
+        assert!(error.to_string().contains("outside rx ownership"), "{error:#}");
+        let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(document["models"]["rx-tokener/model-a"]["model"].as_str(), Some("user-model"));
+    }
+}

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -132,7 +132,7 @@ pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> R
     let model = target.model.as_deref().or(match request.harness {
         Harness::Claude => target.provider.claude_default_model,
         Harness::Codex => target.provider.default_model,
-        Harness::OpenCode | Harness::Pi | Harness::Dsh => None,
+        Harness::OpenCode | Harness::Pi | Harness::Dsh | Harness::Kimi => None,
     });
     if matches!(request.harness, Harness::Claude) {
         let seed = if env.is_real() {
@@ -217,11 +217,21 @@ fn apply_yolo(request: &LaunchRequest, plan: &mut LaunchPlan, env: &EnvLookup) {
             if user_flag(&["--auto"]) {
                 return;
             }
-            plan.args.insert(0, OsString::from("--auto"));
+            let Some(at) = opencode_flag_index(&plan.args) else {
+                return;
+            };
+            plan.args.insert(at, OsString::from("--auto"));
             push_note(plan, &note("--auto"));
         }
         Harness::Pi => {}
         Harness::Dsh => {}
+        Harness::Kimi => {
+            if user_flag(&["--auto", "--yolo", "-y", "--yes", "--auto-approve", "--prompt", "-p"]) {
+                return;
+            }
+            plan.args.insert(0, OsString::from("--auto"));
+            push_note(plan, &note("--auto"));
+        }
     }
 }
 
@@ -549,9 +559,16 @@ fn inject(
                 )?,
             ));
             let mut args = request.passthrough.clone();
-            if let Some(model) = model.filter(|_| !user_sets_opencode_model(&request.passthrough)) {
-                args.insert(0, OsString::from(crate::opencode::prefixed_model(provider_id, model)));
-                args.insert(0, OsString::from("-m"));
+            if let Some(model) = model.filter(|_| !user_sets_opencode_model(&request.passthrough))
+                && let Some(at) = opencode_flag_index(&args)
+            {
+                args.splice(
+                    at..at,
+                    [
+                        OsString::from("-m"),
+                        OsString::from(crate::opencode::prefixed_model(provider_id, model)),
+                    ],
+                );
             }
             Ok(LaunchPlan {
                 program: PathBuf::from("opencode"),
@@ -588,6 +605,7 @@ fn inject(
                 },
             })
         }
+        Harness::Kimi => crate::kimi::prepare(target, model, paths, env, &request.passthrough),
     }
 }
 
@@ -621,6 +639,18 @@ fn user_sets_opencode_model(passthrough: &[OsString]) -> bool {
             || arg == "--model"
             || args::os_prefix(arg, "--model=")
     })
+}
+
+fn opencode_flag_index(passthrough: &[OsString]) -> Option<usize> {
+    match args::before_double_dash(passthrough).first().and_then(|arg| arg.to_str()) {
+        Some("run") => Some(1),
+        Some(
+            "completion" | "acp" | "mcp" | "attach" | "debug" | "providers" | "auth" | "agent"
+            | "upgrade" | "uninstall" | "serve" | "web" | "models" | "stats" | "export" | "import"
+            | "github" | "pr" | "session" | "plugin" | "plug" | "db",
+        ) => None,
+        _ => Some(0),
+    }
 }
 
 fn user_sets_model(passthrough: &[OsString]) -> bool {

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -5,6 +5,7 @@ mod completions;
 mod config;
 mod dsh;
 mod install;
+mod kimi;
 mod launch;
 mod opencode;
 mod pi;

--- a/crates/rx/src/pick.rs
+++ b/crates/rx/src/pick.rs
@@ -43,12 +43,13 @@ struct Choice {
     alias: &'static str,
 }
 
-const CHOICES: [Choice; 5] = [
+const CHOICES: [Choice; 6] = [
     Choice { harness: Harness::Claude, alias: "rxc" },
     Choice { harness: Harness::Codex, alias: "rxx" },
     Choice { harness: Harness::OpenCode, alias: "rxo" },
     Choice { harness: Harness::Pi, alias: "rxp" },
     Choice { harness: Harness::Dsh, alias: "rxd" },
+    Choice { harness: Harness::Kimi, alias: "rxk" },
 ];
 
 struct App {

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -268,6 +268,7 @@ fn completions_scripts_cover_rx_surface() {
             "opencode",
             "pi",
             "dsh",
+            "kimi",
             "providers",
             "update",
             "completions",
@@ -280,6 +281,7 @@ fn completions_scripts_cover_rx_surface() {
             "rxo",
             "rxp",
             "rxd",
+            "rxk",
         ] {
             assert!(script.contains(needle), "{shell:?} missing {needle}");
         }
@@ -406,6 +408,7 @@ fn argv0_harness_resolves_aliases() {
     assert_eq!(crate::args::argv0_harness("rxo.exe"), Some("opencode"));
     assert_eq!(crate::args::argv0_harness("rxp"), Some("pi"));
     assert_eq!(crate::args::argv0_harness("rxd"), Some("dsh"));
+    assert_eq!(crate::args::argv0_harness("rxk"), Some("kimi"));
     assert_eq!(crate::args::argv0_harness("/home/u/.cargo/bin/rx"), None);
 }
 
@@ -481,6 +484,32 @@ fn rx_dsh_is_a_harness() {
             harness: Harness::Dsh,
             provider: None,
             passthrough: os(&["--resume"]),
+        })
+    );
+}
+
+#[test]
+fn rxk_inserts_kimi() {
+    let command = parse_line(&["rxk", "--continue"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Kimi,
+            provider: None,
+            passthrough: os(&["--continue"]),
+        })
+    );
+}
+
+#[test]
+fn rx_kimi_is_a_harness() {
+    let command = parse_line(&["rx", "kimi", "web", "--port", "58627"]);
+    assert_eq!(
+        command,
+        Command::Launch(LaunchRequest {
+            harness: Harness::Kimi,
+            provider: None,
+            passthrough: os(&["web", "--port", "58627"]),
         })
     );
 }
@@ -682,6 +711,121 @@ fn unconfigured_dsh_still_boots_tui_profile() {
     assert_eq!(plan.program, PathBuf::from("dsh"));
     assert_eq!(plan.args, os(&["--profile", "dsh-tui", "--resume"]));
     assert!(plan.env_set.is_empty());
+}
+
+#[test]
+fn unconfigured_kimi_launches_as_is() {
+    let (_dir, paths) = temp_paths();
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Kimi,
+            provider: None,
+            passthrough: os(&["web", "--no-open"]),
+        },
+        &paths,
+        &EnvLookup::isolated(HashMap::new()),
+    )
+    .unwrap();
+    assert_eq!(plan.program, PathBuf::from("kimi"));
+    assert_eq!(plan.args, os(&["web", "--no-open"]));
+    assert!(plan.env_set.is_empty());
+}
+
+#[test]
+fn kimi_explicit_model_seeds_selected_alias_when_catalog_is_unavailable() {
+    let (_dir, paths) = temp_paths();
+    fs::write(&paths.config, "[provider.tokener]\nbase_url = \"http://127.0.0.1:9\"\n").unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Kimi,
+            provider: Some("tokener".to_string()),
+            passthrough: os(&["--model", "rx-tokener/kimi-k3", "--plan"]),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    assert_eq!(plan.program, PathBuf::from("kimi"));
+    assert_eq!(plan.args, os(&["--auto", "--model", "rx-tokener/kimi-k3", "--plan"]));
+    assert_eq!(plan.env_set, vec![("KIMI_MODEL_NAME".to_string(), String::new())]);
+    let config: toml::Value = toml::from_str(
+        &fs::read_to_string(paths.dir.join("kimi-code").join("config.toml")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(config["providers"]["rx-tokener"]["type"].as_str(), Some("openai"));
+    assert_eq!(
+        config["providers"]["rx-tokener"]["base_url"].as_str(),
+        Some("http://127.0.0.1:9/v1")
+    );
+    assert_eq!(config["models"]["rx-tokener/kimi-k3"]["model"].as_str(), Some("kimi-k3"));
+    assert!(plan.stderr_note.as_deref().unwrap().contains("seeding only the selected model"));
+    assert!(plan.stderr_note.as_deref().unwrap().contains("yolo"));
+}
+
+#[test]
+fn kimi_fallback_uses_first_provider_model_and_reports_it() {
+    let (_dir, paths) = temp_paths();
+    let (base_url, server) = serve_openai_models(r#"{"data":[{"id":"glm-5"},{"id":"kimi-k3"}]}"#);
+    fs::write(&paths.config, format!("[provider.tokener]\nbase_url = \"{base_url}\"\n")).unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Kimi,
+            provider: Some("tokener".to_string()),
+            passthrough: os(&["--auto"]),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    server.join().unwrap();
+    assert_eq!(plan.args, os(&["--model", "rx-tokener/glm-5", "--auto"]));
+    assert_eq!(plan.env_set, vec![("KIMI_MODEL_NAME".to_string(), String::new())]);
+    let config: toml::Value = toml::from_str(
+        &fs::read_to_string(paths.dir.join("kimi-code").join("config.toml")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(config["models"].as_table().unwrap().len(), 2);
+    assert_eq!(config["models"]["rx-tokener/glm-5"]["model"].as_str(), Some("glm-5"));
+    assert_eq!(config["models"]["rx-tokener/kimi-k3"]["model"].as_str(), Some("kimi-k3"));
+    assert!(plan.stderr_note.as_deref().unwrap().contains("using first provider model 'glm-5'"));
+    assert!(!plan.stderr_note.as_deref().unwrap().contains("yolo"));
+}
+
+#[test]
+fn kimi_skips_yolo_when_prompt_or_hidden_yolo_alias_is_set() {
+    let (_dir, paths) = temp_paths();
+    fs::write(&paths.config, "[provider.tokener]\nbase_url = \"http://127.0.0.1:9\"\n").unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "TOKENER_API_KEY".to_string(),
+        "sk-tokener".to_string(),
+    )]));
+    for passthrough in [
+        os(&["--model", "kimi-k3", "-p", "hello"]),
+        os(&["--model", "kimi-k3", "--prompt", "hello"]),
+        os(&["--model", "kimi-k3", "--yes"]),
+        os(&["--model", "kimi-k3", "--auto-approve"]),
+    ] {
+        let plan = launch::plan(
+            &LaunchRequest {
+                harness: Harness::Kimi,
+                provider: Some("tokener".to_string()),
+                passthrough,
+            },
+            &paths,
+            &env,
+        )
+        .unwrap();
+        assert!(!plan.args.iter().any(|arg| arg == "--auto"), "{:?}", plan.args);
+        assert!(!plan.stderr_note.as_deref().is_some_and(|note| note.contains("yolo")));
+    }
 }
 
 #[test]
@@ -893,6 +1037,7 @@ fn codex_openrouter_overrides_model_and_uses_command_auth() {
 #[test]
 fn opencode_openrouter_injects_config_and_model() {
     let (_dir, paths) = temp_paths();
+    fs::write(&paths.config, "[provider.openrouter]\nmodel = \"openai/gpt-5\"\n").unwrap();
     let env = EnvLookup::isolated(HashMap::from([(
         "OPENROUTER_API_KEY".to_string(),
         "sk-or-test".to_string(),
@@ -908,7 +1053,7 @@ fn opencode_openrouter_injects_config_and_model() {
     )
     .unwrap();
     assert_eq!(plan.program, PathBuf::from("opencode"));
-    assert_eq!(plan.args, os(&["--auto", "run", "hello"]));
+    assert_eq!(plan.args, os(&["run", "--auto", "-m", "openrouter/openai/gpt-5", "hello"]));
     assert!(plan.env_set.iter().any(|(k, v)| k == "OPENROUTER_API_KEY" && v == "sk-or-test"));
     let config = plan
         .env_set
@@ -918,6 +1063,31 @@ fn opencode_openrouter_injects_config_and_model() {
         .unwrap();
     assert!(config.contains("openrouter"));
     assert!(config.contains("OPENROUTER_API_KEY"));
+}
+
+#[test]
+fn opencode_server_commands_preserve_native_arguments() {
+    let (_dir, paths) = temp_paths();
+    fs::write(&paths.config, "[provider.openrouter]\nmodel = \"openai/gpt-5\"\n").unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "OPENROUTER_API_KEY".to_string(),
+        "sk-or-test".to_string(),
+    )]));
+    for passthrough in [os(&["web", "--port", "4096"]), os(&["serve", "--hostname", "127.0.0.1"])] {
+        let plan = launch::plan(
+            &LaunchRequest {
+                harness: Harness::OpenCode,
+                provider: Some("openrouter".to_string()),
+                passthrough: passthrough.clone(),
+            },
+            &paths,
+            &env,
+        )
+        .unwrap();
+        assert_eq!(plan.args, passthrough);
+        assert!(plan.env_set.iter().any(|(key, _)| key == "OPENCODE_CONFIG_CONTENT"));
+        assert!(!plan.stderr_note.as_deref().is_some_and(|note| note.contains("yolo")));
+    }
 }
 
 #[test]
@@ -2654,6 +2824,12 @@ fn install_specs_use_official_urls() {
     let dsh = crate::install::spec(Harness::Dsh);
     assert_eq!(dsh.program, "dsh");
     assert_eq!(dsh.display, "DeepSeek Harness");
+
+    let kimi = crate::install::spec(Harness::Kimi);
+    assert_eq!(kimi.program, "kimi");
+    assert_eq!(kimi.display, "Kimi Code");
+    assert_eq!(kimi.url, "https://code.kimi.com/kimi-code/install.sh");
+    assert_eq!(kimi.shell, "bash");
 }
 
 #[test]
@@ -2699,4 +2875,6 @@ fn isolated_env_skips_install_offer() {
     assert_eq!(path, std::path::PathBuf::from("pi"));
     let dsh = crate::install::ensure(Harness::Dsh, &EnvLookup::isolated(HashMap::new())).unwrap();
     assert_eq!(dsh, std::path::PathBuf::from("dsh"));
+    let kimi = crate::install::ensure(Harness::Kimi, &EnvLookup::isolated(HashMap::new())).unwrap();
+    assert_eq!(kimi, std::path::PathBuf::from("kimi"));
 }

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -166,8 +166,6 @@ fn confirm(message: &str) -> Result<bool> {
 fn relaunch(raw_args: &[std::ffi::OsString]) -> Result<()> {
     let exe = std::env::current_exe().context("cannot resolve rx executable path")?;
     let mut command = Command::new(&exe);
-    // current_exe() resolves aliases (rxc/rxx/rxo/rxp/rxd) to the plain rx binary,
-    // so the relaunched process would lose the argv0-selected harness.
     if let Some(harness) = raw_args.first().and_then(|argv0| crate::args::argv0_harness(argv0)) {
         command.arg(harness);
     }


### PR DESCRIPTION
### What's changed?

- Add `rx kimi` / `rxk` so rx can seed the selected provider and cached models into Kimi Code's local `config.toml`, then launch `kimi` with `--model rx-<provider>/<id>`.
- Skip injecting `--auto` when the user already passed `-p`/`--prompt` or hidden yolo aliases (`--yes`, `--auto-approve`).
- Insert OpenCode `--auto`/`-m` after `run`, and leave management subcommands untouched.

### Why

- Kimi reads provider credentials only from its config file, so rx writes the selected key with secret-only file permissions and refreshes only unchanged RX-owned catalog entries.
- The official Kimi CLI rejects `--auto` together with `--prompt` or `--yolo`.