### PR TITLE
feat(share): improve session preview experience

### DIFF
--- a/src/share/assets.rs
+++ b/src/share/assets.rs
@@ -3,9 +3,27 @@ pub(crate) const ROBOTS: &str = "User-agent: *\nDisallow: /\n";
 pub(crate) const SESSION_PAGE_CSS: &str = include_str!("assets/session.css");
 pub(crate) const CHEVRON_SVG: &str = "<svg class=\"chev\" viewBox=\"0 0 16 16\" fill=\"none\" aria-hidden=\"true\"><path d=\"M6 4l4 4-4 4\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>";
 
-pub(crate) const TOC_NAV_SCRIPT: &str = r#"<script>
+pub(crate) const SESSION_PAGE_SCRIPT: &str = r#"<script>
 (function(){
   function setup(){
+    var detailsToggle = document.querySelector('.details-toggle');
+    var details = Array.prototype.slice.call(document.querySelectorAll('details'));
+    if(detailsToggle && details.length){
+      detailsToggle.hidden = false;
+      function allOpen(){ return details.every(function(detail){ return detail.open; }); }
+      function syncDetailsToggle(){
+        var expanded = allOpen();
+        detailsToggle.textContent = expanded ? 'Collapse all' : 'Expand all';
+        detailsToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      }
+      detailsToggle.addEventListener('click', function(){
+        var expanded = !allOpen();
+        details.forEach(function(detail){ detail.open = expanded; });
+        syncDetailsToggle();
+      });
+      details.forEach(function(detail){ detail.addEventListener('toggle', syncDetailsToggle); });
+      syncDetailsToggle();
+    }
     var sections = Array.prototype.slice.call(document.querySelectorAll('.turn.user'));
     var ticks = Array.prototype.slice.call(document.querySelectorAll('.tick'));
     if(!sections.length || !ticks.length) return;

--- a/src/share/assets/session.css
+++ b/src/share/assets/session.css
@@ -22,6 +22,9 @@ body{margin:0;background:var(--page-bg);color:var(--text-primary);font:16px/1.6 
 .meta-tags{display:inline-flex;flex-wrap:wrap;gap:6px}
 .meta-tag{display:inline-flex;align-items:center;gap:5px;padding:2px 9px;border:1px solid var(--rule);border-radius:999px;background:var(--surface);font:500 11.5px/1.5 var(--font-mono);color:var(--text-secondary)}
 .meta-tag b{font-weight:500;color:var(--text-primary)}
+.details-toggle{margin-left:auto;padding:4px 10px;border:1px solid var(--rule-strong);border-radius:7px;background:var(--surface);color:var(--text-secondary);font:500 12px/1.5 var(--font-sans);cursor:pointer;transition:border-color .15s,color .15s,background .15s}
+.details-toggle:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
+.details-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 
 .layout{display:grid;grid-template-columns:minmax(0,var(--read-width)) 212px;grid-template-areas:"page toc";justify-content:center;gap:64px;max-width:var(--layout-width);margin:0 auto;padding:40px 32px 28px}
 .page{grid-area:page;min-width:0}

--- a/src/share/mod.rs
+++ b/src/share/mod.rs
@@ -6,8 +6,8 @@ pub(crate) mod render;
 
 pub(crate) use inventory::{ShareFormat, run_list, run_unpublish};
 pub(crate) use publish::{
-    default_project_name, default_publish_dir, expand_path, init_cloudflare_pages,
-    open_session_preview, preflight_cloudflare_pages, preview_session_with_options,
-    publish_session, publish_session_with_options,
+    create_session_preview, default_project_name, default_publish_dir, expand_path,
+    init_cloudflare_pages, open_preview_file, preflight_cloudflare_pages,
+    preview_session_with_options, publish_session, publish_session_with_options,
 };
 pub(crate) use render::ShareRenderOptions;

--- a/src/share/publish.rs
+++ b/src/share/publish.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -10,7 +11,8 @@ use crate::types::{Message, Session, SessionUsageEventRecord};
 use super::assets::{HEADERS, ROBOTS};
 use super::meta::collect_session_display_meta;
 use super::render::{
-    ShareRenderOptions, render_session_html, render_session_html_with_tldr, share_id_for_session,
+    ShareRenderOptions, render_session_html_with_tldr, render_session_preview_html,
+    share_id_for_session,
 };
 
 const PROVIDER_CLOUDFLARE_PAGES: &str = "cloudflare-pages";
@@ -91,32 +93,24 @@ pub(crate) fn init_cloudflare_pages(
     config.save()
 }
 
-pub(crate) fn default_preview_dir() -> Result<PathBuf> {
-    let root = dirs::cache_dir()
-        .or_else(dirs::data_local_dir)
-        .or_else(dirs::data_dir)
-        .ok_or_else(|| anyhow!("cannot determine cache directory"))?;
-    Ok(root.join("recall").join("preview"))
-}
-
-pub(crate) fn write_preview_file(
+pub(crate) fn create_session_preview(
     session: &Session,
     messages: &[Message],
     usage_events: &[SessionUsageEventRecord],
-) -> Result<PathBuf> {
-    let preview_dir = default_preview_dir()?;
-    fs::create_dir_all(&preview_dir)
-        .with_context(|| format!("failed to create {}", preview_dir.display()))?;
-    let share_id = share_id_for_session(session);
-    let file_path = preview_dir.join(format!("{share_id}.html"));
+) -> Result<tempfile::NamedTempFile> {
     let display_meta = collect_session_display_meta(session, usage_events);
-    let html = render_session_html(session, messages, &display_meta);
-    fs::write(&file_path, html)
-        .with_context(|| format!("failed to write {}", file_path.display()))?;
-    Ok(file_path)
+    let html = render_session_preview_html(session, messages, &display_meta);
+    let mut file = tempfile::Builder::new()
+        .prefix("recall-preview-")
+        .suffix(".html")
+        .tempfile()
+        .context("failed to create temporary preview")?;
+    file.write_all(html.as_bytes()).context("failed to write temporary preview")?;
+    file.flush().context("failed to flush temporary preview")?;
+    Ok(file)
 }
 
-pub(crate) fn open_path_in_browser(path: &Path) -> Result<()> {
+pub(crate) fn open_preview_file(path: &Path) -> Result<()> {
     let path_arg = path.as_os_str();
     let status = if cfg!(target_os = "macos") {
         Command::new("open").arg(path_arg).status()
@@ -131,16 +125,6 @@ pub(crate) fn open_path_in_browser(path: &Path) -> Result<()> {
     } else {
         bail!("failed to open browser for {}", path.display());
     }
-}
-
-pub(crate) fn open_session_preview(
-    session: &Session,
-    messages: &[Message],
-    usage_events: &[SessionUsageEventRecord],
-) -> Result<PathBuf> {
-    let path = write_preview_file(session, messages, usage_events)?;
-    open_path_in_browser(&path)?;
-    Ok(path)
 }
 
 pub(crate) fn preview_session_with_options(
@@ -475,7 +459,8 @@ pub(crate) fn validate_project_name(project_name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Session;
+    use crate::share::render::render_session_html;
+    use crate::types::{Message, Role, Session};
 
     #[test]
     fn share_id_prefers_source_id() {
@@ -515,6 +500,27 @@ mod tests {
     #[test]
     fn share_id_sanitizes_path_chars() {
         assert_eq!(share_id_for_session(&session("foo/bar baz")), "foo-bar-baz");
+    }
+
+    #[test]
+    fn preview_file_is_removed_when_dropped() {
+        let file = create_session_preview(
+            &session("preview"),
+            &[Message {
+                session_id: "local-id".to_string(),
+                role: Role::User,
+                content: "hello".to_string(),
+                timestamp: None,
+                seq: 0,
+            }],
+            &[],
+        )
+        .unwrap();
+        let path = file.path().to_path_buf();
+
+        assert!(fs::read_to_string(&path).unwrap().contains("hello"));
+        drop(file);
+        assert!(!path.exists());
     }
 
     #[test]

--- a/src/share/render.rs
+++ b/src/share/render.rs
@@ -3,7 +3,7 @@ use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag, TagEnd,
 use crate::types::{Message, Role, Session};
 use crate::utils;
 
-use super::assets::{CHEVRON_SVG, SESSION_PAGE_CSS, TOC_NAV_SCRIPT};
+use super::assets::{CHEVRON_SVG, SESSION_PAGE_CSS, SESSION_PAGE_SCRIPT};
 use super::meta::SessionDisplayMeta;
 
 #[derive(Debug, Clone, Default)]
@@ -25,12 +25,21 @@ pub(crate) fn share_id_for_session(session: &Session) -> String {
     let trimmed = out.trim_matches('-').to_string();
     if trimmed.is_empty() { session.id.clone() } else { trimmed }
 }
+#[cfg(any(test, feature = "bench"))]
 pub(crate) fn render_session_html(
     session: &Session,
     messages: &[Message],
     display_meta: &SessionDisplayMeta,
 ) -> String {
-    render_session_html_with_tldr(session, messages, display_meta, None)
+    render_session_html_inner(session, messages, display_meta, None, true)
+}
+
+pub(crate) fn render_session_preview_html(
+    session: &Session,
+    messages: &[Message],
+    display_meta: &SessionDisplayMeta,
+) -> String {
+    render_session_html_inner(session, messages, display_meta, None, false)
 }
 
 pub(crate) fn render_session_html_with_tldr(
@@ -38,6 +47,16 @@ pub(crate) fn render_session_html_with_tldr(
     messages: &[Message],
     display_meta: &SessionDisplayMeta,
     tldr_markdown: Option<&str>,
+) -> String {
+    render_session_html_inner(session, messages, display_meta, tldr_markdown, true)
+}
+
+fn render_session_html_inner(
+    session: &Session,
+    messages: &[Message],
+    display_meta: &SessionDisplayMeta,
+    tldr_markdown: Option<&str>,
+    load_external_fonts: bool,
 ) -> String {
     let title = session.custom_title.as_deref().unwrap_or(&session.title);
     let display_title = display_title(title);
@@ -48,9 +67,11 @@ pub(crate) fn render_session_html_with_tldr(
     out.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
     out.push_str("<meta name=\"robots\" content=\"noindex,nofollow\">");
     out.push_str("<link rel=\"icon\" href=\"data:,\">");
-    out.push_str("<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">");
-    out.push_str("<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>");
-    out.push_str("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=JetBrains+Mono:wght@400;500&display=swap\">");
+    if load_external_fonts {
+        out.push_str("<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">");
+        out.push_str("<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>");
+        out.push_str("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=JetBrains+Mono:wght@400;500&display=swap\">");
+    }
     out.push_str("<title>");
     out.push_str(&escape_html(&display_title));
     out.push_str("</title><style>");
@@ -66,6 +87,7 @@ pub(crate) fn render_session_html_with_tldr(
     out.push_str(&messages.len().to_string());
     out.push_str(" messages</span>");
     append_header_display_meta(&mut out, display_meta);
+    out.push_str("<button type=\"button\" class=\"details-toggle\" aria-expanded=\"false\" hidden>Expand all</button>");
     out.push_str("</div></div></header>");
     out.push_str("<div class=\"layout\"><div class=\"page\"><article class=\"document\">");
     if let Some(tldr) = tldr_markdown.filter(|tldr| !tldr.trim().is_empty()) {
@@ -90,7 +112,7 @@ pub(crate) fn render_session_html_with_tldr(
     out.push_str("<footer class=\"site-footer\"><div class=\"site-footer-inner\">");
     out.push_str("<span class=\"brand-dot\"></span><span>Published with <b>Recall</b></span>");
     out.push_str("</div></footer>");
-    out.push_str(TOC_NAV_SCRIPT);
+    out.push_str(SESSION_PAGE_SCRIPT);
     out.push_str("</body></html>");
     out
 }
@@ -776,6 +798,15 @@ mod tests {
     }
 
     #[test]
+    fn local_preview_has_no_render_blocking_network_resources() {
+        let html = render_session_preview_html(&session("s1"), &[], &SessionDisplayMeta::default());
+
+        assert!(!html.contains("fonts.googleapis.com"));
+        assert!(!html.contains("fonts.gstatic.com"));
+        assert!(render_html(&session("s1"), &[]).contains("fonts.googleapis.com"));
+    }
+
+    #[test]
     fn html_renderer_places_tldr_before_transcript_and_escapes_it() {
         let html = render_session_html_with_tldr(
             &session("s1"),
@@ -918,27 +949,6 @@ mod tests {
         assert!(html.contains("<a href=\"https://example.com\">good</a>"));
         assert!(!html.contains("<img"));
         assert!(html.contains("alt"));
-    }
-
-    #[test]
-    fn preview_writes_html_file() {
-        let dir =
-            std::env::temp_dir().join(format!("recall-preview-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let session = session("preview-test");
-        let messages = vec![Message {
-            session_id: "local-id".to_string(),
-            role: Role::User,
-            content: "hello".to_string(),
-            timestamp: None,
-            seq: 0,
-        }];
-        let path = dir.join("preview.html");
-        let html = render_html(&session, &messages);
-        std::fs::write(&path, html).unwrap();
-        let written = std::fs::read_to_string(&path).unwrap();
-        assert!(written.contains("hello"));
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -179,6 +179,7 @@ pub(crate) struct App {
     pub(crate) handoff_target_selected: usize,
     pub(crate) share_popup: Option<SharePopup>,
     pub(crate) share_publish_rx: Option<mpsc::Receiver<Result<String, String>>>,
+    pub(crate) local_preview: Option<Result<tempfile::NamedTempFile, String>>,
     pub(crate) exec_on_exit: Option<(ResumeCommand, Option<String>)>,
     pub(crate) viewing_search_query: String,
     pub(crate) viewing_search_input: Option<String>,
@@ -274,6 +275,7 @@ impl App {
             handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
+            local_preview: None,
             exec_on_exit: None,
             viewing_search_query: String::new(),
             viewing_search_input: None,
@@ -2464,6 +2466,10 @@ impl App {
         self.viewing_children =
             store.child_subagents(&session.source, &session.source_id).unwrap_or_default();
         self.viewing_sanitized_lines = build_viewing_caches(&msgs);
+        self.local_preview = Some(
+            crate::share::create_session_preview(&session, &msgs, &usage_events)
+                .map_err(|error| error.to_string()),
+        );
         self.viewing_messages = msgs;
         self.viewing_session = Some(session);
         self.viewing_selected_msg = 0;
@@ -2585,24 +2591,16 @@ impl App {
     }
 
     fn preview_current_session(&mut self) {
-        let Some(session) = self.viewing_session.clone() else {
-            return;
-        };
-        let messages = self.viewing_messages.clone();
-        let session_id = session.id.clone();
-        let usage_events = crate::db::store::Store::open()
-            .and_then(|store| store.list_usage_events_for_session(&session_id))
-            .unwrap_or_default();
-        match crate::share::open_session_preview(&session, &messages, &usage_events) {
-            Ok(path) => {
-                self.viewing_search_status = None;
-                self.status_message = Some(format!("Opened preview: {}", path.display()));
-            }
-            Err(error) => {
-                self.viewing_search_status = None;
-                self.status_message = Some(format!("Preview failed: {error}"));
-            }
-        }
+        let started = Instant::now();
+        self.viewing_search_status = None;
+        self.status_message = Some(match self.local_preview.as_ref() {
+            Some(Ok(file)) => match crate::share::open_preview_file(file.path()) {
+                Ok(()) => format!("Opened preview in {} ms", started.elapsed().as_millis()),
+                Err(error) => format!("Preview failed: {error}"),
+            },
+            Some(Err(error)) => format!("Preview failed: {error}"),
+            None => "Preview unavailable".to_string(),
+        });
     }
 
     fn share_current_session(&mut self) {
@@ -2832,6 +2830,7 @@ mod tests {
             handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
+            local_preview: None,
             exec_on_exit: None,
             viewing_search_query: String::new(),
             viewing_search_input: None,

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -122,7 +122,6 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
                 app.fail_usage_refresh("Usage worker unavailable");
             }
         }
-
         app.try_search(&store, &search_worker);
         while let Some(response) = search_worker.try_recv() {
             app.apply_search_response(&store, response);
@@ -130,7 +129,6 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
         while let Some(response) = usage_worker.try_recv() {
             app.apply_usage_response(response);
         }
-
         if app.should_quit {
             break;
         }
@@ -139,7 +137,9 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
     drop(guard);
     terminal.show_cursor()?;
 
-    if let Some((command, cwd)) = app.exec_on_exit.take() {
+    let exec_on_exit = app.exec_on_exit.take();
+    drop(app);
+    if let Some((command, cwd)) = exec_on_exit {
         exec_resume(command, cwd)?;
     }
 

--- a/src/tui/ui/viewing.rs
+++ b/src/tui/ui/viewing.rs
@@ -151,6 +151,8 @@ pub(super) fn render_viewing(f: &mut Frame, app: &App) {
         Span::styled(" export  ", Style::default().fg(THEME.text_muted)),
         Span::styled("s", Style::default().fg(THEME.accent)),
         Span::styled(" share  ", Style::default().fg(THEME.text_muted)),
+        Span::styled("v", Style::default().fg(THEME.accent)),
+        Span::styled(" preview  ", Style::default().fg(THEME.text_muted)),
         Span::styled("h", Style::default().fg(THEME.accent)),
         Span::styled(" handoff  ", Style::default().fg(THEME.text_muted)),
     ];


### PR DESCRIPTION
### What's changed?

- generate local session previews in temporary files and keep them ready while viewing
- skip remote fonts for local previews and expose the preview shortcut in the TUI
- add one control to expand or collapse every details section on rendered session pages

### Why

- open local previews within the 200 ms interaction target without leaving persistent files
- make collapsed session details easier to inspect

### Verification

- make check
- real TUI and Chrome validation: preview opened in 113 ms, toggled 0/3 to 3/3 to 0/3, and removed the temporary file on exit