### PR TITLE
build(release): reduce cache churn and enforce subjects

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+workspace_version() {
+    awk '
+        /^\[workspace\.package\]$/ { in_workspace_package = 1; next }
+        /^\[/ { in_workspace_package = 0 }
+        in_workspace_package && $1 == "version" {
+            gsub(/"/, "", $3)
+            print $3
+            exit
+        }
+    '
+}
+
+head_version=$(git show HEAD:Cargo.toml 2>/dev/null | workspace_version)
+index_version=$(git show :Cargo.toml 2>/dev/null | workspace_version)
+
+if [ -z "$head_version" ] || [ -z "$index_version" ] || [ "$head_version" = "$index_version" ]; then
+    exit 0
+fi
+
+subject=$(sed -n '1p' "$1")
+expected="chore(release): bump to v$index_version"
+
+if [ "$subject" != "$expected" ]; then
+    printf "Release version bump requires commit subject: %s\n" "$expected" >&2
+    exit 1
+fi

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       save-cache:
-        description: Save the per-target rust-cache after building
+        description: Warm and save the per-target rust-cache
         required: false
         default: false
         type: boolean
@@ -48,11 +48,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        id: rust-cache
         with:
           shared-key: release-${{ matrix.target }}
           save-if: ${{ inputs.save-cache }}
 
       - name: Build
+        if: ${{ inputs.upload || !inputs.save-cache || steps.rust-cache.outputs.cache-hit != 'true' }}
         run: cargo build --release --target ${{ matrix.target }} -p recall -p rx
 
       - name: Record built commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,3 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo install cargo-audit --locked --version 0.22.2
       - run: make check
-
-  release-cache:
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/build-binaries.yml
-    with:
-      ref: ${{ github.sha }}
-      save-cache: true

--- a/.github/workflows/release-cache.yml
+++ b/.github/workflows/release-cache.yml
@@ -1,0 +1,20 @@
+name: Release cache
+
+on:
+  schedule:
+    - cron: "37 6 1,7,13,19,25,31 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cache
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      ref: ${{ github.sha }}
+      save-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
             echo "::error::checked out commit does not match release tag $RELEASE_TAG"
             exit 1
           fi
+          if git cat-file -e HEAD:.githooks/commit-msg 2>/dev/null; then
+            subject="$(git log -1 --format=%s)"
+            expected_subject="chore(release): bump to v$version"
+            if [ "$subject" != "$expected_subject" ]; then
+              echo "::error::release commit subject '$subject' does not match '$expected_subject'"
+              exit 1
+            fi
+          fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,10 @@ cargo test integration::regression    # regression suite
 cargo test integration::eval_harness  # eval harness
 ```
 
-`make check` must pass before push. CI runs exactly the same command. Its only
-extra job, on pushes to `main`, is the release-binary build from
-`build-binaries.yml`: it exists to keep the per-target caches warm, because a
-tag-triggered run can only restore caches saved from `main`. The gate uses
+`make check` must pass before push. CI runs exactly the same command.
+`release-cache.yml` warms the per-target release caches on a periodic schedule
+or by manual dispatch. Exact cache hits skip rebuilding the binaries.
+Tag-triggered runs restore caches saved from `main`. The gate uses
 `--workspace` and `--features bench`, so it
 covers extension crates, `crates/rx`, and the `bench_api` shim that `benches/` compiles
 against. Build a single extension with `cargo build -p recall-<name>`. Build the
@@ -53,9 +53,9 @@ Extensions release independently: bumping an extension's package version in a
 PR is the release intent — after merge, a workflow creates the
 `recall-<name>-v<version>` tag, builds binaries, and regenerates the catalog.
 
-One-time setup: `git config core.hooksPath .githooks` enables the DCO signoff
-hook. Install `cargo-audit 0.22.2` for `make check`; `brew install git-cliff`
-is also required to cut a release.
+One-time setup: `git config core.hooksPath .githooks` enables DCO signoff and
+rejects malformed core release commit subjects. Install `cargo-audit 0.22.2`
+for `make check`; `brew install git-cliff` is also required to cut a release.
 
 ## Architecture
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,7 +169,7 @@ make run                    # TUI filter should include MT
 
 ## CI
 
-CI runs `make check` — the same single command you run locally. The only CI-only job is the release-binary build on pushes to `main` (`build-binaries.yml`), which keeps the per-target release caches warm; tag-triggered release runs can only restore caches saved from `main`.
+CI runs `make check` — the same single command you run locally. `release-cache.yml` warms the per-target release caches on a periodic schedule or by manual dispatch. Exact cache hits skip rebuilding the binaries, and tag-triggered release runs restore caches saved from `main`.
 
 ```
 make check = cargo audit → cargo fmt --check → cargo clippy --workspace --all-targets --features bench -- -D warnings → cargo test --workspace
@@ -237,12 +237,13 @@ current application release boundary, not a package metadata bug.
 ```bash
 cargo install cargo-release
 cargo install cargo-audit --locked --version 0.22.2
-git config core.hooksPath .githooks   # enables auto DCO signoff
+git config core.hooksPath .githooks   # enables repository commit hooks
 ```
 
 The `.githooks/prepare-commit-msg` hook appends `Signed-off-by` to every
 commit, so both hand-written and `cargo-release`-driven commits satisfy the
-project's DCO convention.
+project's DCO convention. The `.githooks/commit-msg` hook rejects a core
+version bump unless its subject is `chore(release): bump to v{{version}}`.
 
 ### Cut a release
 
@@ -253,6 +254,8 @@ make release-patch EXECUTE=1    # apply: bump, commit, tag, push
 
 `release-minor` and `release-major` work the same way. The tag name is
 `v{{version}}` and the commit subject is `chore(release): bump to v{{version}}`.
+Tag-triggered release runs enforce the same subject before publishing. Manual
+dispatch remains available to rebuild or reattach assets for historical tags.
 
 ### First release after a stale baseline
 


### PR DESCRIPTION
### What’s changed?

- Move release cache warming off every `main` merge to a six-day schedule and manual dispatch.
- Skip binary builds on exact warm-cache hits while always building release artifacts.
- Enforce core release commit subjects locally and before publication while preserving historical tag recovery.

### Why

- Keep release dependencies warm without running four build jobs for every merged pull request.
- Prevent ambiguous `chore: Release` commits from becoming published releases.

### Verification

- `make check`
- `actionlint .github/workflows/*.yml`
- `shellcheck .githooks/commit-msg .githooks/prepare-commit-msg`
- Release hook and workflow behavior harness