### PR TITLE
build(release): reuse main caches and shrink release binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,79 @@
+name: Build binaries
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit or tag ref to build
+        required: true
+        type: string
+      save-cache:
+        description: Save the per-target rust-cache after building
+        required: false
+        default: false
+        type: boolean
+      upload:
+        description: Package and upload release artifacts
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: recall-linux-x86_64
+          - target: x86_64-apple-darwin
+            os: macos-15
+            artifact: recall-macos-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: recall-macos-aarch64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: recall-windows-x86_64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}
+          save-if: ${{ inputs.save-cache }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p recall -p rx
+
+      - name: Record built commit
+        if: inputs.upload
+        shell: bash
+        run: git rev-parse HEAD > ${{ matrix.artifact }}.sha
+
+      - name: Package (unix)
+        if: inputs.upload && runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.artifact }}.tar.gz recall rx
+          cd ../../..
+
+      - name: Package (windows)
+        if: inputs.upload && runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path target/${{ matrix.target }}/release/recall.exe,target/${{ matrix.target }}/release/rx.exe -DestinationPath ${{ matrix.artifact }}.zip
+
+      - uses: actions/upload-artifact@v5
+        if: inputs.upload
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,15 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-audit --locked --version 0.22.2
-      - uses: actions/cache@v5
         with:
-          path: ~/.cache/ort.pyke.io
-          key: ort-${{ hashFiles('Cargo.lock') }}
+          shared-key: check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo install cargo-audit --locked --version 0.22.2
       - run: make check
+
+  release-cache:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: ${{ github.sha }}
+      save-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RUSTFLAGS: -Dwarnings
     outputs:
       sha: ${{ steps.release.outputs.sha }}
     steps:
@@ -49,62 +51,17 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-audit --locked --version 0.22.2
-      - uses: actions/cache@v5
         with:
-          path: ~/.cache/ort.pyke.io
-          key: ort-${{ hashFiles('Cargo.lock') }}
+          shared-key: check
+          save-if: false
+      - run: cargo install cargo-audit --locked --version 0.22.2
       - run: make check
 
   build:
-    needs: check
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: recall-linux-x86_64
-          - target: x86_64-apple-darwin
-            os: macos-15
-            artifact: recall-macos-x86_64
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            artifact: recall-macos-aarch64
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            artifact: recall-windows-x86_64
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.check.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
-
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }} -p recall -p rx
-
-      - name: Package (unix)
-        if: runner.os != 'Windows'
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.artifact }}.tar.gz recall rx
-          cd ../../..
-
-      - name: Package (windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Compress-Archive -Path target/${{ matrix.target }}/release/recall.exe,target/${{ matrix.target }}/release/rx.exe -DestinationPath ${{ matrix.artifact }}.zip
-
-      - uses: actions/upload-artifact@v5
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.*
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: refs/tags/${{ inputs.tag || github.ref_name }}
+      upload: true
 
   release:
     needs: [check, build]
@@ -113,18 +70,26 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_REF }}
+      - uses: actions/download-artifact@v5
+        with:
+          merge-multiple: true
       - name: Verify release commit
         shell: bash
         env:
           VALIDATED_SHA: ${{ needs.check.outputs.sha }}
         run: |
+          set -eu
           if [ "$(git rev-parse HEAD)" != "$VALIDATED_SHA" ]; then
             echo "::error::release tag moved after validation"
             exit 1
           fi
