### PR TITLE
perf(sync): reduce event payload amplification and show progress

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -21,7 +21,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 pub(crate) struct ClaudeCodeAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 5;
-const EVENT_PARSER_VERSION: u32 = 2;
+const EVENT_PARSER_VERSION: u32 = 3;
 const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for ClaudeCodeAdapter {

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -20,7 +20,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 pub(crate) struct CodexAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 4;
-const EVENT_PARSER_VERSION: u32 = 2;
+const EVENT_PARSER_VERSION: u32 = 3;
 const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CodexAdapter {

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -22,7 +22,7 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CopilotAdapter;
 
-const EVENT_PARSER_VERSION: u32 = 1;
+const EVENT_PARSER_VERSION: u32 = 2;
 const USAGE_PARSER_VERSION: u32 = 2;
 
 impl SourceAdapter for CopilotAdapter {

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -25,7 +25,7 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 pub(crate) struct CursorAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 2;
-const EVENT_PARSER_VERSION: u32 = 1;
+const EVENT_PARSER_VERSION: u32 = 2;
 
 #[derive(Debug, Clone)]
 struct ComposerMeta {

--- a/src/adapters/events.rs
+++ b/src/adapters/events.rs
@@ -2,6 +2,8 @@ use serde_json::Value;
 
 use crate::types::RawSessionEvent;
 
+const TOOL_RESULT_SUMMARY_MAX_BYTES: usize = 4096;
+
 pub(crate) struct EventContext {
     pub(crate) event_seq: u32,
     pub(crate) timestamp: Option<i64>,
@@ -83,7 +85,7 @@ pub(crate) fn tool_result_event(
         status: None,
         target: None,
         message_seq: context.message_seq,
-        summary,
+        summary: summary.map(cap_tool_result_summary),
         source_path: context.source_path,
         source_event_id: context.source_event_id,
         attrs_json: None,
@@ -216,4 +218,47 @@ fn infer_tool_kind(name: &str, target: Option<&str>) -> &'static str {
 fn non_empty(text: &str) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}
+
+fn cap_tool_result_summary(summary: String) -> String {
+    if summary.len() <= TOOL_RESULT_SUMMARY_MAX_BYTES {
+        return summary;
+    }
+    let mut end = TOOL_RESULT_SUMMARY_MAX_BYTES;
+    while !summary.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut capped = summary[..end].to_string();
+    capped.push('…');
+    capped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EventContext, TOOL_RESULT_SUMMARY_MAX_BYTES, tool_result_event};
+
+    fn context() -> EventContext {
+        EventContext {
+            event_seq: 0,
+            timestamp: None,
+            source_path: None,
+            source_event_id: None,
+            message_seq: None,
+            parser_version: 1,
+        }
+    }
+
+    #[test]
+    fn tool_result_summary_is_capped_on_a_char_boundary() {
+        let long = "汉".repeat(TOOL_RESULT_SUMMARY_MAX_BYTES);
+        let event = tool_result_event(context(), None, Some(long));
+        let summary = event.summary.unwrap();
+        assert!(summary.ends_with('…'));
+        assert!(summary.len() <= TOOL_RESULT_SUMMARY_MAX_BYTES + '…'.len_utf8());
+        assert!(summary.trim_end_matches('…').chars().all(|c| c == '汉'));
+
+        let short = "ok".to_string();
+        let event = tool_result_event(context(), None, Some(short.clone()));
+        assert_eq!(event.summary, Some(short));
+    }
 }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -14,7 +14,7 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
 pub(crate) const USAGE_PARSER_VERSION: u32 = 1;
-pub(crate) const EVENT_PARSER_VERSION: u32 = 3;
+pub(crate) const EVENT_PARSER_VERSION: u32 = 4;
 pub(crate) const METADATA_PARSER_VERSION: u32 = 1;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
@@ -360,6 +360,7 @@ fn parse_part_events(
         }
         Some("patch") => {
             let files = patch_files(&part);
+            let attrs_json = Some(patch_attrs_without_files(&part));
             if files.is_empty() {
                 return vec![RawSessionEvent {
                     event_seq,
@@ -373,7 +374,7 @@ fn parse_part_events(
                     summary: None,
                     source_path: None,
                     source_event_id: Some(part_id.to_string()),
-                    attrs_json: Some(part.to_string()),
+                    attrs_json,
                     parser_version: EVENT_PARSER_VERSION,
                 }];
             }
@@ -392,7 +393,7 @@ fn parse_part_events(
                     message_seq: None,
                     source_path: None,
                     source_event_id: Some(part_id.to_string()),
-                    attrs_json: Some(part.to_string()),
+                    attrs_json: attrs_json.clone(),
                     parser_version: EVENT_PARSER_VERSION,
                 })
                 .collect()
@@ -616,6 +617,14 @@ fn patch_files(part: &Value) -> Vec<String> {
         .filter(|file| !file.trim().is_empty())
         .map(|file| file.trim().to_string())
         .collect()
+}
+
+fn patch_attrs_without_files(part: &Value) -> String {
+    let mut attrs = part.clone();
+    if let Some(object) = attrs.as_object_mut() {
+        object.remove("files");
+    }
+    attrs.to_string()
 }
 
 fn display_json_value(value: &Value) -> String {
@@ -1155,6 +1164,11 @@ mod tests {
         assert_eq!(raw[0].events[3].name.as_deref(), Some("patch"));
         assert_eq!(raw[0].events[3].target.as_deref(), Some("README.md"));
         assert_eq!(raw[0].events[3].event_seq, raw[0].events[2].event_seq + 1);
+        assert_eq!(
+            raw[0].events[2].attrs_json.as_deref(),
+            Some(r#"{"hash":"abc","type":"patch"}"#)
+        );
+        assert_eq!(raw[0].events[3].attrs_json, raw[0].events[2].attrs_json);
         drop(conn);
         let _ = std::fs::remove_file(path);
     }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -101,7 +101,34 @@ pub(crate) struct SkillAuditEventRow {
     pub(crate) attrs_json: Option<String>,
 }
 
+const COMPACT_MIN_FREE_BYTES: u64 = 1 << 30;
+
+pub(crate) struct CompactionPlan {
+    pub(crate) reclaimable_bytes: u64,
+    pub(crate) required_disk_bytes: u64,
+}
+
 impl Store {
+    fn pragma_u64(&self, name: &str) -> Result<u64> {
+        Ok(self.conn.query_row(&format!("PRAGMA {name}"), [], |row| row.get::<_, i64>(0))? as u64)
+    }
+
+    pub(crate) fn compaction_plan(&self) -> Result<Option<CompactionPlan>> {
+        let page_size = self.pragma_u64("page_size")?;
+        let page_count = self.pragma_u64("page_count")?;
+        let freelist = self.pragma_u64("freelist_count")?;
+        let reclaimable_bytes = freelist * page_size;
+        if reclaimable_bytes < COMPACT_MIN_FREE_BYTES || freelist * 2 < page_count {
+            return Ok(None);
+        }
+        Ok(Some(CompactionPlan { reclaimable_bytes, required_disk_bytes: page_count * page_size }))
+    }
+
+    pub(crate) fn vacuum(&self) -> Result<()> {
+        self.conn.execute_batch("VACUUM;")?;
+        Ok(())
+    }
+
     pub(crate) fn default_db_path() -> Result<PathBuf> {
         let data_dir = dirs::data_dir()
             .ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) mod share;
 pub(crate) mod share_init;
 pub(crate) mod skill_audit;
 pub(crate) mod sync;
+pub(crate) mod sync_progress;
 pub(crate) mod transcript;
 pub(crate) mod tui;
 pub(crate) mod types;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -13,6 +13,7 @@ use crate::project_scope::{ProjectScope, SessionScopeFields};
 use crate::query::resolve_source_filter;
 use crate::repo_identity::{RepoIdentity, RepoIdentityCache};
 use crate::semantic;
+use crate::sync_progress::{SyncProgress, format_bytes, format_elapsed};
 use crate::types::{Message, Role, Session};
 use crate::utils;
 
@@ -48,7 +49,38 @@ pub(crate) fn run_cli(
         sources,
         scope,
     })?;
+    compact_database_if_bloated()?;
     semantic::ensure_background_worker(false)?;
+    Ok(())
+}
+
+fn compact_database_if_bloated() -> Result<()> {
+    let store = Store::open()?;
+    let Some(plan) = store.compaction_plan()? else {
+        return Ok(());
+    };
+    let db_path = Store::default_db_path()?;
+    let available = fs2::available_space(db_path.parent().unwrap_or(&db_path))?;
+    if available < plan.required_disk_bytes {
+        eprintln!(
+            "Compaction skipped: reclaiming {} needs {} of free disk, {} available.",
+            format_bytes(plan.reclaimable_bytes),
+            format_bytes(plan.required_disk_bytes),
+            format_bytes(available)
+        );
+        return Ok(());
+    }
+    eprintln!(
+        "Compacting database to reclaim {} (one-time)...",
+        format_bytes(plan.reclaimable_bytes)
+    );
+    let started = std::time::Instant::now();
+    match store.vacuum() {
+        Ok(()) => {
+            eprintln!("Database compacted in {}.", format_elapsed(started.elapsed().as_millis()))
+        }
+        Err(err) => eprintln!("Compaction skipped ({err}); it will be retried on the next sync."),
+    }
     Ok(())
 }
 
@@ -227,6 +259,8 @@ struct SyncJob {
     repo_cache: RepoIdentityCache,
     stats: SyncStats,
     adapter_runs: Vec<AdapterRun>,
+    progress: SyncProgress,
+    started: std::time::Instant,
 }
 
 impl SyncJob {
@@ -243,7 +277,7 @@ impl SyncJob {
         config.normalize_sources(&labels);
         let since_ts = if options.usage_only { None } else { config.sync_window.to_since_cutoff() };
         let path_excluder = config.build_path_excluder()?;
-        Ok(Self {
+        let mut job = Self {
             store,
             options,
             config,
@@ -253,7 +287,33 @@ impl SyncJob {
             repo_cache: RepoIdentityCache::default(),
             stats: SyncStats::default(),
             adapter_runs: Vec::new(),
-        })
+            progress: SyncProgress::disabled(),
+            started: std::time::Instant::now(),
+        };
+        if job.options.emit && !job.options.verbose {
+            let selected = available_adapters
+                .iter()
+                .filter(|adapter| job.is_selected(adapter.as_ref()))
+                .count();
+            job.progress = SyncProgress::for_terminal(selected);
+        }
+        Ok(job)
+    }
+
+    fn passes_filters(&self, adapter: &dyn adapters::SourceAdapter) -> bool {
+        if self.options.usage_only
+            && !adapters::adapter_supports_usage_dashboard(adapter, self.options.backfill_events)
+        {
+            return false;
+        }
+        self.options
+            .sources
+            .as_ref()
+            .is_none_or(|sources| sources.iter().any(|id| id == adapter.id()))
+    }
+
+    fn is_selected(&self, adapter: &dyn adapters::SourceAdapter) -> bool {
+        self.passes_filters(adapter) && self.config.is_source_enabled(adapter.id())
     }
 
     fn run_with(
@@ -264,6 +324,7 @@ impl SyncJob {
         for adapter in available_adapters {
             self.sync_adapter(adapter.as_ref(), &mut on_source)?;
         }
+        self.progress.finish();
         self.report_progress()
     }
 
@@ -275,15 +336,7 @@ impl SyncJob {
         let source_id = adapter.id();
         let label = adapter.label();
 
-        if self.options.usage_only
-            && !adapters::adapter_supports_usage_dashboard(adapter, self.options.backfill_events)
-        {
-            return Ok(());
-        }
-
-        if let Some(sources) = &self.options.sources
-            && !sources.iter().any(|id| id == source_id)
-        {
+        if !self.passes_filters(adapter) {
             return Ok(());
         }
 
@@ -298,6 +351,7 @@ impl SyncJob {
             on_source(source_id);
         }
 
+        self.progress.begin_source(label);
         let started = std::time::Instant::now();
         let touched_before = self.stats.touched();
         let out_of_scope_before = self.stats.out_of_scope;
@@ -321,16 +375,21 @@ impl SyncJob {
         };
 
         let mut existing = self.load_existing_state(source_id)?;
-        for raw in raw_sessions {
+        let found = raw_sessions.len();
+        for (done, raw) in raw_sessions.into_iter().enumerate() {
+            self.progress.indexing(label, done, found);
             self.process_raw_session(source_id, raw, &mut existing, &mut purged_excluded_ids)?;
         }
 
+        let touched = self.stats.touched() - touched_before;
+        let elapsed_ms = started.elapsed().as_millis();
+        self.progress.end_source(label, found, touched, elapsed_ms);
         self.adapter_runs.push(AdapterRun {
             label: label.to_string(),
             scan,
             out_of_scope: self.stats.out_of_scope - out_of_scope_before,
-            touched: self.stats.touched() - touched_before,
-            elapsed_ms: started.elapsed().as_millis(),
+            touched,
+            elapsed_ms,
         });
 
         info!("{label} done");
@@ -848,13 +907,18 @@ impl SyncJob {
                 );
             }
         } else if self.options.emit {
+            let elapsed = format_elapsed(self.started.elapsed().as_millis());
             if self.options.force {
-                println!("Reprocessed {touched} sessions, {total_messages} messages");
+                println!("Reprocessed {touched} sessions, {total_messages} messages in {elapsed}");
             } else if touched == 0 {
-                println!("Up to date.");
+                println!("Up to date ({elapsed}).");
+            } else if reprocessed_sessions > 0 {
+                println!(
+                    "{new_sessions} new, {updated_sessions} updated, {reprocessed_sessions} backfilled, {total_messages} messages in {elapsed}"
+                );
             } else {
                 println!(
-                    "{new_sessions} new, {updated_sessions} updated, {total_messages} messages"
+                    "{new_sessions} new, {updated_sessions} updated, {total_messages} messages in {elapsed}"
                 );
             }
         }

--- a/src/sync_progress.rs
+++ b/src/sync_progress.rs
@@ -1,0 +1,168 @@
+use std::io::{self, IsTerminal, Write};
+use std::sync::mpsc::{RecvTimeoutError, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const TICK: Duration = Duration::from_millis(500);
+const MIN_REDRAW: Duration = Duration::from_millis(100);
+
+pub(crate) struct SyncProgress {
+    total: usize,
+    index: usize,
+    line: Option<Arc<Mutex<Line>>>,
+    stop: Option<Sender<()>>,
+    ticker: Option<JoinHandle<()>>,
+}
+
+struct Line {
+    transient: Option<(String, Instant)>,
+    last_width: usize,
+    last_draw: Instant,
+}
+
+impl SyncProgress {
+    pub(crate) fn disabled() -> Self {
+        Self { total: 0, index: 0, line: None, stop: None, ticker: None }
+    }
+
+    pub(crate) fn for_terminal(total: usize) -> Self {
+        if total == 0 || !io::stderr().is_terminal() {
+            return Self { total, index: 0, line: None, stop: None, ticker: None };
+        }
+        let line = Arc::new(Mutex::new(Line {
+            transient: None,
+            last_width: 0,
+            last_draw: Instant::now(),
+        }));
+        let (stop, wake) = channel::<()>();
+        let ticker = {
+            let line = Arc::clone(&line);
+            std::thread::spawn(move || {
+                while wake.recv_timeout(TICK) == Err(RecvTimeoutError::Timeout) {
+                    if let Ok(mut line) = line.lock() {
+                        line.redraw_transient();
+                    }
+                }
+            })
+        };
+        Self { total, index: 0, line: Some(line), stop: Some(stop), ticker: Some(ticker) }
+    }
+
+    pub(crate) fn begin_source(&mut self, label: &str) {
+        self.index += 1;
+        let text = format!("[{}/{}] {label}: scanning", self.index, self.total);
+        self.with_line(|line| line.set_transient(text, true));
+    }
+
+    pub(crate) fn indexing(&mut self, label: &str, done: usize, total: usize) {
+        let text = format!("[{}/{}] {label}: indexing {done}/{total}", self.index, self.total);
+        self.with_line(|line| line.set_transient(text, false));
+    }
+
+    pub(crate) fn end_source(&mut self, label: &str, found: usize, touched: u32, elapsed_ms: u128) {
+        if found == 0 && touched == 0 {
+            self.with_line(Line::clear);
+            return;
+        }
+        let text = format!(
+            "[{}/{}] {label}: {found} sessions read, {touched} indexed, {}",
+            self.index,
+            self.total,
+            format_elapsed(elapsed_ms)
+        );
+        if self.line.is_some() {
+            self.with_line(|line| line.print_permanent(&text));
+        } else if self.total > 0 {
+            eprintln!("{text}");
+        }
+    }
+
+    pub(crate) fn finish(&mut self) {
+        self.with_line(Line::clear);
+        drop(self.stop.take());
+        if let Some(ticker) = self.ticker.take() {
+            let _ = ticker.join();
+        }
+    }
+
+    fn with_line(&self, apply: impl FnOnce(&mut Line)) {
+        if let Some(line) = &self.line
+            && let Ok(mut line) = line.lock()
+        {
+            apply(&mut line);
+        }
+    }
+}
+
+impl Drop for SyncProgress {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+impl Line {
+    fn set_transient(&mut self, text: String, restart_clock: bool) {
+        let force = restart_clock || self.transient.is_none();
+        let since = match (&self.transient, restart_clock) {
+            (Some((_, since)), false) => *since,
+            _ => Instant::now(),
+        };
+        self.transient = Some((text, since));
+        if force || self.last_draw.elapsed() >= MIN_REDRAW {
+            self.redraw_transient();
+        }
+    }
+
+    fn redraw_transient(&mut self) {
+        let Some((text, since)) = &self.transient else {
+            return;
+        };
+        let elapsed = since.elapsed().as_secs();
+        let rendered = if elapsed >= 2 { format!("{text} ({elapsed}s)") } else { text.clone() };
+        self.overwrite(&rendered);
+    }
+
+    fn print_permanent(&mut self, text: &str) {
+        self.clear();
+        eprintln!("{text}");
+        let _ = io::stderr().flush();
+    }
+
+    fn overwrite(&mut self, text: &str) {
+        let width = text.chars().count();
+        let padding = " ".repeat(self.last_width.saturating_sub(width));
+        eprint!("\r{text}{padding}");
+        let _ = io::stderr().flush();
+        self.last_width = width.max(self.last_width);
+        self.last_draw = Instant::now();
+    }
+
+    fn clear(&mut self) {
+        self.transient = None;
+        if self.last_width == 0 {
+            return;
+        }
+        eprint!("\r{}\r", " ".repeat(self.last_width));
+        let _ = io::stderr().flush();
+        self.last_width = 0;
+    }
+}
+
+pub(crate) fn format_bytes(bytes: u64) -> String {
+    const GIB: f64 = (1u64 << 30) as f64;
+    const MIB: f64 = (1u64 << 20) as f64;
+    let bytes = bytes as f64;
+    if bytes >= GIB { format!("{:.1} GiB", bytes / GIB) } else { format!("{:.0} MiB", bytes / MIB) }
+}
+
+pub(crate) fn format_elapsed(elapsed_ms: u128) -> String {
+    if elapsed_ms < 1000 {
+        format!("{elapsed_ms}ms")
+    } else if elapsed_ms < 60_000 {
+        format!("{:.1}s", elapsed_ms as f64 / 1000.0)
+    } else {
+        let secs = elapsed_ms / 1000;
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    }
+}


### PR DESCRIPTION
## Summary
- stop duplicating OpenCode patch file lists across every file event
- cap tool-result summaries and backfill affected event sources
- show foreground sync progress and elapsed time
- compact heavily bloated indexes after sync with a disk-space guard

## Verification
- `make check`
- isolated cold sync: 5m13s to 1m29s; database size 22.4 GB to 2.66 GB
- compaction rehearsal: 2.66 GB to 862 MB; `PRAGMA integrity_check` returned `ok`