### PR TITLE
fix(rx): support dsh reasoning effort controls

### DIFF
--- a/crates/rx/DESIGN.md
+++ b/crates/rx/DESIGN.md
@@ -27,6 +27,7 @@ read `recall.db`.
 | RX-ARGS-001 | Preserve argv and executable paths as OS strings. Treat everything after `--` as literal. |
 | RX-ROUTE-001 | `--provider none` or no provider means native passthrough without provider or model injection. |
 | RX-ROUTE-002 | Inject only the selected route, credential reference, model, and permission policy; preserve unrelated native behavior. |
+| RX-CATALOG-001 | Runtime model discovery decides availability only. Protocol-scoped model capabilities come from the bundled provider snapshot and apply only to the matching provider endpoint; unknown capabilities are never inferred. |
 | RX-OWN-001 | Mutate only explicitly rx-owned identities, preserve unowned data, follow each surface's owned-edit rule, lock, write atomically, and fail closed on malformed input. |
 | RX-SECRET-001 | Never put credentials in argv, logs, or broad-permission files. Persist only when unavoidable and owner-approved. |
 | RX-LIFECYCLE-001 | Install policy, planning controls, and child environment are separate scopes; rx-only controls never reach the child. |
@@ -39,6 +40,7 @@ read `recall.db`.
 | Surface | Owner | Rule |
 | --- | --- | --- |
 | `~/.recall/rx.toml`, `rx.keys`, `catalogs/` | rx | Provider config, secret store, and endpoint-scoped catalog cache. |
+| Bundled provider and model capability snapshot | rx release | Stable provider, endpoint, model, and protocol semantics; runtime discovery intersects but never rewrites them. |
 | Claude catalog caches | shared | Marker identity stays rx-owned even if changed or deleted; preserve unmarked entries. |
 | Codex config | launch | Prefer `-c` and environment injection. |
 | OpenCode config | launch | Prefer `OPENCODE_CONFIG_CONTENT`; only warn about native auth conflicts. |

--- a/crates/rx/PROVIDERS.md
+++ b/crates/rx/PROVIDERS.md
@@ -10,6 +10,19 @@ models.dev model on an admitted provider shares one `limit.context`, that value
 is stored as `default_context` and used if live `GET /v1/models` omits a window.
 OpenAI roots that already end in `/vN` (Z.AI `/paas/v4`) are left as-is.
 
+Protocol-scoped model controls live in the admission file's
+`model_capabilities` map and are copied into the bundled snapshot. The key is
+provider ID, normalized endpoint, model ID, and protocol. Live `GET /v1/models`
+only filters which models are currently available. A matching bundled entry
+may declare reasoning as `fixed` or list the selectable effort IDs and their
+wire values. Missing data stays unknown and is not inferred from a model name.
+Overriding a bundled provider's endpoint disables its bundled model
+capabilities and falls back to `openai-completions`. A bundled provider may set
+`dsh_protocol` for its verified agent path. Tokener uses `openai-responses`
+because its Chat Completions tool path does not support selectable effort,
+while Responses accepts `reasoning.effort`. Capabilities remain separate per
+protocol.
+
 Users manage providers with `rx providers list`, `login [provider]`,
 `logout [provider]`, `use [provider]`, and `models update [provider]`. Passing a
 provider ID skips the picker; `use` persistently selects the default provider. The one-launch form
@@ -39,6 +52,10 @@ Passing only the `models.dev` `@ai-sdk/openai-compatible` classification is not
 enough. After the probe prints `ADMIT`, add the models.dev ID (or a managed
 entry) to `crates/rx/data/provider-admission.json`, run
 `crates/rx/scripts/update-rx-providers`, and commit both data files.
