### PR TITLE
feat(recall): add session continuation fallback

### DIFF
--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recall
-description: Use Recall as a project memory layer for local AI coding session history. Trigger when the user mentions recall, wants a live share link (分享会话/分享对话/分享这个对话/给我链接/share session/session link), wants to refresh or update an existing share link (更新分享链接/刷新分享/重新分享/update share link), wants to list or unpublish existing share pages (列出分享/有哪些分享/取消分享/unpublish share), resume or open a session, search or export sessions, review project history, recover decisions, find failed approaches, or inspect Claude Code/Codex/OpenCode/Cursor/Grok session evidence.
+description: Use Recall as a project memory layer for local AI coding session history. Trigger when the user asks to share, refresh, list, or unpublish session pages; resume or open a session; search or export sessions; review project history; recover decisions or failed approaches; inspect evidence from supported coding agents; or continue a numbered unfinished-session candidate previously offered by Recall.
 ---
 
 # Recall
@@ -9,9 +9,9 @@ description: Use Recall as a project memory layer for local AI coding session hi
 
 Recall is a local-first CLI that indexes AI coding sessions from multiple tools. Treat it as a project memory layer: use it to recover history, reduce repeated mistakes, and turn prior sessions into current review evidence.
 
-Use the installed `recall` command when inspecting the user's session history. If you are developing Recall itself, use the project build only for testing Recall behavior, not as a substitute for the user's installed history index.
+Prefer active Recall MCP tools for read-only session lookup. Fall back to the installed `recall` command when Recall MCP is unavailable or the requested workflow is CLI-only. If you are developing Recall itself, use the project build only for testing Recall behavior, not as a substitute for the user's installed history index.
 
-If `recall` is unavailable, stop the Recall workflow, tell the user it is not installed, and offer `brew install samzong/tap/recall` instead of pretending history was inspected.
+If neither active Recall MCP tools nor the `recall` command are available, stop the Recall workflow, tell the user Recall is unavailable, and offer `brew install samzong/tap/recall` instead of pretending history was inspected.
 
 Recall history is evidence, not truth. Verify technical claims, code behavior, commands, paths, and invariants against the current repository before acting.
 
@@ -21,16 +21,40 @@ Pick the workflow from user intent. Do not run the full project-review scoping f
 
 | Intent | Example prompts | Workflow |
 | --- | --- | --- |
-| Share a live link | "分享会话", "分享这个对话", "share this session", "给我链接" | Publish Or Refresh Share Link |
-| Refresh an existing link | "用 recall 更新分享链接", "刷新分享", "重新分享", "update the share link" | Publish Or Refresh Share Link |
-| List published shares | "有哪些分享", "列出分享链接", "what is currently shared" | List Published Shares |
-| Unpublish a share | "取消分享", "下线这个分享", "unpublish this share" | Unpublish Share Page |
-| Resume or open | "继续这个会话", "resume this chat" | Session Resume/Open |
-| Find one session | "找上次讨论 migration 的会话", "当前项目最新 grok 会话" | Latest/Find Session Lookup |
-| Review project history | "用 recall 审查这个项目", "历史风险" | Scoping Protocol + Analysis Modes |
+| Share a live link | "share this session", "give me a session link" | Publish Or Refresh Share Link |
+| Refresh an existing link | "refresh the share link", "share it again" | Publish Or Refresh Share Link |
+| List published shares | "list shared sessions", "what is currently shared" | List Published Shares |
+| Unpublish a share | "unpublish this share", "take this share down" | Unpublish Share Page |
+| Resume or open | "continue this session", "resume this chat" | Session Resume/Open |
+| Find one session | "find the last session about migration", "latest Grok session for this project" | Latest/Find Session Lookup |
+| Review project history | "review this project with Recall", "historical risks" | Scoping Protocol + Analysis Modes |
 | Reflect on AI coding workflow | "reflect on this project", "review my AI coding workflow", "timeline reflection", "workflow friction", "calibration discussion" | Route to the `reflect` skill |
+| No clear Recall task | Recall is invoked without a requested operation or analysis goal | Recent Continuation Check |
 
 Treat "share" and "update/refresh share link" as the same action: sync the latest transcript, publish to Pages, return the live URL.
