### PR TITLE
feat(mcp): add file_history tool with per-file patch events

### DIFF
--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -20,7 +20,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 pub(crate) struct CodexAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 4;
-const EVENT_PARSER_VERSION: u32 = 1;
+const EVENT_PARSER_VERSION: u32 = 2;
 const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CodexAdapter {
@@ -543,6 +543,29 @@ fn collect_codex_response_item_event(
 
     if payload_type.ends_with("_call") {
         let name = codex_call_name(payload_type, payload);
+        let status = payload.get("status").and_then(|status| status.as_str()).map(String::from);
+        if let Some(Value::String(text)) = codex_call_args(payload) {
+            let patch_targets = events::patch_file_targets(text);
+            if !patch_targets.is_empty() {
+                for target in patch_targets {
+                    let mut event = events::file_write_event(
+                        events::EventContext {
+                            event_seq: events_out.len() as u32,
+                            timestamp,
+                            source_path: Some(source_path.to_string()),
+                            source_event_id: Some(source_event_id.clone()),
+                            message_seq: None,
+                            parser_version: EVENT_PARSER_VERSION,
+                        },
+                        name.clone(),
+                        target,
+                    );
+                    event.status = status.clone();
+                    events_out.push(event);
+                }
+                return;
+            }
+        }
         let mut event = match codex_call_args(payload) {
             Some(Value::String(text)) => events::tool_call_event_from_text(
                 events::EventContext {
@@ -569,7 +592,7 @@ fn collect_codex_response_item_event(
                 args,
             ),
         };
-        event.status = payload.get("status").and_then(|status| status.as_str()).map(String::from);
+        event.status = status;
         events_out.push(event);
     }
 }
@@ -1056,7 +1079,7 @@ mod tests {
                 "status": "completed",
                 "call_id": "call_patch",
                 "name": "apply_patch",
-                "input": "*** Begin Patch\n*** End Patch"
+                "input": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n-a\n+b\n*** Add File: docs/new.md\n*** End Patch"
             }
         });
         let custom_result = serde_json::json!({
@@ -1077,19 +1100,24 @@ mod tests {
 
         let raw = parse_codex_session(&path).unwrap().unwrap();
 
-        assert_eq!(raw.events.len(), 4);
+        assert_eq!(raw.events.len(), 5);
         assert_eq!(raw.events[0].kind, "command");
         assert_eq!(raw.events[0].name.as_deref(), Some("exec_command"));
         assert_eq!(raw.events[0].target.as_deref(), Some("sed -n '1,220p' CLAUDE.md"));
         assert_eq!(raw.events[0].source_event_id.as_deref(), Some("call_123"));
         assert_eq!(raw.events[1].kind, "tool_result");
         assert_eq!(raw.events[1].source_event_id.as_deref(), Some("call_123"));
-        assert_eq!(raw.events[2].kind, "tool_call");
+        assert_eq!(raw.events[2].kind, "file_write");
         assert_eq!(raw.events[2].name.as_deref(), Some("apply_patch"));
         assert_eq!(raw.events[2].status.as_deref(), Some("completed"));
+        assert_eq!(raw.events[2].target.as_deref(), Some("src/lib.rs"));
         assert_eq!(raw.events[2].source_event_id.as_deref(), Some("call_patch"));
-        assert_eq!(raw.events[3].kind, "tool_result");
-        assert_eq!(raw.events[3].source_event_id.as_deref(), Some("call_patch"));
+        assert_eq!(raw.events[3].kind, "file_write");
+        assert_eq!(raw.events[3].name.as_deref(), Some("apply_patch"));
+        assert_eq!(raw.events[3].target.as_deref(), Some("docs/new.md"));
+        assert_eq!(raw.events[3].event_seq, 3);
+        assert_eq!(raw.events[4].kind, "tool_result");
+        assert_eq!(raw.events[4].source_event_id.as_deref(), Some("call_patch"));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/events.rs
+++ b/src/adapters/events.rs
@@ -91,6 +91,48 @@ pub(crate) fn tool_result_event(
     }
 }
 
+pub(crate) fn file_write_event(
+    context: EventContext,
+    name: String,
+    target: String,
+) -> RawSessionEvent {
+    let summary = format!("[{name}] {target}");
+    RawSessionEvent {
+        event_seq: context.event_seq,
+        timestamp: context.timestamp,
+        kind: "file_write".to_string(),
+        actor: "assistant".to_string(),
+        name: Some(name),
+        status: None,
+        target: Some(target),
+        message_seq: context.message_seq,
+        summary: Some(summary),
+        source_path: context.source_path,
+        source_event_id: context.source_event_id,
+        attrs_json: None,
+        parser_version: context.parser_version,
+    }
+}
+
+const PATCH_FILE_PREFIXES: [&str; 4] =
+    ["*** Add File: ", "*** Update File: ", "*** Delete File: ", "*** Move to: "];
+
+pub(crate) fn patch_file_targets(text: &str) -> Vec<String> {
+    let mut targets = Vec::new();
+    for line in text.lines() {
+        let path = PATCH_FILE_PREFIXES
+            .iter()
+            .find_map(|prefix| line.trim_start().strip_prefix(prefix))
+            .and_then(non_empty);
+        if let Some(path) = path
+            && !targets.contains(&path)
+        {
+            targets.push(path);
+        }
+    }
+    targets
+}
+
 pub(crate) fn target_from_value(value: &Value) -> Option<String> {
     match value {
         Value::String(text) => non_empty(text),

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -13,7 +13,7 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 const USAGE_PARSER_VERSION: u32 = 1;
-const EVENT_PARSER_VERSION: u32 = 2;
+const EVENT_PARSER_VERSION: u32 = 3;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
     AND json_valid(p.data)
@@ -325,24 +325,42 @@ fn parse_part_events(
         }
         Some("patch") => {
             let files = patch_files(&part);
-            let target = files.first().cloned();
-            let summary =
-                if files.is_empty() { None } else { Some(format!("[patch] {}", files.join(", "))) };
-            vec![RawSessionEvent {
-                event_seq,
-                timestamp,
-                kind: "file_write".to_string(),
-                actor: "assistant".to_string(),
-                name: Some("patch".to_string()),
-                status: None,
-                target,
-                message_seq: None,
-                summary,
-                source_path: None,
-                source_event_id: Some(part_id.to_string()),
-                attrs_json: Some(part.to_string()),
-                parser_version: EVENT_PARSER_VERSION,
-            }]
+            if files.is_empty() {
+                return vec![RawSessionEvent {
+                    event_seq,
+                    timestamp,
+                    kind: "file_write".to_string(),
+                    actor: "assistant".to_string(),
+                    name: Some("patch".to_string()),
+                    status: None,
+                    target: None,
+                    message_seq: None,
+                    summary: None,
+                    source_path: None,
+                    source_event_id: Some(part_id.to_string()),
+                    attrs_json: Some(part.to_string()),
+                    parser_version: EVENT_PARSER_VERSION,
+                }];
+            }
+            files
+                .into_iter()
+                .enumerate()
+                .map(|(offset, file)| RawSessionEvent {
+                    event_seq: event_seq + offset as u32,
+                    timestamp,
+                    kind: "file_write".to_string(),
+                    actor: "assistant".to_string(),
+                    name: Some("patch".to_string()),
+                    status: None,
+                    summary: Some(format!("[patch] {file}")),
+                    target: Some(file),
+                    message_seq: None,
+                    source_path: None,
+                    source_event_id: Some(part_id.to_string()),
+                    attrs_json: Some(part.to_string()),
+                    parser_version: EVENT_PARSER_VERSION,
+                })
+                .collect()
         }
         _ => Vec::new(),
     }
@@ -1005,7 +1023,7 @@ mod tests {
 
         assert_eq!(raw.len(), 1);
         assert_eq!(raw[0].messages.len(), 2);
-        assert_eq!(raw[0].events.len(), 3);
+        assert_eq!(raw[0].events.len(), 4);
         assert_eq!(raw[0].events[0].kind, "file_read");
         assert_eq!(raw[0].events[0].name.as_deref(), Some("read"));
         assert_eq!(raw[0].events[0].status.as_deref(), Some("completed"));
@@ -1017,6 +1035,10 @@ mod tests {
         assert_eq!(raw[0].events[2].kind, "file_write");
         assert_eq!(raw[0].events[2].name.as_deref(), Some("patch"));
         assert_eq!(raw[0].events[2].target.as_deref(), Some("src/main.rs"));
+        assert_eq!(raw[0].events[3].kind, "file_write");
+        assert_eq!(raw[0].events[3].name.as_deref(), Some("patch"));
+        assert_eq!(raw[0].events[3].target.as_deref(), Some("README.md"));
+        assert_eq!(raw[0].events[3].event_seq, raw[0].events[2].event_seq + 1);
         drop(conn);
         let _ = std::fs::remove_file(path);
     }

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -23,6 +23,26 @@ pub(crate) struct SearchFilters {
     pub(crate) thread_role: Option<ThreadRoleFilter>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct SessionEventQuery<'a> {
+    pub(crate) kinds: Option<&'a [String]>,
+    pub(crate) target: &'a str,
+    pub(crate) sources: Option<&'a [String]>,
+    pub(crate) scope: &'a ProjectScope,
+    pub(crate) limit: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SessionEventHit {
+    pub(crate) session: Session,
+    pub(crate) kind: String,
+    pub(crate) name: Option<String>,
+    pub(crate) target: Option<String>,
+    pub(crate) event_seq: u32,
+    pub(crate) summary: Option<String>,
+    pub(crate) timestamp: Option<i64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RepoFilter {
     Remote(String),
@@ -118,6 +138,64 @@ impl<'a> SearchEngine<'a> {
             None => vec![],
         };
         self.search_results(fts_hits, vec_hits, 0, Some(limit))
+    }
+
+    pub(crate) fn list_session_events(
+        &self,
+        query: &SessionEventQuery<'_>,
+    ) -> anyhow::Result<Vec<SessionEventHit>> {
+        let session_cols = qualified_session_columns();
+        let mut sql = format!(
+            "SELECT {session_cols}, e.kind, e.name, e.target, e.event_seq, e.summary, e.timestamp
+             FROM session_events e
+             JOIN sessions s ON s.id = e.session_id
+             WHERE 1=1"
+        );
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1;
+
+        if let Some(kinds) = query.kinds
+            && !kinds.is_empty()
+        {
+            let placeholders: Vec<String> =
+                (0..kinds.len()).map(|offset| format!("?{}", param_idx + offset)).collect();
+            sql.push_str(&format!(" AND e.kind IN ({})", placeholders.join(", ")));
+            for kind in kinds {
+                params.push(Box::new(kind.clone()));
+            }
+            param_idx += kinds.len();
+        }
+        apply_target_path_match(&mut sql, &mut params, &mut param_idx, query.target);
+
+        let filters = SearchFilters {
+            sources: query.sources.map(<[String]>::to_vec),
+            time_range: TimeRange::All,
+            scope: query.scope.clone(),
+            thread_role: None,
+        };
+        apply_filters(&mut sql, &mut params, &mut param_idx, &filters);
+
+        sql.push_str(&format!(
+            " ORDER BY COALESCE(e.timestamp, s.updated_at, s.started_at) DESC, e.event_seq DESC
+              LIMIT ?{param_idx}"
+        ));
+        params.push(Box::new(i64::try_from(query.limit).unwrap_or(i64::MAX)));
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|param| param.as_ref()).collect();
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok(SessionEventHit {
+                session: session_from_row(row)?,
+                kind: row.get(17)?,
+                name: row.get(18)?,
+                target: row.get(19)?,
+                event_seq: row.get(20)?,
+                summary: row.get(21)?,
+                timestamp: row.get(22)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     pub(crate) fn hybrid_search_page(
@@ -274,6 +352,28 @@ impl<'a> SearchEngine<'a> {
     }
 }
 
+fn qualified_session_columns() -> String {
+    SESSION_COLUMNS.split(", ").map(|name| format!("s.{name}")).collect::<Vec<_>>().join(", ")
+}
+
+fn apply_target_path_match(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    param_idx: &mut usize,
+    target: &str,
+) {
+    sql.push_str(&format!(
+        " AND e.target IS NOT NULL AND (
+            e.target = ?{p}
+            OR substr(e.target, -length(?{p}) - 1) IN ('/' || ?{p}, char(92) || ?{p})
+            OR substr(?{p}, -length(e.target) - 1) IN ('/' || e.target, char(92) || e.target)
+         )",
+        p = *param_idx
+    ));
+    params.push(Box::new(target.to_string()));
+    *param_idx += 1;
+}
+
 fn apply_filters(
     sql: &mut String,
     params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
@@ -376,7 +476,11 @@ fn fts5_query(query: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{fts5_query, tokenize_query};
+    use super::{SearchEngine, SessionEventQuery, fts5_query, tokenize_query};
+    use crate::db::schema;
+    use crate::db::store::Store;
+    use crate::project_scope::ProjectScope;
+    use crate::types::{RawSessionEvent, Session};
 
     #[test]
     fn tokenize_query_strips_punctuation_and_case() {
@@ -395,5 +499,166 @@ mod tests {
         );
         assert_eq!(fts5_query("a"), r#""a""#);
         assert_eq!(fts5_query("AND OR NOT"), r#""and" OR "or" OR "not"*"#);
+    }
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    fn session(id: &str, source: &str, directory: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            source: source.to_string(),
+            source_id: format!("src-{id}"),
+            title: id.to_string(),
+            directory: Some(directory.to_string()),
+            repo_remote: None,
+            repo_slug: None,
+            repo_name: None,
+            started_at: 1_000,
+            updated_at: Some(1_000),
+            message_count: 0,
+            entrypoint: None,
+            custom_title: None,
+            summary: None,
+            duration_minutes: None,
+            source_file_path: None,
+            is_import: false,
+        }
+    }
+
+    fn event(seq: u32, kind: &str, target: &str, timestamp: i64) -> RawSessionEvent {
+        RawSessionEvent {
+            event_seq: seq,
+            timestamp: Some(timestamp),
+            kind: kind.to_string(),
+            actor: "assistant".to_string(),
+            name: Some(kind.to_string()),
+            status: None,
+            target: Some(target.to_string()),
+            message_seq: Some(1),
+            summary: Some(format!("{kind} {target}")),
+            source_path: None,
+            source_event_id: None,
+            attrs_json: Some(r#"{"secret":"nope"}"#.to_string()),
+            parser_version: 1,
+        }
+    }
+
+    fn seed_events() -> Store {
+        let store = setup_store();
+        store.insert_session(&session("s1", "codex", "/tmp/demo")).unwrap();
+        store.insert_session(&session("s2", "claude-code", "/tmp/demo")).unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "codex",
+                "src-s1",
+                &[
+                    event(0, "file_write", "/tmp/demo/src/db/schema.rs", 5_000),
+                    event(1, "command", "/tmp/demo/src/db/schema.rs", 6_000),
+                    event(2, "file_write", "old_schema.rs", 4_000),
+                ],
+                1,
+                None,
+            )
+            .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "claude-code",
+                "src-s2",
+                &[event(0, "file_read", "src/db/schema.rs", 8_000)],
+                1,
+                None,
+            )
+            .unwrap();
+        store
+    }
+
+    fn query_events(
+        store: &Store,
+        target: &str,
+        kinds: Option<&[String]>,
+    ) -> Vec<super::SessionEventHit> {
+        SearchEngine::new(&store.conn)
+            .list_session_events(&SessionEventQuery {
+                kinds,
+                target,
+                sources: None,
+                scope: &ProjectScope::Global,
+                limit: 50,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn list_session_events_matches_exact_or_separator_suffix() {
+        let store = seed_events();
+        let kinds = vec!["file_write".to_string(), "file_read".to_string()];
+        let hits = query_events(&store, "src/db/schema.rs", Some(&kinds));
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].session.id, "s2");
+        assert_eq!(hits[0].target.as_deref(), Some("src/db/schema.rs"));
+        assert_eq!(hits[1].session.id, "s1");
+        assert_eq!(hits[1].target.as_deref(), Some("/tmp/demo/src/db/schema.rs"));
+        assert!(hits.iter().all(|hit| hit.kind != "command"));
+
+        let bare = query_events(&store, "schema.rs", Some(&kinds));
+        assert_eq!(bare.len(), 2);
+        assert!(bare.iter().all(|hit| {
+            hit.target.as_deref().is_some_and(|target| {
+                target == "schema.rs"
+                    || target.ends_with("/schema.rs")
+                    || target.ends_with("\\schema.rs")
+            })
+        }));
+
+        let no_substring = query_events(&store, "schema.rs", None);
+        assert!(no_substring.iter().all(|hit| hit.target.as_deref() != Some("old_schema.rs")));
+    }
+
+    #[test]
+    fn list_session_events_matches_relative_target_from_absolute_path() {
+        let store = seed_events();
+        let hits = query_events(&store, "/abs/elsewhere/src/db/schema.rs", None);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session.id, "s2");
+        assert_eq!(hits[0].target.as_deref(), Some("src/db/schema.rs"));
+    }
+
+    #[test]
+    fn list_session_events_orders_newest_event_first() {
+        let store = seed_events();
+        let hits = query_events(&store, "schema.rs", None);
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].timestamp, Some(8_000));
+        assert_eq!(hits[1].timestamp, Some(6_000));
+        assert_eq!(hits[1].kind, "command");
+        assert_eq!(hits[2].timestamp, Some(5_000));
+    }
+
+    #[test]
+    fn list_session_events_ranks_timestampless_events_by_session_activity() {
+        let store = seed_events();
+        let mut recent = session("s3", "cursor", "/tmp/demo");
+        recent.updated_at = Some(9_000);
+        store.insert_session(&recent).unwrap();
+        let mut no_timestamp = event(0, "file_write", "src/db/schema.rs", 0);
+        no_timestamp.timestamp = None;
+        store
+            .persist_session_events_for_existing_session(
+                "cursor",
+                "src-s3",
+                &[no_timestamp],
+                1,
+                None,
+            )
+            .unwrap();
+
+        let hits = query_events(&store, "schema.rs", None);
+        assert_eq!(hits.len(), 4);
+        assert_eq!(hits[0].session.id, "s3");
+        assert_eq!(hits[0].timestamp, None);
+        assert_eq!(hits[1].timestamp, Some(8_000));
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::adapters;
-use crate::db::search::{SearchEngine, SearchFilters, TimeRange};
+use crate::db::search::{SearchEngine, SearchFilters, SessionEventQuery, TimeRange};
 use crate::db::store::Store;
 use crate::project_scope::ProjectScope;
 use crate::query::{query_embedding, resolve_source_filter};
@@ -24,6 +24,9 @@ const SEARCH_LIMIT_DEFAULT: u32 = 10;
 const SEARCH_LIMIT_MAX: u32 = 50;
 const LIST_LIMIT_DEFAULT: u32 = 10;
 const LIST_LIMIT_MAX: u32 = 50;
+const EVENT_LIMIT_DEFAULT: u32 = 20;
+const EVENT_LIMIT_MAX: u32 = 50;
+const FILE_HISTORY_KINDS: [&str; 2] = ["file_write", "file_read"];
 const GET_MAX_MESSAGES_DEFAULT: u32 = 50;
 const GET_MESSAGE_CHAR_CAP: usize = 2_000;
 const GET_RESPONSE_CHAR_CAP: usize = 32_000;
@@ -34,6 +37,7 @@ const MISSING_INDEX: &str =
 const EMPTY_INDEX: &str = "No sessions in the Recall index. Run `recall sync` in a terminal after using a supported coding agent.";
 const SEARCH_EMPTY: &str = "No matching sessions.";
 const SESSION_NOT_FOUND: &str = "Session not found.";
+const PATH_REQUIRED: &str = "path is required.";
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct SearchSessionsArgs {
@@ -78,6 +82,29 @@ struct ListRecentSessionsArgs {
     limit: Option<u32>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct FileHistoryArgs {
+    /// File path, relative or absolute. Matches an event when the shorter of
+    /// the two is a whole path suffix of the other, so an absolute path also
+    /// finds events indexed under a project-relative path and vice versa.
+    path: String,
+    /// Optional absolute indexed directory path, or a repo name/owner-repo
+    /// slug/remote URL derived from git identity. A worktree's own directory
+    /// name alone (e.g. "myrepo--feature") does not match.
+    #[serde(default)]
+    project: Option<String>,
+    /// Optional tool id or label such as claude-code or CUR.
+    #[serde(default)]
+    source: Option<String>,
+    /// Optional event kind. When omitted, only file_write and file_read.
+    #[serde(default)]
+    kind: Option<String>,
+    /// Maximum events to return. Defaults to 20, capped at 50.
+    #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    #[schemars(range(min = 1, max = 50))]
+    limit: Option<u32>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
 struct SessionHit {
     session_id: String,
@@ -92,6 +119,26 @@ struct SessionHit {
 struct HitList {
     message: Option<String>,
     hits: Vec<SessionHit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct EventHit {
+    session_id: String,
+    source: String,
+    project: Option<String>,
+    title: String,
+    timestamp: Option<String>,
+    kind: String,
+    name: Option<String>,
+    target: Option<String>,
+    event_seq: u32,
+    summary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct EventList {
+    message: Option<String>,
+    events: Vec<EventHit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
@@ -230,6 +277,22 @@ impl RecallMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(json_result(list_recent_sessions(&lock_index(&self.index), &args)))
     }
+
+    #[tool(
+        description = "Which indexed sessions touched a file. An event matches when its target equals the given path, or when either one ends with `/` or `\\` followed by the other, so relative and absolute forms of the same path find each other. Defaults to file_write and file_read events. Returns session id, source, project, title, kind, name, target, event_seq, truncated summary, and event timestamp.",
+        annotations(
+            title = "File history",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    fn file_history(
+        &self,
+        Parameters(args): Parameters<FileHistoryArgs>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(json_result(file_history(&lock_index(&self.index), &args)))
+    }
 }
 
 #[tool_handler]
@@ -238,7 +301,7 @@ impl ServerHandler for RecallMcp {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
             .with_instructions(
-                "Read-only memory over the local Recall session index. Search or list past coding sessions, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
+                "Read-only memory over the local Recall session index. Search or list past coding sessions, look up which sessions touched a file, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
             )
     }
 }
@@ -262,6 +325,10 @@ fn to_json(value: impl Serialize) -> Value {
 
 fn empty_hits(message: impl Into<String>) -> HitList {
     HitList { message: Some(message.into()), hits: Vec::new() }
+}
+
+fn empty_events(message: impl Into<String>) -> EventList {
+    EventList { message: Some(message.into()), events: Vec::new() }
 }
 
 fn search_sessions(
@@ -332,6 +399,64 @@ fn list_ready(
             })
             .collect(),
     })
+}
+
+fn file_history(
+    index: &IndexState,
+    args: &FileHistoryArgs,
+) -> std::result::Result<EventList, EventList> {
+    match index {
+        IndexState::Unavailable { message, .. } => Err(empty_events(message.clone())),
+        IndexState::Ready(store) => file_history_ready(store, args).map_err(empty_events),
+    }
+}
+
+fn file_history_ready(
+    store: &Store,
+    args: &FileHistoryArgs,
+) -> std::result::Result<EventList, String> {
+    let path = args.path.trim();
+    if path.is_empty() {
+        return Err(PATH_REQUIRED.to_string());
+    }
+    let kinds = match opt_trimmed(args.kind.as_deref()) {
+        Some(kind) => vec![kind.to_string()],
+        None => FILE_HISTORY_KINDS.iter().map(|kind| (*kind).to_string()).collect(),
+    };
+    let (scope, sources) = resolve_filters(store, args.project.as_deref(), args.source.as_deref())?;
+    let hits = SearchEngine::new(&store.conn)
+        .list_session_events(&SessionEventQuery {
+            kinds: Some(kinds.as_slice()),
+            target: path,
+            sources: sources.as_deref(),
+            scope: &scope,
+            limit: clamp_limit(args.limit, EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX),
+        })
+        .map_err(|error| error.to_string())?;
+    if hits.is_empty() {
+        let message = if store_is_empty(store) { EMPTY_INDEX } else { SEARCH_EMPTY };
+        return Ok(EventList { message: Some(message.to_string()), events: Vec::new() });
+    }
+    Ok(EventList { message: None, events: hits.into_iter().map(event_hit).collect() })
+}
+
+fn opt_trimmed(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn event_hit(hit: crate::db::search::SessionEventHit) -> EventHit {
+    EventHit {
+        session_id: hit.session.id.clone(),
+        source: hit.session.source.clone(),
+        project: hit.session.directory.clone(),
+        title: session_title(&hit.session),
+        timestamp: hit.timestamp.map(iso8601),
+        kind: hit.kind,
+        name: hit.name,
+        target: hit.target,
+        event_seq: hit.event_seq,
+        summary: hit.summary.map(|text| truncate_chars(&text, EXCERPT_CHAR_CAP).0),
+    }
 }
 
 fn get_session(
@@ -524,7 +649,7 @@ where
 mod tests {
     use super::*;
     use crate::db::schema;
-    use crate::types::Session;
+    use crate::types::{RawSessionEvent, Session};
 
     fn setup() -> Store {
         schema::register_sqlite_vec();
@@ -598,6 +723,14 @@ mod tests {
         assert!(listed.hits.is_empty());
         assert_eq!(listed.message.as_deref(), Some(EMPTY_INDEX));
         assert_eq!(json_result(list_recent_sessions(&index, &list_args)).is_error, Some(false));
+
+        let history = file_history(&index, &file_history_args("src/db/schema.rs")).unwrap();
+        assert!(history.events.is_empty());
+        assert_eq!(history.message.as_deref(), Some(EMPTY_INDEX));
+        assert_eq!(
+            json_result(file_history(&index, &file_history_args("src/db/schema.rs"))).is_error,
+            Some(false)
+        );
     }
 
     #[test]
@@ -812,13 +945,342 @@ mod tests {
         assert_eq!(args.limit, Some(12));
         assert_eq!(clamp_limit(Some(80), 10, 50), 50);
         assert_eq!(clamp_limit(None, 10, 50), 10);
+        assert_eq!(clamp_limit(Some(80), EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX), 50);
+        assert_eq!(clamp_limit(None, EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX), 20);
     }
 
     #[test]
     fn tools_advertise_read_only_closed_world() {
-        let notes = RecallMcp::search_sessions_tool_attr().annotations.unwrap();
-        assert_eq!(notes.read_only_hint, Some(true));
-        assert_eq!(notes.idempotent_hint, Some(true));
-        assert_eq!(notes.open_world_hint, Some(false));
+        for notes in [
+            RecallMcp::search_sessions_tool_attr().annotations.unwrap(),
+            RecallMcp::get_session_tool_attr().annotations.unwrap(),
+            RecallMcp::list_recent_sessions_tool_attr().annotations.unwrap(),
+            RecallMcp::file_history_tool_attr().annotations.unwrap(),
+        ] {
+            assert_eq!(notes.read_only_hint, Some(true));
+            assert_eq!(notes.idempotent_hint, Some(true));
+            assert_eq!(notes.open_world_hint, Some(false));
+        }
+    }
+
+    fn event(
+        seq: u32,
+        kind: &str,
+        target: Option<&str>,
+        timestamp: Option<i64>,
+        summary: Option<&str>,
+        name: Option<&str>,
+    ) -> RawSessionEvent {
+        RawSessionEvent {
+            event_seq: seq,
+            timestamp,
+            kind: kind.to_string(),
+            actor: "assistant".to_string(),
+            name: name.map(str::to_string),
+            status: None,
+            target: target.map(str::to_string),
+            message_seq: Some(1),
+            summary: summary.map(str::to_string),
+            source_path: None,
+            source_event_id: None,
+            attrs_json: Some(r#"{"token":"secret-value"}"#.to_string()),
+            parser_version: 1,
+        }
+    }
+
+    fn persist_events(store: &Store, source: &str, session_id: &str, events: &[RawSessionEvent]) {
+        assert!(
+            store
+                .persist_session_events_for_existing_session(
+                    source,
+                    &format!("src-{session_id}"),
+                    events,
+                    1,
+                    None,
+                )
+                .unwrap()
+        );
+    }
+
+    fn seed_agent_events() -> Store {
+        let store = setup();
+        store.insert_session(&session("codex-demo", "codex", "codex demo", 2_000)).unwrap();
+        store.insert_session(&session("claude-demo", "claude-code", "claude demo", 3_000)).unwrap();
+        let mut other = session("codex-other", "codex", "other project", 1_500);
+        other.directory = Some("/tmp/other".to_string());
+        store.insert_session(&other).unwrap();
+        persist_events(
+            &store,
+            "codex",
+            "codex-demo",
+            &[
+                event(
+                    0,
+                    "file_write",
+                    Some("/tmp/demo/src/db/schema.rs"),
+                    Some(5_000),
+                    Some("wrote schema"),
+                    Some("Edit"),
+                ),
+                event(
+                    1,
+                    "command",
+                    Some("/tmp/demo/src/db/schema.rs"),
+                    Some(6_000),
+                    Some("ran cargo test"),
+                    Some("Bash"),
+                ),
+                event(
+                    2,
+                    "file_write",
+                    Some("old_schema.rs"),
+                    Some(4_000),
+                    Some("renamed"),
+                    Some("Edit"),
+                ),
+                event(
+                    3,
+                    "file_read",
+                    Some(r"src\db\schema.rs"),
+                    Some(7_000),
+                    Some("win path"),
+                    Some("Read"),
+                ),
+            ],
+        );
+        persist_events(
+            &store,
+            "claude-code",
+            "claude-demo",
+            &[event(
+                0,
+                "file_read",
+                Some("src/db/schema.rs"),
+                Some(8_000),
+                Some("read schema"),
+                Some("Read"),
+            )],
+        );
+        persist_events(
+            &store,
+            "codex",
+            "codex-other",
+            &[event(
+                0,
+                "file_write",
+                Some("/tmp/other/src/db/schema.rs"),
+                Some(9_000),
+                Some("other schema"),
+                Some("Edit"),
+            )],
+        );
+        store
+    }
+
+    fn file_history_args(path: &str) -> FileHistoryArgs {
+        FileHistoryArgs {
+            path: path.to_string(),
+            project: None,
+            source: None,
+            kind: None,
+            limit: None,
+        }
+    }
+
+    #[test]
+    fn missing_index_is_a_tool_error_for_file_history() {
+        let index = IndexState::Unavailable { path: None, message: MISSING_INDEX.to_string() };
+        let history = file_history(&index, &file_history_args("src/db/schema.rs"))
+            .expect_err("missing index");
+        assert!(history.events.is_empty());
+        assert_eq!(history.message.as_deref(), Some(MISSING_INDEX));
+        assert_eq!(
+            json_result(file_history(&index, &file_history_args("src/db/schema.rs"))).is_error,
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn file_history_defaults_to_file_kinds_and_suffix_match() {
+        let index = ready(seed_agent_events());
+        let list = file_history(&index, &file_history_args("src/db/schema.rs")).unwrap();
+        assert!(list.message.is_none());
+        let targets: Vec<_> = list.events.iter().map(|event| event.target.clone()).collect();
+        assert!(targets.contains(&Some("/tmp/demo/src/db/schema.rs".into())));
+        assert!(targets.contains(&Some("src/db/schema.rs".into())));
+        assert!(targets.contains(&Some("/tmp/other/src/db/schema.rs".into())));
+        assert!(!targets.contains(&Some("old_schema.rs".into())));
+        assert!(list.events.iter().all(|event| event.kind != "command"));
+        assert_eq!(list.events[0].timestamp.as_deref(), Some(iso8601(9_000).as_str()));
+
+        let payload = to_json(&list);
+        assert!(
+            payload.to_string().contains("wrote schema")
+                || payload.to_string().contains("read schema")
+        );
+        assert!(!payload.to_string().contains("secret-value"));
+        assert!(
+            payload
+                .get("events")
+                .and_then(|events| events.get(0))
+                .and_then(|event| event.get("attrs_json"))
+                .is_none()
+        );
+
+        let bare = file_history(&index, &file_history_args("schema.rs")).unwrap();
+        assert!(
+            bare.events.iter().any(|event| event.target.as_deref() == Some(r"src\db\schema.rs"))
+        );
+        assert!(bare.events.iter().all(|event| {
+            event.target.as_deref().is_some_and(|target| {
+                target == "schema.rs"
+                    || target.ends_with("/schema.rs")
+                    || target.ends_with(r"\schema.rs")
+            })
+        }));
+        assert!(bare.events.iter().all(|event| event.target.as_deref() != Some("old_schema.rs")));
+
+        let absolute =
+            file_history(&index, &file_history_args("/abs/elsewhere/src/db/schema.rs")).unwrap();
+        assert!(
+            absolute.events.iter().any(|event| event.target.as_deref() == Some("src/db/schema.rs"))
+        );
+
+        let commands = file_history(
+            &index,
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: None,
+                source: None,
+                kind: Some("command".into()),
+                limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(commands.events.len(), 1);
+        assert_eq!(commands.events[0].kind, "command");
+        assert_eq!(commands.events[0].session_id, "codex-demo");
+    }
+
+    #[test]
+    fn file_history_honors_project_source_and_unknown_source() {
+        let index = ready(seed_agent_events());
+        let scoped = file_history(
+            &index,
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: Some("/tmp/demo".into()),
+                source: None,
+                kind: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(scoped.events.len(), 2);
+        assert!(scoped.events.iter().all(|event| event.project.as_deref() == Some("/tmp/demo")));
+
+        let by_source = file_history(
+            &index,
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: Some("/tmp/demo".into()),
+                source: Some("claude-code".into()),
+                kind: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(by_source.events.len(), 1);
+        assert_eq!(by_source.events[0].source, "claude-code");
+
+        let unknown = file_history(
+            &index,
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: None,
+                source: Some("not-a-source".into()),
+                kind: None,
+                limit: None,
+            },
+        )
+        .expect_err("unknown source");
+        assert!(unknown.events.is_empty());
+        assert!(unknown.message.unwrap().contains("unknown source"));
+        assert_eq!(
+            json_result(file_history(&index, &file_history_args("src/db/schema.rs"))).is_error,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn file_history_clamps_limit_and_rejects_blank_path() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "many", 1_000)).unwrap();
+        let events: Vec<_> = (0..51)
+            .map(|seq| {
+                event(
+                    seq,
+                    "file_read",
+                    Some("src/db/schema.rs"),
+                    Some(10_000 + i64::from(seq)),
+                    Some("read"),
+                    Some("Read"),
+                )
+            })
+            .collect();
+        persist_events(&store, "codex", "s1", &events);
+        let index = ready(store);
+        let list = file_history(
+            &index,
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: None,
+                source: None,
+                kind: None,
+                limit: Some(80),
+            },
+        )
+        .unwrap();
+        assert_eq!(list.events.len(), 50);
+
+        let blank = file_history(&index, &file_history_args("   ")).expect_err("blank path");
+        assert_eq!(blank.message.as_deref(), Some(PATH_REQUIRED));
+        assert_eq!(
+            json_result(file_history(&index, &file_history_args("   "))).is_error,
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn file_history_truncates_long_summaries() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "long", 1_000)).unwrap();
+        persist_events(
+            &store,
+            "codex",
+            "s1",
+            &[event(
+                0,
+                "tool_call",
+                Some("src/db/schema.rs"),
+                Some(1_000),
+                Some(&"z".repeat(EXCERPT_CHAR_CAP + 20)),
+                Some("Tool"),
+            )],
+        );
+        let list = file_history(
+            &ready(store),
+            &FileHistoryArgs {
+                path: "src/db/schema.rs".into(),
+                project: None,
+                source: None,
+                kind: Some("tool_call".into()),
+                limit: None,
+            },
+        )
+        .unwrap();
+        let summary = list.events[0].summary.as_deref().unwrap();
+        assert_eq!(summary.chars().count(), EXCERPT_CHAR_CAP);
+        assert!(summary.ends_with('…'));
     }
 }


### PR DESCRIPTION
### What's changed?

- Add a read-only `file_history` MCP tool: reports which indexed sessions touched a file, with session id, source, project, title, kind, name, target, event_seq, truncated summary, and event timestamp.
- Match targets bidirectionally at `/` or `\\` boundaries so relative and absolute forms of the same path find each other.
- Normalize patch writes into per-file `file_write` events: Codex `apply_patch` calls previously produced target-less `tool_call` events, and OpenCode multi-file patches kept only the first file. Event parser versions bumped (codex 1→2, opencode 2→3) so existing sessions backfill on the next sync.
- Order events by `COALESCE(e.timestamp, s.updated_at, s.started_at)` so sources that omit event timestamps (Cursor) still surface by session activity.

### Why

- Agents need a fast answer to "which sessions touched this file" that full-text search cannot express; without the patch normalization the tool would systematically miss Codex file writes, its primary write path.

### Verification

- `make check` (audit → fmt → clippy -D warnings → workspace tests incl. bench feature) passes.
- New tests cover bidirectional suffix matching, per-file patch events for Codex and OpenCode, timestamp-less event ordering, limit clamping, and that `attrs_json` never leaks into tool output.