### PR TITLE
fix(wrapped): align metrics with indexed session data

### DIFF
--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,371 +1,143 @@
 ---
 name: recall
-description: Use Recall as a project memory layer for local AI coding session history. Trigger when the user asks to share, refresh, list, or unpublish session pages; resume or open a session; search or export sessions; review project history; recover decisions or failed approaches; inspect evidence from supported coding agents; or continue a numbered unfinished-session candidate previously offered by Recall.
+description: Use Recall to search, inspect, continue, export, resume, or share indexed AI coding sessions. Trigger for project-history lookup, recent work from other agents, file history, unfinished-session continuation, and published session-page management.
 ---
 
 # Recall
 
-## Overview
+Recall is a local-first index of AI coding sessions. Use past sessions as evidence, then verify current code, commands, paths, and invariants before acting.
 
-Recall is a local-first CLI that indexes AI coding sessions from multiple tools. Treat it as a project memory layer: use it to recover history, reduce repeated mistakes, and turn prior sessions into current review evidence.
+Prefer active Recall MCP tools for read-only lookup. Use the installed `recall` CLI when no equivalent MCP tool exists or MCP is unavailable. File-event history is MCP-only. When developing Recall itself, do not use the project build as a substitute for the user's installed history index.
 
-Prefer active Recall MCP tools for read-only session lookup. Fall back to the installed `recall` command when Recall MCP is unavailable or the requested workflow is CLI-only. If you are developing Recall itself, use the project build only for testing Recall behavior, not as a substitute for the user's installed history index.
+If neither MCP nor the installed CLI is available, stop and offer `brew install samzong/tap/recall`. Never claim to have inspected unavailable history. Return only the session content needed for the task because history may contain private code, credentials, prompts, and user intent.
 
-If neither active Recall MCP tools nor the `recall` command are available, stop the Recall workflow, tell the user Recall is unavailable, and offer `brew install samzong/tap/recall` instead of pretending history was inspected.
+## Scope
 
-Recall history is evidence, not truth. Verify technical claims, code behavior, commands, paths, and invariants against the current repository before acting.
+- An exact path covers that directory and its children.
+- `owner/repo` or a remote URL covers all worktrees of that repository.
+- `all` covers every indexed project.
+- The CLI derives an omitted `--project` from its working directory. Recall MCP treats an omitted `project` as global, so pass the current project unless the user explicitly requests all projects.
 
-## Intent Routing
+## Find Sessions
 
-Pick the workflow from user intent. Do not run the full project-review scoping flow for one-shot session actions.
+Use MCP `list_recent_sessions` without a query, `search_sessions` with a query, and `get_session` only when transcript evidence is needed.
 
-| Intent | Example prompts | Workflow |
-| --- | --- | --- |
-| Share a live link | "share this session", "give me a session link" | Publish Or Refresh Share Link |
-| Refresh an existing link | "refresh the share link", "share it again" | Publish Or Refresh Share Link |
-| List published shares | "list shared sessions", "what is currently shared" | List Published Shares |
-| Unpublish a share | "unpublish this share", "take this share down" | Unpublish Share Page |
-| Resume or open | "continue this session", "resume this chat" | Session Resume/Open |
-| Find one session | "find the last session about migration", "latest Grok session for this project" | Latest/Find Session Lookup |
-| Review project history | "review this project with Recall", "historical risks" | Scoping Protocol + Analysis Modes |
-| Reflect on AI coding workflow | "reflect on this project", "review my AI coding workflow", "timeline reflection", "workflow friction", "calibration discussion" | Route to the `reflect` skill |
-| No clear Recall task | Recall is invoked without a requested operation or analysis goal | Recent Continuation Check |
+Use the equivalent CLI workflow when needed:
 
-Treat "share" and "update/refresh share link" as the same action: sync the latest transcript, publish to Pages, return the live URL.
+```bash
+recall session list --project /absolute/project/path --source <source> --limit 20 --sort updated --format json
+recall session list --project owner/repo --query "<keywords>" --time 7d --limit 20 --sort updated --format json
+recall session show --id <session-id> --format json --include metadata,messages
+```
 
-## Recent Continuation Check
+Add `--sync` only when current data matters and index mutation is permitted. Check the selected session's project before using it. Discover current sources and protocol details with `recall info --format json` or `recall mcp capabilities --format json` instead of maintaining a catalog in this skill.
 
-Use this fallback only after Intent Routing determines that Recall was invoked without a clear operation or analysis goal. Decide from the meaning of the request, never by matching an invocation token or fixed phrase. If the user states an intent, follow that intent and do not run this fallback.
+Search results are relevance-ranked and bounded. In a queried CLI listing, `--sort updated` does not change that ranking. Select the newest timestamp only within the returned candidates, and do not claim an exact latest match.
 
-1. Resolve the current project with Project Scope Defaults. Do not broaden to all projects when the current project cannot be resolved.
-2. Prefer active Recall MCP tools:
-   - Call `list_recent_sessions` for the current project with no source filter and a limit of 5.
-   - Call `get_session` for each candidate with `max_messages` set to 12 and `tail` set to `true`.
-3. If Recall MCP tools are unavailable, use the CLI:
-   ```bash
-   recall session list --project /absolute/project/path --limit 5 --sort updated --format json
-   recall session show --id <session-id> --format json --include metadata,messages --from-seq <max(message_count-12,0)>
-   ```
-   Use the indexed session record. If the index is missing or empty, report that and offer `recall sync`; do not inspect raw source transcript files.
-4. Judge unfinished work from the meaning of the session ending, never from tool status, event status, or the final message role alone. Strong evidence includes an unanswered user request, explicitly remaining work or blockers, and interrupted execution. Exclude sessions whose ending reports completion. Exclude the current conversation when identifiable, including a candidate whose tail contains the current fallback request. Omit ambiguous candidates.
-5. Show at most 3 candidates with short reasons and stable numbering:
-   ```text
-   1. [source] title — why it appears unfinished
-   2. [source] title — why it appears unfinished
-   ```
-   Tell the user they can reply with a number to continue. If none qualify, state that no clearly unfinished recent session was found.
-6. A numeric reply selects that candidate. Load the relevant history with Recall MCP or CLI and continue the work in the current agent. Do not launch native resume behavior unless the user explicitly asks for it.
+## Find Recent Work
 
-## Project Scope Defaults
+When the user asks what other agents recently did, call `list_recent_sessions` for the current project with no source filter and a limit of 10. Exclude the current conversation when identifiable and call `get_session` only for relevant candidates.
 
-`--project` is the single scope selector and Recall resolves repo identity
-itself, so no manual repo-identity reconstruction is needed.
+If MCP is unavailable, use:
 
-- A path scopes to that directory and its children only. Use it for "just this
-  worktree" or a subdirectory of a monorepo.
-- `owner/repo` or a remote URL scopes to the repository identity, spanning every
-  worktree of that repo.
-- `all` scopes to every project.
-- Without `--project`, Recall derives the scope from the current directory: a
-  checkout with a resolvable `origin` means that repository, a checkout without
-  one means its top-level directory, anything else means every project.
+```bash
+recall session list --project /absolute/project/path --limit 10 --sort updated --format json
+```
 
-Default scoping rules:
+The result proves only that sessions were recently indexed. Do not describe them as live peers or attribute them to another agent without supporting metadata. The listing may fold spawned subagents beneath a visible parent, so it is not an exhaustive peer inventory. Report when the bounded result cannot isolate relevant work.
 
-- If the user explicitly says global, all projects, or no project filter, pass
-  `--project all` rather than omitting the flag.
-- If the user gives an exact path, pass that path.
-- If the request is about the current checkout only, pass
-  `git rev-parse --show-toplevel`.
-- If the request is about the current project and may include other worktrees,
-  omit `--project` when the command runs inside that checkout, or pass the
-  `owner/repo` slug explicitly.
-- Every structured response carries `filters.effective_scope`; report which
-  scope was used so path/worktree ambiguity stays visible.
+## Find File History
 