+
+## Recent Continuation Check
+
+Use this fallback only after Intent Routing determines that Recall was invoked without a clear operation or analysis goal. Decide from the meaning of the request, never by matching an invocation token or fixed phrase. If the user states an intent, follow that intent and do not run this fallback.
+
+1. Resolve the current project with Project Scope Defaults. Do not broaden to all projects when the current project cannot be resolved.
+2. Prefer active Recall MCP tools:
+   - Call `list_recent_sessions` for the current project with no source filter and a limit of 5.
+   - Call `get_session` for each candidate with `max_messages` set to 12 and `tail` set to `true`.
+3. If Recall MCP tools are unavailable, use the CLI:
+   ```bash
+   recall session list --project /absolute/project/path --limit 5 --sort updated --format json
+   recall session show --id <session-id> --format json --include metadata,messages --from-seq <max(message_count-12,0)>
+   ```
+   Use the indexed session record. If the index is missing or empty, report that and offer `recall sync`; do not inspect raw source transcript files.
+4. Judge unfinished work from the meaning of the session ending, never from tool status, event status, or the final message role alone. Strong evidence includes an unanswered user request, explicitly remaining work or blockers, and interrupted execution. Exclude sessions whose ending reports completion. Exclude the current conversation when identifiable, including a candidate whose tail contains the current fallback request. Omit ambiguous candidates.
+5. Show at most 3 candidates with short reasons and stable numbering:
+   ```text
+   1. [source] title — why it appears unfinished
+   2. [source] title — why it appears unfinished
+   ```
+   Tell the user they can reply with a number to continue. If none qualify, state that no clearly unfinished recent session was found.
+6. A numeric reply selects that candidate. Load the relevant history with Recall MCP or CLI and continue the work in the current agent. Do not launch native resume behavior unless the user explicitly asks for it.
 
 ## Project Scope Defaults
 
@@ -85,8 +109,8 @@ When the user wants to share a session or update an existing share link, execute
 
 ### What the user expects
 
-- "分享会话" -> a **live, openable URL** for the current conversation.
-- "用 recall 更新分享链接" -> **re-publish** the current conversation so the page reflects the latest messages. The URL usually stays the same; the deployed HTML changes.
+- "share this session" -> a **live, openable URL** for the current conversation.
+- "refresh the Recall share link" -> **re-publish** the current conversation so the page reflects the latest messages. The URL usually stays the same; the deployed HTML changes.
 
 ### Steps
 
