### PR TITLE
fix(sync): reconcile stale sessions safely

### DIFF
--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -8,8 +8,11 @@ apply when working here.
 
 - The `SourceAdapter` trait in `mod.rs` is the authoritative contract, not the
   DEVELOPMENT.md example. `id()`, `label()`, `scan()`, and `resume_command()`
-  are required; `scan_for_sync()`, `prune()`, `app_command()`, and
-  `usage_parser_version()` are optional overrides.
+  are required; `scan_for_sync()`, `scan_for_sync_output()`, `app_command()`,
+  and `usage_parser_version()` are optional overrides.
+- Adapters never delete from `Store`. An adapter with a complete source
+  inventory may return a bounded `ReconcilePlan`; sync owns applying it after
+  the source run succeeds and only in global scope.
 - Register new adapters in `all_adapters()` in `mod.rs`. Registration alone
   wires the adapter into sync, search, the TUI source filter, and the CLI
   `--source` flag. No schema change is needed — `sessions.source` is a value,

--- a/src/adapters/goose.rs
+++ b/src/adapters/goose.rs
@@ -9,8 +9,8 @@ use tracing::{debug, warn};
 use crate::adapters::events;
 use crate::adapters::opencode;
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-    first_timestamp, last_timestamp,
+    InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
+    SyncScanOutput, SyncScanResult, SyncScanStats, first_timestamp, last_timestamp,
 };
 use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
@@ -91,32 +91,17 @@ impl SourceAdapter for GooseAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        Ok(scan_db(open_goose_db()?, None, None, true)?.sessions)
+        Ok(scan_db(open_goose_db()?, None, None, true, false)?.scan.sessions)
     }
 
-    fn scan_for_sync(
+    fn scan_for_sync_output(
         &self,
         store: &Store,
         since_ts: Option<i64>,
         include_events: bool,
-    ) -> anyhow::Result<Option<SyncScanResult>> {
-        Ok(Some(scan_db(open_goose_db()?, Some(store), since_ts, include_events)?))
-    }
-
-    fn prune(&self, store: &Store) -> anyhow::Result<()> {
-        let Some((conn, _)) = open_goose_db()? else {
-            return Ok(());
-        };
-        if !has_table(&conn, "sessions") {
-            return Ok(());
-        }
-        let live = load_all_session_ids(&conn)?;
-        for source_id in store.session_meta_map(SOURCE)?.keys() {
-            if !live.contains(source_id) {
-                store.delete_session_data(SOURCE, source_id)?;
-            }
-        }
-        Ok(())
+        force: bool,
+    ) -> anyhow::Result<Option<SyncScanOutput>> {
+        Ok(Some(scan_db(open_goose_db()?, Some(store), since_ts, include_events, force)?))
     }
 }
 