-## Latest/Find Session Lookup
+Use MCP `file_history` for requests about sessions that touched a path. Pass `path` and the current `project`; add `source` only when requested. Omit `kind` to include the default `file_write` and `file_read` events, and default `limit` to 20.
 
-Use this workflow for one-shot requests such as "latest Grok session for this project" or "find the last session about X". Do not run the broad project-review scoping flow.
+Run `recall sync --project <same-scope>` first only when recent writes may be absent and index mutation is permitted. If MCP is unavailable, explain that file history requires MCP and offer `recall mcp install`. Transcript search and raw transcript inspection are not substitutes for file-event targets.
 
-1. Determine source, recency, and project scope from the user wording.
-2. If a single exact directory scope is intended, use:
-   ```bash
-   recall session list --project /absolute/project/path --source <source> --limit 20 --sort updated --sync --format json
-   ```
-3. If repo identity scope is intended, especially in gmc or alternate worktrees, pass the identity directly:
-   ```bash
-   recall session list --project owner/repo --source <source> --limit 20 --sort updated --sync --format json
-   ```
-   Running inside the checkout without `--project` resolves to the same scope. Check the selected session's `project` before acting on it.
-4. For a named or older session, add `--query "<keywords>"` and/or `--time 7d`, but keep the same project-scope rules.
-5. Show the selected session with:
-   ```bash
-   recall session show --id <recall-session-id> --format json --include metadata,messages,usage,events
-   ```
+Return the matching event rows with session, source, title, kind, target, and time. The limit applies to recent events, not distinct sessions, so do not claim exhaustive session coverage. Load transcript evidence only when needed.
 
-## Publish Or Refresh Share Link
+## Continue Work
 
-When the user wants to share a session or update an existing share link, execute immediately. Do not ask scoping questions. Do not use `--dry-run` unless they explicitly ask to preview or validate only.
+When Recall is invoked without a clear task, list the five most recent sessions in the current project and inspect their latest 12 messages. Do not broaden to all projects.
 
-### What the user expects
+With MCP, call `list_recent_sessions`, then `get_session` with `max_messages: 12` and `tail: true`. Without MCP, use:
 
-- "share this session" -> a **live, openable URL** for the current conversation.
-- "refresh the Recall share link" -> **re-publish** the current conversation so the page reflects the latest messages. The URL usually stays the same; the deployed HTML changes.
+```bash
+recall session list --project /absolute/project/path --limit 5 --sort updated --format json
+recall session show --id <session-id> --format json --include metadata,messages --from-seq <calculated-sequence>
+```
 
-### Steps
+Set `<calculated-sequence>` to `max(message_count - 12, 0)` from the list result. Offer at most three numbered candidates. Include only sessions whose ending contains an unanswered request, explicit remaining work, a blocker, or interrupted execution. Exclude completed and ambiguous sessions. Exclude the current session when identifiable; otherwise state that self-exclusion could not be verified. Treat the bounded list as candidates, not a complete inventory of unfinished work. A numeric reply selects the same candidate and continues it in the current agent.
 
-1. Infer the active source from the runtime when possible:
-   - Grok -> `grok`
-   - Cursor -> `cursor`
-   - Codex -> `codex`
-   - Claude Code -> `claude-code`
-   - OpenCode -> `opencode`
-   - Kimi Code -> `kimi-code`
-   - Qwen Code -> `qwen-code`
-   - Kilo Code -> `kilo-code`
-   - Crush -> `crush`
-   - MiMo Code -> `mimo-code`
-   - ZCode -> `zcode`
-   - Goose -> `goose`
-   - OMP -> `omp`
-   If the source is unclear, omit `--source` and rely on project + recency.
+Do not launch native resume or app-open behavior unless the user explicitly requests it.
 
-2. Sync and resolve the session id. Always include `--sync` so share/update uses the latest messages.
-   - Current conversation (default):
-     ```bash
-     recall session list --project /absolute/project/path --source <source> --limit 1 --sort updated --sync --format json
-     ```
-   - Named or older session: add `--query "<keywords>"` and/or `--time 7d`, still prefer `--sort updated`.
-   - Explicit id from the user: skip list and use that id directly.
+## Resume Or Open
 
-3. Publish for real. This is mandatory for share/update requests:
-   ```bash
-   recall session share --id <recall-session-id> --format json
-   ```
-   Never stop at `--dry-run` for these requests. Dry-run only computes a future URL locally and leaves the live page at 404 or stale.
-   Progress text goes to stderr; read the URL from stdout JSON at `share.url`.
-   Add `--copy-url` when they ask to copy it; add `--open` when they ask to open it.
+"Continue here" loads history into the current agent. Native resume and app-open start another process, so run them only when explicitly requested. Resolve the exact session first; add `--print-command` for read-only inspection.
 
-   Before publishing, write a short TL;DR markdown file from the current agent
-   context and pass it with `--tldr-file`. Weight the user's request highest,
-   weight the final outcome next, and use trace/process details only as
-   low-weight context:
-   ```bash
-   # Agent writes /tmp/recall-tldr.md from the current conversation context.
-   recall session share --id <recall-session-id> --tldr-file /tmp/recall-tldr.md --format json
-   ```
-   If the TL;DR file is missing, unreadable, or blank, Recall skips the TL;DR
-   block and still publishes the session.
+```bash
+recall session resume --id <session-id> --print-command
+recall session open --id <session-id> --print-command
+```
 
-4. Reply in this shape:
-   ```text
-   <url>
+## Share Sessions
 
-   <one-line context: title, source, and whether this was a fresh share or refreshed publish>
-   ```
-   Do not dump raw JSON unless debugging.
+An explicit share or refresh request authorizes a real deployment. Use `--dry-run` only for an explicit preview. Before publishing, stop if the selected session contains concrete credentials or private material the user did not authorize sharing.
 
-### Failure handling
+Use an explicit session id when provided. Otherwise sync and list recent sessions for the active project, filtering by source only when known. Select the current conversation only when its identity is unambiguous; inspect the smallest necessary tail or ask the user if several candidates remain.
 
-- If sharing fails because Pages is not configured, tell the user to run `recall share init` once, then retry publish.
-- If publish succeeds but the URL still 404s, rerun step 3 without `--dry-run` and report that redeploy finished.
+```bash
+recall session list --project /absolute/project/path --source <source> --limit 5 --sort updated --sync --format json
+```
 
-Sharing publishes session content to the configured share target. Warn briefly if the session may contain secrets.
+Create a unique temporary file with `mktemp /tmp/recall-tldr.XXXXXX`, write a short Markdown TL;DR from the current conversation context, and do not reload the transcript just to summarize it. Then publish with that path:
 
-## List Published Shares
+```bash
+recall session share --id <session-id> --tldr-file <temporary-tldr-path> --format json
+```
 
-When the user asks which sessions are currently shared or wants the live URLs, run:
+Remove the temporary file after publishing. Missing, unreadable, or blank TL;DR input does not block publishing. Read `share.url` from the JSON and verify it with `curl -I -L`. If the first check returns 404, publish once more and recheck, then stop. If sharing is not configured, tell the user to run `recall share init`. Return the live URL rather than raw JSON.
+
+List and unpublish shared pages with:
 
 ```bash
 recall share list --format json
+recall share unpublish <share-id-or-url> --yes --format json
 ```
 
-Read `shares[].url`, `shares[].title`, and `shares[].share_id`. This lists the local publish inventory that the next Pages deploy publishes. If sharing is not initialized, tell the user to run `recall share init`.
+The list is the local publish inventory, not a live crawl. Unpublish only an exact target selected by the user; list first and ask when no target was supplied.
 
