### PR TITLE
feat(adapters): index Kilo Code CLI kilo.db sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ One index across every AI coding CLI. Sync once, search everywhere, resume right
 | Grok            |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |        |
 | Kimi Code       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Qwen Code       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
+| Kilo Code       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 
 ## Acknowledgements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,6 +55,7 @@ recall skill install # 自动检测 agent 并安装 skills
 | Grok            |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |      |
 | Kimi Code       |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
 | Qwen Code       |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
+| Kilo Code       |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
 
 ## 致谢
 

--- a/docs/recall-architecture.svg
+++ b/docs/recall-architecture.svg
@@ -31,7 +31,7 @@
   <rect x="24" y="16" width="636" height="114" class="box" fill="#e9f4fb" stroke="#287bb5"/>
   <text x="40" y="42" class="t">Local AI-coding session data</text>
   <text x="40" y="68" class="d">Claude Code · OpenCode · Codex · Pi · Antigravity · Gemini · Grok</text>
-  <text x="40" y="88" class="d">Kiro · Copilot · Cursor · Cline · DeepSeek Harness · Kimi Code · Qwen Code</text>
+  <text x="40" y="88" class="d">Kiro · Copilot · Cursor · Cline · DeepSeek Harness · Kimi Code · Qwen Code · Kilo Code</text>
   <text x="40" y="110" class="p">local files · external databases opened read-only</text>
   <g fill="#fff9e9" stroke="#287bb5" stroke-width="1.8" stroke-linejoin="round">
     <rect x="574" y="46" width="42" height="34" rx="5"/>

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -96,6 +96,7 @@ When the user wants to share a session or update an existing share link, execute
    - OpenCode -> `opencode`
    - Kimi Code -> `kimi-code`
    - Qwen Code -> `qwen-code`
+   - Kilo Code -> `kilo-code`
    If the source is unclear, omit `--source` and rely on project + recency.
 
 2. Sync and resolve the session id. Always include `--sync` so share/update uses the latest messages.
@@ -268,7 +269,7 @@ recall usage --json
 
 Supported time filters are `today`, `7d` or `week`, and `30d` or `month`. Unknown time values fall back to all history.
 
-Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `kimi-code`, `deepseek-harness`, and `qwen-code`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
+Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `kimi-code`, `deepseek-harness`, `qwen-code`, and `kilo-code`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
 
 ## Export Schema
 