@@ -175,33 +160,38 @@ fn scan_db(
     store: Option<&Store>,
     since_ts: Option<i64>,
     include_events: bool,
-) -> anyhow::Result<SyncScanResult> {
+    force: bool,
+) -> anyhow::Result<SyncScanOutput> {
     let Some((conn, db_path)) = opened else {
-        return Ok(SyncScanResult { sessions: Vec::new(), stats: SyncScanStats::default() });
+        return unavailable_scan_result(store);
     };
-    if !has_table(&conn, "sessions") || !has_table(&conn, "messages") {
+    let snapshot = conn.unchecked_transaction()?;
+    if !has_table(&snapshot, "sessions") || !has_table(&snapshot, "messages") {
         debug!("Goose sessions.db missing required tables, skipping");
-        return Ok(SyncScanResult { sessions: Vec::new(), stats: SyncScanStats::default() });
+        return unavailable_scan_result(store);
     }
 
-    let existing = match store {
+    let incremental_store = if force { None } else { store };
+    let since_ts = if force { None } else { since_ts };
+    let existing = match incremental_store {
         Some(store) => store.session_meta_map(SOURCE)?,
         None => HashMap::new(),
     };
-    let usage_state = match store {
+    let usage_state = match incremental_store {
         Some(store) => store.usage_state_meta_map(SOURCE)?,
         None => HashMap::new(),
     };
-    let event_state = match store {
+    let event_state = match incremental_store {
         Some(store) if include_events => store.event_state_meta_map(SOURCE)?,
         _ => HashMap::new(),
     };
-    let metadata_state = match store {
+    let metadata_state = match incremental_store {
         Some(store) => store.metadata_state_meta_map(SOURCE)?,
         None => HashMap::new(),
     };
 
-    let rows = load_session_rows(&conn)?;
+    let (live, inventory_issues) = load_all_session_ids(&snapshot, &db_path)?;
+    let rows = load_session_rows(&snapshot)?;
     let mut sessions = Vec::new();
     let mut stats = SyncScanStats::default();
 
@@ -216,7 +206,7 @@ fn scan_db(
             stats.filtered_sessions += 1;
             continue;
         }
-        if store.is_some()
+        if incremental_store.is_some()
             && existing.get(&row.id).is_some_and(|&(old_updated_at, _)| {
                 old_updated_at == freshness
                     && crate::adapters::sync_state::session_state_is_current(
@@ -237,7 +227,7 @@ fn scan_db(
             stats.skipped_sessions += 1;
             continue;
         }
-        match scan_session(&conn, &row, &db_path, include_events) {
+        match scan_session(&snapshot, &row, &db_path, include_events) {
             Ok(Some(raw)) => {
                 stats.parsed += 1;
                 sessions.push(raw);
@@ -247,7 +237,28 @@ fn scan_db(
         }
     }
 
-    Ok(SyncScanResult { sessions, stats })
+    snapshot.commit()?;
+    let reconcile = if inventory_issues.is_empty() {
+        ReconcilePlan::CompleteLiveSet(live)
+    } else {
+        ReconcilePlan::PartialInventory(inventory_issues)
+    };
+    Ok(SyncScanOutput { scan: SyncScanResult { sessions, stats }, reconcile: Some(reconcile) })
+}
+
+fn unavailable_scan_result(store: Option<&Store>) -> anyhow::Result<SyncScanOutput> {
+    let result = SyncScanResult { sessions: Vec::new(), stats: SyncScanStats::default() };
+    let has_history = match store {
+        Some(store) => !store.session_meta_map(SOURCE)?.is_empty(),
+        None => false,
+    };
+    if has_history {
+        return Ok(SyncScanOutput {
+            scan: result,
+            reconcile: Some(ReconcilePlan::UnavailableInventory(Vec::new())),
+        });
+    }
+    Ok(SyncScanOutput { scan: result, reconcile: None })
 }
 
 fn include_session_type(session_type: &str) -> bool {
@@ -291,19 +302,26 @@ fn load_session_rows(conn: &Connection) -> anyhow::Result<Vec<SessionRow>> {
     Ok(sessions)
 }
 
-fn load_all_session_ids(conn: &Connection) -> anyhow::Result<HashSet<String>> {
+fn load_all_session_ids(
+    conn: &Connection,
+    db_path: &Path,
+) -> anyhow::Result<(HashSet<String>, Vec<InventoryIssue>)> {
     let mut stmt = conn.prepare("SELECT id FROM sessions")?;
     let rows = stmt.query_map([], |row| row.get(0))?;
     let mut ids = HashSet::new();
+    let mut issues = Vec::new();
     for row in rows {
         match row {
             Ok(id) => {
                 ids.insert(id);
             }
-            Err(err) => warn!("skipping malformed Goose session id: {err}"),
+            Err(_) => issues.push(InventoryIssue {
+                path: db_path.to_path_buf(),
+                category: std::io::ErrorKind::InvalidData,
+            }),
         }
     }
-    Ok(ids)
+    Ok((ids, issues))
 }
 
 fn scan_session(
@@ -917,8 +935,8 @@ mod tests {
         assert!(
             resolve_db_path_from(None, None, Some(PathBuf::from("/no/such/home")), None).is_none()
         );
-        let result = scan_db(None, None, None, true).unwrap();
-        assert!(result.sessions.is_empty());
+        let result = scan_db(None, None, None, true, false).unwrap();
+        assert!(result.scan.sessions.is_empty());
     }
 
     #[test]
@@ -973,9 +991,9 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, None, None, true).unwrap();
-        assert_eq!(result.sessions.len(), 1);
-        let raw = &result.sessions[0];
+        let result = scan_db(opened, None, None, true, false).unwrap();
+        assert_eq!(result.scan.sessions.len(), 1);
+        let raw = &result.scan.sessions[0];
         assert_eq!(raw.source_id, "20250310_2");
         assert_eq!(raw.directory.as_deref(), Some("/repo"));
         assert_eq!(raw.custom_title.as_deref(), Some("seed title"));
@@ -1022,7 +1040,7 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let raw = &scan_db(opened, None, None, false).unwrap().sessions[0];
+        let raw = &scan_db(opened, None, None, false, false).unwrap().scan.sessions[0];
         assert_eq!(raw.started_at, 1_741_615_822_000);
         assert_eq!(raw.updated_at, Some(1_741_615_823_000));
         assert_eq!(raw.messages[0].timestamp, Some(1_741_615_822_000));
@@ -1048,10 +1066,10 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, None, None, false).unwrap();
-        assert_eq!(result.stats.rejected_before_parse, 3);
-        assert_eq!(result.sessions.len(), 1);
-        assert_eq!(result.sessions[0].source_id, "u1");
+        let result = scan_db(opened, None, None, false, false).unwrap();
+        assert_eq!(result.scan.stats.rejected_before_parse, 3);
+        assert_eq!(result.scan.sessions.len(), 1);
+        assert_eq!(result.scan.sessions[0].source_id, "u1");
     }
 
     #[test]
@@ -1073,7 +1091,7 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let raw = &scan_db(opened, None, None, false).unwrap().sessions[0];
+        let raw = &scan_db(opened, None, None, false, false).unwrap().scan.sessions[0];
         assert_eq!(raw.custom_title, None);
         assert_eq!(raw.thread_role, Some(ThreadRole::Subagent));
         assert_eq!(raw.parent_links[0].source, SOURCE);
@@ -1110,7 +1128,7 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let raw = &scan_db(opened, None, None, true).unwrap().sessions[0];
+        let raw = &scan_db(opened, None, None, true, false).unwrap().scan.sessions[0];
         assert!(raw.usage_events.is_empty());
         assert_eq!(raw.messages[0].content, "hi");
     }
@@ -1157,9 +1175,17 @@ mod tests {
             .unwrap();
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, Some(&store), None, true).unwrap();
-        assert_eq!(result.stats.skipped_sessions, 1);
-        assert!(result.sessions.is_empty());
+        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        assert_eq!(result.scan.stats.skipped_sessions, 1);
+        assert!(result.scan.sessions.is_empty());
+
+        let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
+        let forced = scan_db(opened, Some(&store), None, true, true).unwrap();
+        assert_eq!(forced.scan.sessions.len(), 1);
+        assert!(matches!(
+            forced.reconcile,
+            Some(ReconcilePlan::CompleteLiveSet(ids)) if ids == HashSet::from(["s1".to_string()])
+        ));
     }
 
     #[test]
@@ -1205,11 +1231,11 @@ mod tests {
             .unwrap();
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, Some(&store), None, true).unwrap();
-        assert_eq!(result.stats.skipped_sessions, 0);
-        assert_eq!(result.sessions.len(), 1);
-        assert_eq!(result.sessions[0].updated_at, Some(400_000));
-        assert_eq!(result.sessions[0].messages.len(), 2);
+        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        assert_eq!(result.scan.stats.skipped_sessions, 0);
+        assert_eq!(result.scan.sessions.len(), 1);
+        assert_eq!(result.scan.sessions[0].updated_at, Some(400_000));
+        assert_eq!(result.scan.sessions[0].messages.len(), 2);
     }
 
     #[test]
@@ -1222,10 +1248,10 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, None, Some(300_000), false).unwrap();
-        assert_eq!(result.stats.filtered_sessions, 0);
-        assert_eq!(result.sessions.len(), 1);
-        assert_eq!(result.sessions[0].updated_at, Some(400_000));
+        let result = scan_db(opened, None, Some(300_000), false, false).unwrap();
+        assert_eq!(result.scan.stats.filtered_sessions, 0);
+        assert_eq!(result.scan.sessions.len(), 1);
+        assert_eq!(result.scan.sessions[0].updated_at, Some(400_000));
     }
 
     #[test]
@@ -1248,7 +1274,7 @@ mod tests {
         drop(conn);
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let raw = &scan_db(opened, None, None, true).unwrap().sessions[0];
+        let raw = &scan_db(opened, None, None, true, false).unwrap().scan.sessions[0];
         assert!(raw.messages.is_empty());
         assert_eq!(raw.events.len(), 1);
         assert_eq!(raw.started_at, 400_000);
@@ -1256,7 +1282,7 @@ mod tests {
     }
 
     #[test]
-    fn prune_deletes_sessions_missing_from_goose() {
+    fn complete_scan_returns_live_set_without_mutating_store() {
         let root = tempfile::tempdir().unwrap();
         let db_path = root.path().join("sessions.db");
         let conn = setup_goose_db(&db_path);
@@ -1267,16 +1293,72 @@ mod tests {
         store.insert_session(&make_session("keep", Some(200_000), 1)).unwrap();
         store.insert_session(&make_session("gone", Some(200_000), 1)).unwrap();
 
-        let opened = opencode::open_readonly(&db_path).unwrap().unwrap();
-        let live = load_all_session_ids(&opened).unwrap();
-        for source_id in store.session_meta_map(SOURCE).unwrap().keys() {
-            if !live.contains(source_id) {
-                store.delete_session_data(SOURCE, source_id).unwrap();
-            }
-        }
+        let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
+        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
         let remaining = store.session_meta_map(SOURCE).unwrap();
         assert!(remaining.contains_key("keep"));
-        assert!(!remaining.contains_key("gone"));
+        assert!(remaining.contains_key("gone"));
+        assert!(matches!(
+            result.reconcile,
+            Some(ReconcilePlan::CompleteLiveSet(ids)) if ids == HashSet::from(["keep".to_string()])
+        ));
+    }
+
+    #[test]
+    fn external_database_query_failure_preserves_existing_sessions() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join("sessions.db");
+        let conn = setup_goose_db(&db_path);
+        conn.execute(
+            "ALTER TABLE sessions RENAME COLUMN working_dir TO unexpected_working_dir",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let store = setup_store();
+        store.insert_session(&make_session("existing", Some(200_000), 1)).unwrap();
+        let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
+
+        assert!(scan_db(opened, Some(&store), None, true, false).is_err());
+        assert!(store.session_meta(SOURCE, "existing").unwrap().is_some());
+    }
+
+    #[test]
+    fn malformed_live_id_marks_inventory_partial_and_keeps_valid_sessions() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join("sessions.db");
+        let conn = setup_goose_db(&db_path);
+        insert_session(&conn, &SessionSpec { id: "keep", ..SessionSpec::default() });
+        insert_message(&conn, "keep", "user", r#"[{"type":"text","text":"hello"}]"#, 100, None);
+        conn.execute(
+            "INSERT INTO sessions (id, working_dir) VALUES (?1, '/broken')",
+            rusqlite::params![vec![0xff_u8]],
+        )
+        .unwrap();
+        drop(conn);
+
+        let store = setup_store();
+        store.insert_session(&make_session("keep", Some(200_000), 1)).unwrap();
+        store.insert_session(&make_session("stale", Some(200_000), 1)).unwrap();
+        let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
+
+        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+
+        assert!(matches!(result.reconcile, Some(ReconcilePlan::PartialInventory(_))));
+        assert!(result.scan.sessions.iter().any(|session| session.source_id == "keep"));
+        assert!(store.session_meta(SOURCE, "stale").unwrap().is_some());
+    }
+
+    #[test]
+    fn missing_database_with_history_is_unavailable() {
+        let store = setup_store();
+        store.insert_session(&make_session("existing", Some(200_000), 1)).unwrap();
+
+        let result = scan_db(None, Some(&store), None, true, false).unwrap();
+
+        assert!(matches!(result.reconcile, Some(ReconcilePlan::UnavailableInventory(_))));
+        assert!(store.session_meta(SOURCE, "existing").unwrap().is_some());
     }
 
     #[test]

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -10,7 +10,8 @@ use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+    InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
+    SyncScanOutput, SyncScanResult, SyncScanStats,
 };
 use crate::db::store::Store;
 use crate::types::{RawUsageEvent, Role};
@@ -57,23 +58,24 @@ impl SourceAdapter for GrokAdapter {
         Ok(sessions)
     }
 
-    fn scan_for_sync(
+    fn scan_for_sync_output(
         &self,
         store: &Store,
         since_ts: Option<i64>,
         _include_events: bool,
-    ) -> anyhow::Result<Option<SyncScanResult>> {
+        force: bool,
+    ) -> anyhow::Result<Option<SyncScanOutput>> {
         let Some(sessions_dir) = resolve_grok_sessions_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            let result = SyncScanResult { sessions: vec![], stats: SyncScanStats::default() };
+            if store.session_meta_map("grok")?.is_empty() {
+                return Ok(Some(SyncScanOutput { scan: result, reconcile: None }));
+            }
+            return Ok(Some(SyncScanOutput {
+                scan: result,
+                reconcile: Some(ReconcilePlan::UnavailableInventory(Vec::new())),
+            }));
         };
-        Ok(Some(scan_for_sync_impl(&sessions_dir, store, since_ts)?))
-    }
-
-    fn prune(&self, store: &Store) -> anyhow::Result<()> {
-        let Some(sessions_dir) = resolve_grok_sessions_dir()? else {
-            return Ok(());
-        };
-        prune_impl(&sessions_dir, store)
+        Ok(Some(scan_for_sync_impl(&sessions_dir, store, since_ts, force)?))
     }
 }
 
@@ -111,51 +113,80 @@ fn scan_for_sync_impl(
     sessions_dir: &Path,
     store: &Store,
     since_ts: Option<i64>,
-) -> anyhow::Result<SyncScanResult> {
-    let (entries, _) = collect_grok_entries(sessions_dir);
-    file_scan::run_file_scan_with_options(
-        store,
-        "grok",
-        since_ts,
-        FileScanOptions {
-            usage_parser_version: Some(USAGE_PARSER_VERSION),
-            event_parser_version: None,
-            metadata_parser_version: None,
-        },
-        entries,
-        |entry, mtime_ms| parse_grok_session_for_entry(&entry, mtime_ms),
-    )
-}
-
-fn prune_impl(sessions_dir: &Path, store: &Store) -> anyhow::Result<()> {
-    let (_, subagent_ids) = collect_grok_entries(sessions_dir);
-    if subagent_ids.is_empty() {
-        return Ok(());
-    }
-    let existing = store.session_meta_map("grok")?;
-    for source_id in &subagent_ids {
-        if existing.contains_key(source_id) {
-            store.delete_session_data("grok", source_id)?;
+    force: bool,
+) -> anyhow::Result<SyncScanOutput> {
+    let (entries, reconcile) = collect_grok_entries(sessions_dir);
+    let result = if force {
+        let mut sessions = Vec::new();
+        let mut stats = SyncScanStats::default();
+        for entry in entries {
+            stats.candidates += 1;
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                stats.rejected_before_parse += 1;
+                continue;
+            };
+            stats.parsed += 1;
+            if let Some(raw) = parse_grok_session_for_entry(&entry, mtime_ms)? {
+                sessions.push(raw);
+            }
         }
-    }
-    Ok(())
+        SyncScanResult { sessions, stats }
+    } else {
+        file_scan::run_file_scan_with_options(
+            store,
+            "grok",
+            since_ts,
+            FileScanOptions {
+                usage_parser_version: Some(USAGE_PARSER_VERSION),
+                event_parser_version: None,
+                metadata_parser_version: None,
+            },
+            entries,
+            |entry, mtime_ms| parse_grok_session_for_entry(&entry, mtime_ms),
+        )?
+    };
+    Ok(SyncScanOutput { scan: result, reconcile: Some(reconcile) })
 }
 
-fn collect_grok_entries(sessions_dir: &Path) -> (Vec<FileScanEntry>, Vec<String>) {
+fn collect_grok_entries(sessions_dir: &Path) -> (Vec<FileScanEntry>, ReconcilePlan) {
     let mut entries = Vec::new();
     let mut subagent_ids = Vec::new();
+    let mut issues = Vec::new();
 
     let workspace_dirs = match fs::read_dir(sessions_dir) {
         Ok(dirs) => dirs,
         Err(err) => {
             debug!("cannot read Grok sessions dir: {err}");
-            return (entries, subagent_ids);
+            return (
+                entries,
+                ReconcilePlan::UnavailableInventory(vec![InventoryIssue {
+                    path: sessions_dir.to_path_buf(),
+                    category: err.kind(),
+                }]),
+            );
         }
     };
 
-    for workspace_entry in workspace_dirs.flatten() {
+    for workspace_entry in workspace_dirs {
+        let workspace_entry = match workspace_entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                issues.push(InventoryIssue {
+                    path: sessions_dir.to_path_buf(),
+                    category: err.kind(),
+                });
+                continue;
+            }
+        };
         let workspace_path = workspace_entry.path();
-        if !workspace_path.is_dir() {
+        let workspace_metadata = match fs::metadata(&workspace_path) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                issues.push(InventoryIssue { path: workspace_path, category: err.kind() });
+                continue;
+            }
+        };
+        if !workspace_metadata.is_dir() {
             continue;
         }
         let workspace_name =
@@ -165,40 +196,86 @@ fn collect_grok_entries(sessions_dir: &Path) -> (Vec<FileScanEntry>, Vec<String>
         }
 
         let fallback_directory = decode_grok_workspace_dir(workspace_name);
-
-        let session_dirs = match fs::read_dir(&workspace_path) {
-            Ok(dirs) => dirs,
-            Err(_) => continue,
-        };
-
-        for session_entry in session_dirs.flatten() {
-            let session_path = session_entry.path();
-            if !session_path.is_dir() {
-                continue;
-            }
-            let session_id = match session_path.file_name().and_then(|name| name.to_str()) {
-                Some(id) if is_grok_session_id(id) => id.to_string(),
-                _ => continue,
-            };
-
-            let updates_path = session_path.join("updates.jsonl");
-            if !updates_path.is_file() {
-                continue;
-            }
-
-            let (summary_directory, session_kind) = load_summary_probe(&session_path);
-            if matches!(session_kind.as_deref(), Some("subagent" | "subagent_resume")) {
-                subagent_ids.push(session_id);
-                continue;
-            }
-
-            let directory = summary_directory.or(fallback_directory.clone());
-
-            entries.push(FileScanEntry { session_id, stat_target: updates_path, directory });
-        }
+        collect_grok_workspace(
+            &workspace_path,
+            fallback_directory,
+            &mut entries,
+            &mut subagent_ids,
+            &mut issues,
+        );
     }
 
-    (entries, subagent_ids)
+    let reconcile = if issues.is_empty() {
+        ReconcilePlan::ExactTombstones(subagent_ids.into_iter().collect::<HashSet<_>>())
+    } else {
+        ReconcilePlan::PartialInventory(issues)
+    };
+    (entries, reconcile)
+}
+
+fn collect_grok_workspace(
+    workspace_path: &Path,
+    fallback_directory: Option<String>,
+    entries: &mut Vec<FileScanEntry>,
+    subagent_ids: &mut Vec<String>,
+    issues: &mut Vec<InventoryIssue>,
+) {
+    let session_dirs = match fs::read_dir(workspace_path) {
+        Ok(dirs) => dirs,
+        Err(err) => {
+            issues
+                .push(InventoryIssue { path: workspace_path.to_path_buf(), category: err.kind() });
+            return;
+        }
+    };
+
+    for session_entry in session_dirs {
+        let session_entry = match session_entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                issues.push(InventoryIssue {
+                    path: workspace_path.to_path_buf(),
+                    category: err.kind(),
+                });
+                continue;
+            }
+        };
+        let session_path = session_entry.path();
+        let session_metadata = match fs::metadata(&session_path) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                issues.push(InventoryIssue { path: session_path, category: err.kind() });
+                continue;
+            }
+        };
+        if !session_metadata.is_dir() {
+            continue;
+        }
+        let session_id = match session_path.file_name().and_then(|name| name.to_str()) {
+            Some(id) if is_grok_session_id(id) => id.to_string(),
+            _ => continue,
+        };
+
+        let updates_path = session_path.join("updates.jsonl");
+        match fs::metadata(&updates_path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => continue,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                issues.push(InventoryIssue { path: updates_path, category: err.kind() });
+                continue;
+            }
+        }
+
+        let (summary_directory, session_kind) = load_summary_probe(&session_path);
+        if matches!(session_kind.as_deref(), Some("subagent" | "subagent_resume")) {
+            subagent_ids.push(session_id);
+            continue;
+        }
+
+        let directory = summary_directory.or(fallback_directory.clone());
+        entries.push(FileScanEntry { session_id, stat_target: updates_path, directory });
+    }
 }
 
 fn load_summary_probe(session_dir: &Path) -> (Option<String>, Option<String>) {
@@ -747,11 +824,14 @@ mod tests {
             r#"{"timestamp":1,"method":"session/update","params":{"sessionId":"019e9003-1ed9-70e3-803b-1e7f96a072eb","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"hey"}}}}"#,
         );
 
-        let (entries, subagent_ids) = collect_grok_entries(&root);
+        let (entries, reconcile) = collect_grok_entries(&root);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].session_id, session_id);
         assert_eq!(entries[0].directory.as_deref(), Some("/tmp/from-summary"));
