### PR TITLE
fix(sync): defer file-scan metadata writes

### DIFF
--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -59,7 +59,11 @@ impl SourceAdapter for AntigravityAdapter {
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(cli_dir) = resolve_antigravity_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         Ok(Some(scan_for_sync_impl(&cli_dir, store, since_ts)?))
     }

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -72,7 +72,11 @@ impl SourceAdapter for ClaudeCodeAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(claude_dir) = resolve_claude_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         let result = scan_for_sync_impl(&claude_dir, store, since_ts, include_events)?;
         Ok(Some(result))

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -358,6 +358,7 @@ fn is_cli_source_path(path: Option<&str>) -> bool {
 
 fn merge_scan_results(into: &mut SyncScanResult, extra: SyncScanResult) {
     into.sessions.extend(extra.sessions);
+    into.observations.extend(extra.observations);
     into.stats.skipped_sessions += extra.stats.skipped_sessions;
     into.stats.filtered_sessions += extra.stats.filtered_sessions;
     into.stats.candidates += extra.stats.candidates;

--- a/src/adapters/cline/cli_store.rs
+++ b/src/adapters/cline/cli_store.rs
@@ -34,7 +34,11 @@ pub(super) fn scan_for_sync(
     covered: &HashSet<String>,
 ) -> anyhow::Result<SyncScanResult> {
     let Some(sessions_dir) = resolve_sessions_dir()? else {
-        return Ok(SyncScanResult { sessions: vec![], stats: Default::default() });
+        return Ok(SyncScanResult {
+            sessions: vec![],
+            stats: Default::default(),
+            observations: Vec::new(),
+        });
     };
     let entries = collect_session_entries(&sessions_dir, covered);
     file_scan::run_file_scan_with_options_and_mtime(

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -72,7 +72,11 @@ impl SourceAdapter for CodexAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(codex_dir) = resolve_codex_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         let result = scan_for_sync_impl(&codex_dir, store, since_ts, include_events)?;
         Ok(Some(result))

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -73,7 +73,11 @@ impl SourceAdapter for CopilotAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(sessions_dir) = resolve_copilot_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         let result = scan_for_sync_impl(
             &sessions_dir,

--- a/src/adapters/crush.rs
+++ b/src/adapters/crush.rs
@@ -229,7 +229,7 @@ fn scan_projects(
         }
     }
 
-    Ok(SyncScanResult { sessions, stats })
+    Ok(SyncScanResult { sessions, stats, observations: Vec::new() })
 }
 
 fn crush_db_path(project_path: &str, data_dir: &str) -> PathBuf {

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -84,7 +84,11 @@ impl SourceAdapter for CursorAdapter {
         let mut result = if let Some(conn) = open_global_db()? {
             scan_for_sync_conn(&conn, store, since_ts, include_events, &transcript_paths)?
         } else {
-            SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }
+            SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }
         };
         let covered = ids_covered_by_ide(store, &result.sessions);
         let store_result =
@@ -159,7 +163,7 @@ fn scan_for_sync_conn(
         }
     }
 
-    Ok(SyncScanResult { sessions, stats })
+    Ok(SyncScanResult { sessions, stats, observations: Vec::new() })
 }
 
 fn scan_cursor_sessions(
@@ -1101,6 +1105,7 @@ fn ids_covered_by_ide(store: &Store, emitted: &[RawSession]) -> HashSet<String> 
 
 fn merge_scan_results(into: &mut SyncScanResult, extra: SyncScanResult) {
     into.sessions.extend(extra.sessions);
+    into.observations.extend(extra.observations);
     into.stats.skipped_sessions += extra.stats.skipped_sessions;
     into.stats.filtered_sessions += extra.stats.filtered_sessions;
     into.stats.candidates += extra.stats.candidates;

--- a/src/adapters/cursor/cli_store.rs
+++ b/src/adapters/cursor/cli_store.rs
@@ -53,7 +53,11 @@ pub(super) fn scan_for_sync(
     usage_parser_version: u32,
 ) -> anyhow::Result<SyncScanResult> {
     let Some(chats_dir) = resolve_chats_dir()? else {
-        return Ok(SyncScanResult { sessions: vec![], stats: Default::default() });
+        return Ok(SyncScanResult {
+            sessions: vec![],
+            stats: Default::default(),
+            observations: Vec::new(),
+        });
     };
     let entries = collect_store_entries(&chats_dir, covered);
     file_scan::run_file_scan_with_options_and_mtime(

--- a/src/adapters/deepseek_harness.rs
+++ b/src/adapters/deepseek_harness.rs
@@ -62,7 +62,11 @@ impl SourceAdapter for DeepSeekHarnessAdapter {
         _include_events: bool,
     ) -> Result<Option<SyncScanResult>> {
         let Some(sessions_dir) = resolve_dsh_sessions_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: Vec::new(), stats: Default::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: Vec::new(),
+                stats: Default::default(),
+                observations: Vec::new(),
+            }));
         };
 
         Ok(Some(file_scan::run_file_scan_with_options(

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -9,7 +9,7 @@ use crate::adapters::sync_state::{
     event_state_is_current_for_mtime, metadata_state_is_current_for_mtime,
     usage_state_is_current_for_mtime,
 };
-use crate::adapters::{RawSession, SyncScanResult, SyncScanStats};
+use crate::adapters::{RawSession, SourceObservation, SyncScanResult, SyncScanStats};
 use crate::db::store::Store;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -178,7 +178,6 @@ where
     S: Fn(&FileScanEntry) -> Option<FileScanSnapshot<T>>,
 {
     let existing = store.session_meta_map(source_id)?;
-    let mut imported = store.imported_source_ids(source_id)?;
     let usage_state = match options.usage_parser_version {
         Some(_) => store.usage_state_meta_map(source_id)?,
         None => Default::default(),
@@ -192,6 +191,7 @@ where
         None => Default::default(),
     };
     let mut sessions = Vec::new();
+    let mut observations = Vec::new();
     let mut stats = SyncScanStats::default();
 
     for entry in entries {
@@ -201,26 +201,15 @@ where
             continue;
         };
         let mtime_ms = snapshot.effective_mtime_ms();
-
-        if existing.contains_key(&entry.session_id) {
-            if let Some(source_file_path) = entry.stat_target.to_str() {
-                store.update_session_fields(
-                    source_id,
-                    &entry.session_id,
-                    None,
-                    None,
-                    None,
-                    Some(source_file_path),
-                )?;
-            }
-            if imported.remove(&entry.session_id) {
-                store.clear_import_marker(source_id, &entry.session_id)?;
-            }
-        }
+        let observation = existing.contains_key(&entry.session_id).then(|| SourceObservation {
+            source_id: entry.session_id.clone(),
+            source_file_path: entry.stat_target.to_str().map(str::to_string),
+        });
 
         if let Some(cutoff) = since_ts
             && mtime_ms < cutoff
         {
+            observations.extend(observation);
             stats.filtered_sessions += 1;
             stats.rejected_before_parse += 1;
             continue;
@@ -244,6 +233,7 @@ where
                 mtime_ms,
             )
         {
+            observations.extend(observation);
             stats.skipped_sessions += 1;
             stats.rejected_before_parse += 1;
             continue;
@@ -256,11 +246,12 @@ where
             continue;
         }
         if let Some(raw) = raw {
+            observations.extend(observation);
             sessions.push(raw);
         }
     }
 
-    Ok(SyncScanResult { sessions, stats })
+    Ok(SyncScanResult { sessions, stats, observations })
 }
 
 pub(crate) fn stat_mtime_ms(path: &Path) -> Option<i64> {
@@ -345,6 +336,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(result.sessions.len(), 0);
+        assert!(result.observations.is_empty());
         assert_eq!(result.stats.skipped_sessions, 0);
         assert_eq!(result.stats.filtered_sessions, 0);
     }
@@ -365,6 +357,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.sessions.len(), 1);
+        assert!(result.observations.is_empty());
         assert_eq!(result.sessions[0].source_id, "sess-new");
         assert_eq!(result.stats.skipped_sessions, 0);
         let _ = fs::remove_file(&path);
@@ -379,6 +372,7 @@ mod tests {
             stat_target: path.clone(),
             directory: None,
         };
+        store.insert_session(&make_session("s1", "sess-changing", Some(0), 1)).unwrap();
 
         let result = run_file_scan_with_options_and_snapshot(
             &store,
@@ -398,6 +392,7 @@ mod tests {
         .unwrap();
 
         assert!(result.sessions.is_empty());
+        assert!(result.observations.is_empty());
         assert_eq!(result.stats.unstable_sessions, 1);
 
         let entry = FileScanEntry {
@@ -420,12 +415,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(retry.sessions.len(), 1);
+        assert_eq!(retry.observations.len(), 1);
         assert_eq!(retry.stats.unstable_sessions, 0);
         let _ = fs::remove_file(&path);
     }
 
     #[test]
-    fn matching_mtime_skips_without_parsing() {
+    fn matching_mtime_skip_returns_observation_without_parsing() {
         let store = setup_store();
         let path = temp_file_with_mtime("skip");
         let mtime_ms = stat_mtime_ms(&path).unwrap();
@@ -444,36 +440,32 @@ mod tests {
 
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
-        let paths = store.session_paths_for_source("test-source").unwrap();
-        let stored = paths.iter().find(|path| path.source_id == "sess-skip").unwrap();
-        assert_eq!(stored.source_file_path.as_deref(), path.to_str());
+        assert_eq!(
+            result.observations,
+            vec![SourceObservation {
+                source_id: "sess-skip".to_string(),
+                source_file_path: path.to_str().map(str::to_string),
+            }]
+        );
         let _ = fs::remove_file(&path);
     }
 
     #[test]
-    fn matching_mtime_skip_still_clears_import_marker() {
+    fn parse_rejection_does_not_return_observation() {
         let store = setup_store();
-        let path = temp_file_with_mtime("import-clear");
-        let mtime_ms = stat_mtime_ms(&path).unwrap();
-        let mut session = make_session("s1", "sess-imported", Some(mtime_ms), 1);
-        session.is_import = true;
-        store.insert_session(&session).unwrap();
-
+        let path = temp_file_with_mtime("parse-rejection");
+        store.insert_session(&make_session("s1", "sess-rejected", Some(0), 1)).unwrap();
         let entry = FileScanEntry {
-            session_id: "sess-imported".to_string(),
+            session_id: "sess-rejected".to_string(),
             stat_target: path.clone(),
             directory: None,
         };
 
-        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
-            panic!("parse should not be called for skipped entry")
-        })
-        .unwrap();
+        let result =
+            run_file_scan(&store, "test-source", None, vec![entry], |_, _| Ok(None)).unwrap();
 
-        assert_eq!(result.stats.skipped_sessions, 1);
-        let sessions = store.list_recent_sessions(10).unwrap();
-        assert_eq!(sessions.len(), 1);
-        assert!(!sessions[0].is_import, "local raw backing must clear the import marker");
+        assert!(result.sessions.is_empty());
+        assert!(result.observations.is_empty());
         let _ = fs::remove_file(&path);
     }
 
@@ -705,9 +697,9 @@ mod tests {
 
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.filtered_sessions, 1);
-        let paths = store.session_paths_for_source("test-source").unwrap();
-        let stored = paths.iter().find(|path| path.source_id == "sess-old").unwrap();
-        assert_eq!(stored.source_file_path.as_deref(), path.to_str());
+        assert_eq!(result.observations.len(), 1);
+        assert_eq!(result.observations[0].source_id, "sess-old");
+        assert_eq!(result.observations[0].source_file_path.as_deref(), path.to_str());
         let _ = fs::remove_file(&path);
     }
 

--- a/src/adapters/goose.rs
+++ b/src/adapters/goose.rs
@@ -243,11 +243,18 @@ fn scan_db(
     } else {
         ReconcilePlan::PartialInventory(inventory_issues)
     };
-    Ok(SyncScanOutput { scan: SyncScanResult { sessions, stats }, reconcile: Some(reconcile) })
+    Ok(SyncScanOutput {
+        scan: SyncScanResult { sessions, stats, observations: Vec::new() },
+        reconcile: Some(reconcile),
+    })
 }
 
 fn unavailable_scan_result(store: Option<&Store>) -> anyhow::Result<SyncScanOutput> {
-    let result = SyncScanResult { sessions: Vec::new(), stats: SyncScanStats::default() };
+    let result = SyncScanResult {
+        sessions: Vec::new(),
+        stats: SyncScanStats::default(),
+        observations: Vec::new(),
+    };
     let has_history = match store {
         Some(store) => !store.session_meta_map(SOURCE)?.is_empty(),
         None => false,

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -66,7 +66,11 @@ impl SourceAdapter for GrokAdapter {
         force: bool,
     ) -> anyhow::Result<Option<SyncScanOutput>> {
         let Some(sessions_dir) = resolve_grok_sessions_dir()? else {
-            let result = SyncScanResult { sessions: vec![], stats: SyncScanStats::default() };
+            let result = SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            };
             if store.session_meta_map("grok")?.is_empty() {
                 return Ok(Some(SyncScanOutput { scan: result, reconcile: None }));
             }
@@ -130,7 +134,7 @@ fn scan_for_sync_impl(
                 sessions.push(raw);
             }
         }
-        SyncScanResult { sessions, stats }
+        SyncScanResult { sessions, stats, observations: Vec::new() }
     } else {
         file_scan::run_file_scan_with_options(
             store,

--- a/src/adapters/kilo.rs
+++ b/src/adapters/kilo.rs
@@ -42,7 +42,11 @@ impl SourceAdapter for KiloCodeAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_kilo_db()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         Ok(Some(opencode::scan_for_sync_conn(&conn, store, since_ts, "kilo-code", include_events)?))
     }

--- a/src/adapters/kimi_code.rs
+++ b/src/adapters/kimi_code.rs
@@ -62,7 +62,11 @@ impl SourceAdapter for KimiCodeAdapter {
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(sessions_dir) = resolve_kimi_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         let result = file_scan::run_file_scan_with_options_and_snapshot(
             store,

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -9,8 +9,8 @@ use tracing::{debug, warn};
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-    first_timestamp, last_timestamp,
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SourceObservation, SyncScanResult,
+    SyncScanStats, first_timestamp, last_timestamp,
 };
 use crate::db::store::{SessionPath, Store};
 use crate::types::Role;
@@ -60,12 +60,16 @@ impl SourceAdapter for KiroAdapter {
                 parse_kiro_file_entry,
             )?
         } else {
-            SyncScanResult { sessions: Vec::new(), stats: SyncScanStats::default() }
+            SyncScanResult {
+                sessions: Vec::new(),
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }
         };
 
         let paths = store.session_paths_for_source("kiro-cli").unwrap_or_default();
         reconcile_file_source_ids(&mut result.sessions, &paths);
-        let mut covered = covered_for_sqlite(&result.sessions, &paths);
+        let mut covered = covered_for_sqlite(&result.sessions, &result.observations, &paths);
         for session in scan_sqlite_sessions() {
             if covered_contains(&covered, &session.source_id) {
                 continue;
@@ -518,8 +522,15 @@ fn reconcile_file_source_ids(sessions: &mut [RawSession], paths: &[SessionPath])
     }
 }
 
-fn covered_for_sqlite(sessions: &[RawSession], paths: &[SessionPath]) -> HashSet<String> {
+fn covered_for_sqlite(
+    sessions: &[RawSession],
+    observations: &[SourceObservation],
+    paths: &[SessionPath],
+) -> HashSet<String> {
     let mut covered = covered_ids(sessions);
+    for observation in observations {
+        insert_id_keys(&mut covered, &observation.source_id);
+    }
     for path in paths {
         if path.source_file_path.is_some() {
             insert_id_keys(&mut covered, &path.source_id);
@@ -870,9 +881,31 @@ mod tests {
         let file = raw("file-1");
         let paths =
             [session_path("file-1", Some("/tmp/file.jsonl")), session_path("sqlite-only", None)];
-        let covered = covered_for_sqlite(&[file], &paths);
+        let covered = covered_for_sqlite(&[file], &[], &paths);
         assert!(covered_contains(&covered, "file-1"));
         assert!(!covered_contains(&covered, "sqlite-only"));
+    }
+
+    #[test]
+    fn observed_file_sessions_are_covered_before_sqlite_overlay() {
+        let result = SyncScanResult {
+            sessions: Vec::new(),
+            stats: SyncScanStats::default(),
+            observations: vec![crate::adapters::SourceObservation {
+                source_id: "file-1".to_string(),
+                source_file_path: Some("/tmp/file.jsonl".to_string()),
+            }],
+        };
+        let paths = [session_path("file-1", None)];
+
+        let covered = covered_for_sqlite(&result.sessions, &result.observations, &paths);
+
+        assert!(
+            result
+                .observations
+                .iter()
+                .all(|observation| covered_contains(&covered, &observation.source_id))
+        );
     }
 
     #[test]

--- a/src/adapters/mimo_code.rs
+++ b/src/adapters/mimo_code.rs
@@ -44,7 +44,11 @@ impl SourceAdapter for MimoCodeAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_mimo_db()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         let mut result =
             opencode::scan_for_sync_conn(&conn, store, since_ts, "mimo-code", include_events)?;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -183,6 +183,13 @@ pub(crate) struct SyncScanStats {
 pub(crate) struct SyncScanResult {
     pub(crate) sessions: Vec<RawSession>,
     pub(crate) stats: SyncScanStats,
+    pub(crate) observations: Vec<SourceObservation>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SourceObservation {
+    pub(crate) source_id: String,
+    pub(crate) source_file_path: Option<String>,
 }
 
 pub(crate) struct SyncScanOutput {

--- a/src/adapters/omp.rs
+++ b/src/adapters/omp.rs
@@ -70,7 +70,11 @@ impl SourceAdapter for OmpAdapter {
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let session_dirs = resolve_omp_session_dirs()?;
         if session_dirs.is_empty() {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         }
 
         Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts, include_events)?))

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -91,7 +91,11 @@ impl SourceAdapter for OpenCodeAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_opencode_db()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
 
         Ok(Some(scan_for_sync_conn(&conn, store, since_ts, self.id(), include_events)?))
@@ -702,7 +706,7 @@ pub(crate) fn scan_for_sync_conn_with_options(
     }
 
     let sessions = scan_session_messages(conn, candidates, include_events, options)?;
-    Ok(SyncScanResult { sessions, stats })
+    Ok(SyncScanResult { sessions, stats, observations: Vec::new() })
 }
 
 #[cfg(test)]

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -70,7 +70,11 @@ impl SourceAdapter for PiAdapter {
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let session_dirs = resolve_pi_session_dirs()?;
         if session_dirs.is_empty() {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         }
 
         Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts, include_events)?))

--- a/src/adapters/qwen.rs
+++ b/src/adapters/qwen.rs
@@ -54,7 +54,11 @@ impl SourceAdapter for QwenAdapter {
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(runtime_dir) = resolve_qwen_runtime_dir()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         Ok(Some(file_scan::run_file_scan_with_options(
             store,

--- a/src/adapters/zcode.rs
+++ b/src/adapters/zcode.rs
@@ -46,7 +46,11 @@ impl SourceAdapter for ZcodeAdapter {
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let Some(conn) = open_zcode_db()? else {
-            return Ok(Some(SyncScanResult { sessions: vec![], stats: SyncScanStats::default() }));
+            return Ok(Some(SyncScanResult {
+                sessions: vec![],
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
         };
         Ok(Some(opencode::scan_for_sync_conn_with_options(
             &conn,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -375,13 +375,11 @@ impl SyncJob {
             self.stats.excluded_out += n;
         }
 
-        let Some(scan_result) =
-            self.scan_sessions(adapter, source_id, label, &mut purged_excluded_ids)?
-        else {
+        let Some(scan_result) = self.scan_sessions(adapter, label)? else {
             return Ok(());
         };
         let adapters::SyncScanOutput {
-            scan: adapters::SyncScanResult { sessions: raw_sessions, stats: scan },
+            scan: adapters::SyncScanResult { sessions: raw_sessions, stats: scan, observations },
             reconcile,
         } = scan_result;
 
@@ -390,6 +388,17 @@ impl SyncJob {
         for (done, raw) in raw_sessions.into_iter().enumerate() {
             self.progress.indexing(label, done, found);
             self.process_raw_session(source_id, raw, &mut existing, &mut purged_excluded_ids)?;
+        }
+        self.apply_source_observations(source_id, observations, &mut existing)?;
+        if let Some(matcher) = &self.path_excluder {
+            let n = delete_excluded_sessions_for_source(
+                &self.store,
+                source_id,
+                matcher,
+                &self.options.scope,
+                &mut purged_excluded_ids,
+            )?;
+            self.stats.excluded_out += n;
         }
         self.reconcile_source(source_id, label, reconcile)?;
 
@@ -411,9 +420,7 @@ impl SyncJob {
     fn scan_sessions(
         &mut self,
         adapter: &dyn adapters::SourceAdapter,
-        source_id: &str,
         label: &str,
-        purged_excluded_ids: &mut HashSet<String>,
     ) -> Result<Option<adapters::SyncScanOutput>> {
         if self.options.verbose {
             println!("Scanning {label}...");
@@ -456,6 +463,7 @@ impl SyncJob {
                             parsed,
                             ..Default::default()
                         },
+                        observations: Vec::new(),
                     },
                     reconcile: None,
                 }
@@ -463,20 +471,58 @@ impl SyncJob {
         };
         self.stats.skipped += scan_result.scan.stats.skipped_sessions;
         self.stats.filtered_out += scan_result.scan.stats.filtered_sessions;
-        if let Some(matcher) = &self.path_excluder {
-            let n = delete_excluded_sessions_for_source(
-                &self.store,
-                source_id,
-                matcher,
-                &self.options.scope,
-                purged_excluded_ids,
-            )?;
-            self.stats.excluded_out += n;
-        }
         if self.options.verbose {
             println!("  Found {} sessions", scan_result.scan.sessions.len());
         }
         Ok(Some(scan_result))
+    }
+
+    fn apply_source_observations(
+        &mut self,
+        source_id: &str,
+        observations: Vec<adapters::SourceObservation>,
+        existing: &mut ExistingState,
+    ) -> Result<()> {
+        for observation in observations {
+            let Some(stored) = existing.paths.get_mut(&observation.source_id) else {
+                continue;
+            };
+            let repo_identity = self.repo_cache.resolve(stored.directory.as_deref());
+            if !self.options.scope.matches(SessionScopeFields {
+                directory: stored.directory.as_deref(),
+                repo_remote: stored
+                    .repo_remote
+                    .as_deref()
+                    .or_else(|| repo_identity.as_ref().map(|repo| repo.remote.as_str())),
+                repo_slug: stored
+                    .repo_slug
+                    .as_deref()
+                    .or_else(|| repo_identity.as_ref().map(|repo| repo.slug.as_str())),
+                repo_name: stored
+                    .repo_name
+                    .as_deref()
+                    .or_else(|| repo_identity.as_ref().map(|repo| repo.name.as_str())),
+            }) {
+                continue;
+            }
+            if let Some(source_file_path) = observation.source_file_path.as_deref()
+                && stored.source_file_path.as_deref() != Some(source_file_path)
+            {
+                self.store.update_session_fields(
+                    source_id,
+                    &observation.source_id,
+                    None,
+                    None,
+                    None,
+                    Some(source_file_path),
+                )?;
+                stored.source_file_path = Some(source_file_path.to_string());
+            }
+            if existing.imported_ids.remove(&observation.source_id) {
+                self.store.clear_import_marker(source_id, &observation.source_id)?;
+            }
+        }
+        Ok(())
     }
 
     fn reconcile_source(
@@ -1109,14 +1155,17 @@ fn path_or_ancestor_matches(path: &str, matcher: &globset::GlobSet) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::path::PathBuf;
 
+    use crate::adapters::file_scan::{self, FileScanEntry};
     use crate::adapters::{
         InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
-        SyncScanOutput, SyncScanResult,
+        SourceObservation, SyncScanOutput, SyncScanResult,
     };
     use crate::config::AppConfig;
     use crate::db::{
         schema,
+        search::RepoFilter,
         store::{SessionPath, Store},
     };
     use crate::project_scope::ProjectScope;
@@ -1140,6 +1189,12 @@ mod tests {
     struct ReconcileAdapter {
         plan: ReconcilePlan,
         include_session: bool,
+    }
+
+    struct ObservationAdapter {
+        directory: Option<&'static str>,
+        include_session: bool,
+        failing_path: Option<PathBuf>,
     }
 
     impl SourceAdapter for FailingAdapter {
@@ -1195,8 +1250,76 @@ mod tests {
             _force: bool,
         ) -> anyhow::Result<Option<SyncScanOutput>> {
             Ok(Some(SyncScanOutput {
-                scan: SyncScanResult { sessions: self.scan()?, stats: Default::default() },
+                scan: SyncScanResult {
+                    sessions: self.scan()?,
+                    stats: Default::default(),
+                    observations: Vec::new(),
+                },
                 reconcile: Some(self.plan.clone()),
+            }))
+        }
+
+        fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+            None
+        }
+    }
+
+    impl SourceAdapter for ObservationAdapter {
+        fn id(&self) -> &str {
+            "test"
+        }
+
+        fn label(&self) -> &str {
+            "Test"
+        }
+
+        fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+            if self.include_session {
+                return Ok(vec![RawSession::search_only(
+                    "new",
+                    self.directory.map(str::to_string),
+                    1_000,
+                    Some(2_000),
+                    None,
+                    vec![RawMessage {
+                        role: Role::User,
+                        content: "new".to_string(),
+                        timestamp: Some(2_000),
+                    }],
+                )]);
+            }
+            Ok(Vec::new())
+        }
+
+        fn scan_for_sync_output(
+            &self,
+            store: &Store,
+            since_ts: Option<i64>,
+            _include_events: bool,
+            _force: bool,
+        ) -> anyhow::Result<Option<SyncScanOutput>> {
+            if let Some(path) = &self.failing_path {
+                let entry = FileScanEntry {
+                    session_id: "observed".to_string(),
+                    stat_target: path.clone(),
+                    directory: None,
+                };
+                let scan =
+                    file_scan::run_file_scan(store, "test", since_ts, vec![entry], |_, _| {
+                        anyhow::bail!("injected parse failure")
+                    })?;
+                return Ok(Some(SyncScanOutput { scan, reconcile: None }));
+            }
+            Ok(Some(SyncScanOutput {
+                scan: SyncScanResult {
+                    sessions: self.scan()?,
+                    stats: Default::default(),
+                    observations: vec![SourceObservation {
+                        source_id: "observed".to_string(),
+                        source_file_path: Some("/tmp/observed.jsonl".to_string()),
+                    }],
+                },
+                reconcile: None,
             }))
         }
 
@@ -1243,6 +1366,7 @@ mod tests {
             Ok(Some(crate::adapters::SyncScanResult {
                 sessions: self.scan()?,
                 stats: Default::default(),
+                observations: Vec::new(),
             }))
         }
 
@@ -1530,6 +1654,145 @@ mod tests {
         job.run_with(&adapters, None).unwrap();
 
         assert!(job.store.session_meta("test", "stale").unwrap().is_some());
+    }
+
+    #[test]
+    fn failed_file_parse_does_not_apply_source_observation() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+            directory: None,
+            include_session: false,
+            failing_path: Some(file.path().to_path_buf()),
+        })];
+        let mut job = global_job(&adapters);
+        let mut imported = session("imported", "test", "observed");
+        imported.is_import = true;
+        job.store.insert_session(&imported).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        let stored = job.store.list_recent_sessions(10).unwrap().pop().unwrap();
+        assert!(stored.is_import);
+        assert!(stored.source_file_path.is_none());
+    }
+
+    #[test]
+    fn successful_skipped_observation_updates_path_and_clears_import_marker() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+            directory: None,
+            include_session: false,
+            failing_path: None,
+        })];
+        let mut job = global_job(&adapters);
+        let mut imported = session("imported", "test", "observed");
+        imported.is_import = true;
+        job.store.insert_session(&imported).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        let stored = job.store.list_recent_sessions(10).unwrap().pop().unwrap();
+        assert!(!stored.is_import);
+        assert_eq!(stored.source_file_path.as_deref(), Some("/tmp/observed.jsonl"));
+    }
+
+    #[test]
+    fn scoped_observation_without_directory_uses_stored_session_scope() {
+        let scopes = [
+            ProjectScope::Directory("/repo/root".to_string()),
+            ProjectScope::Repository {
+                filter: RepoFilter::Name("unmatched".to_string()),
+                local_root: Some("/repo/root".to_string()),
+            },
+        ];
+        for scope in scopes {
+            let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+                directory: None,
+                include_session: false,
+                failing_path: None,
+            })];
+            let (mut job, _) = scoped_job(scope);
+            let mut imported = session("imported", "test", "observed");
+            imported.directory = Some("/repo/root/project".to_string());
+            imported.is_import = true;
+            job.store.insert_session(&imported).unwrap();
+
+            job.run_with(&adapters, None).unwrap();
+
+            let stored = job.store.list_recent_sessions(10).unwrap().pop().unwrap();
+            assert!(!stored.is_import);
+            assert_eq!(stored.source_file_path.as_deref(), Some("/tmp/observed.jsonl"));
+        }
+    }
+
+    #[test]
+    fn skipped_observation_applies_path_exclusion_after_success() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+            directory: None,
+            include_session: false,
+            failing_path: None,
+        })];
+        let mut config = AppConfig::default();
+        config.excluded_paths = vec!["**/observed.jsonl".to_string()];
+        let mut job = SyncJob::new(
+            SyncRunOptions {
+                force: false,
+                verbose: false,
+                emit: false,
+                usage_only: false,
+                backfill_events: false,
+                sources: None,
+                scope: ProjectScope::Global,
+            },
+            Store::open_in_memory().unwrap(),
+            config,
+            &adapters,
+        )
+        .unwrap();
+        job.store.insert_session(&session("existing", "test", "observed")).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "observed").unwrap().is_none());
+    }
+
+    #[test]
+    fn out_of_scope_observation_does_not_update_existing_session() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+            directory: Some("/elsewhere"),
+            include_session: false,
+            failing_path: None,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Directory("/repo/root".to_string()));
+        let mut imported = session("imported", "test", "observed");
+        imported.directory = Some("/elsewhere".to_string());
+        imported.is_import = true;
+        job.store.insert_session(&imported).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        let stored = job.store.list_recent_sessions(10).unwrap().pop().unwrap();
+        assert!(stored.is_import);
+        assert!(stored.source_file_path.is_none());
+    }
+
+    #[test]
+    fn session_processing_failure_does_not_apply_source_observation() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
+            directory: None,
+            include_session: true,
+            failing_path: None,
+        })];
+        let mut job = global_job(&adapters);
+        let mut imported = session("imported", "test", "observed");
+        imported.is_import = true;
+        job.store.insert_session(&imported).unwrap();
+        job.store.conn.execute("DROP TABLE messages", []).unwrap();
+
+        assert!(job.run_with(&adapters, None).is_err());
+
+        let stored = job.store.list_recent_sessions(10).unwrap().pop().unwrap();
+        assert!(stored.is_import);
+        assert!(stored.source_file_path.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- defer file-scan metadata writes until session processing succeeds
- apply stored session scope before updating source paths or clearing import markers
- preserve file-backed Kiro sessions when merging SQLite overlays

## Testing

- `cargo test observation`
- `cargo test adapters::kiro::tests`
- `make check`