-Reply with the URLs and titles. Do not dump raw JSON unless debugging.
+## Review Project History
 
-## Unpublish Share Page
+If a broad review lacks a topic or depth, ask one scoping question. Otherwise search before exporting, start with recent history, and expand only when the request or evidence requires it:
 
-When the user asks to take a share down, do not unpublish until they confirm the exact URL.
-
-1. If they did not give a URL or share id, run `recall share list --format json` and ask which page to remove.
-2. After they confirm, run:
-   ```bash
-   recall share unpublish <share-id-or-url> --yes --format json
-   ```
-   `--yes` is required when stdin is not a terminal. Never unpublish because a share list was requested.
-
-## Scoping Protocol
-
-When the request is broad, such as "use Recall to review this project", do not jump straight to full export. Ask one concise scoping question that makes Recall's value clear:
-
-```text
-Default Recall review: historical risk audit, decision archaeology, failed approaches, unfinished work, and current-code assumptions to verify. Should I start with that quick scan, go deep across all project history, or focus on a topic like architecture, tests, performance, a feature, or PR readiness?
+```bash
+recall info --format json
+recall search "<query>" --project /absolute/project/path --format json
+recall export --project /absolute/project/path --limit 0
 ```
 
-Do not ask when the user already provides enough scope. Proceed directly when the request includes the project path plus a clear topic, time range, or depth.
+Treat search snippets as leads. Parse exports as JSONL instead of text, and verify historical conclusions against current code. Token usage is not monetary cost without an explicit price source.
 
-Prefer these defaults for broad reviews:
-
-- Analysis mode: historical risk audit + decision archaeology + failed approaches.
-- Time range: recent history first, then all history when the user asks for deep analysis or the quick scan finds dense evidence.
-- Source scope: all sources unless the user names a source.
-- Output: concise findings with historical evidence and current verification steps.
-
-## Analysis Modes
-
-Choose one or more modes based on the user's request:
-
-- Historical risk audit: find repeated problems, long-lived bugs, regressions, unresolved risks, and repeated rework.
-- Decision archaeology: recover why designs changed, what trade-offs were made, and which alternatives were rejected.
-- Failed approaches: identify attempted fixes or designs that failed, were reverted, or were rejected by the user.
-- Current task context: search around a specific feature, file, bug, PR, module, command, or product area before changing code.
-- User preference extraction: capture repeated user constraints, style preferences, review standards, forbidden abstractions, and acceptance criteria.
-- PR/readiness scan: check whether a proposed change conflicts with historical constraints or known failure modes.
-- Project timeline: summarize how the project evolved across sessions.
-- Usage/cost analysis: use only when the user explicitly asks about tokens, model usage, or cost patterns.
-
-## Depth Levels
-
-Use a depth that matches the request and data size:
-
-- Quick scan: `recall info`, optional `recall sync`, then targeted `recall search` queries. Use this to find leads quickly.
-- Standard review: run several targeted searches, then export a bounded sample such as `--limit 100` or `--limit 300`.
-- Deep review: export all matching project sessions with `--limit 0`, parse JSONL structurally, and synthesize themes across sessions.
-
-If the user asks for "deep", "full", "comprehensive", or "analyze history", use deep review unless the export is impractically large. If the export is large, start with a bounded export and report the next deepening step.
-
-## Workflow
-
-1. Identify the project scope and analysis mode.
-   - Apply Project Scope Defaults before choosing `--project`.
-   - A path matches that directory and child paths only; an `owner/repo` identity spans every worktree.
-   - Ask at most one scoping question for broad requests.
-   - State the default analysis mode when proceeding without a question.
-
-2. Refresh or inspect the index.
-   - Run `recall info` to inspect indexed sources and status.
-   - Run `recall sync` before relying on recent history, unless the user requested read-only inspection.
-   - Use `recall sync --source <source>` only when a single source is relevant.
-   - Do not run `recall sync --force` unless the user asks to rebuild or there is evidence the index is stale in a way incremental sync cannot fix.
-
-3. Search before exporting when the question has a target.
-   - Use `recall search "<query>" --project /absolute/project/path`.
-   - Add `--source <source>` or `--time <range>` to narrow noisy results.
-   - Treat search snippets as leads, not complete evidence.
-   - Search for both the user's topic and generic project-memory signals such as "failed", "reverted", "decision", "root cause", "regression", "do not", "not again", "unfinished", and "follow-up".
-
-4. Export for deep analysis.
-   - Use `recall export --project /absolute/project/path --limit 0` for full project history.
-   - Use `recall session export --id <session-id> --format jsonl` for selected sessions.
-   - Use `recall session show --id <session-id> --format json --include metadata,messages,usage,events` when one session needs structured inspection.
-   - Start with a smaller `--limit` when exploring very large histories.
-   - Write temporary analysis artifacts outside the repo unless the user asked for a tracked artifact.
-   - Parse JSONL with structured JSON tooling, line by line. Do not parse JSON with grep or ad hoc string splitting.
-
-5. Cross-check conclusions.
-   - Use Recall to find prior decisions, failed attempts, constraints, and user preferences.
-   - Verify any code behavior, path, command, or invariant against the current repository before changing files.
-
-## Output Protocol
-
-Do not merely report that Recall found sessions. Convert history into useful project memory:
-
-- Historical facts: what prior sessions actually show.
-- Evidence: cite source, title or session id, and approximate time when available.
-- Repeated patterns: problems or requests that recur across sessions.
-- Failed or rejected paths: approaches the agent should not repeat without new evidence.
-- Current verification list: assumptions from history that must be checked against current code.
-- Actionable next steps: the smallest current-code checks or changes suggested by the history.
-
-For broad project reviews, prefer this shape:
+Return project memory, not a list of matching sessions. Cite source, title or session id, and approximate time for each fact. Summarize transcripts and quote only short excerpts that serve as evidence. For a broad review, use this shape:
 
 ```text
 Recall review of <project>:
 
 1. Historical facts that matter now
 2. Repeated risks or unresolved problems
-3. Failed/rejected approaches to avoid
-4. User/project preferences extracted from history
+3. Failed or rejected approaches to avoid
+4. User or project constraints extracted from history
 5. Current code assumptions to verify