-        assert!(subagent_ids.is_empty());
+        assert!(matches!(
+            reconcile,
+            ReconcilePlan::ExactTombstones(ids) if ids.is_empty()
+        ));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -784,17 +864,73 @@ mod tests {
             r#"{"timestamp":1,"method":"session/update","params":{"sessionId":"229e9003-1ed9-70e3-803b-1e7f96a072eb","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"machinery"}}}}"#,
         );
 
-        let (entries, mut subagent_ids) = collect_grok_entries(&root);
+        let (entries, reconcile) = collect_grok_entries(&root);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].session_id, normal_id);
-        subagent_ids.sort();
-        assert_eq!(subagent_ids, vec![subagent_id.to_string(), resume_id.to_string()]);
+        assert!(matches!(
+            reconcile,
+            ReconcilePlan::ExactTombstones(ids)
+                if ids == HashSet::from([subagent_id.to_string(), resume_id.to_string()])
+        ));
 
         let _ = fs::remove_dir_all(&root);
     }
 
     #[test]
-    fn prune_deletes_existing_subagent_session() {
+    fn unreadable_root_is_unavailable_without_reconcile_plan() {
+        let root = tempfile::tempdir().unwrap();
+        let not_directory = root.path().join("sessions");
+        fs::write(&not_directory, "not a directory").unwrap();
+        let store = setup_store();
+
+        let result = scan_for_sync_impl(&not_directory, &store, None, false).unwrap();
+
+        assert!(matches!(result.reconcile, Some(ReconcilePlan::UnavailableInventory(_))));
+    }
+
+    #[test]
+    fn unreadable_nested_directory_is_partial_without_reconcile_plan() {
+        let root = tempfile::tempdir().unwrap();
+        let not_directory = root.path().join("workspace");
+        fs::write(&not_directory, "not a directory").unwrap();
+        let mut entries = Vec::new();
+        let mut subagent_ids = Vec::new();
+        let mut issues = Vec::new();
+
+        collect_grok_workspace(&not_directory, None, &mut entries, &mut subagent_ids, &mut issues);
+
+        assert!(entries.is_empty());
+        assert_eq!(issues.len(), 1);
+    }
+
+    #[test]
+    fn parse_failure_preserves_existing_session() {
+        let root = temp_grok_root("parse-failure");
+        let session_id = "019e9003-1ed9-70e3-803b-1e7f96a072eb";
+        write_grok_session(
+            &root,
+            "%2Ftmp%2Fproject",
+            session_id,
+            r#"{"info":{"id":"019e9003-1ed9-70e3-803b-1e7f96a072eb","cwd":"/tmp/project"},"created_at":"2026-06-04T00:00:00Z"}"#,
+            "not json",
+        );
+        let store = setup_store();
+        store.insert_session(&make_existing_session(session_id, 1, 1)).unwrap();
+
+        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+
+        assert!(result.scan.sessions.is_empty());
+        assert!(store.session_meta("grok", session_id).unwrap().is_some());
+        assert!(matches!(
+            result.reconcile,
+            Some(ReconcilePlan::ExactTombstones(ids)) if ids.is_empty()
+        ));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn complete_scan_returns_exact_subagent_tombstone() {
         let root = temp_grok_root("subagent-delete");
         let normal_id = "019e9003-1ed9-70e3-803b-1e7f96a072eb";
         let subagent_id = "119e9003-1ed9-70e3-803b-1e7f96a072eb";
@@ -815,12 +951,15 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(subagent_id, 1, 1)).unwrap();
 
-        prune_impl(&root, &store).unwrap();
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
 
-        assert!(!store.session_meta_map("grok").unwrap().contains_key(subagent_id));
-        assert_eq!(result.sessions.len(), 1);
-        assert_eq!(result.sessions[0].source_id, normal_id);
+        assert!(store.session_meta_map("grok").unwrap().contains_key(subagent_id));
+        assert_eq!(result.scan.sessions.len(), 1);
+        assert_eq!(result.scan.sessions[0].source_id, normal_id);
+        assert!(matches!(
+            result.reconcile,
+            Some(ReconcilePlan::ExactTombstones(ids)) if ids == HashSet::from([subagent_id.to_string()])
+        ));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -840,8 +979,12 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(session_id, mtime, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
-        assert_eq!(result.sessions.len(), 1, "missing usage state must trigger a backfill parse");
+        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        assert_eq!(
+            result.scan.sessions.len(),
+            1,
+            "missing usage state must trigger a backfill parse"
+        );
 
         store
             .persist_usage_events_for_existing_session(
@@ -853,9 +996,16 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
-        assert_eq!(result.sessions.len(), 0);
-        assert_eq!(result.stats.skipped_sessions, 1);
+        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        assert_eq!(result.scan.sessions.len(), 0);
+        assert_eq!(result.scan.stats.skipped_sessions, 1);
+
+        let forced = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        assert_eq!(forced.scan.sessions.len(), 1);
+        assert!(matches!(
+            forced.reconcile,
+            Some(ReconcilePlan::ExactTombstones(ids)) if ids.is_empty()
+        ));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -27,6 +27,10 @@ pub(crate) mod sync_state;
 pub(crate) mod usage;
 pub(crate) mod zcode;
 
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+
 use crate::db::store::Store;
 use crate::types::{ParentLink, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
@@ -45,8 +49,19 @@ pub(crate) trait SourceAdapter {
     ) -> anyhow::Result<Option<SyncScanResult>> {
         Ok(None)
     }
-    fn prune(&self, _store: &Store) -> anyhow::Result<()> {
-        Ok(())
+    fn scan_for_sync_output(
+        &self,
+        store: &Store,
+        since_ts: Option<i64>,
+        include_events: bool,
+        force: bool,
+    ) -> anyhow::Result<Option<SyncScanOutput>> {
+        if force {
+            return Ok(None);
+        }
+        Ok(self
+            .scan_for_sync(store, since_ts, include_events)?
+            .map(|scan| SyncScanOutput { scan, reconcile: None }))
     }
     fn resume_command(&self, source_id: &str) -> Option<ResumeCommand>;
     fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
@@ -167,6 +182,25 @@ pub(crate) struct SyncScanStats {
 pub(crate) struct SyncScanResult {
     pub(crate) sessions: Vec<RawSession>,
     pub(crate) stats: SyncScanStats,
+}
+
+pub(crate) struct SyncScanOutput {
+    pub(crate) scan: SyncScanResult,
+    pub(crate) reconcile: Option<ReconcilePlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InventoryIssue {
+    pub(crate) path: PathBuf,
+    pub(crate) category: io::ErrorKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReconcilePlan {
+    CompleteLiveSet(HashSet<String>),
+    ExactTombstones(HashSet<String>),
+    PartialInventory(Vec<InventoryIssue>),
+    UnavailableInventory(Vec<InventoryIssue>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -368,11 +368,15 @@ impl SyncJob {
             self.stats.excluded_out += n;
         }
 
-        let Some((raw_sessions, scan)) =
+        let Some(scan_result) =
             self.scan_sessions(adapter, source_id, label, &mut purged_excluded_ids)?
         else {
             return Ok(());
         };
+        let adapters::SyncScanOutput {
+            scan: adapters::SyncScanResult { sessions: raw_sessions, stats: scan },
+            reconcile,
+        } = scan_result;
 
         let mut existing = self.load_existing_state(source_id)?;
         let found = raw_sessions.len();
@@ -380,6 +384,7 @@ impl SyncJob {
             self.progress.indexing(label, done, found);
             self.process_raw_session(source_id, raw, &mut existing, &mut purged_excluded_ids)?;
         }
+        self.reconcile_source(source_id, label, reconcile)?;
 
         let touched = self.stats.touched() - touched_before;
         let elapsed_ms = started.elapsed().as_millis();
@@ -402,35 +407,27 @@ impl SyncJob {
         source_id: &str,
         label: &str,
         purged_excluded_ids: &mut HashSet<String>,
-    ) -> Result<Option<(Vec<adapters::RawSession>, adapters::SyncScanStats)>> {
+    ) -> Result<Option<adapters::SyncScanOutput>> {
         if self.options.verbose {
             println!("Scanning {label}...");
         }
-        // Prune deletes every row whose source file disappeared, which a
-        // scoped run must not do outside its scope. Adapters cannot prune by
-        // scope, so a scoped sync leaves it to global runs.
-        if matches!(self.options.scope, ProjectScope::Global)
-            && let Err(e) = adapter.prune(&self.store)
-            && self.options.emit
-        {
-            eprintln!("Error pruning {label}: {e}");
-        }
         let include_events = !self.options.usage_only || self.options.backfill_events;
-        let optimized = if self.options.force {
-            None
-        } else {
-            match adapter.scan_for_sync(&self.store, self.since_ts, include_events) {
-                Ok(scan) => scan,
-                Err(e) => {
-                    if self.options.emit {
-                        eprintln!("Error scanning {label}: {e}");
-                    }
-                    return Ok(None);
+        let optimized = match adapter.scan_for_sync_output(
+            &self.store,
+            self.since_ts,
+            include_events,
+            self.options.force,
+        ) {
+            Ok(scan) => scan,
+            Err(e) => {
+                if self.options.emit {
+                    eprintln!("Error scanning {label}: {e}");
                 }
+                return Ok(None);
             }
         };
-        let (raw_sessions, scan_stats) = match optimized {
-            Some(scan) => (scan.sessions, scan.stats),
+        let scan_result = match optimized {
+            Some(scan) => scan,
             None => {
                 let raw_sessions = match adapter.scan() {
                     Ok(s) => s,
@@ -444,14 +441,21 @@ impl SyncJob {
                 // A full scan parses everything it finds; there is no
                 // candidate stage to account for separately.
                 let parsed = raw_sessions.len() as u32;
-                (
-                    raw_sessions,
-                    adapters::SyncScanStats { candidates: parsed, parsed, ..Default::default() },
-                )
+                adapters::SyncScanOutput {
+                    scan: adapters::SyncScanResult {
+                        sessions: raw_sessions,
+                        stats: adapters::SyncScanStats {
+                            candidates: parsed,
+                            parsed,
+                            ..Default::default()
+                        },
+                    },
+                    reconcile: None,
+                }
             }
         };
-        self.stats.skipped += scan_stats.skipped_sessions;
-        self.stats.filtered_out += scan_stats.filtered_sessions;
+        self.stats.skipped += scan_result.scan.stats.skipped_sessions;
+        self.stats.filtered_out += scan_result.scan.stats.filtered_sessions;
         if let Some(matcher) = &self.path_excluder {
             let n = delete_excluded_sessions_for_source(
                 &self.store,
@@ -463,9 +467,67 @@ impl SyncJob {
             self.stats.excluded_out += n;
         }
         if self.options.verbose {
-            println!("  Found {} sessions", raw_sessions.len());
+            println!("  Found {} sessions", scan_result.scan.sessions.len());
         }
-        Ok(Some((raw_sessions, scan_stats)))
+        Ok(Some(scan_result))
+    }
+
+    fn reconcile_source(
+        &self,
+        source_id: &str,
+        label: &str,
+        reconcile: Option<adapters::ReconcilePlan>,
+    ) -> Result<()> {
+        if !matches!(self.options.scope, ProjectScope::Global) {
+            return Ok(());
+        }
+        let Some(reconcile) = reconcile else {
+            return Ok(());
+        };
+        match reconcile {
+            adapters::ReconcilePlan::PartialInventory(issues) => {
+                self.report_incomplete_inventory(label, "partial", &issues);
+            }
+            adapters::ReconcilePlan::UnavailableInventory(issues) => {
+                self.report_incomplete_inventory(label, "unavailable", &issues);
+            }
+            adapters::ReconcilePlan::CompleteLiveSet(live) => {
+                let existing = self.store.session_meta_map(source_id)?;
+                for source_id_to_delete in existing.keys().filter(|id| !live.contains(*id)) {
+                    self.store.delete_session_data(source_id, source_id_to_delete)?;
+                }
+            }
+            adapters::ReconcilePlan::ExactTombstones(source_ids) => {
+                let existing = self.store.session_meta_map(source_id)?;
+                for source_id_to_delete in
+                    source_ids.into_iter().filter(|id| existing.contains_key(id))
+                {
+                    self.store.delete_session_data(source_id, &source_id_to_delete)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn report_incomplete_inventory(
+        &self,
+        label: &str,
+        state: &str,
+        issues: &[adapters::InventoryIssue],
+    ) {
+        if !self.options.emit {
+            return;
+        }
+        if let Some(issue) = issues.first() {
+            eprintln!(
+                "Reconciliation skipped for {label}: inventory {state} at {} ({:?}; {} issue(s)).",
+                issue.path.display(),
+                issue.category,
+                issues.len()
+            );
+        } else {
+            eprintln!("Reconciliation skipped for {label}: inventory {state}.");
+        }
     }
 
     fn load_existing_state(&mut self, source_id: &str) -> Result<ExistingState> {
@@ -1040,7 +1102,10 @@ fn path_or_ancestor_matches(path: &str, matcher: &globset::GlobSet) -> bool {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
+    use crate::adapters::{
+        InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
+        SyncScanOutput, SyncScanResult,
+    };
     use crate::config::AppConfig;
     use crate::db::{
         schema,
@@ -1060,6 +1125,76 @@ mod tests {
         messages: &'static [&'static str],
         source_file_path: Option<&'static str>,
         optimized: bool,
+    }
+
+    struct FailingAdapter;
+
+    struct ReconcileAdapter {
+        plan: ReconcilePlan,
+        include_session: bool,
+    }
+
+    impl SourceAdapter for FailingAdapter {
+        fn id(&self) -> &str {
+            "test"
+        }
+
+        fn label(&self) -> &str {
+            "Test"
+        }
+
+        fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+            anyhow::bail!("injected scan failure")
+        }
+
+        fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+            None
+        }
+    }
+
+    impl SourceAdapter for ReconcileAdapter {
+        fn id(&self) -> &str {
+            "test"
+        }
+
+        fn label(&self) -> &str {
+            "Test"
+        }
+
+        fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+            if self.include_session {
+                return Ok(vec![RawSession::search_only(
+                    "new",
+                    None,
+                    1_000,
+                    Some(2_000),
+                    None,
+                    vec![RawMessage {
+                        role: Role::User,
+                        content: "new".to_string(),
+                        timestamp: Some(2_000),
+                    }],
+                )]);
+            }
+            Ok(Vec::new())
+        }
+
+        fn scan_for_sync_output(
+            &self,
+            _store: &Store,
+            _since_ts: Option<i64>,
+            _include_events: bool,
+            _force: bool,
+        ) -> anyhow::Result<Option<SyncScanOutput>> {
+            Ok(Some(SyncScanOutput {
+                scan: SyncScanResult { sessions: self.scan()?, stats: Default::default() },
+                reconcile: Some(self.plan.clone()),
+            }))
+        }
+
+        fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+            None
+        }
     }
 
     impl SourceAdapter for StaticAdapter {
@@ -1342,6 +1477,112 @@ mod tests {
         job.run_with(&adapters, None).unwrap();
 
         assert_eq!(job.store.session_meta("test", "outside").unwrap(), Some((Some(1), 7)));
+    }
+
+    #[test]
+    fn failed_scan_preserves_existing_sessions() {
+        schema::register_sqlite_vec();
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(FailingAdapter)];
+        let mut job = SyncJob::new(
+            SyncRunOptions {
+                force: false,
+                verbose: false,
+                emit: false,
+                usage_only: false,
+                backfill_events: false,
+                sources: None,
+                scope: ProjectScope::Global,
+            },
+            Store::open_in_memory().unwrap(),
+            AppConfig::default(),
+            &adapters,
+        )
+        .unwrap();
+        job.store.insert_session(&session("stale", "test", "stale")).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "stale").unwrap().is_some());
+    }
+
+    #[test]
+    fn complete_live_set_deletes_only_stale_sessions() {
+        for force in [false, true] {
+            let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+                plan: ReconcilePlan::CompleteLiveSet(HashSet::from(["keep".to_string()])),
+                include_session: false,
+            })];
+            let (mut job, _) = scoped_job(ProjectScope::Global);
+            job.options.force = force;
+            job.store.insert_session(&session("keep", "test", "keep")).unwrap();
+            job.store.insert_session(&session("stale", "test", "stale")).unwrap();
+
+            job.run_with(&adapters, None).unwrap();
+
+            assert!(job.store.session_meta("test", "keep").unwrap().is_some());
+            assert!(job.store.session_meta("test", "stale").unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn complete_exact_tombstone_deletes_owned_session() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+            plan: ReconcilePlan::ExactTombstones(HashSet::from(["subagent".to_string()])),
+            include_session: false,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Global);
+        job.store.insert_session(&session("subagent", "test", "subagent")).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "subagent").unwrap().is_none());
+    }
+
+    #[test]
+    fn partial_inventory_preserves_existing_sessions() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+            plan: ReconcilePlan::PartialInventory(vec![InventoryIssue {
+                path: "/unreadable".into(),
+                category: std::io::ErrorKind::PermissionDenied,
+            }]),
+            include_session: false,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Global);
+        job.store.insert_session(&session("stale", "test", "stale")).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "stale").unwrap().is_some());
+    }
+
+    #[test]
+    fn scoped_sync_cannot_apply_complete_reconcile_plan() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+            plan: ReconcilePlan::CompleteLiveSet(HashSet::new()),
+            include_session: false,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Directory("/repo/root".to_string()));
+        let mut existing = session("stale", "test", "stale");
+        existing.directory = Some("/repo/root".to_string());
+        job.store.insert_session(&existing).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "stale").unwrap().is_some());
+    }
+
+    #[test]
+    fn session_processing_failure_does_not_apply_reconcile_plan() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+            plan: ReconcilePlan::CompleteLiveSet(HashSet::new()),
+            include_session: true,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Global);
+        job.store.insert_session(&session("stale", "test", "stale")).unwrap();
+        job.store.conn.execute("DROP TABLE messages", []).unwrap();
+
+        assert!(job.run_with(&adapters, None).is_err());
+        assert!(job.store.session_meta("test", "stale").unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
### What’s changed?

- Move Goose and Grok stale-session reconciliation out of adapters and into sync.
- Require complete source inventory and successful global processing before deleting indexed sessions.
- Preserve existing sessions when scans fail or inventory is partial or unavailable, with focused regression coverage.
- Simplify the reconciliation result model to prevent invalid state and plan combinations.

### Why

- Prevent cleanup from deleting indexed data before source scans complete or when the live inventory cannot be trusted.

### Verification

- `cargo test adapters::goose::tests --lib`
- `cargo test adapters::grok::tests --lib`
- `cargo test sync::tests --lib`
- `make check`