-      - uses: actions/download-artifact@v5
-        with:
-          merge-multiple: true
+          for built in recall-*.sha; do
+            sha="$(tr -d '[:space:]' < "$built")"
+            if [ "$sha" != "$VALIDATED_SHA" ]; then
+              echo "::error::$built was built from $sha, not from validated commit $VALIDATED_SHA"
+              exit 1
+            fi
+          done
 
       - name: Publish release
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,11 @@ cargo test integration::regression    # regression suite
 cargo test integration::eval_harness  # eval harness
 ```
 
-`make check` must pass before push. CI runs exactly the same command — there is
-no CI-only logic. The gate uses `--workspace` and `--features bench`, so it
+`make check` must pass before push. CI runs exactly the same command. Its only
+extra job, on pushes to `main`, is the release-binary build from
+`build-binaries.yml`: it exists to keep the per-target caches warm, because a
+tag-triggered run can only restore caches saved from `main`. The gate uses
+`--workspace` and `--features bench`, so it
 covers extension crates, `crates/rx`, and the `bench_api` shim that `benches/` compiles
 against. Build a single extension with `cargo build -p recall-<name>`. Build the
 launcher with `cargo build -p rx`.
@@ -42,7 +45,10 @@ the release, not derived from the commit types. A pre-release hook prepends the
 changelog entry for that version with git-cliff, so `CHANGELOG.md` is part of
 the release commit and of the tag it describes, and the GitHub release notes
 are read back out of it. Existing changelog content is never rewritten, so
-hand-written upgrade notes survive. The `v*` tag triggers the binary build.
+hand-written upgrade notes survive. The `v*` tag triggers the Release workflow:
+`make check` on the tag runs in parallel with the four platform builds, and
+publishing requires both to pass and every binary to come from the validated
+commit.
 Extensions release independently: bumping an extension's package version in a
 PR is the release intent — after merge, a workflow creates the
 `recall-<name>-v<version>` tag, builds binaries, and regenerates the catalog.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ bench = []
 [profile.release]
 opt-level = 3
 lto = true
+codegen-units = 1
+panic = "abort"
 strip = true
 
 # Benchmarks are compiled with the release profile; thin LTO keeps build times

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,7 +169,7 @@ make run                    # TUI filter should include MT
 
 ## CI
 
-CI runs `make check` — the same single command you run locally. There is no separate CI-only logic.
+CI runs `make check` — the same single command you run locally. The only CI-only job is the release-binary build on pushes to `main` (`build-binaries.yml`), which keeps the per-target release caches warm; tag-triggered release runs can only restore caches saved from `main`.
 
 ```
 make check = cargo audit → cargo fmt --check → cargo clippy --workspace --all-targets --features bench -- -D warnings → cargo test --workspace

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -38,15 +38,30 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
         semantic::ensure_background_worker(true)?;
     }
 
+    fn restore_terminal() {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            io::stdout(),
+            crossterm::event::DisableMouseCapture,
+            LeaveAlternateScreen,
+            crossterm::cursor::Show
+        );
+    }
+
     struct TerminalGuard;
     impl Drop for TerminalGuard {
         fn drop(&mut self) {
-            let _ = disable_raw_mode();
-            let _ =
-                execute!(io::stdout(), crossterm::event::DisableMouseCapture, LeaveAlternateScreen);
+            restore_terminal();
         }
     }
 
+    let previous_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if cfg!(panic = "abort") {
+            restore_terminal();
+        }
+        previous_panic_hook(info);
+    }));
     enable_raw_mode()?;
     let guard = TerminalGuard;
     let mut stdout = io::stdout();


### PR DESCRIPTION
### What's changed?

- New `build-binaries.yml` (`workflow_call`) holds the single four-platform build matrix with a `shared-key` per target; CI calls it on pushes to `main` to warm the caches, Release calls it with `upload: true` and never saves.
- Release runs `make check` in parallel with the builds, restores the CI `check` cache (same `shared-key` and `RUSTFLAGS`), and the publish job verifies every uploaded binary was built from the validated tag commit via a `.sha` file per artifact.
- The dead `~/.cache/ort.pyke.io` cache step is removed from CI and Release; `ort` is no longer in `Cargo.lock`.
- `[profile.release]` adds `codegen-units = 1` and `panic = "abort"`; `opt-level = 3` and fat LTO are unchanged. Measured on macOS arm64: `recall` 14.9 MB -> 12.4 MB, `rx` 3.7 MB -> 2.9 MB.
- The TUI installs a panic hook that restores raw mode, the alternate screen, and cursor visibility under `panic = "abort"`, where the `TerminalGuard` drop and ratatui's `Terminal::drop` no longer run. Unwind builds keep the existing drop-based cleanup.
- `AGENTS.md` / `DEVELOPMENT.md` describe the main-only warm job.

### Why

- Release run logs for v0.5.8 show `No cache found` in all five jobs. Their saved caches live under `refs/tags/v0.5.x`, and GitHub never shares caches across tags, so every release cold-compiled the full dependency graph on five machines and spent ~6 minutes re-running `make check` before any build started. The only cache scope a tag run can read is `main`, so `main` has to be the writer.
- The Release check job also had a different `RUSTFLAGS` than CI, so it could not hit the CI cache even in principle.
- Nine tag-scoped caches (~3.6 GB) that could never be restored were consuming the 10 GB repository quota; they have been deleted.
- Verified locally: `make check`, `actionlint` on all workflows, `cargo bench --features bench --no-run` under the new profile, and an out-of-tree probe confirming the panic hook runs (and drop does not) with `panic = "abort"`. The cache hit on a real tag run can only be confirmed by the next release; a miss falls back to today's cold build with no other change in behavior.