+Reasoning capability entries additionally require a request-level probe for
+each declared wire value on the exact protocol. A fixed entry requires
+evidence that the protocol has no selectable control; another protocol's
+support does not qualify.
 
 ```sh
 RX_PROVIDER_URL=https://api.example.com/v1 \

--- a/crates/rx/data/provider-admission.json
+++ b/crates/rx/data/provider-admission.json
@@ -69,6 +69,148 @@
     "zhipuai": "https://open.bigmodel.cn/api/anthropic",
     "zhipuai-coding-plan": "https://open.bigmodel.cn/api/anthropic"
   },
+  "dsh_protocol": {
+    "tokener": "openai-responses",
+    "tokener-dev": "openai-responses"
+  },
+  "model_capabilities": {
+    "tokener": {
+      "gpt-5.6-luna": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "gpt-5.6-sol": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "gpt-5.6-terra": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "glm-5.2": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium"
+            }
+          }
+        }
+      },
+      "deepseek-v4-flash": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "deepseek-v4-pro": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      }
+    },
+    "tokener-dev": {
+      "gpt-5.6-luna": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "gpt-5.6-sol": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      },
+      "gpt-5.6-terra": {
+        "openai-responses": {
+          "reasoning": {
+            "kind": "effort",
+            "levels": {
+              "off": "none",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh",
+              "max": "max"
+            }
+          }
+        }
+      }
+    }
+  },
   "managed": [
     {
       "id": "tokener",

--- a/crates/rx/data/providers.json
+++ b/crates/rx/data/providers.json
@@ -12,7 +12,97 @@
       "id": "tokener",
       "name": "Tokener",
       "endpoint": "https://api.tokener.dev/v1",
-      "env": "TOKENER_API_KEY"
+      "env": "TOKENER_API_KEY",
+      "dsh_protocol": "openai-responses",
+      "model_capabilities": {
+        "gpt-5.6-luna": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "gpt-5.6-sol": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "gpt-5.6-terra": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "glm-5.2": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium"
+              }
+            }
+          }
+        },
+        "deepseek-v4-flash": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "deepseek-v4-pro": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "abacus",
@@ -312,7 +402,55 @@
       "id": "tokener-dev",
       "name": "Tokener Dev",
       "endpoint": "https://api-dev.tokener.dev/v1",
-      "env": "TOKENER_DEV_API_KEY"
+      "env": "TOKENER_DEV_API_KEY",
+      "dsh_protocol": "openai-responses",
+      "model_capabilities": {
+        "gpt-5.6-luna": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "gpt-5.6-sol": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        },
+        "gpt-5.6-terra": {
+          "openai-responses": {
+            "reasoning": {
+              "kind": "effort",
+              "levels": {
+                "off": "none",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max"
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/crates/rx/scripts/update-rx-providers
+++ b/crates/rx/scripts/update-rx-providers
@@ -16,6 +16,8 @@ jq --slurpfile admission "$admission" --arg source "$source_url" --arg updated_a
   ($admission[0].models_dev_ids) as $ids
   | ($admission[0].endpoint // {}) as $ends
   | ($admission[0].anthropic_base // {}) as $claude
+  | ($admission[0].dsh_protocol // {}) as $dsh
+  | ($admission[0].model_capabilities // {}) as $capabilities
   | ([
       $ids[] as $id
       | .[$id] as $provider
@@ -56,6 +58,10 @@ jq --slurpfile admission "$admission" --arg source "$source_url" --arg updated_a
             end
           else {} end)
         + (if ($claude[.id] | type) == "string" then {anthropic_base: $claude[.id]} else {} end)
+        + (if ($dsh[.id] | type) == "string" then {dsh_protocol: $dsh[.id]} else {} end)
+        + (if ($capabilities[.id] | type) == "object" then
+            {model_capabilities: $capabilities[.id]}
+          else {} end)
     )
   | {
       source: $source,

--- a/crates/rx/src/dsh.rs
+++ b/crates/rx/src/dsh.rs
@@ -9,7 +9,7 @@ use serde_yaml::{Mapping, Value};
 use crate::catalog;
 use crate::config::Paths;
 use crate::launch::{EnvLookup, openai_base};
-use crate::provider::{Provider, Setup};
+use crate::provider::{ModelProtocol, Provider, ReasoningControl, Setup};
 
 pub(crate) const PROFILE: &str = "dsh-tui";
 pub(crate) const CLI_PACKAGE: &str = "@deepseek-ai/dsh";
@@ -17,6 +17,20 @@ pub(crate) const PLUGIN_PACKAGE: &str = "@deepseek-harness-tui/dsh-tui";
 pub(crate) const PLUGIN_SPEC: &str = "@deepseek-harness-tui/dsh-tui@latest";
 const OFFICIAL_DEEPSEEK: &str = "https://api.deepseek.com";
 const OFFICIAL_DEEPSEEK_ROUTE: &str = "deepseek-official";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DshModel {
+    id: String,
+    reasoning: Option<ReasoningControl>,
+}
+
+struct RouteContext<'a> {
+    provider_id: &'a str,
+    provider: &'a Provider,
+    base_url: &'a str,
+    protocol: ModelProtocol,
+    env: &'a EnvLookup,
+}
 
 pub(crate) fn npm_install_cmd() -> String {
     format!("npm install -g --legacy-peer-deps {CLI_PACKAGE} {PLUGIN_PACKAGE}")
@@ -107,38 +121,37 @@ pub(crate) fn prepare(
     env: &EnvLookup,
 ) -> Result<PathBuf> {
     let model = model.filter(|value| !value.is_empty());
+    let protocol = crate::provider::dsh_protocol(provider_id, base_url);
+    let context = RouteContext { provider_id, provider, base_url, protocol, env };
     let models = if official_deepseek(provider_id) {
         Vec::new()
     } else {
-        load_models(provider_id, provider, base_url, key, model, paths, env)?
+        load_models(&context, key, model, paths)?
     };
     let dir = paths.dir.join("dsh");
     fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
     let settings_path = dir.join("settings.yaml");
-    write_settings_overlay(&settings_path, provider_id, provider, base_url, model, &models, env)?;
+    write_settings_overlay(&settings_path, &context, model, &models)?;
     let patch_path = dir.join("launch.cordis.yml");
     write_launch_patch(&patch_path, &settings_path, official_deepseek(provider_id))?;
     Ok(patch_path)
 }
 
 fn load_models(
-    provider_id: &str,
-    provider: &Provider,
-    base_url: &str,
+    context: &RouteContext<'_>,
     key: &str,
     model: Option<&str>,
     paths: &Paths,
-    env: &EnvLookup,
-) -> Result<Vec<String>> {
-    let allow_fetch = env.is_real() || provider.setup == Setup::Generated;
+) -> Result<Vec<DshModel>> {
+    let allow_fetch = context.env.is_real() || context.provider.setup == Setup::Generated;
     let mut models = Vec::new();
-    match catalog::load_pi_models(paths, provider_id, base_url, key, allow_fetch) {
+    match catalog::load_pi_models(paths, context.provider_id, context.base_url, key, allow_fetch) {
         Ok(values) => {
             for value in values {
                 push_model_id(&mut models, &value);
             }
         }
-        Err(error) if provider.setup != Setup::Generated => {
+        Err(error) if context.provider.setup != Setup::Generated => {
             eprintln!("[rx] model catalog skipped: {error:#}");
         }
         Err(error) => return Err(error),
@@ -148,10 +161,24 @@ fn load_models(
     }
     if models.is_empty() {
         bail!(
-            "dsh could not load models for '{provider_id}'; run: rx providers models update {provider_id}"
+            "dsh could not load models for '{}'; run: rx providers models update {}",
+            context.provider_id,
+            context.provider_id
         );
     }
-    Ok(models)
+    Ok(models
+        .into_iter()
+        .map(|id| DshModel {
+            reasoning: crate::provider::reasoning_control(
+                context.provider_id,
+                context.base_url,
+                &id,
+                context.protocol,
+            )
+            .cloned(),
+            id,
+        })
+        .collect())
 }
 
 fn push_model_id(models: &mut Vec<String>, value: &serde_json::Value) {
@@ -166,18 +193,15 @@ fn push_model_id(models: &mut Vec<String>, value: &serde_json::Value) {
 
 fn write_settings_overlay(
     path: &Path,
-    provider_id: &str,
-    provider: &Provider,
-    base_url: &str,
+    context: &RouteContext<'_>,
     model: Option<&str>,
-    models: &[String],
-    env: &EnvLookup,
+    models: &[DshModel],
 ) -> Result<()> {
-    let mut document = load_user_settings(env)?;
+    let mut document = load_user_settings(context.env)?;
     let root = as_mapping(&mut document)?;
-    root.insert("llm-pi-ai".into(), llm_pi_ai_section(provider_id, provider, base_url, models));
-    root.insert("agent-default-model".into(), default_model_section(provider_id, model));
-    if crate::launch::yolo_enabled(env) {
+    root.insert("llm-pi-ai".into(), llm_pi_ai_section(context, models));
+    root.insert("agent-default-model".into(), default_model_section(context.provider_id, model));
+    if crate::launch::yolo_enabled(context.env) {
         let mut permission = Mapping::new();
         permission.insert("defaultPreset".into(), Value::String("danger-full-access".into()));
         root.insert("permission".into(), Value::Mapping(permission));
@@ -200,32 +224,47 @@ fn load_user_settings(env: &EnvLookup) -> Result<Value> {
     }
 }
 
-fn llm_pi_ai_section(
-    provider_id: &str,
-    provider: &Provider,
-    base_url: &str,
-    models: &[String],
-) -> Value {
+fn llm_pi_ai_section(context: &RouteContext<'_>, models: &[DshModel]) -> Value {
     let mut providers = Mapping::new();
-    if !official_deepseek(provider_id) && !models.is_empty() {
+    if !official_deepseek(context.provider_id) && !models.is_empty() {
         let mut route = Mapping::new();
-        route.insert("apiKeyEnv".into(), Value::String(provider.env.clone()));
-        route.insert("api".into(), Value::String("openai-completions".into()));
-        route.insert("baseURL".into(), Value::String(openai_base(base_url)));
+        route.insert("apiKeyEnv".into(), Value::String(context.provider.env.clone()));
+        route.insert("api".into(), Value::String(context.protocol.as_str().to_string()));
+        route.insert("baseURL".into(), Value::String(openai_base(context.base_url)));
         let entries = models
             .iter()
-            .map(|id| {
+            .map(|model| {
                 let mut entry = Mapping::new();
-                entry.insert("id".into(), Value::String(id.clone()));
+                entry.insert("id".into(), Value::String(model.id.clone()));
+                if let Some(reasoning) = &model.reasoning {
+                    entry.insert("reasoningEfforts".into(), reasoning_efforts(reasoning));
+                }
                 Value::Mapping(entry)
             })
             .collect();
         route.insert("models".into(), Value::Sequence(entries));
-        providers.insert(Value::String(provider_id.to_string()), Value::Mapping(route));
+        providers.insert(Value::String(context.provider_id.to_string()), Value::Mapping(route));
     }
     let mut section = Mapping::new();
     section.insert("providers".into(), Value::Mapping(providers));
     Value::Mapping(section)
+}
+
+fn reasoning_efforts(control: &ReasoningControl) -> Value {
+    match control {
+        ReasoningControl::Fixed => Value::Bool(false),
+        ReasoningControl::Effort { levels } => Value::Mapping(
+            levels
+                .iter()
+                .map(|(level, wire)| {
+                    (
+                        Value::String(level.as_str().to_string()),
+                        wire.as_ref().map_or(Value::Null, |wire| Value::String(wire.clone())),
+                    )
+                })
+                .collect(),
+        ),
+    }
 }
 
 fn default_model_section(provider_id: &str, model: Option<&str>) -> Value {
@@ -406,5 +445,60 @@ mod tests {
         )
         .unwrap();
         assert!(profile_ready(&env));
+    }
+
+    #[test]
+    fn tokener_reasoning_capabilities_project_to_dsh_models() {
+        let provider = crate::provider::find("tokener").unwrap();
+        let protocol = crate::provider::dsh_protocol("tokener", &provider.endpoint);
+        let env = EnvLookup::isolated(std::collections::HashMap::new());
+        let context = RouteContext {
+            provider_id: "tokener",
+            provider,
+            base_url: &provider.endpoint,
+            protocol,
+            env: &env,
+        };
+        assert_eq!(protocol, ModelProtocol::OpenAiResponses);
+        let models = ["gpt-5.6-sol", "glm-5.2", "kimi-k3"]
+            .into_iter()
+            .map(|id| DshModel {
+                id: id.to_string(),
+                reasoning: crate::provider::reasoning_control(
+                    "tokener",
+                    &provider.endpoint,
+                    id,
+                    protocol,
+                )
+                .cloned(),
+            })
+            .collect::<Vec<_>>();
+        let section = llm_pi_ai_section(&context, &models);
+        assert_eq!(section["providers"]["tokener"]["api"], "openai-responses");
+        let entries = section["providers"]["tokener"]["models"].as_sequence().unwrap();
+        assert_eq!(entries[0]["reasoningEfforts"]["off"], "none");
+        assert_eq!(entries[0]["reasoningEfforts"]["low"], "low");
+        assert_eq!(entries[0]["reasoningEfforts"]["medium"], "medium");
+        assert_eq!(entries[0]["reasoningEfforts"]["high"], "high");
+        assert_eq!(entries[0]["reasoningEfforts"]["xhigh"], "xhigh");
+        assert_eq!(entries[0]["reasoningEfforts"]["max"], "max");
+        assert_eq!(entries[1]["reasoningEfforts"]["off"], "none");
+        assert_eq!(entries[1]["reasoningEfforts"]["low"], "low");
+        assert_eq!(entries[1]["reasoningEfforts"]["medium"], "medium");
+        assert!(entries[1]["reasoningEfforts"].get("high").is_none());
+        assert!(entries[2].get("reasoningEfforts").is_none());
+        assert_eq!(
+            crate::provider::dsh_protocol("tokener", "https://proxy.example.com/v1"),
+            ModelProtocol::OpenAiCompletions
+        );
+        assert!(
+            crate::provider::reasoning_control(
+                "tokener",
+                "https://proxy.example.com/v1",
+                "gpt-5.6-sol",
+                ModelProtocol::OpenAiResponses,
+            )
+            .is_none()
+        );
     }
 }

--- a/crates/rx/src/provider.rs
+++ b/crates/rx/src/provider.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 
 use anyhow::{Result, bail};
@@ -8,7 +8,7 @@ use crate::config::{ProviderConfig, RxConfig};
 
 pub(crate) const NONE: &str = "none";
 
-const SNAPSHOT: &str = include_str!("../data/providers.json");
+const SNAPSHOT_JSON: &str = include_str!("../data/providers.json");
 
 #[derive(Debug, Deserialize)]
 struct Snapshot {
@@ -25,6 +25,67 @@ struct SnapshotProvider {
     anthropic_base: Option<String>,
     #[serde(default)]
     default_context: Option<i64>,
+    #[serde(default)]
+    dsh_protocol: Option<ModelProtocol>,
+    #[serde(default)]
+    model_capabilities: BTreeMap<String, BTreeMap<ModelProtocol, ProtocolCapabilities>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+pub(crate) enum ModelProtocol {
+    #[serde(rename = "openai-completions")]
+    OpenAiCompletions,
+    #[serde(rename = "openai-responses")]
+    OpenAiResponses,
+}
+
+impl ModelProtocol {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenAiCompletions => "openai-completions",
+            Self::OpenAiResponses => "openai-responses",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ReasoningLevel {
+    Off,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+impl ReasoningLevel {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Xhigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum ReasoningControl {
+    Fixed,
+    Effort { levels: BTreeMap<ReasoningLevel, Option<String>> },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProtocolCapabilities {
+    #[serde(default)]
+    reasoning: Option<ReasoningControl>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,15 +109,37 @@ pub(crate) struct Provider {
 
 pub(crate) fn catalog() -> &'static [Provider] {
     static CATALOG: OnceLock<Vec<Provider>> = OnceLock::new();
-    CATALOG.get_or_init(|| {
-        let snapshot: Snapshot =
-            serde_json::from_str(SNAPSHOT).expect("bundled provider catalog must be valid JSON");
-        snapshot.providers.into_iter().map(from_snapshot).collect()
-    })
+    CATALOG.get_or_init(|| snapshot().providers.iter().cloned().map(from_snapshot).collect())
 }
 
 pub(crate) fn find(id: &str) -> Option<&'static Provider> {
     catalog().iter().find(|provider| provider.id == id)
+}
+
+pub(crate) fn reasoning_control(
+    provider_id: &str,
+    endpoint: &str,
+    model_id: &str,
+    protocol: ModelProtocol,
+) -> Option<&'static ReasoningControl> {
+    let provider = snapshot().providers.iter().find(|provider| provider.id == provider_id)?;
+    if crate::catalog::openai_base(&provider.endpoint) != crate::catalog::openai_base(endpoint) {
+        return None;
+    }
+    provider.model_capabilities.get(model_id)?.get(&protocol)?.reasoning.as_ref()
+}
+
+pub(crate) fn dsh_protocol(provider_id: &str, endpoint: &str) -> ModelProtocol {
+    snapshot()
+        .providers
+        .iter()
+        .find(|provider| {
+            provider.id == provider_id
+                && crate::catalog::openai_base(&provider.endpoint)
+                    == crate::catalog::openai_base(endpoint)
+        })
+        .and_then(|provider| provider.dsh_protocol)
+        .unwrap_or(ModelProtocol::OpenAiCompletions)
 }
 
 pub(crate) fn resolve(id: &str, entry: Option<&ProviderConfig>) -> Result<Provider> {
@@ -150,6 +233,46 @@ fn from_snapshot(provider: SnapshotProvider) -> Provider {
         setup,
         default_model,
         claude_default_model,
+    }
+}
+
+fn snapshot() -> &'static Snapshot {
+    static SNAPSHOT: OnceLock<Snapshot> = OnceLock::new();
+    SNAPSHOT.get_or_init(|| {
+        let snapshot: Snapshot = serde_json::from_str(SNAPSHOT_JSON)
+            .expect("bundled provider catalog must be valid JSON");
+        validate_snapshot(&snapshot);
+        snapshot
+    })
+}
+
+fn validate_snapshot(snapshot: &Snapshot) {
+    for provider in &snapshot.providers {
+        for (model_id, protocols) in &provider.model_capabilities {
+            assert!(!model_id.trim().is_empty(), "bundled model capability ID must not be empty");
+            for capabilities in protocols.values() {
+                let Some(ReasoningControl::Effort { levels }) = &capabilities.reasoning else {
+                    continue;
+                };
+                assert!(
+                    levels.keys().any(|level| *level != ReasoningLevel::Off),
+                    "bundled effort control must offer a thinking level"
+                );
+                for (level, wire) in levels {
+                    match wire {
+                        Some(wire) => assert!(
+                            !wire.trim().is_empty(),
+                            "bundled reasoning wire value must not be empty"
+                        ),
+                        None => assert_eq!(
+                            *level,
+                            ReasoningLevel::Off,
+                            "only the off reasoning level may omit a wire value"
+                        ),
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1165,9 +1165,12 @@ fn dsh_tokener_injects_provider_catalog() {
     )
     .unwrap();
     let models = settings["llm-pi-ai"]["providers"]["tokener"]["models"].as_sequence().unwrap();
+    assert_eq!(settings["llm-pi-ai"]["providers"]["tokener"]["api"], "openai-completions");
     assert_eq!(models.len(), 2);
     assert_eq!(models[0]["id"], "kimi-k3");
     assert_eq!(models[1]["id"], "gpt-5.6-sol");
+    assert!(models[0].get("reasoningEfforts").is_none());
+    assert!(models[1].get("reasoningEfforts").is_none());
     assert_eq!(settings["agent-default-model"]["provider"], "tokener");
     assert!(settings["agent-default-model"].get("model").is_none());
 }


### PR DESCRIPTION
### What’s changed?

- Publish protocol-scoped model capabilities from the bundled rx provider snapshot.
- Route verified Tokener DSH endpoints through the Responses API and project supported reasoning effort choices into DSH settings.
- Keep runtime discovery limited to availability, prevent capability inheritance on custom endpoints, and restrict Tokener Dev to models verified on that endpoint.

### Why

- Tokener-launched DSH used Chat Completions and model entries without effort metadata, so reasoning effort switching was unavailable and tool requests could reject selectable effort values.

### Verification

- make check
- Built rx and verified the generated DSH route is openai-responses with GLM 5.2 limited to off, low, and medium.
- Verified a production GLM 5.2 Low request through Responses with tools returns HTTP 200.