### PR TITLE
feat(adapters): index ZCode cli/db.sqlite sessions

### DIFF
--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -99,6 +99,7 @@ When the user wants to share a session or update an existing share link, execute
    - Kilo Code -> `kilo-code`
    - Crush -> `crush`
    - MiMo Code -> `mimo-code`
+   - ZCode -> `zcode`
    If the source is unclear, omit `--source` and rely on project + recency.
 
 2. Sync and resolve the session id. Always include `--sync` so share/update uses the latest messages.
@@ -271,7 +272,7 @@ recall usage --json
 
 Supported time filters are `today`, `7d` or `week`, and `30d` or `month`. Unknown time values fall back to all history.
 
-Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `kimi-code`, `deepseek-harness`, `qwen-code`, `kilo-code`, `crush`, and `mimo-code`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
+Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `kimi-code`, `deepseek-harness`, `qwen-code`, `kilo-code`, `crush`, `mimo-code`, and `zcode`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
 
 ## Export Schema
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod pi;
 pub(crate) mod qwen;
 pub(crate) mod sync_state;
 pub(crate) mod usage;
+pub(crate) mod zcode;
 
 use crate::db::store::Store;
 use crate::types::{ParentLink, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
@@ -200,6 +201,7 @@ pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(kilo::KiloCodeAdapter),
         Box::new(crush::CrushAdapter),
         Box::new(mimo_code::MimoCodeAdapter),
+        Box::new(zcode::ZcodeAdapter),
     ]
 }
 
@@ -226,6 +228,7 @@ pub(crate) fn source_supports_event_backfill(source_id: &str) -> bool {
             | "kilo-code"
             | "crush"
             | "mimo-code"
+            | "zcode"
     )
 }
 

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -23,6 +23,29 @@ const PARSED_PART_FILTER_SQL: &str = "
     AND json_extract(p.data, '$.type') = 'text'
     AND NULLIF(TRIM(CAST(json_extract(p.data, '$.text') AS TEXT)), '') IS NOT NULL
 ";
+const HIDDEN_TRANSCRIPT_FILTER_SQL: &str =
+    "AND json_extract(m.data, '$.semantics.transcriptVisibility') IS NOT 'hidden'";
+const TIMELINE_USAGE_FILTER_SQL: &str =
+    "AND json_extract(data, '$.semantics.kind') IS NOT 'timeline_event'";
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ScanOptions {
+    pub exclude_hidden_transcript: bool,
+    pub exclude_timeline_usage: bool,
+}
+
+impl ScanOptions {
+    pub(crate) const ZCODE: Self =
+        Self { exclude_hidden_transcript: true, exclude_timeline_usage: true };
+
+    fn transcript_sql(self) -> &'static str {
+        if self.exclude_hidden_transcript { HIDDEN_TRANSCRIPT_FILTER_SQL } else { "" }
+    }
+
+    fn usage_sql(self) -> &'static str {
+        if self.exclude_timeline_usage { TIMELINE_USAGE_FILTER_SQL } else { "" }
+    }
+}
 
 pub(crate) struct OpenCodeAdapter;
 