--- a/src/adapters/kilo.rs
+++ b/src/adapters/kilo.rs
@@ -1,0 +1,225 @@
+use std::path::{Path, PathBuf};
+
+use tracing::debug;
+
+use crate::adapters::opencode;
+use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats};
+use crate::db::store::Store;
+
+pub(crate) struct KiloCodeAdapter;
+
+impl SourceAdapter for KiloCodeAdapter {
+    fn id(&self) -> &str {
+        "kilo-code"
+    }
+
+    fn label(&self) -> &str {
+        "KL"
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(opencode::USAGE_PARSER_VERSION)
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "kilo".to_string(),
+            args: vec!["--session".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let Some(conn) = open_kilo_db()? else {
+            return Ok(vec![]);
+        };
+        opencode::scan(&conn, true)
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+        include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(conn) = open_kilo_db()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+        Ok(Some(opencode::scan_for_sync_conn(&conn, store, since_ts, "kilo-code", include_events)?))
+    }
+}
+
+fn open_kilo_db() -> anyhow::Result<Option<rusqlite::Connection>> {
+    let Some(db_path) = resolve_kilo_db_path() else {
+        debug!("Kilo Code DB not found, skipping");
+        return Ok(None);
+    };
+    opencode::open_readonly(&db_path)
+}
+
+fn resolve_kilo_db_path() -> Option<PathBuf> {
+    resolve_kilo_db_path_from(
+        std::env::var("KILO_DB").ok(),
+        std::env::var("XDG_DATA_HOME").ok(),
+        dirs::home_dir()?,
+    )
+}
+
+fn resolve_kilo_db_path_from(
+    kilo_db: Option<String>,
+    xdg_data_home: Option<String>,
+    home: PathBuf,
+) -> Option<PathBuf> {
+    let data_dir = kilo_data_dir(xdg_data_home.as_deref(), &home);
+    let path = match kilo_db.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+        Some(":memory:") => return None,
+        Some(raw) => {
+            let candidate = Path::new(raw);
+            if candidate.is_absolute() { candidate.to_path_buf() } else { data_dir.join(raw) }
+        }
+        None => data_dir.join("kilo.db"),
+    };
+    path.exists().then_some(path)
+}
+
+fn kilo_data_dir(xdg_data_home: Option<&str>, home: &Path) -> PathBuf {
+    match xdg_data_home.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(xdg) => PathBuf::from(xdg).join("kilo"),
+        None => home.join(".local/share/kilo"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_uses_official_flag() {
+        let command = KiloCodeAdapter.resume_command("ses_123").unwrap();
+        assert_eq!(command.program, "kilo");
+        assert_eq!(command.args, vec!["--session", "ses_123"]);
+    }
+
+    #[test]
+    fn default_path_is_xdg_share_kilo_db() {
+        let empty_home = tempfile::tempdir().unwrap();
+        assert!(resolve_kilo_db_path_from(None, None, empty_home.path().to_path_buf()).is_none());
+
+        let root = tempfile::tempdir().unwrap();
+        let db = root.path().join(".local/share/kilo/kilo.db");
+        fs_write_empty(&db);
+        let resolved = resolve_kilo_db_path_from(None, None, root.path().to_path_buf()).unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn xdg_data_home_overrides_default_root() {
+        let root = tempfile::tempdir().unwrap();
+        let xdg = root.path().join("xdg-data");
+        let db = xdg.join("kilo/kilo.db");
+        fs_write_empty(&db);
+        let resolved = resolve_kilo_db_path_from(
+            None,
+            Some(xdg.to_string_lossy().into_owned()),
+            PathBuf::from("/unused"),
+        )
+        .unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn kilo_db_absolute_path_wins() {
+        let root = tempfile::tempdir().unwrap();
+        let db = root.path().join("custom.db");
+        fs_write_empty(&db);
+        let resolved = resolve_kilo_db_path_from(
+            Some(db.to_string_lossy().into_owned()),
+            None,
+            PathBuf::from("/unused"),
+        )
+        .unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn kilo_db_relative_path_is_under_data_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let xdg = root.path().join("xdg-data");
+        let db = xdg.join("kilo/alt.db");
+        fs_write_empty(&db);
+        let resolved = resolve_kilo_db_path_from(
+            Some("alt.db".to_string()),
+            Some(xdg.to_string_lossy().into_owned()),
+            PathBuf::from("/unused"),
+        )
+        .unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn memory_and_missing_paths_are_skipped() {
+        assert!(
+            resolve_kilo_db_path_from(Some(":memory:".to_string()), None, PathBuf::from("/tmp"))
+                .is_none()
+        );
+        assert!(
+            resolve_kilo_db_path_from(
+                Some("/no/such/kilo.db".to_string()),
+                None,
+                PathBuf::from("/tmp")
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn scan_reads_opencode_shaped_kilo_db() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join("kilo.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created INTEGER,
+                time_updated INTEGER
+            );
+            CREATE TABLE message (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                data TEXT,
+                time_created INTEGER
+            );
+            CREATE TABLE part (
+                id INTEGER PRIMARY KEY,
+                message_id INTEGER,
+                data TEXT
+            );
+            INSERT INTO session (id, title, directory, time_created, time_updated)
+            VALUES ('ses_123', 'seed', '/repo', 100, 200);
+            INSERT INTO message (session_id, data, time_created)
+            VALUES ('ses_123', '{\"role\":\"user\"}', 110);
+            INSERT INTO part (message_id, data)
+            VALUES (1, '{\"type\":\"text\",\"text\":\"hello kilo\"}');
+            ",
+        )
+        .unwrap();
+        drop(conn);
+
+        let conn = opencode::open_readonly(&db_path).unwrap().unwrap();
+        let sessions = opencode::scan(&conn, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].source_id, "ses_123");
+        assert_eq!(sessions[0].directory.as_deref(), Some("/repo"));
+        assert_eq!(sessions[0].messages.len(), 1);
+        assert_eq!(sessions[0].messages[0].content, "hello kilo");
+    }
+
+    fn fs_write_empty(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, []).unwrap();
+    }
+}

--- a/src/adapters/kilo.rs
+++ b/src/adapters/kilo.rs
@@ -200,20 +200,29 @@ mod tests {
             VALUES ('ses_123', 'seed', '/repo', 100, 200);
             INSERT INTO message (session_id, data, time_created)
             VALUES ('ses_123', '{\"role\":\"user\"}', 110);
+            INSERT INTO message (session_id, data, time_created)
+            VALUES ('ses_123', '{\"role\":\"assistant\"}', 120);
             INSERT INTO part (message_id, data)
             VALUES (1, '{\"type\":\"text\",\"text\":\"hello kilo\"}');
+            INSERT INTO part (message_id, data)
+            VALUES (2, '{\"type\":\"tool\",\"tool\":\"bash\",\"state\":{\"status\":\"completed\",\"input\":{\"command\":\"ls\"},\"output\":\"file body\"}}');
             ",
         )
         .unwrap();
         drop(conn);
 
         let conn = opencode::open_readonly(&db_path).unwrap().unwrap();
-        let sessions = opencode::scan(&conn, false).unwrap();
+        let sessions = opencode::scan(&conn, true).unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].source_id, "ses_123");
         assert_eq!(sessions[0].directory.as_deref(), Some("/repo"));
+        assert_eq!(sessions[0].custom_title.as_deref(), Some("seed"));
+        assert_eq!(sessions[0].metadata_parser_version, Some(opencode::METADATA_PARSER_VERSION));
         assert_eq!(sessions[0].messages.len(), 1);
         assert_eq!(sessions[0].messages[0].content, "hello kilo");
+        assert_eq!(sessions[0].events.len(), 2);
+        assert_eq!(sessions[0].events[0].kind, "command");
+        assert_eq!(sessions[0].events[0].name.as_deref(), Some("bash"));
     }
 
     fn fs_write_empty(path: &Path) {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod file_scan;
 pub(crate) mod gemini;
 pub(crate) mod grok;
 pub(crate) mod json_util;
+pub(crate) mod kilo;
 pub(crate) mod kimi_code;
 pub(crate) mod kiro;
 pub(crate) mod opencode;
@@ -194,6 +195,7 @@ pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(deepseek_harness::DeepSeekHarnessAdapter),
         Box::new(kimi_code::KimiCodeAdapter),
         Box::new(qwen::QwenAdapter),
+        Box::new(kilo::KiloCodeAdapter),
     ]
 }
 
