### PR TITLE
feat(adapters): scan Cline across editor hosts and add Roo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ One index across every AI coding CLI. Sync once, search everywhere, resume right
 | Copilot     |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
 | Cursor          |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |   ✅   |
 | Cline           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |       |
+| Roo             |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |       |
 | DeepSeek Harness |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |   ✅   |
 | Grok            |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Kimi Code       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,7 @@ recall skill install # 自动检测 agent 并安装 skills
 | Copilot         |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |      |
 | Cursor          |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |  ✅  |
 | Cline           |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |      |
+| Roo             |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |      |
 | DeepSeek Harness |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  —   |  ✅  |
 | Grok            |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |
 | Kimi Code       |  ✅  |    ✅    |    ✅    |    ✅    |  ✅  |  ✅  |  ✅  |

--- a/docs/recall-architecture.svg
+++ b/docs/recall-architecture.svg
@@ -31,7 +31,7 @@
   <rect x="24" y="16" width="636" height="114" class="box" fill="#e9f4fb" stroke="#287bb5"/>
   <text x="40" y="42" class="t">Local AI-coding session data</text>
   <text x="40" y="68" class="d">Claude Code · OpenCode · Codex · Pi · OMP · Antigravity · Gemini · Grok · Kiro · Copilot · Cursor</text>
-  <text x="40" y="88" class="d">Cline · DeepSeek Harness · Kimi Code · Qwen Code · Kilo Code · Crush · MiMo Code · ZCode</text>
+  <text x="40" y="88" class="d">Cline · Roo · DeepSeek Harness · Kimi Code · Qwen Code · Kilo Code · Crush · MiMo Code · ZCode</text>
   <text x="40" y="110" class="p">local files · external databases opened read-only</text>
   <g fill="#fff9e9" stroke="#287bb5" stroke-width="1.8" stroke-linejoin="round">
     <rect x="574" y="46" width="42" height="34" rx="5"/>

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -273,7 +273,7 @@ recall usage --json
 
 Supported time filters are `today`, `7d` or `week`, and `30d` or `month`. Unknown time values fall back to all history.
 
-Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `omp`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `kimi-code`, `deepseek-harness`, `qwen-code`, `kilo-code`, `crush`, `mimo-code`, and `zcode`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
+Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `omp`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `cursor`, `cline`, `roo`, `kimi-code`, `deepseek-harness`, `qwen-code`, `kilo-code`, `crush`, `mimo-code`, and `zcode`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
 
 ## Export Schema
 

--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -19,9 +19,10 @@ apply when working here.
   `file_scan::run_file_scan_with_options` for mtime tracking,
   `json_util::jsonl_indexed` for per-line JSONL read loops,
   `json_util::rfc3339_ms` and `json_util::json_i64` for timestamp/number
-  coercion, `paths::resolve_home_dir` for `~/…` directory resolution, and
-  `first_timestamp`/`last_timestamp` (`mod.rs`) for started_at/updated_at
-  fallback chains.
+  coercion, `paths::resolve_home_dir` for `~/…` directory resolution,
+  `paths::vscode_extension_task_dirs` for VS Code-family `globalStorage`
+  extension task roots, and `first_timestamp`/`last_timestamp` (`mod.rs`)
+  for started_at/updated_at fallback chains.
 - Usage and session events are extensions on the same `RawSession`
   (`with_usage`, `with_events`), each with its own parser version. Bump the
   parser version when parsing changes — that is what triggers backfill for

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -5,12 +5,13 @@ use serde_json::Value;
 use tracing::debug;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
-use crate::adapters::paths::resolve_home_dir;
-use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-};
+use crate::adapters::json_util;
+use crate::adapters::paths;
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult};
 use crate::db::store::Store;
 use crate::types::Role;
+
+const CLINE_EXTENSION_ID: &str = "saoudrizwan.claude-dev";
 
 pub(crate) struct ClineAdapter;
 
@@ -27,19 +28,7 @@ impl SourceAdapter for ClineAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let Some(tasks_dir) = resolve_tasks_dir()? else {
-            return Ok(vec![]);
-        };
-        let mut sessions = Vec::new();
-        for entry in collect_cline_entries(&tasks_dir) {
-            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
-                continue;
-            };
-            if let Some(raw) = parse_cline_task(entry, mtime_ms)? {
-                sessions.push(raw);
-            }
-        }
-        Ok(sessions)
+        scan_task_dirs(&resolve_tasks_dirs())
     }
 
     fn scan_for_sync(
@@ -48,30 +37,45 @@ impl SourceAdapter for ClineAdapter {
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        let Some(tasks_dir) = resolve_tasks_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
-        };
-        let result = scan_for_sync_impl(&tasks_dir, store, since_ts)?;
-        Ok(Some(result))
+        Ok(Some(scan_task_dirs_for_sync(&resolve_tasks_dirs(), store, since_ts, "cline")?))
     }
 }
 