@@ -94,8 +117,16 @@ pub(crate) fn open_readonly(db_path: &Path) -> anyhow::Result<Option<Connection>
 }
 
 pub(crate) fn scan(conn: &Connection, include_events: bool) -> anyhow::Result<Vec<RawSession>> {
+    scan_with_options(conn, include_events, ScanOptions::default())
+}
+
+pub(crate) fn scan_with_options(
+    conn: &Connection,
+    include_events: bool,
+    options: ScanOptions,
+) -> anyhow::Result<Vec<RawSession>> {
     let sessions = load_session_rows(conn, None)?;
-    scan_session_messages(conn, sessions, include_events)
+    scan_session_messages(conn, sessions, include_events, options)
 }
 
 fn count_filtered_sessions(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<u32> {
@@ -154,6 +185,7 @@ fn scan_session_messages(
     conn: &Connection,
     sessions: Vec<SessionRow>,
     include_events: bool,
+    options: ScanOptions,
 ) -> anyhow::Result<Vec<RawSession>> {
     if sessions.is_empty() {
         return Ok(vec![]);
@@ -165,8 +197,8 @@ fn scan_session_messages(
     let mut session_events: HashMap<String, Vec<RawSessionEvent>> = HashMap::new();
 
     for chunk in session_ids.chunks(MAX_SQL_VARS_PER_BATCH) {
-        load_message_chunk(conn, chunk, &mut session_messages)?;
-        load_usage_chunk(conn, chunk, &mut session_usage_events)?;
+        load_message_chunk(conn, chunk, &mut session_messages, options)?;
+        load_usage_chunk(conn, chunk, &mut session_usage_events, options)?;
         if include_events {
             load_event_chunk(conn, chunk, &mut session_events)?;
         }
@@ -373,14 +405,17 @@ fn load_message_chunk(
     conn: &Connection,
     session_ids: &[String],
     session_messages: &mut HashMap<String, Vec<RawMessage>>,
+    options: ScanOptions,
 ) -> anyhow::Result<()> {
     let placeholders = std::iter::repeat_n("?", session_ids.len()).collect::<Vec<_>>().join(", ");
+    let transcript_sql = options.transcript_sql();
     let sql = format!(
         "SELECT m.session_id, json_extract(m.data, '$.role') AS role, p.data, m.time_created
          FROM message m
          JOIN part p ON p.message_id = m.id
          WHERE m.session_id IN ({placeholders})
            AND {PARSED_PART_FILTER_SQL}
+           {transcript_sql}
          ORDER BY m.time_created, p.id"
     );
 
@@ -416,8 +451,10 @@ fn load_usage_chunk(
     conn: &Connection,
     session_ids: &[String],
     session_usage_events: &mut HashMap<String, Vec<RawUsageEvent>>,
+    options: ScanOptions,
 ) -> anyhow::Result<()> {
     let placeholders = std::iter::repeat_n("?", session_ids.len()).collect::<Vec<_>>().join(", ");
+    let usage_sql = options.usage_sql();
     let sql = format!(
         "SELECT CAST(id AS TEXT), session_id, data, time_created
          FROM message
@@ -425,6 +462,7 @@ fn load_usage_chunk(
            AND json_valid(data)
            AND json_extract(data, '$.role') = 'assistant'
            AND json_type(data, '$.tokens') = 'object'
+           {usage_sql}
          ORDER BY time_created, id"
     );
 
@@ -509,17 +547,20 @@ fn cache_token_count(tokens: &Value, key: &str) -> i64 {
 fn load_message_counts(
     conn: &Connection,
     session_ids: &[String],
+    options: ScanOptions,
 ) -> anyhow::Result<HashMap<String, u32>> {
     let mut counts = HashMap::new();
 
     for chunk in session_ids.chunks(MAX_SQL_VARS_PER_BATCH) {
         let placeholders = std::iter::repeat_n("?", chunk.len()).collect::<Vec<_>>().join(", ");
+        let transcript_sql = options.transcript_sql();
         let sql = format!(
             "SELECT m.session_id, COUNT(*)
              FROM message m
              JOIN part p ON p.message_id = m.id
              WHERE m.session_id IN ({placeholders})
                AND {PARSED_PART_FILTER_SQL}
+               {transcript_sql}
              GROUP BY m.session_id"
         );
 
@@ -591,6 +632,24 @@ pub(crate) fn scan_for_sync_conn(
     source_id: &str,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
+    scan_for_sync_conn_with_options(
+        conn,
+        store,
+        since_ts,
+        source_id,
+        include_events,
+        ScanOptions::default(),
+    )
+}
+
+pub(crate) fn scan_for_sync_conn_with_options(
+    conn: &Connection,
+    store: &Store,
+    since_ts: Option<i64>,
+    source_id: &str,
+    include_events: bool,
+    options: ScanOptions,
+) -> anyhow::Result<SyncScanResult> {
     let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
     let sessions = load_session_rows(conn, since_ts)?;
     let existing = store.session_meta_map(source_id)?;
@@ -601,6 +660,7 @@ pub(crate) fn scan_for_sync_conn(
     let current_counts = load_message_counts(
         conn,
         &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
+        options,
     )?;
 
     let mut stats = SyncScanStats { filtered_sessions, ..Default::default() };
@@ -632,7 +692,7 @@ pub(crate) fn scan_for_sync_conn(
         candidates.push(session);
     }
 
-    let sessions = scan_session_messages(conn, candidates, include_events)?;
+    let sessions = scan_session_messages(conn, candidates, include_events, options)?;
     Ok(SyncScanResult { sessions, stats })
 }
 
@@ -978,7 +1038,7 @@ mod tests {
         .unwrap();
 
         let sessions = load_session_rows(&conn, None).unwrap();
-        let raw = scan_session_messages(&conn, sessions, false).unwrap();
+        let raw = scan_session_messages(&conn, sessions, false, ScanOptions::default()).unwrap();
         let titled = raw.iter().find(|session| session.source_id == "s1").unwrap();
         let blank = raw.iter().find(|session| session.source_id == "s2").unwrap();
         assert_eq!(titled.custom_title.as_deref(), Some("Test"));
@@ -1024,7 +1084,7 @@ mod tests {
         .unwrap();
 
         let sessions = load_session_rows(&conn, None).unwrap();
-        let raw = scan_session_messages(&conn, sessions, true).unwrap();
+        let raw = scan_session_messages(&conn, sessions, true, ScanOptions::default()).unwrap();
 
         assert_eq!(raw.len(), 1);
         assert!(raw[0].messages.is_empty());
@@ -1074,7 +1134,7 @@ mod tests {
         .unwrap();
 
         let sessions = load_session_rows(&conn, None).unwrap();
-        let raw = scan_session_messages(&conn, sessions, true).unwrap();
+        let raw = scan_session_messages(&conn, sessions, true, ScanOptions::default()).unwrap();
 
         assert_eq!(raw.len(), 1);
         assert!(raw[0].messages.is_empty());

--- a/src/adapters/zcode.rs
+++ b/src/adapters/zcode.rs
@@ -1,0 +1,271 @@
+use std::path::PathBuf;
+
+use tracing::debug;
+
+use crate::adapters::opencode;
+use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats};
+use crate::db::store::Store;
+
+pub(crate) struct ZcodeAdapter;
+
+impl SourceAdapter for ZcodeAdapter {
+    fn id(&self) -> &str {
+        "zcode"
+    }
+
+    fn label(&self) -> &str {
+        "ZC"
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(opencode::USAGE_PARSER_VERSION)
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "zcode".to_string(),
+            args: vec!["--resume".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        open_zcode_app()
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let Some(conn) = open_zcode_db()? else {
+            return Ok(vec![]);
+        };
+        opencode::scan_with_options(&conn, true, opencode::ScanOptions::ZCODE)
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+        include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(conn) = open_zcode_db()? else {
+            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+        };
+        Ok(Some(opencode::scan_for_sync_conn_with_options(
+            &conn,
+            store,
+            since_ts,
+            "zcode",
+            include_events,
+            opencode::ScanOptions::ZCODE,
+        )?))
+    }
+}
+
+fn open_zcode_db() -> anyhow::Result<Option<rusqlite::Connection>> {
+    let Some(db_path) = resolve_zcode_db_path() else {
+        debug!("ZCode DB not found, skipping");
+        return Ok(None);
+    };
+    opencode::open_readonly(&db_path)
+}
+
+fn resolve_zcode_db_path() -> Option<PathBuf> {
+    resolve_zcode_db_path_from(std::env::var("ZCODE_STORAGE_DIR").ok(), dirs::home_dir()?)
+}
+
+fn resolve_zcode_db_path_from(storage_dir: Option<String>, home: PathBuf) -> Option<PathBuf> {
+    let root = match storage_dir.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+        Some(raw) => PathBuf::from(raw),
+        None => home.join(".zcode"),
+    };
+    let path = root.join("cli/db/db.sqlite");
+    path.exists().then_some(path)
+}
+
+#[cfg(target_os = "macos")]
+fn open_zcode_app() -> Option<ResumeCommand> {
+    Some(ResumeCommand {
+        program: "open".to_string(),
+        args: vec!["-a".to_string(), "ZCode".to_string()],
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn open_zcode_app() -> Option<ResumeCommand> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn resume_uses_official_flag() {
+        let command = ZcodeAdapter.resume_command("sess_123").unwrap();
+        assert_eq!(command.program, "zcode");
+        assert_eq!(command.args, vec!["--resume", "sess_123"]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn app_command_opens_desktop_app() {
+        let command = ZcodeAdapter.app_command("sess_123").unwrap();
+        assert_eq!(command.program, "open");
+        assert_eq!(command.args, vec!["-a", "ZCode"]);
+    }
+
+    #[test]
+    fn default_path_is_home_zcode_cli_db() {
+        let empty_home = tempfile::tempdir().unwrap();
+        assert!(resolve_zcode_db_path_from(None, empty_home.path().to_path_buf()).is_none());
+
+        let root = tempfile::tempdir().unwrap();
+        let db = root.path().join(".zcode/cli/db/db.sqlite");
+        fs_write_empty(&db);
+        let resolved = resolve_zcode_db_path_from(None, root.path().to_path_buf()).unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn storage_dir_overrides_home_root() {
+        let root = tempfile::tempdir().unwrap();
+        let storage = root.path().join("custom-zcode");
+        let db = storage.join("cli/db/db.sqlite");
+        fs_write_empty(&db);
+        let resolved = resolve_zcode_db_path_from(
+            Some(storage.to_string_lossy().into_owned()),
+            PathBuf::from("/unused"),
+        )
+        .unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn blank_storage_dir_falls_back_to_home() {
+        let root = tempfile::tempdir().unwrap();
+        let db = root.path().join(".zcode/cli/db/db.sqlite");
+        fs_write_empty(&db);
+        let resolved =
+            resolve_zcode_db_path_from(Some("   ".to_string()), root.path().to_path_buf()).unwrap();
+        assert_eq!(resolved, db);
+    }
+
+    #[test]
+    fn missing_storage_dir_is_skipped() {
+        assert!(
+            resolve_zcode_db_path_from(Some("/no/such/zcode".to_string()), PathBuf::from("/tmp"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn scan_reads_opencode_shaped_zcode_db() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join("db.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                parent_id TEXT,
+                directory TEXT,
+                title TEXT,
+                time_created INTEGER,
+                time_updated INTEGER,
+                task_type TEXT
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT,
+                time_created INTEGER,
+                data TEXT,
+                sequence INTEGER
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT,
+                session_id TEXT,
+                time_created INTEGER,
+                data TEXT,
+                sequence INTEGER
+            );
+            INSERT INTO session (id, parent_id, directory, title, time_created, time_updated, task_type)
+            VALUES ('sess_123', NULL, '/repo', 'seed', 100, 200, 'interactive');
+            INSERT INTO message (id, session_id, time_created, data, sequence)
+            VALUES ('msg_user', 'sess_123', 110, '{\"role\":\"user\"}', 1);
+            INSERT INTO message (id, session_id, time_created, data, sequence)
+            VALUES (
+                'msg_hidden',
+                'sess_123',
+                115,
+                '{\"role\":\"user\",\"semantics\":{\"origin\":\"system\",\"kind\":\"fork_notice\",\"transcriptVisibility\":\"hidden\"}}',
+                2
+            );
+            INSERT INTO message (id, session_id, time_created, data, sequence)
+            VALUES (
+                'msg_asst',
+                'sess_123',
+                120,
+                '{\"role\":\"assistant\",\"providerID\":\"builtin:zai\",\"modelID\":\"GLM-5.3\",\"tokens\":{\"input\":10,\"output\":4,\"reasoning\":2,\"cache\":{\"read\":1,\"write\":0}}}',
+                3
+            );
+            INSERT INTO message (id, session_id, time_created, data, sequence)
+            VALUES (
+                'msg_timeline',
+                'sess_123',
+                125,
+                '{\"role\":\"assistant\",\"semantics\":{\"kind\":\"timeline_event\"},\"providerID\":\"builtin:zai\",\"modelID\":\"GLM-5.3\",\"tokens\":{\"input\":0,\"output\":0,\"reasoning\":0,\"cache\":{\"read\":0,\"write\":0}}}',
+                4
+            );
+            INSERT INTO part (id, message_id, session_id, time_created, data, sequence)
+            VALUES ('part_user', 'msg_user', 'sess_123', 110, '{\"type\":\"text\",\"text\":\"hello zcode\"}', 0);
+            INSERT INTO part (id, message_id, session_id, time_created, data, sequence)
+            VALUES ('part_hidden', 'msg_hidden', 'sess_123', 115, '{\"type\":\"text\",\"text\":\"internal fork notice\"}', 0);
+            INSERT INTO part (id, message_id, session_id, time_created, data, sequence)
+            VALUES ('part_think', 'msg_asst', 'sess_123', 120, '{\"type\":\"reasoning\",\"text\":\"hidden\"}', 1);
+            INSERT INTO part (id, message_id, session_id, time_created, data, sequence)
+            VALUES ('part_text', 'msg_asst', 'sess_123', 121, '{\"type\":\"text\",\"text\":\"ready\"}', 2);
+            INSERT INTO part (id, message_id, session_id, time_created, data, sequence)
+            VALUES (
+                'part_tool',
+                'msg_asst',
+                'sess_123',
+                122,
+                '{\"type\":\"tool\",\"tool\":\"Bash\",\"state\":{\"status\":\"completed\",\"input\":{\"command\":\"ls\"},\"output\":\"file body\"}}',
+                3
+            );
+            ",
+        )
+        .unwrap();
+        drop(conn);
+
+        let conn = opencode::open_readonly(&db_path).unwrap().unwrap();
+        let sessions =
+            opencode::scan_with_options(&conn, true, opencode::ScanOptions::ZCODE).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].source_id, "sess_123");
+        assert_eq!(sessions[0].directory.as_deref(), Some("/repo"));
+        assert_eq!(sessions[0].custom_title.as_deref(), Some("seed"));
+        assert_eq!(sessions[0].metadata_parser_version, Some(opencode::METADATA_PARSER_VERSION));
+        assert_eq!(sessions[0].messages.len(), 2);
+        assert_eq!(sessions[0].messages[0].content, "hello zcode");
+        assert_eq!(sessions[0].messages[1].content, "ready");
+        assert!(
+            sessions[0].messages.iter().all(|message| message.content != "internal fork notice")
+        );
+        assert_eq!(sessions[0].usage_events.len(), 1);
+        assert_eq!(sessions[0].usage_events[0].model, "GLM-5.3");
+        assert_eq!(sessions[0].usage_events[0].provider, "builtin:zai");
+        assert_eq!(sessions[0].usage_events[0].input_tokens, 10);
+        assert_eq!(sessions[0].usage_events[0].output_tokens, 4);
+        assert_eq!(sessions[0].events.len(), 2);
+        assert_eq!(sessions[0].events[0].name.as_deref(), Some("Bash"));
+    }
+
+    fn fs_write_empty(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, []).unwrap();
+    }
+}


### PR DESCRIPTION
### What's changed?

- Add a `zcode` adapter that indexes `~/.zcode/cli/db/db.sqlite` (`ZCODE_STORAGE_DIR` overrides the root).
- Reuse the OpenCode scanner with ZCode-only filters that drop `transcriptVisibility=hidden` text and `timeline_event` usage rows.
- Resume with `zcode --resume <sessionId>`. On macOS, `app_command` opens the ZCode desktop app.

### Why

- Index ZCode desktop ADE sessions without importing synthetic transcript rows or zeroed timeline usage events.