@@ -210,7 +212,10 @@ pub(crate) fn source_labels() -> Vec<(String, String)> {
 }
 
 pub(crate) fn source_supports_event_backfill(source_id: &str) -> bool {
-    matches!(source_id, "codex" | "claude-code" | "cursor" | "copilot-cli" | "opencode")
+    matches!(
+        source_id,
+        "codex" | "claude-code" | "cursor" | "copilot-cli" | "opencode" | "kilo-code"
+    )
 }
 
 pub(crate) fn adapter_supports_usage_dashboard(

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use rusqlite::{Connection, OpenFlags, params_from_iter};
 use serde_json::Value;
@@ -12,8 +13,8 @@ use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
-const USAGE_PARSER_VERSION: u32 = 1;
-const EVENT_PARSER_VERSION: u32 = 3;
+pub(crate) const USAGE_PARSER_VERSION: u32 = 1;
+pub(crate) const EVENT_PARSER_VERSION: u32 = 3;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
     AND json_valid(p.data)
@@ -66,8 +67,7 @@ impl SourceAdapter for OpenCodeAdapter {
         let Some(conn) = open_opencode_db()? else {
             return Ok(vec![]);
         };
-        let sessions = load_session_rows(&conn, None)?;
-        scan_session_messages(&conn, sessions, true)
+        scan(&conn, true)
     }
 
     fn scan_for_sync(
@@ -88,15 +88,23 @@ fn open_opencode_db() -> anyhow::Result<Option<Connection>> {
     let db_path = dirs::home_dir()
         .ok_or_else(|| anyhow::anyhow!("no home dir"))?
         .join(".local/share/opencode/opencode.db");
+    open_readonly(&db_path)
+}
 
+pub(crate) fn open_readonly(db_path: &Path) -> anyhow::Result<Option<Connection>> {
     if !db_path.exists() {
-        debug!("OpenCode DB not found at {}, skipping", db_path.display());
+        debug!("session DB not found at {}, skipping", db_path.display());
         return Ok(None);
     }
 
-    Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+    Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .map(Some)
         .map_err(Into::into)
+}
+
+pub(crate) fn scan(conn: &Connection, include_events: bool) -> anyhow::Result<Vec<RawSession>> {
+    let sessions = load_session_rows(conn, None)?;
+    scan_session_messages(conn, sessions, include_events)
 }
 
 fn count_filtered_sessions(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<u32> {
@@ -607,7 +615,7 @@ fn display_json_value(value: &Value) -> String {
     }
 }
 
-fn scan_for_sync_conn(
+pub(crate) fn scan_for_sync_conn(
     conn: &Connection,
     store: &Store,
     since_ts: Option<i64>,

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -15,23 +15,13 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 pub(crate) const USAGE_PARSER_VERSION: u32 = 1;
 pub(crate) const EVENT_PARSER_VERSION: u32 = 3;
+pub(crate) const METADATA_PARSER_VERSION: u32 = 1;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
     AND json_valid(p.data)
     AND json_extract(m.data, '$.role') IN ('user', 'assistant')
-    AND (
-        (json_extract(p.data, '$.type') = 'text'
-            AND NULLIF(TRIM(CAST(json_extract(p.data, '$.text') AS TEXT)), '') IS NOT NULL)
-        OR (json_extract(p.data, '$.type') = 'tool-invocation'
-            AND json_type(p.data, '$.input') IS NOT NULL)
-        OR (json_extract(p.data, '$.type') = 'tool-result'
-            AND json_type(p.data, '$.result') IS NOT NULL)
-        OR (json_extract(p.data, '$.type') = 'tool'
-            AND (json_type(p.data, '$.state.input') IS NOT NULL
-                OR json_type(p.data, '$.state.output') IS NOT NULL))
-        OR (json_extract(p.data, '$.type') = 'patch'
-            AND json_type(p.data, '$.files') = 'array')
-    )
+    AND json_extract(p.data, '$.type') = 'text'
+    AND NULLIF(TRIM(CAST(json_extract(p.data, '$.text') AS TEXT)), '') IS NOT NULL
 ";
 
 pub(crate) struct OpenCodeAdapter;
@@ -41,6 +31,7 @@ struct SessionRow {
     directory: String,
     time_created: i64,
     time_updated: Option<i64>,
+    title: Option<String>,
 }
 
 impl SourceAdapter for OpenCodeAdapter {
@@ -125,11 +116,11 @@ fn count_filtered_sessions(conn: &Connection, since_ts: Option<i64>) -> anyhow::
 
 fn load_session_rows(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<Vec<SessionRow>> {
     let sql = if since_ts.is_some() {
-        "SELECT id, directory, time_created, time_updated
+        "SELECT id, directory, time_created, time_updated, title
          FROM session
          WHERE COALESCE(time_updated, time_created) >= ?1"
     } else {
-        "SELECT id, directory, time_created, time_updated FROM session"
+        "SELECT id, directory, time_created, time_updated, title FROM session"
     };
 
     let mut stmt = conn.prepare(sql)?;
@@ -155,6 +146,7 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
         directory: row.get(1)?,
         time_created: row.get(2)?,
         time_updated: row.get(3)?,
+        title: row.get(4)?,
     })
 }
 
@@ -189,7 +181,7 @@ fn scan_session_messages(
             continue;
         }
 
-        let raw = RawSession::search_only(
+        let mut raw = RawSession::search_only(
             session.id,
             Some(session.directory),
             session.time_created,
@@ -198,6 +190,9 @@ fn scan_session_messages(
             messages,
         )
         .with_usage(usage_events, USAGE_PARSER_VERSION);
+        raw.custom_title =
+            session.title.map(|title| title.trim().to_string()).filter(|title| !title.is_empty());
+        raw.metadata_parser_version = Some(METADATA_PARSER_VERSION);
         raw_sessions.push(if include_events {
             raw.with_events(events, EVENT_PARSER_VERSION)
         } else {
@@ -559,32 +554,6 @@ fn parse_part_content(part_data: &str) -> Option<String> {
             .get("text")
             .and_then(|t| t.as_str())
             .and_then(|text| if text.trim().is_empty() { None } else { Some(text.to_string()) }),
-        "tool-invocation" | "tool-result" => {
-            let name = part.get("toolName").and_then(|n| n.as_str()).unwrap_or("tool");
-            if let Some(input) = part.get("input") {
-                Some(format!("[{name}] {input}"))
-            } else {
-                part.get("result").map(|result| format!("[{name}] {result}"))
-            }
-        }
-        "tool" => {
-            let name = opencode_tool_name(&part);
-            let state = part.get("state")?;
-            match (state.get("input"), state.get("output")) {
-                (Some(input), Some(output)) => Some(format!(
-                    "[{name}] input: {}\noutput: {}",
-                    display_json_value(input),
-                    display_json_value(output)
-                )),
-                (Some(input), None) => Some(format!("[{name}] {}", display_json_value(input))),
-                (None, Some(output)) => Some(format!("[{name}] {}", display_json_value(output))),
-                (None, None) => None,
-            }
-        }
-        "patch" => {
-            let files = patch_files(&part);
-            if files.is_empty() { None } else { Some(format!("[patch] {}", files.join(", "))) }
-        }
         _ => None,
     }
 }
@@ -628,6 +597,7 @@ pub(crate) fn scan_for_sync_conn(
     let usage_state = store.usage_state_meta_map(source_id)?;
     let event_state =
         if include_events { store.event_state_meta_map(source_id)? } else { Default::default() };
+    let metadata_state = store.metadata_state_meta_map(source_id)?;
     let current_counts = load_message_counts(
         conn,
         &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
@@ -649,6 +619,11 @@ pub(crate) fn scan_for_sync_conn(
                     session.time_updated,
                     include_events,
                 )
+                && crate::adapters::sync_state::metadata_state_is_current(
+                    METADATA_PARSER_VERSION,
+                    metadata_state.get(&session.id).copied(),
+                    session.time_updated,
+                )
             {
                 stats.skipped_sessions += 1;
                 continue;
@@ -666,6 +641,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::db::store::SessionTopologyWrite;
     use crate::db::{schema, store::Store};
     use crate::types::Session;
 
@@ -783,6 +759,20 @@ mod tests {
             .unwrap();
     }
 
+    fn mark_metadata_current(store: &Store, source_id: &str) {
+        store
+            .persist_topology_for_existing_session(
+                "opencode",
+                source_id,
+                &SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
+            )
+            .unwrap();
+    }
+
     #[test]
     fn incremental_scan_skips_sessions_with_matching_updated_at_and_message_count() {
         let (path, conn) = setup_opencode_db();
@@ -792,10 +782,30 @@ mod tests {
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
         mark_usage_current(&store, "s1", Some(200));
         mark_event_current(&store, "s1", Some(200));
+        mark_metadata_current(&store, "s1");
 
         let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
         assert!(result.sessions.is_empty());
         assert_eq!(result.stats.skipped_sessions, 1);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incremental_scan_resyncs_when_metadata_parser_is_stale() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 200, 100, "hello");
+
+        let store = setup_store();
+        store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
+        mark_usage_current(&store, "s1", Some(200));
+        mark_event_current(&store, "s1", Some(200));
+
+        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].custom_title.as_deref(), Some("Test"));
+        assert_eq!(result.sessions[0].metadata_parser_version, Some(METADATA_PARSER_VERSION));
         drop(conn);
         let _ = std::fs::remove_file(path);
     }
@@ -808,6 +818,7 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
         mark_usage_current(&store, "s1", Some(200));
+        mark_metadata_current(&store, "s1");
 
         let result = scan_for_sync_conn(&conn, &store, None, "opencode", false).unwrap();
         assert!(result.sessions.is_empty());
@@ -848,6 +859,7 @@ mod tests {
         store.insert_session(&make_session("local-s2", "s2", Some(150), 1)).unwrap();
         mark_usage_current(&store, "s2", Some(150));
         mark_event_current(&store, "s2", Some(150));
+        mark_metadata_current(&store, "s2");
 
         let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
         assert_eq!(result.stats.skipped_sessions, 1);
@@ -933,14 +945,47 @@ mod tests {
     }
 
     #[test]
-    fn parse_part_content_includes_current_tool_input_and_output() {
+    fn parse_part_content_skips_tool_parts() {
         let parsed = parse_part_content(
             r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"src/main.rs"},"output":"needle result"}}"#,
         );
 
-        let content = parsed.unwrap();
-        assert!(content.contains("\"filePath\":\"src/main.rs\""));
-        assert!(content.contains("needle result"));
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn scan_session_messages_sets_custom_title_from_session_title() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "s1", 200, 100, "hello");
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('s2', '   ', '/tmp/project', 100, 200)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('s2', '{\"role\":\"user\"}', 110)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, '{\"type\":\"text\",\"text\":\"blank title\"}')",
+            rusqlite::params![message_id],
+        )
+        .unwrap();
+
+        let sessions = load_session_rows(&conn, None).unwrap();
+        let raw = scan_session_messages(&conn, sessions, false).unwrap();
+        let titled = raw.iter().find(|session| session.source_id == "s1").unwrap();
+        let blank = raw.iter().find(|session| session.source_id == "s2").unwrap();
+        assert_eq!(titled.custom_title.as_deref(), Some("Test"));
+        assert_eq!(titled.metadata_parser_version, Some(METADATA_PARSER_VERSION));
+        assert_eq!(blank.custom_title, None);
+        drop(conn);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
@@ -982,6 +1027,8 @@ mod tests {
         let raw = scan_session_messages(&conn, sessions, true).unwrap();
 
         assert_eq!(raw.len(), 1);
+        assert!(raw[0].messages.is_empty());
+        assert_eq!(raw[0].custom_title.as_deref(), Some("Test"));
         assert_eq!(raw[0].events.len(), 2);
         assert_eq!(raw[0].events[0].kind, "file_read");
         assert_eq!(raw[0].events[0].name.as_deref(), Some("readFile"));
@@ -1030,7 +1077,8 @@ mod tests {
         let raw = scan_session_messages(&conn, sessions, true).unwrap();
 
         assert_eq!(raw.len(), 1);
-        assert_eq!(raw[0].messages.len(), 2);
+        assert!(raw[0].messages.is_empty());
+        assert_eq!(raw[0].custom_title.as_deref(), Some("Test"));
         assert_eq!(raw[0].events.len(), 4);
         assert_eq!(raw[0].events[0].kind, "file_read");
         assert_eq!(raw[0].events[0].name.as_deref(), Some("read"));
@@ -1070,6 +1118,12 @@ mod tests {
         conn.execute(
             "INSERT INTO part (id, message_id, data)
              VALUES (NULL, ?1, ?2)",
+            rusqlite::params![message_id, r#"{"type":"text","text":"hello"}"#],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (NULL, ?1, ?2)",
             rusqlite::params![
                 message_id,
                 r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"src/main.rs"},"output":"file body"}}"#
@@ -1082,6 +1136,7 @@ mod tests {
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].messages.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "hello");
         assert!(result.sessions[0].events.is_empty());
         assert_eq!(result.sessions[0].event_parser_version, None);
         drop(conn);


### PR DESCRIPTION
## Summary
- Add a `kilo-code` adapter for the current Kilo CLI store at `~/.local/share/kilo/kilo.db` (`KILO_DB` / `XDG_DATA_HOME` override the path).
- Reuse the OpenCode session/message/part scanner so search, usage, and tool events stay in one place.
- Resume with `kilo --session <id>`. Missing or empty DBs still scan as no sessions.
- This is the CLI database, not the legacy VS Code `kilocode.kilo-code/tasks` store.

## Test plan
- [x] `cargo test -p recall --lib adapters::kilo`
- [x] `cargo test -p recall --lib adapters::opencode`
- [x] `cargo clippy -p recall --lib -- -D warnings`
- [ ] `kilo auth login` then one seed chat so `session` is non-empty
- [ ] `cargo run -- sync --source kilo-code -v`
- [ ] `recall session resume --id <kilo-session>` prints `kilo --session <id>`