### PR TITLE
fix(sync): preserve session ids across refreshes

### DIFF
--- a/src/adapters/crush.rs
+++ b/src/adapters/crush.rs
@@ -188,8 +188,8 @@ fn scan_projects(
                 continue;
             }
             if store.is_some()
-                && existing.get(&row.id).is_some_and(|&(old_updated_at, _)| {
-                    old_updated_at == Some(updated_at)
+                && existing.get(&row.id).is_some_and(|old| {
+                    old.updated_at == Some(updated_at)
                         && crate::adapters::sync_state::session_state_is_current(
                             USAGE_PARSER_VERSION,
                             EVENT_PARSER_VERSION,

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -136,8 +136,8 @@ fn scan_for_sync_conn(
         }
 
         let source_updated_at = updated_at.or(global_mtime);
-        if let Some((old_updated_at, _)) = existing.get(&composer_id)
-            && *old_updated_at == source_updated_at
+        if let Some(old) = existing.get(&composer_id)
+            && old.updated_at == source_updated_at
             && crate::adapters::sync_state::session_state_is_current(
                 USAGE_PARSER_VERSION,
                 EVENT_PARSER_VERSION,

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -226,8 +226,8 @@ where
             continue;
         }
 
-        if let Some((old_updated_at, _)) = existing.get(&entry.session_id)
-            && *old_updated_at == Some(mtime_ms)
+        if let Some(old) = existing.get(&entry.session_id)
+            && old.updated_at == Some(mtime_ms)
             && usage_state_is_current_for_mtime(
                 options.usage_parser_version,
                 usage_state.get(&entry.session_id).copied(),

--- a/src/adapters/goose.rs
+++ b/src/adapters/goose.rs
@@ -207,8 +207,8 @@ fn scan_db(
             continue;
         }
         if incremental_store.is_some()
-            && existing.get(&row.id).is_some_and(|&(old_updated_at, _)| {
-                old_updated_at == freshness
+            && existing.get(&row.id).is_some_and(|old| {
+                old.updated_at == freshness
                     && crate::adapters::sync_state::session_state_is_current(
                         USAGE_PARSER_VERSION,
                         EVENT_PARSER_VERSION,

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -676,10 +676,10 @@ pub(crate) fn scan_for_sync_conn_with_options(
     let mut candidates = Vec::new();
 
     for session in sessions {
-        if let Some(&(old_updated_at, old_message_count)) = existing.get(&session.id) {
+        if let Some(old) = existing.get(&session.id) {
             let current_message_count = current_counts.get(&session.id).copied().unwrap_or(0);
-            if session.time_updated == old_updated_at
-                && current_message_count == old_message_count
+            if session.time_updated == old.updated_at
+                && current_message_count == old.message_count
                 && crate::adapters::sync_state::session_state_is_current(
                     USAGE_PARSER_VERSION,
                     EVENT_PARSER_VERSION,

--- a/src/db/semantic_store.rs
+++ b/src/db/semantic_store.rs
@@ -125,7 +125,7 @@ impl Store {
             "UPDATE session_embedding_state
              SET status = 'processing',
                  units_done = ?2
-             WHERE session_id = ?1",
+             WHERE session_id = ?1 AND status = 'processing'",
             rusqlite::params![session_id, units_done as i64],
         )?;
         Ok(())
@@ -139,7 +139,7 @@ impl Store {
                  units_done = units_total,
                  finished_at = ?2,
                  last_error = NULL
-             WHERE session_id = ?1",
+             WHERE session_id = ?1 AND status = 'processing'",
             rusqlite::params![session_id, now],
         )?;
         Ok(())
@@ -152,7 +152,7 @@ impl Store {
              SET status = 'failed',
                  finished_at = ?2,
                  last_error = ?3
-             WHERE session_id = ?1",
+             WHERE session_id = ?1 AND status = 'processing'",
             rusqlite::params![session_id, now, error],
         )?;
         Ok(())

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -7,8 +7,8 @@ use rusqlite::OptionalExtension;
 use super::event_store::replace_session_events;
 use super::project_store::apply_scope_filters;
 use super::store::{
-    MetadataSessionStateMeta, SESSION_COLUMNS, SessionListSort, SessionTopologyWrite, Store,
-    session_from_row,
+    IndexedSessionMeta, MetadataSessionStateMeta, SESSION_COLUMNS, SessionListSort,
+    SessionTopologyWrite, Store, session_from_row,
 };
 use crate::db::search::{ThreadRoleFilter, TimeRange};
 use crate::project_scope::ProjectScope;
@@ -42,12 +42,19 @@ impl Store {
     pub(crate) fn session_meta_map(
         &self,
         source: &str,
-    ) -> Result<HashMap<String, (Option<i64>, u32)>> {
+    ) -> Result<HashMap<String, IndexedSessionMeta>> {
         let mut stmt = self.conn.prepare(
-            "SELECT source_id, updated_at, message_count FROM sessions WHERE source = ?1",
+            "SELECT source_id, id, updated_at, message_count FROM sessions WHERE source = ?1",
         )?;
         let rows = stmt.query_map(rusqlite::params![source], |row| {
-            Ok((row.get::<_, String>(0)?, (row.get(1)?, row.get(2)?)))
+            Ok((
+                row.get::<_, String>(0)?,
+                IndexedSessionMeta {
+                    id: row.get(1)?,
+                    updated_at: row.get(2)?,
+                    message_count: row.get(3)?,
+                },
+            ))
         })?;
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -51,6 +51,13 @@ pub(crate) struct SessionPath {
     pub(crate) repo_name: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct IndexedSessionMeta {
+    pub(crate) id: String,
+    pub(crate) updated_at: Option<i64>,
+    pub(crate) message_count: u32,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SessionListSort {
     Newest,

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -1522,6 +1522,58 @@ fn replace_session_clears_import_marker_on_success() {
 }
 
 #[test]
+fn stale_embedding_job_cannot_update_replacement_state() {
+    let store = setup();
+    let mut original = make_session("stable-id", "test", "raw-1", "Original");
+    original.updated_at = Some(2_000);
+    store
+        .persist_session_with_usage_and_events(
+            &original,
+            &[make_message("stable-id", Role::User, "old content", 0)],
+            &[],
+            None,
+            &[],
+            None,
+        )
+        .unwrap();
+    let job = store.claim_next_session_embedding_job().unwrap().unwrap();
+    let status = || {
+        store
+            .conn
+            .query_row(
+                "SELECT status FROM session_embedding_state WHERE session_id = 'stable-id'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(status(), "processing");
+
+    let mut replacement = make_session("stable-id", "test", "raw-1", "Replacement");
+    replacement.updated_at = Some(3_000);
+    store
+        .replace_session_with_usage_and_events(
+            "test",
+            "raw-1",
+            &replacement,
+            &[make_message("stable-id", Role::User, "new content", 0)],
+            &[],
+            None,
+            &[],
+            None,
+        )
+        .unwrap();
+    assert_eq!(status(), "pending");
+
+    store.update_session_embedding_progress(&job.session_id, 1).unwrap();
+    assert_eq!(status(), "pending");
+    store.complete_session_embedding(&job.session_id).unwrap();
+    assert_eq!(status(), "pending");
+    store.fail_session_embedding(&job.session_id, "stale").unwrap();
+    assert_eq!(status(), "pending");
+}
+
+#[test]
 fn gemini_parser_plain_conversation() {
     let json = r#"{
         "sessionId": "abc-123",

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,8 +6,8 @@ use tracing::info;
 use crate::adapters;
 use crate::config::AppConfig;
 use crate::db::store::{
-    EventSessionStateMeta, MetadataSessionStateMeta, SessionPath, SessionTopologyWrite, Store,
-    UsageSessionStateMeta,
+    EventSessionStateMeta, IndexedSessionMeta, MetadataSessionStateMeta, SessionPath,
+    SessionTopologyWrite, Store, UsageSessionStateMeta,
 };
 use crate::project_scope::{ProjectScope, SessionScopeFields};
 use crate::query::resolve_source_filter;
@@ -174,7 +174,7 @@ impl SyncStats {
 }
 
 struct ExistingState {
-    meta: HashMap<String, (Option<i64>, u32)>,
+    meta: HashMap<String, IndexedSessionMeta>,
     paths: HashMap<String, SessionPath>,
     imported_ids: HashSet<String>,
     usage_meta: HashMap<String, UsageSessionStateMeta>,
@@ -202,7 +202,14 @@ impl ExistingState {
         event_parser_version: Option<u32>,
         metadata_parser_version: Option<u32>,
     ) {
-        self.meta.insert(session.source_id.clone(), (session.updated_at, session.message_count));
+        self.meta.insert(
+            session.source_id.clone(),
+            IndexedSessionMeta {
+                id: session.id.clone(),
+                updated_at: session.updated_at,
+                message_count: session.message_count,
+            },
+        );
         self.paths.insert(
             session.source_id.clone(),
             SessionPath {
@@ -668,15 +675,15 @@ impl SyncJob {
                 )
             });
 
-        match existing.meta.get(&raw_source_id).copied() {
-            Some((old_updated_at, old_msg_count)) => {
+        let session_uuid = match existing.meta.get(&raw_source_id).cloned() {
+            Some(old) => {
                 let was_imported = existing.imported_ids.remove(&raw_source_id);
                 let metadata_changed = existing.paths.get(&raw_source_id).is_some_and(|old| {
                     raw_session_metadata_changed(&raw, repo_identity.as_ref(), old)
                 });
-                let content_changed = old_msg_count != msg_count
+                let content_changed = old.message_count != msg_count
                     || metadata_changed
-                    || (raw.updated_at.is_some() && raw.updated_at != old_updated_at);
+                    || (raw.updated_at.is_some() && raw.updated_at != old.updated_at);
                 match decide_existing_session_action(
                     self.options.usage_only,
                     self.options.backfill_events,
@@ -714,13 +721,14 @@ impl SyncJob {
                 } else {
                     self.stats.reprocessed_sessions += 1;
                 }
+                old.id
             }
             None => {
                 self.stats.new_sessions += 1;
+                uuid::Uuid::new_v4().to_string()
             }
-        }
+        };
 
-        let session_uuid = uuid::Uuid::new_v4().to_string();
         let title = raw
             .custom_title
             .clone()
@@ -1112,7 +1120,7 @@ mod tests {
         store::{SessionPath, Store},
     };
     use crate::project_scope::ProjectScope;
-    use crate::types::{Role, Session};
+    use crate::types::{Message, Role, Session};
 
     use super::{
         BackfillPlan, ExistingSessionAction, SyncJob, SyncRunOptions,
@@ -1269,6 +1277,25 @@ mod tests {
             source_file_path: None,
             is_import: false,
         }
+    }
+
+    fn global_job(adapters: &[Box<dyn SourceAdapter>]) -> SyncJob {
+        schema::register_sqlite_vec();
+        SyncJob::new(
+            SyncRunOptions {
+                force: false,
+                verbose: false,
+                emit: false,
+                usage_only: false,
+                backfill_events: false,
+                sources: None,
+                scope: ProjectScope::Global,
+            },
+            Store::open_in_memory().unwrap(),
+            AppConfig::default(),
+            adapters,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1598,48 +1625,61 @@ mod tests {
     }
 
     #[test]
-    fn sync_job_refreshes_changed_session_through_adapter_seam() {
-        schema::register_sqlite_vec();
+    fn sync_job_refresh_preserves_session_id_and_replaces_indexed_content() {
         let initial: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
             updated_at: 2_000,
-            messages: &["first"],
+            messages: &["old content"],
             source_file_path: None,
             optimized: false,
         })];
-        let mut job = SyncJob::new(
-            SyncRunOptions {
-                force: false,
-                verbose: false,
-                emit: false,
-                usage_only: false,
-                backfill_events: false,
-                sources: None,
-                scope: ProjectScope::Global,
-            },
-            Store::open_in_memory().unwrap(),
-            AppConfig::default(),
-            &initial,
-        )
-        .unwrap();
+        let mut job = global_job(&initial);
 
         job.run_with(&initial, None).unwrap();
-        assert_eq!(job.store.session_meta("test", "raw1").unwrap(), Some((Some(2_000), 1)));
+        let original = job.store.list_recent_sessions(1).unwrap().pop().unwrap();
 
         let updated: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
             updated_at: 3_000,
-            messages: &["first", "second"],
+            messages: &["new content"],
             source_file_path: None,
             optimized: false,
         })];
         job.run_with(&updated, None).unwrap();
 
-        assert_eq!(job.store.session_meta("test", "raw1").unwrap(), Some((Some(3_000), 2)));
-        let session = job.store.list_recent_sessions(1).unwrap().pop().unwrap();
-        let messages = job.store.get_messages(&session.id).unwrap();
-        assert_eq!(
-            messages.iter().map(|message| message.content.as_str()).collect::<Vec<_>>(),
-            ["first", "second"]
-        );
+        let refreshed = job.store.list_recent_sessions(1).unwrap().pop().unwrap();
+        assert_eq!(refreshed.id, original.id);
+        assert_eq!(job.store.get_messages(&refreshed.id).unwrap()[0].content, "new content");
+    }
+
+    #[test]
+    fn imported_session_takeover_preserves_session_id_and_replaces_content() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(StaticAdapter {
+            updated_at: 3_000,
+            messages: &["sourceownedtoken"],
+            source_file_path: None,
+            optimized: false,
+        })];
+        let mut job = global_job(&adapters);
+        let mut imported = session("imported-id", "test", "raw1");
+        imported.updated_at = Some(2_000);
+        imported.message_count = 1;
+        imported.is_import = true;
+        job.store.insert_session(&imported).unwrap();
+        job.store
+            .insert_messages(&[Message {
+                session_id: imported.id.clone(),
+                role: Role::User,
+                content: "importeduniquetoken".to_string(),
+                timestamp: Some(2_000),
+                seq: 0,
+            }])
+            .unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        let refreshed = job.store.list_recent_sessions(1).unwrap().pop().unwrap();
+        assert_eq!(refreshed.id, "imported-id");
+        assert!(!refreshed.is_import);
+        assert_eq!(job.store.get_messages(&refreshed.id).unwrap()[0].content, "sourceownedtoken");
     }
 
     #[test]


### PR DESCRIPTION
### What's changed?

- Preserve the existing Recall session ID when sync refreshes or takes over an imported session.
- Prevent stale embedding workers from mutating replacement job state.
- Add focused regression coverage for refresh, import takeover, and stale worker updates.

### Why

- Session refreshes should not break stable references, and old background work must not mark newly indexed content as complete.

### Verification

- cargo test sync::tests::sync_job_refresh_preserves_session_id_and_replaces_indexed_content -- --exact
- cargo test sync::tests::imported_session_takeover_preserves_session_id_and_replaces_content -- --exact
- cargo test integration::regression::stale_embedding_job_cannot_update_replacement_state -- --exact
- make check