-6. Recommended next verification steps
+6. Recommended next checks
 ```
 
-Keep transcript content summarized. Quote only short excerpts when they are necessary evidence.
+Route requests about workflow friction, handoffs, repeated corrections, or calibration to the installed `reflect` skill.
 
-## Reflect Routing
+## Avoid In Tool Calls
 
-When the user wants project-level reflection on their AI coding process, workflow friction, handoffs, repeated corrections, or possible future calibration, route to the installed `reflect` skill. Keep this `recall` skill focused on project memory lookup, sharing, export, and review workflows.
-
-## Commands For Tool Calls
-
-Use these Recall commands in agent tool calls:
-
-```bash
-recall info
-recall mcp capabilities --format json
-recall sync
-recall sync --source codex
-recall search "migration bug" --project /absolute/project/path
-recall search "migration bug" --project /absolute/project/path --source codex --time 30d
-recall export --project /absolute/project/path --limit 0
-recall export --project /absolute/project/path --source codex --time 30d --limit 100
-recall session list --project /absolute/project/path --limit 20 --format json
-recall session show --id <session-id> --format json --include metadata,messages,usage,events
-recall session export --id <session-id> --format jsonl
-recall session share --id <session-id> --format json
-recall session share --id <session-id> --tldr-file /tmp/recall-tldr.md --format json
-recall session share --id <session-id> --dry-run --format json  # preview only; never use for share/update requests
-recall share list --format json
-recall share unpublish <share-id-or-url> --yes --format json
-recall session resume --id <session-id> --print-command
-recall import recall-export.jsonl --dry-run
-recall import recall-export.jsonl
-recall usage --json
-```
-
-Supported time filters are `today`, `7d` or `week`, and `30d` or `month`. Unknown time values fall back to all history.
-
-Supported source ids include `claude-code`, `opencode`, `codex`, `pi`, `omp`, `antigravity-cli`, `gemini-cli`, `grok`, `kiro-cli`, `copilot-cli`, `copilot-chat`, `cursor`, `cline`, `roo`, `kimi-code`, `deepseek-harness`, `qwen-code`, `kilo-code`, `crush`, `mimo-code`, `zcode`, and `goose`. Source labels such as `CC`, `OC`, `CDX`, and `CUR` are also accepted by the CLI, but source ids are clearer in scripts.
-
-## Export Schema
-
-`recall export` and `recall session export --format jsonl` emit one JSON object per indexed session. `recall session show --format json` uses the same top-level record schema for one selected session. Each record includes:
-
-- `schema_version`
-- `record_type`
-- `session`
-- `messages`
-- `usage_events`
-- `events`
-
-Since schema_version 3 the export is lossless against the Recall index: it also carries `session.source_file_path`, usage-event `parser_version` / `source_path` / `raw_usage_json`, and event `attrs_json` / `parser_version`. Expect optional fields to be `null`. `recall import` accepts schema_version 2 and 3 files and skips sessions that already exist locally by `(source, source_id)`.
-
-Important fields:
-
-- `session.source`: the adapter id, such as `codex` or `claude-code`.
-- `session.source_id`: the original tool's session id.
-- `session.title`: the indexed session title.
-- `session.directory`: the project directory captured for the session.
-- `session.started_at` and `session.updated_at`: millisecond timestamps.
-- `messages[].role`: `user` or `assistant`.
-- `messages[].content`: the indexed message text.
-- `usage_events[]`: token usage when available.
-- `events[]`: tool/session events when available, including `attrs_json` raw attributes.
-
-## Avoid In Agent Tool Calls
-
-Do not use these as the primary workflow for analysis:
-
-- `recall` with no subcommand: launches the TUI.
-- `recall usage` without `--json`: launches a dashboard flow.
-- `recall session share --dry-run` when the user asked to share, update, or refresh a link.
-- Returning a URL without running `recall session share` (no `--dry-run`).
-- `recall share unpublish` unless the user asked to take that public page down.
-- Resume or app-launch behavior from the TUI: it opens another interactive session and has side effects.
-- Hidden commands such as `__bench-*` or `__background-worker`: internal or development-only.
-- Raw source transcript paths: use the public export unless the user explicitly asks for source-level forensics.
-
-## Privacy And Output
-
-Session history can contain private code, prompts, credentials, and user intent. Summarize only what is needed for the task. Do not paste full transcripts unless the user explicitly asks for them.
+- `recall` with no subcommand launches the TUI.
+- `recall usage` without `--json` launches an interactive dashboard.
+- `recall session share --dry-run` when the user asked to share or refresh a link, and returning a URL without a real publish.
+- `recall share unpublish` without an exact target selected by the user.
+- `recall sync --force` unless the user asks for a rebuild or incremental sync provably cannot repair the index.
+- Hidden `__bench-*` and `__background-worker` commands.
+- Raw source transcript paths unless the user explicitly asks for source-level forensics.

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -19,7 +19,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 
 pub(crate) struct CodexAdapter;
 
-const USAGE_PARSER_VERSION: u32 = 4;
+const USAGE_PARSER_VERSION: u32 = 5;
 const EVENT_PARSER_VERSION: u32 = 3;
 const METADATA_PARSER_VERSION: u32 = 1;
 
@@ -863,8 +863,8 @@ fn extract_codex_usage_event(
 
     let cache_read_tokens = tokens.cached.min(tokens.input).max(0);
     let input_tokens = tokens.input.saturating_sub(cache_read_tokens).max(0);
-    let output_tokens = tokens.output.max(0);
     let reasoning_tokens = tokens.reasoning.max(0);
+    let output_tokens = tokens.output.saturating_sub(reasoning_tokens).max(0);
     if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
         return None;
     }
@@ -1500,7 +1500,7 @@ mod tests {
         assert_eq!(raw.usage_events[0].provider, "openai");
         assert_eq!(raw.usage_events[0].input_tokens, 8);
         assert_eq!(raw.usage_events[0].cache_read_tokens, 2);
-        assert_eq!(raw.usage_events[0].output_tokens, 3);
+        assert_eq!(raw.usage_events[0].output_tokens, 2);
         assert_eq!(raw.usage_events[0].reasoning_tokens, 1);
         assert_eq!(raw.usage_events[0].token_source, crate::types::TokenSource::Derived);
 
@@ -1556,7 +1556,7 @@ mod tests {
         assert_eq!(raw.usage_events[0].provider, "openai");
         assert_eq!(raw.usage_events[0].input_tokens, 500);
         assert_eq!(raw.usage_events[0].cache_read_tokens, 1000);
-        assert_eq!(raw.usage_events[0].output_tokens, 200);
+        assert_eq!(raw.usage_events[0].output_tokens, 150);
         assert_eq!(raw.usage_events[0].reasoning_tokens, 50);
 
         assert_eq!(raw.thread_role, Some(ThreadRole::Subagent));

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -12,7 +12,7 @@ use crate::types::{RawUsageEvent, Role};
 
 pub(crate) struct GeminiAdapter;
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 impl SourceAdapter for GeminiAdapter {
     fn id(&self) -> &str {
@@ -181,10 +181,10 @@ fn extract_gemini_usage_event(
     source_path: Option<&str>,
 ) -> Option<RawUsageEvent> {
     let tokens = msg.get("tokens")?;
-    let input_tokens = usage_count(tokens, &["input"]);
     let output_tokens = usage_count(tokens, &["output"]);
     let cache_read_tokens = usage_count(tokens, &["cached"]);
     let reasoning_tokens = usage_count(tokens, &["thoughts"]);
+    let input_tokens = usage_count(tokens, &["input"]).saturating_sub(cache_read_tokens);
     if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
         return None;
     }
@@ -279,7 +279,7 @@ mod tests {
         let event = &session.usage_events[0];
         assert_eq!(event.model, "gemini-2.5-pro");
         assert_eq!(event.provider, "google");
-        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.input_tokens, 70);
         assert_eq!(event.output_tokens, 20);
         assert_eq!(event.cache_read_tokens, 30);
         assert_eq!(event.reasoning_tokens, 5);

--- a/src/adapters/omp.rs
+++ b/src/adapters/omp.rs
@@ -9,7 +9,7 @@ use walkdir::WalkDir;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
-use crate::adapters::usage::usage_count;
+use crate::adapters::usage::{disjoint_output_and_reasoning, usage_count};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
@@ -21,7 +21,7 @@ pub(crate) struct OmpAdapter;
 
 const METADATA_PARSER_VERSION: u32 = 1;
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 impl SourceAdapter for OmpAdapter {
     fn id(&self) -> &str {
@@ -506,37 +506,47 @@ fn extract_omp_usage_event(
         .map(|id| format!("message:{id}"))
         .unwrap_or_else(|| format!("line:{event_seq}"));
 
+    let input_tokens = usage_count(usage, &["input", "inputTokens", "input_tokens"]);
+    let raw_output_tokens = usage_count(usage, &["output", "outputTokens", "output_tokens"]);
+    let cache_read_tokens = usage_count(
+        usage,
+        &[
+            "cacheRead",
+            "cache_read",
+            "cacheReadTokens",
+            "cache_read_tokens",
+            "cachedInputTokens",
+            "cached_input_tokens",
+        ],
+    );
+    let cache_write_tokens = usage_count(
+        usage,
+        &["cacheWrite", "cache_write", "cacheWriteTokens", "cache_write_tokens"],
+    );
+    let raw_reasoning_tokens = usage_count(
+        usage,
+        &[
+            "reasoning",
+            "reasoningTokens",
+            "reasoning_tokens",
+            "reasoningOutputTokens",
+            "reasoning_output_tokens",
+        ],
+    );
+    let other_tokens =
+        input_tokens.saturating_add(cache_read_tokens).saturating_add(cache_write_tokens);
+    let (output_tokens, reasoning_tokens) =
+        disjoint_output_and_reasoning(usage, raw_output_tokens, raw_reasoning_tokens, other_tokens);
+
     Some(RawUsageEvent {
         message_seq,
         model,
         provider,
-        input_tokens: usage_count(usage, &["input", "inputTokens", "input_tokens"]),
-        output_tokens: usage_count(usage, &["output", "outputTokens", "output_tokens"]),
-        cache_read_tokens: usage_count(
-            usage,
-            &[
-                "cacheRead",
-                "cache_read",
-                "cacheReadTokens",
-                "cache_read_tokens",
-                "cachedInputTokens",
-                "cached_input_tokens",
-            ],
-        ),
-        cache_write_tokens: usage_count(
-            usage,
-            &["cacheWrite", "cache_write", "cacheWriteTokens", "cache_write_tokens"],
-        ),
-        reasoning_tokens: usage_count(
-            usage,
-            &[
-                "reasoning",
-                "reasoningTokens",
-                "reasoning_tokens",
-                "reasoningOutputTokens",
-                "reasoning_output_tokens",
-            ],
-        ),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        reasoning_tokens,
         source_path: Some(source_path.to_string()),
         raw_usage_json: Some(usage.to_string()),
         ..RawUsageEvent::observed(event_key, event_seq, timestamp, USAGE_PARSER_VERSION)
@@ -895,6 +905,37 @@ mod tests {
         assert_eq!(event.source_path.as_deref(), Some(path.to_string_lossy().as_ref()));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn usage_normalizes_reasoning_included_in_output() {
+        let entry = serde_json::json!({"id": "assistant1"});
+        let message = serde_json::json!({
+            "provider": "openrouter",
+            "model": "deepseek",
+            "usage": {
+                "input": 10,
+                "output": 7,
+                "cacheRead": 2,
+                "cacheWrite": 1,
+                "reasoningTokens": 4,
+                "totalTokens": 20
+            }
+        });
+
+        let event = extract_omp_usage_event(
+            &entry,
+            &message,
+            1,
+            3_000,
+            Some(1),
+            (None, None),
+            "/tmp/session.jsonl",
+        )
+        .unwrap();
+
+        assert_eq!(event.output_tokens, 3);
+        assert_eq!(event.reasoning_tokens, 4);
     }
 
     #[test]

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -9,7 +9,7 @@ use walkdir::WalkDir;
 
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
-use crate::adapters::usage::usage_count;
+use crate::adapters::usage::{disjoint_output_and_reasoning, usage_count};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
@@ -21,7 +21,7 @@ pub(crate) struct PiAdapter;
 
 const METADATA_PARSER_VERSION: u32 = 1;
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 impl SourceAdapter for PiAdapter {
     fn id(&self) -> &str {
@@ -529,37 +529,47 @@ fn extract_pi_usage_event(
         .map(|id| format!("message:{id}"))
         .unwrap_or_else(|| format!("line:{event_seq}"));
 
+    let input_tokens = usage_count(usage, &["input", "inputTokens", "input_tokens"]);
+    let raw_output_tokens = usage_count(usage, &["output", "outputTokens", "output_tokens"]);
+    let cache_read_tokens = usage_count(
+        usage,
+        &[
+            "cacheRead",
+            "cache_read",
+            "cacheReadTokens",
+            "cache_read_tokens",
+            "cachedInputTokens",
+            "cached_input_tokens",
+        ],
+    );
+    let cache_write_tokens = usage_count(
+        usage,
+        &["cacheWrite", "cache_write", "cacheWriteTokens", "cache_write_tokens"],
+    );
+    let raw_reasoning_tokens = usage_count(
+        usage,
+        &[
+            "reasoning",
+            "reasoningTokens",
+            "reasoning_tokens",
+            "reasoningOutputTokens",
+            "reasoning_output_tokens",
+        ],
+    );
+    let other_tokens =
+        input_tokens.saturating_add(cache_read_tokens).saturating_add(cache_write_tokens);
+    let (output_tokens, reasoning_tokens) =
+        disjoint_output_and_reasoning(usage, raw_output_tokens, raw_reasoning_tokens, other_tokens);
+
     Some(RawUsageEvent {
         message_seq,
         model,
         provider,
-        input_tokens: usage_count(usage, &["input", "inputTokens", "input_tokens"]),
-        output_tokens: usage_count(usage, &["output", "outputTokens", "output_tokens"]),
-        cache_read_tokens: usage_count(
-            usage,
-            &[
-                "cacheRead",
-                "cache_read",
-                "cacheReadTokens",
-                "cache_read_tokens",
-                "cachedInputTokens",
-                "cached_input_tokens",
-            ],
-        ),
-        cache_write_tokens: usage_count(
-            usage,
-            &["cacheWrite", "cache_write", "cacheWriteTokens", "cache_write_tokens"],
-        ),
-        reasoning_tokens: usage_count(
-            usage,
-            &[
-                "reasoning",
-                "reasoningTokens",
-                "reasoning_tokens",
-                "reasoningOutputTokens",
-                "reasoning_output_tokens",
-            ],
-        ),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        reasoning_tokens,
         source_path: Some(source_path.to_string()),
         raw_usage_json: Some(usage.to_string()),
         ..RawUsageEvent::observed(event_key, event_seq, timestamp, USAGE_PARSER_VERSION)
@@ -864,6 +874,67 @@ mod tests {
         assert_eq!(event.source_path.as_deref(), Some(path.to_string_lossy().as_ref()));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn usage_normalizes_reasoning_included_in_output() {
+        let entry = serde_json::json!({"id": "assistant1"});
+        let message = serde_json::json!({
+            "provider": "openrouter",
+            "model": "deepseek",
+            "usage": {
+                "input": 10,
+                "output": 7,
+                "cacheRead": 2,
+                "cacheWrite": 1,
+                "reasoningTokens": 4,
+                "totalTokens": 20
+            }
+        });
+
+        let event = extract_pi_usage_event(
+            &entry,
+            &message,
+            1,
+            3_000,
+            Some(1),
+            (None, None),
+            "/tmp/session.jsonl",
+        )
+        .unwrap();
+
+        assert_eq!(event.output_tokens, 3);
+        assert_eq!(event.reasoning_tokens, 4);
+    }
+
+    #[test]
+    fn usage_caps_reasoning_that_exceeds_inclusive_output() {
+        let entry = serde_json::json!({"id": "assistant1"});
+        let message = serde_json::json!({
+            "provider": "xai",
+            "model": "grok",
+            "usage": {
+                "input": 10,
+                "output": 3,
+                "cacheRead": 2,
+                "reasoningTokens": 4,
+                "totalTokens": 15
+            }
+        });
+
+        let event = extract_pi_usage_event(
+            &entry,
+            &message,
+            1,
+            3_000,
+            Some(1),
+            (None, None),
+            "/tmp/session.jsonl",
+        )
+        .unwrap();
+
+        assert_eq!(event.output_tokens, 0);
+        assert_eq!(event.reasoning_tokens, 3);
     }
 
     #[test]

--- a/src/adapters/qwen.rs
+++ b/src/adapters/qwen.rs
@@ -16,7 +16,7 @@ use crate::adapters::{
 use crate::db::store::Store;
 use crate::types::{RawUsageEvent, Role};
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 pub(crate) struct QwenAdapter;
 
@@ -305,10 +305,11 @@ fn extract_usage_event(
     source_path: Option<&str>,
 ) -> Option<RawUsageEvent> {
     let usage = record.get("usageMetadata").or_else(|| record.get("tokens"))?;
-    let input_tokens = usage_count(usage, &["promptTokenCount", "input"]);
     let output_tokens = usage_count(usage, &["candidatesTokenCount", "output"]);
     let cache_read_tokens = usage_count(usage, &["cachedContentTokenCount", "cached"]);
     let reasoning_tokens = usage_count(usage, &["thoughtsTokenCount", "thoughts"]);
+    let input_tokens =
+        usage_count(usage, &["promptTokenCount", "input"]).saturating_sub(cache_read_tokens);
     if input_tokens == 0 && output_tokens == 0 && cache_read_tokens == 0 && reasoning_tokens == 0 {
         return None;
     }
@@ -381,7 +382,7 @@ mod tests {
         let event = &session.usage_events[0];
         assert_eq!(event.model, "qwen3-coder-plus");
         assert_eq!(event.provider, "qwen");
-        assert_eq!(event.input_tokens, 100);
+        assert_eq!(event.input_tokens, 70);
         assert_eq!(event.output_tokens, 20);
         assert_eq!(event.cache_read_tokens, 30);
         assert_eq!(event.reasoning_tokens, 5);

--- a/src/adapters/usage.rs
+++ b/src/adapters/usage.rs
@@ -52,3 +52,21 @@ impl RawUsageEvent {
 pub(crate) fn usage_count(usage: &Value, keys: &[&str]) -> i64 {
     keys.iter().find_map(|key| json_i64(usage.get(*key))).unwrap_or(0).max(0)
 }
+
+pub(crate) fn disjoint_output_and_reasoning(
+    usage: &Value,
+    output_tokens: i64,
+    reasoning_tokens: i64,
+    other_tokens: i64,
+) -> (i64, i64) {
+    let reported_total = ["totalTokens", "total_tokens"]
+        .iter()
+        .find_map(|key| json_i64(usage.get(*key)))
+        .filter(|total| *total >= 0);
+    if reasoning_tokens > 0 && reported_total == Some(other_tokens.saturating_add(output_tokens)) {
+        let disjoint_reasoning = reasoning_tokens.min(output_tokens);
+        (output_tokens - disjoint_reasoning, disjoint_reasoning)
+    } else {
+        (output_tokens, reasoning_tokens)
+    }
+}

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -73,6 +73,21 @@ impl Store {
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
+    pub(crate) fn indexed_active_sessions_after(
+        &self,
+        after_millis: Option<i64>,
+    ) -> Result<Vec<(String, String)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source, id
+             FROM sessions
+             WHERE (?1 IS NULL OR COALESCE(updated_at, started_at) >= ?1)",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![after_millis], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
     pub(crate) fn imported_source_ids(&self, source: &str) -> Result<HashSet<String>> {
         let mut stmt = self
             .conn

--- a/src/db/usage_store.rs
+++ b/src/db/usage_store.rs
@@ -8,6 +8,19 @@ use super::store::{Store, UsageSessionStateMeta};
 use crate::db::search::TimeRange;
 use crate::types::{RawUsageEvent, SessionUsageEventRecord, UsageEventRecord};
 
+const CODEX_DISJOINT_REASONING_VERSION: u32 = 5;
+const CACHE_EXCLUSIVE_INPUT_VERSION: u32 = 2;
+const FLEXIBLE_REASONING_VERSION: u32 = 2;
+
+struct PersistedUsage {
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+    reasoning_tokens: i64,
+    parser_version: u32,
+}
+
 impl Store {
     pub(crate) fn usage_state_meta_map(
         &self,
@@ -142,7 +155,7 @@ impl Store {
         let mut sql = String::from(
             "SELECT session_id, source, source_id, event_key, timestamp, model, provider,
                     input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-                    reasoning_tokens, token_source
+                    reasoning_tokens, token_source, parser_version, raw_usage_json
              FROM usage_events
              WHERE 1 = 1",
         );
@@ -177,19 +190,33 @@ impl Store {
             params.iter().map(|p| p.as_ref()).collect();
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            let source = row.get::<_, String>(1)?;
+            let raw_usage_json = row.get::<_, Option<String>>(14)?;
+            let usage = normalize_persisted_usage(
+                &source,
+                PersistedUsage {
+                    input_tokens: row.get(7)?,
+                    output_tokens: row.get(8)?,
+                    cache_read_tokens: row.get(9)?,
+                    cache_write_tokens: row.get(10)?,
+                    reasoning_tokens: row.get(11)?,
+                    parser_version: row.get(13)?,
+                },
+                raw_usage_json.as_deref(),
+            );
             Ok(UsageEventRecord {
                 session_id: row.get(0)?,
-                source: row.get(1)?,
+                source,
                 source_id: row.get(2)?,
                 event_key: row.get(3)?,
                 timestamp: row.get(4)?,
                 model: row.get(5)?,
                 provider: row.get(6)?,
-                input_tokens: row.get(7)?,
-                output_tokens: row.get(8)?,
-                cache_read_tokens: row.get(9)?,
-                cache_write_tokens: row.get(10)?,
-                reasoning_tokens: row.get(11)?,
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_read_tokens: usage.cache_read_tokens,
+                cache_write_tokens: usage.cache_write_tokens,
+                reasoning_tokens: usage.reasoning_tokens,
                 token_source: row.get(12)?,
             })
         })?;
@@ -207,12 +234,26 @@ impl Store {
         let mut stmt = self.conn.prepare(
             "SELECT event_key, event_seq, message_seq, timestamp, model, provider,
                     input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-                    reasoning_tokens, token_source, parser_version, source_path, raw_usage_json
+                    reasoning_tokens, token_source, parser_version, source_path, raw_usage_json,
+                    source
              FROM usage_events
              WHERE session_id = ?1
              ORDER BY event_seq ASC, event_key ASC",
         )?;
         let rows = stmt.query_map(rusqlite::params![session_id], |row| {
+            let raw_usage_json = row.get::<_, Option<String>>(14)?;
+            let usage = normalize_persisted_usage(
+                &row.get::<_, String>(15)?,
+                PersistedUsage {
+                    input_tokens: row.get(6)?,
+                    output_tokens: row.get(7)?,
+                    cache_read_tokens: row.get(8)?,
+                    cache_write_tokens: row.get(9)?,
+                    reasoning_tokens: row.get(10)?,
+                    parser_version: row.get(12)?,
+                },
+                raw_usage_json.as_deref(),
+            );
             Ok(SessionUsageEventRecord {
                 event_key: row.get(0)?,
                 event_seq: row.get(1)?,
@@ -220,17 +261,65 @@ impl Store {
                 timestamp: row.get(3)?,
                 model: row.get(4)?,
                 provider: row.get(5)?,
-                input_tokens: row.get(6)?,
-                output_tokens: row.get(7)?,
-                cache_read_tokens: row.get(8)?,
-                cache_write_tokens: row.get(9)?,
-                reasoning_tokens: row.get(10)?,
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_read_tokens: usage.cache_read_tokens,
+                cache_write_tokens: usage.cache_write_tokens,
+                reasoning_tokens: usage.reasoning_tokens,
                 token_source: row.get(11)?,
-                parser_version: row.get(12)?,
+                parser_version: usage.parser_version,
                 source_path: row.get(13)?,
-                raw_usage_json: row.get(14)?,
+                raw_usage_json,
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
+}
+
+fn normalize_persisted_usage(
+    source: &str,
+    mut usage: PersistedUsage,
+    raw_usage_json: Option<&str>,
+) -> PersistedUsage {
+    match source {
+        "codex" if usage.parser_version < CODEX_DISJOINT_REASONING_VERSION => {
+            split_inclusive_output(&mut usage);
+            usage.parser_version = CODEX_DISJOINT_REASONING_VERSION;
+        }
+        "gemini-cli" | "qwen-code" if usage.parser_version < CACHE_EXCLUSIVE_INPUT_VERSION => {
+            usage.input_tokens = usage.input_tokens.saturating_sub(usage.cache_read_tokens).max(0);
+            usage.parser_version = CACHE_EXCLUSIVE_INPUT_VERSION;
+        }
+        "pi" | "omp" if usage.parser_version < FLEXIBLE_REASONING_VERSION => {
+            if persisted_usage_total(raw_usage_json)
+                == Some(
+                    usage
+                        .input_tokens
+                        .saturating_add(usage.output_tokens)
+                        .saturating_add(usage.cache_read_tokens)
+                        .saturating_add(usage.cache_write_tokens),
+                )
+            {
+                split_inclusive_output(&mut usage);
+            }
+            usage.parser_version = FLEXIBLE_REASONING_VERSION;
+        }
+        _ => {}
+    }
+
+    usage
+}
+
+fn split_inclusive_output(usage: &mut PersistedUsage) {
+    let reasoning_tokens = usage.reasoning_tokens.min(usage.output_tokens);
+    usage.output_tokens -= reasoning_tokens;
+    usage.reasoning_tokens = reasoning_tokens;
+}
+
+fn persisted_usage_total(raw_usage_json: Option<&str>) -> Option<i64> {
+    let usage = serde_json::from_str::<serde_json::Value>(raw_usage_json?).ok()?;
+    ["totalTokens", "total_tokens"]
+        .iter()
+        .find_map(|key| usage.get(*key).and_then(serde_json::Value::as_i64))
+        .filter(|total| *total >= 0)
 }

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -350,7 +350,9 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     assert_eq!(value["usage_events"][0]["message_seq"], 1);
     assert_eq!(value["usage_events"][0]["model"], "gpt-5");
     assert_eq!(value["usage_events"][0]["token_source"], "observed");
-    assert_eq!(value["usage_events"][0]["parser_version"], 1);
+    assert_eq!(value["usage_events"][0]["output_tokens"], 4);
+    assert_eq!(value["usage_events"][0]["reasoning_tokens"], 1);
+    assert_eq!(value["usage_events"][0]["parser_version"], 5);
     assert_eq!(value["usage_events"][0]["source_path"], "/tmp/source.jsonl");
     assert_eq!(value["usage_events"][0]["raw_usage_json"], r#"{"input_tokens":10}"#);
     assert_eq!(value["events"][0]["kind"], "file_read");

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -2,17 +2,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, IsTerminal, Write};
 
 use anyhow::Result;
-use chrono::{DateTime, Datelike, Local, NaiveDate, TimeZone, Timelike};
+use chrono::{
+    DateTime, Datelike, Days, Local, NaiveDate, NaiveDateTime, TimeDelta, TimeZone, Timelike,
+};
 use serde::Serialize;
 use unicode_width::UnicodeWidthStr;
 
-use crate::db::search::TimeRange;
 use crate::db::store::Store;
 use crate::types::UsageEventRecord;
 use crate::usage::{TokenTotals, UsageDedup};
 
 const INNER: usize = 52;
-const YEAR_MS: i64 = 365 * 24 * 3600 * 1000;
 const WEEKDAYS: [&str; 7] =
     ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
 
@@ -42,13 +42,32 @@ impl WrappedPeriod {
     }
 
     fn after_millis_at(self, now: DateTime<Local>) -> Option<i64> {
-        match self {
-            Self::Week => TimeRange::Week.cutoff_millis_at(now),
-            Self::Month => TimeRange::Month.cutoff_millis_at(now),
-            Self::Year => Some(now.timestamp_millis() - YEAR_MS),
-            Self::All => None,
-        }
+        let lookback_days = match self {
+            Self::Week => 6,
+            Self::Month => 29,
+            Self::Year => 364,
+            Self::All => return None,
+        };
+        let start = now
+            .date_naive()
+            .checked_sub_days(Days::new(lookback_days))?
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is a valid wall-clock value");
+        Some(first_valid_local_millis(start, |candidate| {
+            Local.from_local_datetime(&candidate).earliest().map(|value| value.timestamp_millis())
+        }))
     }
+}
+
+fn first_valid_local_millis(
+    start: NaiveDateTime,
+    mut resolve: impl FnMut(NaiveDateTime) -> Option<i64>,
+) -> i64 {
+    (0_i64..=48 * 60)
+        .find_map(|minutes| {
+            start.checked_add_signed(TimeDelta::minutes(minutes)).and_then(&mut resolve)
+        })
+        .expect("local period boundary resolves within 48 hours")
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -134,7 +153,8 @@ impl WrappedAcc {
     }
 
     fn finish(self, period: WrappedPeriod) -> WrappedReport {
-        let empty = self.days.is_empty();
+        let has_usage = !self.days.is_empty();
+        let empty = !has_usage && self.sessions.is_empty();
         let mut by_source = self
             .by_source
             .into_iter()
@@ -174,8 +194,8 @@ impl WrappedAcc {
             sessions: self.sessions.len(),
             active_days: self.days.len(),
             longest_streak: longest_streak(&self.days),
-            top_model: if empty { None } else { top_model },
-            top_source: if empty { None } else { top_source },
+            top_model: if has_usage { top_model } else { None },
+            top_source: if has_usage { top_source } else { None },
             busiest_weekday,
             busiest_hour,
             by_source,
@@ -209,9 +229,14 @@ fn build_wrapped_report_at(
     now: DateTime<Local>,
 ) -> Result<WrappedReport> {
     let after = period.after_millis_at(now);
-    let acc = store.fold_usage_events_after(None, after, WrappedAcc::default(), |acc, event| {
-        acc.add(&event);
-    })?;
+    let mut acc =
+        store.fold_usage_events_after(None, after, WrappedAcc::default(), |acc, event| {
+            acc.add(&event);
+        })?;
+    for (source, session_id) in store.indexed_active_sessions_after(after)? {
+        acc.sessions.insert(session_id.clone());
+        acc.by_source.entry(source).or_default().sessions.insert(session_id);
+    }
     Ok(acc.finish(period))
 }
 
@@ -879,19 +904,33 @@ mod tests {
     }
 
     #[test]
-    fn period_cutoff_matches_usage_windows() {
+    fn period_cutoff_uses_local_calendar_days() {
         let now = fixture_now();
         let events = vec![
+            event("codex", "before-week", "w0", local_ts(2026, 8, 19, 13), "gpt-5.5", 10, 1),
             event("codex", "s1", "k1", local_ts(2026, 8, 24, 12), "gpt-5.5", 10, 1),
+            event("codex", "before-month", "m0", local_ts(2026, 7, 27, 13), "gpt-5.5", 10, 1),
             event("codex", "s2", "k2", local_ts(2026, 8, 10, 12), "gpt-5.5", 10, 1),
             event("codex", "s3", "k3", local_ts(2026, 4, 1, 12), "gpt-5.5", 10, 1),
+            event("codex", "before-year", "y0", local_ts(2025, 8, 26, 13), "gpt-5.5", 10, 1),
             event("codex", "s4", "k4", local_ts(2025, 6, 1, 12), "gpt-5.5", 10, 1),
         ];
 
         assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::Week, now).sessions, 1);
-        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::Month, now).sessions, 2);
-        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::Year, now).sessions, 3);
-        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::All, now).sessions, 4);
+        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::Month, now).sessions, 3);
+        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::Year, now).sessions, 5);
+        assert_eq!(aggregate_wrapped_events(&events, WrappedPeriod::All, now).sessions, 7);
+    }
+
+    #[test]
+    fn local_day_start_advances_through_timezone_gap() {
+        let start = NaiveDate::from_ymd_opt(2026, 9, 6).unwrap().and_hms_opt(0, 0, 0).unwrap();
+        let expected = start.checked_add_signed(TimeDelta::minutes(45)).unwrap();
+        let resolved = first_valid_local_millis(start, |candidate| {
+            (candidate >= expected).then(|| candidate.and_utc().timestamp_millis())
+        });
+
+        assert_eq!(resolved, expected.and_utc().timestamp_millis());
     }
 
     #[test]
@@ -995,7 +1034,7 @@ mod tests {
     }
 
     #[test]
-    fn period_card_labels_describe_rolling_windows() {
+    fn period_card_labels_describe_calendar_windows() {
         assert_eq!(WrappedPeriod::Week.card_label(), "last 7 days");
         assert_eq!(WrappedPeriod::Month.card_label(), "last 30 days");
         assert_eq!(WrappedPeriod::Year.card_label(), "last 365 days");
@@ -1053,10 +1092,26 @@ mod tests {
     }
 
     #[test]
-    fn store_backed_report_reads_existing_usage_events() {
+    fn store_backed_reports_use_indexed_session_counts() {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
         let session = make_session("s1", "claude-code");
+        store.insert_session(&make_session("s2", "claude-code")).unwrap();
+        let mut old_session = make_session("s3", "codex");
+        old_session.started_at = local_ts(2026, 8, 19, 13);
+        old_session.updated_at = Some(local_ts(2026, 8, 25, 13));
+        store.insert_session(&old_session).unwrap();
+        let mut usage_only_session = make_session("s4", "codex");
+        usage_only_session.started_at = local_ts(2026, 8, 1, 13);
+        usage_only_session.updated_at = Some(local_ts(2026, 8, 1, 13));
+        store
+            .persist_session_with_usage(
+                &usage_only_session,
+                &[],
+                &[make_usage("evt-2", local_ts(2026, 8, 25, 14), "gpt-5.5", 10, 1)],
+                Some(4),
+            )
+            .unwrap();
         let messages = vec![Message {
             session_id: "s1".to_string(),
             role: Role::User,
@@ -1075,14 +1130,105 @@ mod tests {
 
         let report = build_wrapped_report_at(&store, WrappedPeriod::All, fixture_now()).unwrap();
         assert!(!report.empty);
-        assert_eq!(report.sessions, 1);
-        assert_eq!(report.tokens.total_tokens, 120);
+        assert_eq!(report.sessions, 4);
+        assert_eq!(report.by_source[0].sessions, 2);
+        assert_eq!(report.tokens.total_tokens, 131);
         assert_eq!(report.top_source.unwrap().source, "claude-code");
+
+        let week = build_wrapped_report_at(&store, WrappedPeriod::Week, fixture_now()).unwrap();
+        assert_eq!(week.sessions, 4);
+        assert_eq!(week.by_source.iter().map(|row| row.sessions).sum::<usize>(), 4);
+        let codex = week.by_source.iter().find(|row| row.source == "codex").unwrap();
+        assert_eq!(codex.sessions, 2);
+        assert_eq!(codex.tokens.total_tokens, 11);
 
         let week_cutoff_now =
             Local.with_ymd_and_hms(2026, 9, 20, 12, 0, 0).single().expect("valid local time");
         let empty = build_wrapped_report_at(&store, WrappedPeriod::Week, week_cutoff_now).unwrap();
         assert!(empty.empty);
+    }
+
+    #[test]
+    fn store_backed_report_keeps_indexed_sessions_without_usage() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        store.insert_session(&make_session("s1", "cursor")).unwrap();
+
+        let report = build_wrapped_report_at(&store, WrappedPeriod::Week, fixture_now()).unwrap();
+        assert!(!report.empty);
+        assert_eq!(report.sessions, 1);
+        assert_eq!(report.tokens.total_tokens, 0);
+        assert_eq!(report.by_source.len(), 1);
+        assert_eq!(report.by_source[0].source, "cursor");
+        assert_eq!(report.by_source[0].sessions, 1);
+    }
+
+    #[test]
+    fn store_backed_report_normalizes_legacy_usage_rows() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+
+        let mut codex = make_usage("codex", local_ts(2026, 8, 20, 14), "gpt-5.5", 0, 10);
+        codex.reasoning_tokens = 4;
+        codex.parser_version = 4;
+        store
+            .persist_session_with_usage(&make_session("codex", "codex"), &[], &[codex], Some(4))
+            .unwrap();
+
+        let mut gemini = make_usage("gemini", local_ts(2026, 8, 20, 14), "gemini-2.5-pro", 100, 20);
+        gemini.cache_read_tokens = 30;
+        gemini.reasoning_tokens = 5;
+        store
+            .persist_session_with_usage(
+                &make_session("gemini", "gemini-cli"),
+                &[],
+                &[gemini],
+                Some(1),
+            )
+            .unwrap();
+
+        let mut qwen = make_usage("qwen", local_ts(2026, 8, 20, 14), "qwen3", 100, 20);
+        qwen.cache_read_tokens = 30;
+        qwen.reasoning_tokens = 5;
+        store
+            .persist_session_with_usage(&make_session("qwen", "qwen-code"), &[], &[qwen], Some(1))
+            .unwrap();
+
+        let mut pi = make_usage("pi", local_ts(2026, 8, 20, 14), "deepseek", 10, 7);
+        pi.cache_read_tokens = 2;
+        pi.cache_write_tokens = 1;
+        pi.reasoning_tokens = 4;
+        pi.parser_version = 1;
+        pi.raw_usage_json = Some(r#"{"totalTokens":20}"#.to_string());
+        store.persist_session_with_usage(&make_session("pi", "pi"), &[], &[pi], Some(1)).unwrap();
+
+        let report = build_wrapped_report_at(&store, WrappedPeriod::All, fixture_now()).unwrap();
+        assert_eq!(report.tokens.input_tokens, 150);
+        assert_eq!(report.tokens.output_tokens, 49);
+        assert_eq!(report.tokens.cache_read_tokens, 62);
+        assert_eq!(report.tokens.cache_write_tokens, 1);
+        assert_eq!(report.tokens.reasoning_tokens, 18);
+        assert_eq!(report.tokens.total_tokens, 280);
+
+        let codex = store.list_usage_events_for_session("codex").unwrap();
+        assert_eq!(codex[0].output_tokens, 6);
+        assert_eq!(codex[0].reasoning_tokens, 4);
+        assert_eq!(codex[0].parser_version, 5);
+
+        let gemini = store.list_usage_events_for_session("gemini").unwrap();
+        assert_eq!(gemini[0].input_tokens, 70);
+        assert_eq!(gemini[0].cache_read_tokens, 30);
+        assert_eq!(gemini[0].parser_version, 2);
+
+        let qwen = store.list_usage_events_for_session("qwen").unwrap();
+        assert_eq!(qwen[0].input_tokens, 70);
+        assert_eq!(qwen[0].cache_read_tokens, 30);
+        assert_eq!(qwen[0].parser_version, 2);
+
+        let pi = store.list_usage_events_for_session("pi").unwrap();
+        assert_eq!(pi[0].output_tokens, 3);
+        assert_eq!(pi[0].reasoning_tokens, 4);
+        assert_eq!(pi[0].parser_version, 2);
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- Count Wrapped sessions from indexed sessions, including sessions without usage events, using local-calendar period cutoffs.
- Normalize legacy and newly parsed usage events for Codex, Gemini CLI, Qwen Code, PI, and OMP.
- Simplify the bundled Recall skill guidance and extend behavior-level regression coverage.

### Why

- Keep `recall wrapped` session and token metrics consistent with `recall info` and canonical usage aggregation.

### Verification

- `make check`