-fn scan_for_sync_impl(
-    tasks_dir: &Path,
+pub(crate) fn scan_task_dirs(tasks_dirs: &[PathBuf]) -> anyhow::Result<Vec<RawSession>> {
+    let mut sessions = Vec::new();
+    for entry in collect_all_entries(tasks_dirs) {
+        let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+            continue;
+        };
+        if let Some(raw) = parse_cline_task(entry, mtime_ms)? {
+            sessions.push(raw);
+        }
+    }
+    Ok(sessions)
+}
+
+pub(crate) fn scan_task_dirs_for_sync(
+    tasks_dirs: &[PathBuf],
     store: &Store,
     since_ts: Option<i64>,
+    source: &str,
 ) -> anyhow::Result<SyncScanResult> {
-    let entries = collect_cline_entries(tasks_dir);
-    file_scan::run_file_scan(store, "cline", since_ts, entries, |entry, mtime_ms| {
+    let entries = collect_all_entries(tasks_dirs);
+    file_scan::run_file_scan(store, source, since_ts, entries, |entry, mtime_ms| {
         parse_cline_task(entry, mtime_ms)
     })
 }
 
-fn resolve_tasks_dir() -> anyhow::Result<Option<PathBuf>> {
-    resolve_home_dir(
-        "Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/tasks",
-        "Cline tasks directory not found, skipping Cline",
-    )
+fn resolve_tasks_dirs() -> Vec<PathBuf> {
+    let dirs = paths::vscode_extension_task_dirs(CLINE_EXTENSION_ID);
+    if dirs.is_empty() {
+        debug!("Cline tasks directory not found, skipping Cline");
+    }
+    dirs
+}
+
+fn collect_all_entries(tasks_dirs: &[PathBuf]) -> Vec<FileScanEntry> {
+    tasks_dirs.iter().flat_map(|dir| collect_cline_entries(dir)).collect()
 }
 
 fn collect_cline_entries(tasks_dir: &Path) -> Vec<FileScanEntry> {
@@ -94,11 +98,6 @@ fn collect_cline_entries(tasks_dir: &Path) -> Vec<FileScanEntry> {
             Some(n) => n.to_string(),
             None => continue,
         };
-        // Directory name is a timestamp (e.g., "1765706891317")
-        let _started_at: i64 = match dir_name.parse() {
-            Ok(ts) => ts,
-            Err(_) => continue,
-        };
         let messages_path = path.join("ui_messages.json");
         if !messages_path.exists() {
             continue;
@@ -114,8 +113,6 @@ fn collect_cline_entries(tasks_dir: &Path) -> Vec<FileScanEntry> {
 }
 
 fn parse_cline_task(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<Option<RawSession>> {
-    // Directory name is a timestamp, parse it for started_at
-    let started_at: i64 = entry.session_id.parse().unwrap_or(0);
     let messages = match load_ui_messages(&entry.stat_target) {
         Ok(m) => m,
         Err(e) => {
@@ -128,6 +125,7 @@ fn parse_cline_task(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<Optio
         return Ok(None);
     }
 
+    let started_at = task_started_at(&entry, &messages);
     let directory = extract_directory(&entry.stat_target);
     let source_file_path = entry.stat_target.to_str().map(str::to_string);
 
@@ -276,9 +274,47 @@ fn format_tool_message(msg: &Value) -> Option<String> {
     Some(formatted)
 }
 
+fn task_started_at(entry: &FileScanEntry, messages: &[RawMessage]) -> i64 {
+    if let Ok(ts) = entry.session_id.parse::<i64>() {
+        return ts;
+    }
+    let Some(task_dir) = entry.stat_target.parent() else {
+        return messages.first().and_then(|message| message.timestamp).unwrap_or(0);
+    };
+    read_history_i64(&task_dir.join("history_item.json"), "ts")
+        .or_else(|| read_history_i64(&task_dir.join("history.json"), "ts"))
+        .or_else(|| messages.first().and_then(|message| message.timestamp))
+        .unwrap_or(0)
+}
+
+fn read_history_i64(path: &Path, field: &str) -> Option<i64> {
+    let content = fs::read_to_string(path).ok()?;
+    let meta: Value = serde_json::from_str(&content).ok()?;
+    json_util::json_i64(meta.get(field))
+}
+
 fn extract_directory(messages_path: &Path) -> Option<String> {
-    let metadata_path = messages_path.parent()?.join("task_metadata.json");
-    let content = fs::read_to_string(&metadata_path).ok()?;
+    let task_dir = messages_path.parent()?;
+    if let Some(workspace) = read_history_workspace(&task_dir.join("history_item.json"))
+        .or_else(|| read_history_workspace(&task_dir.join("history.json")))
+    {
+        return Some(workspace);
+    }
+    extract_directory_from_metadata(&task_dir.join("task_metadata.json"))
+}
+
+fn read_history_workspace(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let meta: Value = serde_json::from_str(&content).ok()?;
+    meta.get("workspace")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn extract_directory_from_metadata(metadata_path: &Path) -> Option<String> {
+    let content = fs::read_to_string(metadata_path).ok()?;
     let meta: Value = serde_json::from_str(&content).ok()?;
     let files = meta.get("files_in_context").and_then(|v| v.as_array())?;
     if let Some(first_file) = files.first()
@@ -462,19 +498,33 @@ mod tests {
     }
 
     #[test]
-    fn collect_cline_entries_skips_non_timestamp_dirs() {
+    fn collect_cline_entries_skips_dirs_without_ui_messages() {
         let root = temp_root("collect");
         let good = root.join("1765706891317");
         fs::create_dir_all(&good).unwrap();
         fs::write(good.join("ui_messages.json"), "[]").unwrap();
 
-        let bad = root.join("not-a-timestamp");
-        fs::create_dir_all(&bad).unwrap();
-        fs::write(bad.join("ui_messages.json"), "[]").unwrap();
+        let empty = root.join("019e6d8d-588b-7fd2-a326-c525469ed120");
+        fs::create_dir_all(&empty).unwrap();
 
         let entries = collect_cline_entries(&root);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].session_id, "1765706891317");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_cline_entries_accepts_uuid_task_ids() {
+        let root = temp_root("uuid-collect");
+        let uuid = "019e6d8d-588b-7fd2-a326-c525469ed120";
+        let task = root.join(uuid);
+        fs::create_dir_all(&task).unwrap();
+        fs::write(task.join("ui_messages.json"), "[]").unwrap();
+
+        let entries = collect_cline_entries(&root);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, uuid);
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -500,6 +550,29 @@ mod tests {
         assert_eq!(raw.updated_at, Some(mtime));
         assert_eq!(raw.source_file_path.as_deref(), path.to_str());
         assert_eq!(raw.messages.len(), 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_cline_task_sets_started_at_from_history_item_for_uuid() {
+        let root = temp_root("uuid-startedat");
+        let uuid = "019e6d8d-588b-7fd2-a326-c525469ed120";
+        let messages_json = r#"[{"ts":1000,"type":"say","say":"text","text":"hello"}]"#;
+        let path = write_task(&root, uuid, messages_json);
+        fs::write(
+            path.parent().unwrap().join("history_item.json"),
+            r#"{"ts":1765706891317,"workspace":"/work/roo"}"#,
+        )
+        .unwrap();
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let entry =
+            FileScanEntry { session_id: uuid.to_string(), stat_target: path, directory: None };
+        let raw = parse_cline_task(entry, mtime).unwrap().unwrap();
+        assert_eq!(raw.source_id, uuid);
+        assert_eq!(raw.started_at, 1765706891317);
+        assert_eq!(raw.directory.as_deref(), Some("/work/roo"));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -553,7 +626,8 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session("1765706891317", mtime, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result =
+            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -574,7 +648,8 @@ mod tests {
             .insert_session(&make_existing_session("1765706891317", actual_mtime - 1_000, 1))
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result =
+            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "1765706891317");
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -593,10 +668,94 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result =
+            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "1765706891317");
         assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_all_entries_reads_every_host_dir() {
+        let first = temp_root("host-a");
+        let second = temp_root("host-b");
+        write_task(&first, "1765706891317", "[]");
+        write_task(&second, "1765706891318", "[]");
+
+        let entries = collect_all_entries(&[first.clone(), second.clone()]);
+        let mut ids: Vec<_> = entries.into_iter().map(|entry| entry.session_id).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["1765706891317", "1765706891318"]);
+
+        let _ = fs::remove_dir_all(&first);
+        let _ = fs::remove_dir_all(&second);
+    }
+
+    #[test]
+    fn extract_directory_prefers_history_item_workspace() {
+        let root = temp_root("history-workspace");
+        let path = write_task(
+            &root,
+            "1765706891317",
+            r#"[{"ts":1,"type":"say","say":"text","text":"hi"}]"#,
+        );
+        fs::write(
+            path.parent().unwrap().join("history_item.json"),
+            r#"{"workspace":"/Users/x/git/samzong/Recall"}"#,
+        )
+        .unwrap();
+        fs::write(
+            path.parent().unwrap().join("task_metadata.json"),
+            r#"{"files_in_context":[{"path":"/tmp/other/file.rs"}]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(extract_directory(&path).as_deref(), Some("/Users/x/git/samzong/Recall"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn extract_directory_falls_back_to_task_metadata() {
+        let root = temp_root("metadata-workspace");
+        let path = write_task(
+            &root,
+            "1765706891317",
+            r#"[{"ts":1,"type":"say","say":"text","text":"hi"}]"#,
+        );
+        fs::write(
+            path.parent().unwrap().join("task_metadata.json"),
+            r#"{"files_in_context":[{"path":"/repo/src/main.rs"}]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(extract_directory(&path).as_deref(), Some("/repo/src"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_task_dirs_sets_roo_source_id_and_workspace() {
+        let root = temp_root("roo-scan");
+        let path = write_task(
+            &root,
+            "1765706891317",
+            r#"[{"ts":1000,"type":"say","say":"task","text":"fix it"}]"#,
+        );
+        fs::write(
+            path.parent().unwrap().join("history_item.json"),
+            r#"{"workspace":"/work/roo-project"}"#,
+        )
+        .unwrap();
+
+        let store = setup_store();
+        let result =
+            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "roo").unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].source_id, "1765706891317");
+        assert_eq!(result.sessions[0].directory.as_deref(), Some("/work/roo-project"));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod opencode;
 pub(crate) mod paths;
 pub(crate) mod pi;
 pub(crate) mod qwen;
+pub(crate) mod roo;
 pub(crate) mod sync_state;
 pub(crate) mod usage;
 pub(crate) mod zcode;
@@ -197,6 +198,7 @@ pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(copilot::CopilotAdapter),
         Box::new(cursor::CursorAdapter),
         Box::new(cline::ClineAdapter),
+        Box::new(roo::RooAdapter),
         Box::new(deepseek_harness::DeepSeekHarnessAdapter),
         Box::new(kimi_code::KimiCodeAdapter),
         Box::new(qwen::QwenAdapter),

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -1,5 +1,15 @@
 use std::path::PathBuf;
 
+const VSCODE_HOSTS: &[&str] = &[
+    "Code",
+    "Code - Insiders",
+    "Cursor",
+    "VSCodium",
+    "VSCodium - Insiders",
+    "Windsurf",
+    "Code - OSS",
+];
+
 pub(crate) fn resolve_home_dir(
     relative: &str,
     missing_message: &str,
@@ -11,4 +21,104 @@ pub(crate) fn resolve_home_dir(
         return Ok(None);
     }
     Ok(Some(dir))
+}
+
+pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
+    vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
+}
+
+pub(crate) fn vscode_extension_task_dirs_from(
+    config_dir: Option<PathBuf>,
+    extension_id: &str,
+) -> Vec<PathBuf> {
+    let Some(config_dir) = config_dir else {
+        return Vec::new();
+    };
+    VSCODE_HOSTS
+        .iter()
+        .map(|host| {
+            config_dir
+                .join(host)
+                .join("User")
+                .join("globalStorage")
+                .join(extension_id)
+                .join("tasks")
+        })
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_tasks_dir(config: &std::path::Path, host: &str, extension_id: &str) -> PathBuf {
+        let tasks =
+            config.join(host).join("User").join("globalStorage").join(extension_id).join("tasks");
+        fs::create_dir_all(&tasks).unwrap();
+        tasks
+    }
+
+    #[test]
+    fn missing_config_dir_returns_empty() {
+        assert!(vscode_extension_task_dirs_from(None, "saoudrizwan.claude-dev").is_empty());
+    }
+
+    #[test]
+    fn empty_config_dir_returns_empty() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(
+            vscode_extension_task_dirs_from(
+                Some(root.path().to_path_buf()),
+                "saoudrizwan.claude-dev"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn collects_only_existing_host_task_dirs() {
+        let root = tempfile::tempdir().unwrap();
+        let cursor = write_tasks_dir(root.path(), "Cursor", "saoudrizwan.claude-dev");
+        let code = write_tasks_dir(root.path(), "Code", "saoudrizwan.claude-dev");
+        write_tasks_dir(root.path(), "Code", "rooveterinaryinc.roo-cline");
+        fs::create_dir_all(
+            root.path()
+                .join("VSCodium")
+                .join("User")
+                .join("globalStorage")
+                .join("saoudrizwan.claude-dev"),
+        )
+        .unwrap();
+
+        let dirs = vscode_extension_task_dirs_from(
+            Some(root.path().to_path_buf()),
+            "saoudrizwan.claude-dev",
+        );
+        assert_eq!(dirs, vec![code, cursor]);
+    }
+
+    #[test]
+    fn roo_extension_id_is_independent() {
+        let root = tempfile::tempdir().unwrap();
+        let roo = write_tasks_dir(root.path(), "Code", "rooveterinaryinc.roo-cline");
+        write_tasks_dir(root.path(), "Code", "saoudrizwan.claude-dev");
+        let dirs = vscode_extension_task_dirs_from(
+            Some(root.path().to_path_buf()),
+            "rooveterinaryinc.roo-cline",
+        );
+        assert_eq!(dirs, vec![roo]);
+    }
+
+    #[test]
+    fn linux_style_code_oss_is_included() {
+        let root = tempfile::tempdir().unwrap();
+        let oss = write_tasks_dir(root.path(), "Code - OSS", "saoudrizwan.claude-dev");
+        let dirs = vscode_extension_task_dirs_from(
+            Some(root.path().to_path_buf()),
+            "saoudrizwan.claude-dev",
+        );
+        assert_eq!(dirs, vec![oss]);
+    }
 }

--- a/src/adapters/roo.rs
+++ b/src/adapters/roo.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+use tracing::debug;
+
+use crate::adapters::cline;
+use crate::adapters::paths;
+use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult};
+use crate::db::store::Store;
+
+const EXTENSION_ID: &str = "rooveterinaryinc.roo-cline";
+
+pub(crate) struct RooAdapter;
+
+impl SourceAdapter for RooAdapter {
+    fn id(&self) -> &str {
+        "roo"
+    }
+
+    fn label(&self) -> &str {
+        "ROO"
+    }
+
+    fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        None
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        cline::scan_task_dirs(&resolve_tasks_dirs())
+    }
+
+    fn scan_for_sync(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+        _include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        Ok(Some(cline::scan_task_dirs_for_sync(&resolve_tasks_dirs(), store, since_ts, "roo")?))
+    }
+}
+
+fn resolve_tasks_dirs() -> Vec<PathBuf> {
+    let dirs = paths::vscode_extension_task_dirs(EXTENSION_ID);
+    if dirs.is_empty() {
+        debug!("Roo tasks directory not found, skipping Roo");
+    }
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{schema, store::Store};
+
+    #[test]
+    fn adapter_identity() {
+        assert_eq!(RooAdapter.id(), "roo");
+        assert_eq!(RooAdapter.label(), "ROO");
+        assert!(RooAdapter.resume_command("1").is_none());
+    }
+
+    #[test]
+    fn missing_tasks_dirs_scan_empty() {
+        let sessions = cline::scan_task_dirs(&[]).unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn missing_tasks_dirs_sync_empty() {
+        schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let result = cline::scan_task_dirs_for_sync(&[], &store, None, "roo").unwrap();
+        assert!(result.sessions.is_empty());
+        assert_eq!(result.stats.candidates, 0);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -805,7 +805,7 @@ mod tests {
     fn dashboard_sync_skips_sources_without_usage_or_events() {
         for adapter in all_adapters() {
             let id = adapter.id();
-            if matches!(id, "cline" | "antigravity-cli" | "kiro-cli") {
+            if matches!(id, "cline" | "roo" | "antigravity-cli" | "kiro-cli") {
                 assert!(
                     !adapter_supports_usage_dashboard(adapter.as_ref(), true),
                     "{id} should be skipped during dashboard sync"


### PR DESCRIPTION
## Summary
- Scan Cline tasks under every VS Code-family host (`Code`, Insiders, Cursor, VSCodium, Windsurf, Code - OSS) via `dirs::config_dir()`, instead of the hardcoded macOS VS Code path.
- Add a `roo` adapter that reuses the same `ui_messages` parser on `rooveterinaryinc.roo-cline`, including current uuidv7 task ids and `history_item.json` workspace/start time.
- Cline CLI (`~/.cline/data/sessions`) is intentionally out of scope; it is a second store and should land later on the same `cline` source, like Cursor's CLI store.

## Test plan
- [x] `cargo test --lib adapters::`
- [x] `cargo clippy --workspace --all-targets --features bench -- -D warnings`
- [ ] `recall sync -v` on a machine with Cline in VS Code and/or Cursor
- [ ] `recall search --source cline` and `--source roo` after sync
- [ ] Confirm an existing macOS VS Code Cline index keeps the same `(source, source_id)`