@@ -279,6 +303,7 @@ Use these Recall commands in agent tool calls:
 
 ```bash
 recall info
+recall mcp capabilities --format json
 recall sync
 recall sync --source codex
 recall search "migration bug" --project /absolute/project/path

--- a/skills/recall/agents/openai.yaml
+++ b/skills/recall/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Recall"
   short_description: "Use project memory from AI sessions"
-  default_prompt: "Use $recall to review this project through its local AI session history before drawing conclusions."
+  default_prompt: "Use $recall to check this project's recent AI coding sessions for unfinished work I can continue here."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ enum Commands {
         #[arg(help = "Target shell")]
         shell: Shell,
     },
-    #[command(about = "Serve a read-only MCP server over stdio")]
+    #[command(about = "Serve and inspect the read-only MCP server")]
     Mcp {
         #[arg(long, help = "Read this Recall database instead of the default index")]
         db: Option<PathBuf>,
@@ -181,6 +181,11 @@ enum ShareCommands {
 
 #[derive(Subcommand)]
 enum McpCommands {
+    #[command(about = "Print the Recall MCP server capabilities and tools")]
+    Capabilities {
+        #[arg(long, value_enum, default_value_t = crate::mcp::McpCapabilitiesFormat::Text)]
+        format: crate::mcp::McpCapabilitiesFormat,
+    },
     #[command(about = "Register the Recall MCP server with local agent hosts")]
     Install {
         #[arg(
@@ -326,6 +331,9 @@ pub(crate) fn run() -> Result<()> {
             anyhow::bail!("--db is only valid when serving (`recall mcp`)");
         }
         Some(Commands::Mcp { db, command: None }) => crate::mcp::run(db)?,
+        Some(Commands::Mcp { command: Some(McpCommands::Capabilities { format }), .. }) => {
+            crate::mcp::run_capabilities(format)?
+        }
         Some(Commands::Mcp {
             command: Some(McpCommands::Install { agents, dry_run, bin }),
             ..
@@ -641,7 +649,7 @@ mod tests {
         assert!(compact_help.contains("extension Manage Recall extensions"));
         assert!(compact_help.contains("session Operate on indexed sessions"));
         assert!(compact_help.contains("completions Generate shell completion script"));
-        assert!(compact_help.contains("mcp Serve a read-only MCP server over stdio"));
+        assert!(compact_help.contains("mcp Serve and inspect the read-only MCP server"));
     }
 
     #[test]
@@ -728,9 +736,30 @@ mod tests {
     }
 
     #[test]
-    fn mcp_help_lists_install_and_uninstall() {
+    fn mcp_capabilities_parses_formats() {
+        let cli = Cli::try_parse_from(["recall", "mcp", "capabilities"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp { command: Some(McpCommands::Capabilities { format }), .. }) => {
+                assert_eq!(format, crate::mcp::McpCapabilitiesFormat::Text)
+            }
+            _ => panic!("expected mcp capabilities command"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["recall", "mcp", "capabilities", "--format", "json"]).unwrap();
+        match cli.command {
+            Some(Commands::Mcp { command: Some(McpCommands::Capabilities { format }), .. }) => {
+                assert_eq!(format, crate::mcp::McpCapabilitiesFormat::Json)
+            }
+            _ => panic!("expected mcp capabilities command"),
+        }
+    }
+
+    #[test]
+    fn mcp_help_lists_subcommands() {
         let mut command = Cli::command();
         let help = command.find_subcommand_mut("mcp").unwrap().render_long_help().to_string();
+        assert!(help.contains("capabilities"));
         assert!(help.contains("install"));
         assert!(help.contains("uninstall"));
         assert!(help.contains("--db"));

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use chrono::SecondsFormat;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, Implementation, ServerCapabilities, ServerInfo, Tool};
 use rmcp::{
     ServerHandler, ServiceExt, schemars, tool, tool_handler, tool_router, transport::stdio,
 };
@@ -61,9 +61,16 @@ struct SearchSessionsArgs {
 struct GetSessionArgs {
     /// Recall session id from search_sessions or list_recent_sessions.
     session_id: String,
-    /// Maximum messages to return from the start of the session. Defaults to 50.
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
+    #[schemars(
+        description = "Maximum messages to return. Defaults to 50. Reads from the start unless tail is true."
+    )]
     max_messages: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Return the newest messages instead of the oldest, preserving sequence order."
+    )]
+    tail: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -156,6 +163,18 @@ struct SessionDetail {
     messages: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum McpCapabilitiesFormat {
+    Text,
+    Json,
+}
+
+#[derive(Serialize)]
+struct McpCapabilities {
+    server: ServerInfo,
+    tools: Vec<Tool>,
+}
+
 enum IndexState {
     Ready(Store),
     Unavailable { path: Option<PathBuf>, message: String },
@@ -213,6 +232,17 @@ pub(crate) fn run(db: Option<PathBuf>) -> Result<()> {
     let runtime =
         tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build()?;
     runtime.block_on(serve(db))
+}
+
+pub(crate) fn run_capabilities(format: McpCapabilitiesFormat) -> Result<()> {
+    let report = mcp_capabilities();
+    match format {
+        McpCapabilitiesFormat::Text => print!("{}", render_capabilities(&report)),
+        McpCapabilitiesFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+    }
+    Ok(())
 }
 
 async fn serve(db: Option<PathBuf>) -> Result<()> {
@@ -298,12 +328,59 @@ impl RecallMcp {
 #[tool_handler]
 impl ServerHandler for RecallMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
-            .with_instructions(
-                "Read-only memory over the local Recall session index. Search or list past coding sessions, look up which sessions touched a file, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
-            )
+        mcp_server_info()
     }
+}
+
+fn mcp_server_info() -> ServerInfo {
+    ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
+        .with_instructions(
+            "Read-only memory over the local Recall session index. Search or list past coding sessions, look up which sessions touched a file, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
+        )
+}
+
+fn mcp_capabilities() -> McpCapabilities {
+    McpCapabilities { server: mcp_server_info(), tools: RecallMcp::tool_router().list_all() }
+}
+
+fn render_capabilities(report: &McpCapabilities) -> String {
+    let mut output = format!("Recall MCP {}\n", env!("CARGO_PKG_VERSION"));
+    if let Some(instructions) = report.server.instructions.as_deref() {
+        output.push_str(instructions);
+        output.push('\n');
+    }
+    let capabilities = serde_json::to_value(&report.server.capabilities)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .map(|values| values.into_iter().map(|(key, _)| key).collect::<Vec<_>>().join(", "))
+        .unwrap_or_default();
+    if !capabilities.is_empty() {
+        output.push_str("Capabilities: ");
+        output.push_str(&capabilities);
+        output.push('\n');
+    }
+    for tool in &report.tools {
+        output.push('\n');
+        output.push_str(tool.name.as_ref());
+        output.push('\n');
+        if let Some(description) = tool.description.as_deref() {
+            output.push_str(description);
+            output.push('\n');
+        }
+        let inputs = tool
+            .input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .map(|values| values.keys().cloned().collect::<Vec<_>>().join(", "))
+            .unwrap_or_default();
+        if !inputs.is_empty() {
+            output.push_str("Inputs: ");
+            output.push_str(&inputs);
+            output.push('\n');
+        }
+    }
+    output
 }
 
 fn lock_index(index: &Mutex<IndexState>) -> std::sync::MutexGuard<'_, IndexState> {
@@ -482,7 +559,7 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
     };
     let max_messages = clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, u32::MAX);
     let messages = store.get_messages(&session.id).map_err(|error| error.to_string())?;
-    let (text, returned, truncated) = render_messages(&messages, max_messages);
+    let (text, returned, truncated) = render_messages(&messages, max_messages, args.tail);
     Ok(SessionDetail {
         message: None,
         session_id: Some(session.id.clone()),
@@ -565,35 +642,34 @@ fn clamp_limit(limit: Option<u32>, default: u32, max: u32) -> usize {
     usize::try_from(limit.unwrap_or(default).clamp(1, max)).unwrap_or(max as usize)
 }
 
-fn render_messages(messages: &[Message], max_messages: usize) -> (String, usize, bool) {
-    let mut text = String::new();
-    let mut returned = 0;
-    let mut truncated = messages.len() > max_messages;
-    for message in messages.iter().take(max_messages) {
+fn render_messages(messages: &[Message], max_messages: usize, tail: bool) -> (String, usize, bool) {
+    let selected = if tail {
+        messages.iter().rev().take(max_messages).collect::<Vec<_>>()
+    } else {
+        messages.iter().take(max_messages).collect::<Vec<_>>()
+    };
+    let mut blocks = Vec::new();
+    let mut bytes = 0;
+    let mut truncated = messages.len() > selected.len();
+    for message in selected {
         let (body, cut) = truncate_chars(&message.content, GET_MESSAGE_CHAR_CAP);
         if cut {
             truncated = true;
         }
         let block = format!("[{}] {body}", role_label(&message.role));
-        let extra = if text.is_empty() { block.len() } else { block.len() + 2 };
-        if !text.is_empty() && text.len() + extra > GET_RESPONSE_CHAR_CAP {
+        let extra = if blocks.is_empty() { block.len() } else { block.len() + 2 };
+        if bytes + extra > GET_RESPONSE_CHAR_CAP {
             truncated = true;
             break;
         }
-        if !text.is_empty() {
-            text.push_str("\n\n");
-        }
-        if text.len() + block.len() > GET_RESPONSE_CHAR_CAP {
-            let remaining = GET_RESPONSE_CHAR_CAP.saturating_sub(text.len());
-            text.push_str(&truncate_chars(&block, remaining).0);
-            truncated = true;
-            returned += 1;
-            break;
-        }
-        text.push_str(&block);
-        returned += 1;
+        bytes += extra;
+        blocks.push(block);
     }
-    (text, returned, truncated)
+    if tail {
+        blocks.reverse();
+    }
+    let returned = blocks.len();
+    (blocks.join("\n\n"), returned, truncated)
 }
 
 fn role_label(role: &Role) -> &'static str {
@@ -813,9 +889,11 @@ mod tests {
             .unwrap();
         let index = ready(store);
 
-        let detail =
-            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1) })
-                .unwrap();
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1), tail: false },
+        )
+        .unwrap();
         assert_eq!(detail.session_id.as_deref(), Some("s1"));
         assert_eq!(detail.returned_messages, 1);
         assert!(detail.truncated);
@@ -828,11 +906,71 @@ mod tests {
     }
 
     #[test]
+    fn get_session_tail_returns_latest_messages_in_sequence_order() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "unfinished", 1_000);
+        stored.message_count = 4;
+        store.insert_session(&stored).unwrap();
+        store
+            .insert_messages(&[
+                message("s1", Role::User, "first", 0),
+                message("s1", Role::Assistant, "second", 1),
+                message("s1", Role::User, "third", 2),
+                message("s1", Role::Assistant, "fourth", 3),
+            ])
+            .unwrap();
+        let index = ready(store);
+
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(2), tail: true },
+        )
+        .unwrap();
+
+        assert_eq!(detail.returned_messages, 2);
+        assert!(detail.truncated);
+        assert_eq!(detail.messages, "[user] third\n\n[assistant] fourth");
+    }
+
+    #[test]
+    fn get_session_tail_keeps_newest_messages_under_response_cap() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "long tail", 1_000);
+        stored.message_count = 20;
+        store.insert_session(&stored).unwrap();
+        let messages = (0..20)
+            .map(|seq| {
+                message(
+                    "s1",
+                    Role::Assistant,
+                    &format!("message-{seq:02}-{}", "x".repeat(1_990)),
+                    seq,
+                )
+            })
+            .collect::<Vec<_>>();
+        store.insert_messages(&messages).unwrap();
+        let index = ready(store);
+
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(20), tail: true },
+        )
+        .unwrap();
+
+        assert!(detail.truncated);
+        assert!(detail.returned_messages < 20);
+        assert!(!detail.messages.contains("message-00-"));
+        assert!(
+            detail.messages.rsplit("\n\n").next().unwrap().starts_with("[assistant] message-19-")
+        );
+    }
+
+    #[test]
     fn get_session_missing_id_is_a_tool_error() {
         let store = setup();
         store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
         let index = ready(store);
-        let args = GetSessionArgs { session_id: "missing".into(), max_messages: None };
+        let args = GetSessionArgs { session_id: "missing".into(), max_messages: None, tail: false };
         let error = get_session(&index, &args).expect_err("missing session");
         assert!(error.contains(SESSION_NOT_FOUND));
         assert_eq!(
@@ -927,9 +1065,11 @@ mod tests {
         let content = "x".repeat(GET_MESSAGE_CHAR_CAP + 1);
         store.insert_messages(&[message("s1", Role::User, &content, 0)]).unwrap();
         let index = ready(store);
-        let detail =
-            get_session(&index, &GetSessionArgs { session_id: "s1".into(), max_messages: None })
-                .unwrap();
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "s1".into(), max_messages: None, tail: false },
+        )
+        .unwrap();
         assert!(detail.truncated);
         assert!(detail.messages.ends_with('…'));
         assert_eq!(
@@ -961,6 +1101,24 @@ mod tests {
             assert_eq!(notes.idempotent_hint, Some(true));
             assert_eq!(notes.open_world_hint, Some(false));
         }
+    }
+
+    #[test]
+    fn capabilities_report_uses_registered_tool_schemas() {
+        let report = mcp_capabilities();
+        let value = serde_json::to_value(&report).unwrap();
+        let tools = value["tools"].as_array().unwrap();
+        let get_session = tools
+            .iter()
+            .find(|tool| tool["name"] == "get_session")
+            .expect("get_session capability");
+
+        assert!(get_session["inputSchema"]["properties"]["tail"].is_object());
+        assert!(report.server.capabilities.tools.is_some());
+        let text = render_capabilities(&report);
+        assert!(text.contains("get_session"));
+        assert!(text.contains("Inputs: "));
+        assert!(text.contains("tail"));
     }
 
     fn event(


### PR DESCRIPTION
### What changed?

- Add a semantic fallback for Recall invocations without an explicit task, with numbered unfinished-session candidates that continue in the current agent.
- Prefer Recall MCP for recent-session lookup and retain an independent CLI fallback.
- Add tail-aware `get_session` reads and a `recall mcp capabilities` command backed by the live MCP router and schemas.
- Keep the bundled Recall skill English-only so staged changes pass the repository CJK gate.

### Why

- Make a bare Recall invocation useful without overriding explicit user intent or relying on tool-status heuristics.

### Verification

- `make check`
- `cargo test mcp::tests --lib`
- `cargo test cli::tests::mcp --lib`
- Recall skill validator
- Live MCP capability JSON schema check