### PR TITLE
refactor(sync): restrict adapters to immutable sync context

### DIFF
--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -7,12 +7,12 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::Store;
 use crate::types::Role;
 
 const TRANSCRIPT_RELATIVE_PATH: &[&str] = &[".system_generated", "logs", "transcript.jsonl"];
@@ -54,7 +54,7 @@ impl SourceAdapter for AntigravityAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -65,7 +65,7 @@ impl SourceAdapter for AntigravityAdapter {
                 observations: Vec::new(),
             }));
         };
-        Ok(Some(scan_for_sync_impl(&cli_dir, store, since_ts)?))
+        Ok(Some(scan_for_sync_impl(&cli_dir, context, since_ts)?))
     }
 }
 
@@ -78,17 +78,11 @@ fn resolve_antigravity_dir() -> anyhow::Result<Option<PathBuf>> {
 
 fn scan_for_sync_impl(
     cli_dir: &Path,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_antigravity_entries(cli_dir)?;
-    file_scan::run_file_scan(
-        store,
-        "antigravity-cli",
-        since_ts,
-        entries,
-        parse_antigravity_session_for_entry,
-    )
+    file_scan::run_file_scan(context, since_ts, entries, parse_antigravity_session_for_entry)
 }
 
 fn collect_antigravity_entries(cli_dir: &Path) -> anyhow::Result<Vec<FileScanEntry>> {
@@ -383,12 +377,22 @@ mod tests {
         let mtime = file_scan::stat_mtime_ms(&transcript).unwrap();
         let store = setup_store();
 
-        let fresh = scan_for_sync_impl(&root, &store, None).unwrap();
+        let fresh = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "antigravity-cli").unwrap(),
+            None,
+        )
+        .unwrap();
         assert_eq!(fresh.sessions[0].source_file_path.as_deref(), transcript.to_str());
 
         store.insert_session(&make_existing_session(conversation_id, mtime, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "antigravity-cli").unwrap(),
+            None,
+        )
+        .unwrap();
 
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
@@ -15,7 +16,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct ClaudeCodeAdapter;
@@ -67,7 +67,7 @@ impl SourceAdapter for ClaudeCodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -78,7 +78,7 @@ impl SourceAdapter for ClaudeCodeAdapter {
                 observations: Vec::new(),
             }));
         };
-        let result = scan_for_sync_impl(&claude_dir, store, since_ts, include_events)?;
+        let result = scan_for_sync_impl(&claude_dir, context, since_ts, include_events)?;
         Ok(Some(result))
     }
 }
@@ -105,7 +105,7 @@ fn resolve_claude_dir() -> anyhow::Result<Option<PathBuf>> {
 
 fn scan_for_sync_impl(
     claude_dir: &Path,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
@@ -114,8 +114,7 @@ fn scan_for_sync_impl(
     entries.extend(collect_transcript_entries(claude_dir));
 
     file_scan::run_file_scan_with_options(
-        store,
-        "claude-code",
+        context,
         since_ts,
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -1033,7 +1032,13 @@ mod tests {
         fs::write(project.join("sessions-index.json"), index.to_string()).unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].summary.as_deref(), Some("Project index summary"));
@@ -1193,7 +1198,13 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -1212,7 +1223,13 @@ mod tests {
             .insert_session(&make_existing_session("sess-stale", actual_mtime - 1_000, 1))
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "sess-stale");
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -1229,7 +1246,13 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "sess-fresh");
         assert_eq!(result.stats.skipped_sessions, 0);

--- a/src/adapters/cline.rs
+++ b/src/adapters/cline.rs
@@ -7,11 +7,11 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util;
 use crate::adapters::paths;
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult};
-use crate::db::store::Store;
 use crate::types::Role;
 
 const CLINE_EXTENSION_ID: &str = "saoudrizwan.claude-dev";
@@ -36,13 +36,13 @@ impl SourceAdapter for ClineAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        let mut result = scan_task_dirs_for_sync(&resolve_tasks_dirs(), store, since_ts, "cline")?;
-        let covered = ids_covered_by_plugin(store, &result.sessions);
-        merge_scan_results(&mut result, cli_store::scan_for_sync(store, since_ts, &covered)?);
+        let mut result = scan_task_dirs_for_sync(&resolve_tasks_dirs(), context, since_ts)?;
+        let covered = ids_covered_by_plugin(context, &result.sessions);
+        merge_scan_results(&mut result, cli_store::scan_for_sync(context, since_ts, &covered)?);
         Ok(Some(result))
     }
 }
@@ -62,12 +62,11 @@ pub(crate) fn scan_task_dirs(tasks_dirs: &[PathBuf]) -> anyhow::Result<Vec<RawSe
 
 pub(crate) fn scan_task_dirs_for_sync(
     tasks_dirs: &[PathBuf],
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
-    source: &str,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_all_entries(tasks_dirs);
-    file_scan::run_file_scan(store, source, since_ts, entries, |entry, mtime_ms| {
+    file_scan::run_file_scan(context, since_ts, entries, |entry, mtime_ms| {
         parse_cline_task(entry, mtime_ms)
     })
 }
@@ -338,13 +337,11 @@ fn append_cli_store_sessions(mut sessions: Vec<RawSession>) -> anyhow::Result<Ve
     Ok(sessions)
 }
 
-fn ids_covered_by_plugin(store: &Store, emitted: &[RawSession]) -> HashSet<String> {
+fn ids_covered_by_plugin(context: &AdapterSyncContext, emitted: &[RawSession]) -> HashSet<String> {
     let mut ids = emitted.iter().map(|session| session.source_id.clone()).collect::<HashSet<_>>();
-    if let Ok(paths) = store.session_paths_for_source("cline") {
-        for path in paths {
-            if !is_cli_source_path(path.source_file_path.as_deref()) {
-                ids.insert(path.source_id);
-            }
+    for path in context.session_paths() {
+        if !is_cli_source_path(path.source_file_path.as_deref()) {
+            ids.insert(path.source_id.clone());
         }
     }
     ids
@@ -666,8 +663,12 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session("1765706891317", mtime, 1)).unwrap();
 
-        let result =
-            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
+        let result = scan_task_dirs_for_sync(
+            std::slice::from_ref(&root),
+            &AdapterSyncContext::from_store_for_test(&store, "cline").unwrap(),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -688,8 +689,12 @@ mod tests {
             .insert_session(&make_existing_session("1765706891317", actual_mtime - 1_000, 1))
             .unwrap();
 
-        let result =
-            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
+        let result = scan_task_dirs_for_sync(
+            std::slice::from_ref(&root),
+            &AdapterSyncContext::from_store_for_test(&store, "cline").unwrap(),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "1765706891317");
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -708,8 +713,12 @@ mod tests {
 
         let store = setup_store();
 
-        let result =
-            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "cline").unwrap();
+        let result = scan_task_dirs_for_sync(
+            std::slice::from_ref(&root),
+            &AdapterSyncContext::from_store_for_test(&store, "cline").unwrap(),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "1765706891317");
         assert_eq!(result.stats.skipped_sessions, 0);
@@ -791,8 +800,12 @@ mod tests {
         .unwrap();
 
         let store = setup_store();
-        let result =
-            scan_task_dirs_for_sync(std::slice::from_ref(&root), &store, None, "roo").unwrap();
+        let result = scan_task_dirs_for_sync(
+            std::slice::from_ref(&root),
+            &AdapterSyncContext::from_store_for_test(&store, "roo").unwrap(),
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "1765706891317");
         assert_eq!(result.sessions[0].directory.as_deref(), Some("/work/roo-project"));

--- a/src/adapters/cline/cli_store.rs
+++ b/src/adapters/cline/cli_store.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util;
 use crate::adapters::paths;
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SyncScanResult};
-use crate::db::store::Store;
 use crate::types::Role;
 
 pub(super) fn resume_command(source_id: &str) -> Option<ResumeCommand> {
@@ -29,7 +29,7 @@ pub(super) fn scan_uncovered(covered: &HashSet<String>) -> anyhow::Result<Vec<Ra
 }
 
 pub(super) fn scan_for_sync(
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     covered: &HashSet<String>,
 ) -> anyhow::Result<SyncScanResult> {
@@ -42,8 +42,7 @@ pub(super) fn scan_for_sync(
     };
     let entries = collect_session_entries(&sessions_dir, covered);
     file_scan::run_file_scan_with_options_and_mtime(
-        store,
-        "cline",
+        context,
         since_ts,
         Default::default(),
         entries,
@@ -509,8 +508,7 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(session_id, mtime)).unwrap();
         let result = file_scan::run_file_scan_with_options_and_mtime(
-            &store,
-            "cline",
+            &AdapterSyncContext::from_store_for_test(&store, "cline").unwrap(),
             None,
             Default::default(),
             collect_session_entries(&root, &HashSet::new()),

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
@@ -14,7 +15,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct CodexAdapter;
@@ -67,7 +67,7 @@ impl SourceAdapter for CodexAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -78,7 +78,7 @@ impl SourceAdapter for CodexAdapter {
                 observations: Vec::new(),
             }));
         };
-        let result = scan_for_sync_impl(&codex_dir, store, since_ts, include_events)?;
+        let result = scan_for_sync_impl(&codex_dir, context, since_ts, include_events)?;
         Ok(Some(result))
     }
 }
@@ -111,7 +111,7 @@ fn resolve_codex_dir() -> anyhow::Result<Option<PathBuf>> {
 
 fn scan_for_sync_impl(
     codex_dir: &Path,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
@@ -119,8 +119,7 @@ fn scan_for_sync_impl(
     let archived_dir = codex_dir.join("archived_sessions");
     let entries = collect_codex_entries(&[&sessions_dir, &archived_dir]);
     file_scan::run_file_scan_with_options(
-        store,
-        "codex",
+        context,
         since_ts,
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -1766,7 +1765,13 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -1793,7 +1798,13 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -1808,10 +1819,22 @@ mod tests {
         write_codex_event_only_rollout(&sessions_dir, uuid);
         let store = setup_store();
 
-        let usage_result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let usage_result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
         assert!(usage_result.sessions.is_empty());
 
-        let full_result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let full_result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(full_result.sessions.len(), 1);
         assert!(full_result.sessions[0].messages.is_empty());
         assert!(full_result.sessions[0].usage_events.is_empty());
@@ -1831,7 +1854,13 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -1858,7 +1887,13 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, good_uuid);
 
@@ -1874,7 +1909,13 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].source_file_path.as_deref(), path.to_str());

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 
 use rusqlite::params;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
@@ -17,7 +18,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CopilotAdapter;
@@ -68,7 +68,7 @@ impl SourceAdapter for CopilotAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -81,7 +81,7 @@ impl SourceAdapter for CopilotAdapter {
         };
         let result = scan_for_sync_impl(
             &sessions_dir,
-            store,
+            context,
             since_ts,
             include_events,
             resolve_session_store_db().as_deref(),
@@ -275,7 +275,7 @@ fn attach_usage(raw: RawSession, usage: &CopilotUsageIndex) -> RawSession {
 
 fn scan_for_sync_impl(
     sessions_dir: &Path,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
     usage_db: Option<&Path>,
@@ -283,8 +283,7 @@ fn scan_for_sync_impl(
     let entries = collect_copilot_entries(sessions_dir);
     let usage = load_copilot_usage_index(usage_db);
     file_scan::run_file_scan_with_options_and_mtime(
-        store,
-        "copilot-cli",
+        context,
         since_ts,
         FileScanOptions {
             usage_parser_version: usage.is_available().then_some(USAGE_PARSER_VERSION),
@@ -791,7 +790,14 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 
@@ -809,7 +815,14 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(uuid, actual_mtime - 1_000, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].updated_at, Some(actual_mtime));
@@ -827,7 +840,14 @@ mod tests {
 
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].source_file_path.as_deref(), events_path.to_str());
@@ -855,7 +875,14 @@ mod tests {
         writeln!(f, "{user}").unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, dir_name);
 
@@ -877,7 +904,14 @@ mod tests {
         f.write_all(&[0xFF, 0xFE, 0xFD, 0xFC]).unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, good_uuid);
 
@@ -926,8 +960,14 @@ mod tests {
         write_usage_db(&usage_db, uuid, "2026-08-27T19:12:13.186Z");
 
         let store = setup_store();
-        let result =
-            scan_for_sync_impl(&sessions_dir, &store, None, true, Some(&usage_db)).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            Some(&usage_db),
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].usage_parser_version, Some(USAGE_PARSER_VERSION));
         assert_eq!(result.sessions[0].usage_events.len(), 1);
@@ -960,8 +1000,14 @@ mod tests {
         .unwrap();
 
         let store = setup_store();
-        let result =
-            scan_for_sync_impl(&sessions_dir, &store, None, true, Some(&usage_db)).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            Some(&usage_db),
+        )
+        .unwrap();
         assert_eq!(result.sessions[0].usage_events[0].input_tokens, 2);
         assert_eq!(result.sessions[0].usage_events[0].cache_read_tokens, 30_612);
         assert_eq!(result.sessions[0].usage_events[0].cache_write_tokens, 1_120);
@@ -979,8 +1025,14 @@ mod tests {
         write_usage_schema(&usage_db);
 
         let store = setup_store();
-        let result =
-            scan_for_sync_impl(&sessions_dir, &store, None, true, Some(&usage_db)).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            Some(&usage_db),
+        )
+        .unwrap();
         assert_eq!(result.sessions[0].usage_parser_version, Some(USAGE_PARSER_VERSION));
         assert!(result.sessions[0].usage_events.is_empty());
 
@@ -1007,15 +1059,28 @@ mod tests {
             )
             .unwrap();
 
-        let skipped = scan_for_sync_impl(&sessions_dir, &store, None, true, None).unwrap();
+        let skipped = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            None,
+        )
+        .unwrap();
         assert_eq!(skipped.sessions.len(), 0);
         assert_eq!(skipped.stats.skipped_sessions, 1);
 
         let usage_db = root.join("session-store.db");
         write_usage_db(&usage_db, uuid, "2020-01-01T00:00:00.000Z");
 
-        let result =
-            scan_for_sync_impl(&sessions_dir, &store, None, true, Some(&usage_db)).unwrap();
+        let result = scan_for_sync_impl(
+            &sessions_dir,
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-cli").unwrap(),
+            None,
+            true,
+            Some(&usage_db),
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].usage_events.len(), 1);
         assert_eq!(result.sessions[0].usage_events[0].input_tokens, 95);

--- a/src/adapters/copilot_chat.rs
+++ b/src/adapters/copilot_chat.rs
@@ -6,12 +6,12 @@ use std::path::{Path, PathBuf};
 use serde_json::{Map, Value};
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::json_i64;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::Role;
 
 pub(crate) struct CopilotChatAdapter;
@@ -46,18 +46,13 @@ impl SourceAdapter for CopilotChatAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let entries = collect_chat_entries(&vscode_user_roots());
-        let result = file_scan::run_file_scan(
-            store,
-            "copilot-chat",
-            since_ts,
-            entries,
-            parse_chat_session_for_entry,
-        )?;
+        let result =
+            file_scan::run_file_scan(context, since_ts, entries, parse_chat_session_for_entry)?;
         Ok(Some(result))
     }
 }
@@ -695,8 +690,7 @@ mod tests {
 
         let entries = collect_chat_entries(&[user]);
         let result = file_scan::run_file_scan(
-            &store,
-            "copilot-chat",
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-chat").unwrap(),
             None,
             entries,
             parse_chat_session_for_entry,
@@ -762,8 +756,7 @@ mod tests {
 
         let entries = collect_chat_entries(&[user]);
         let result = file_scan::run_file_scan(
-            &store,
-            "copilot-chat",
+            &AdapterSyncContext::from_store_for_test(&store, "copilot-chat").unwrap(),
             None,
             entries,
             parse_chat_session_for_entry,

--- a/src/adapters/crush.rs
+++ b/src/adapters/crush.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
@@ -6,12 +5,12 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::opencode;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 const USAGE_PARSER_VERSION: u32 = 1;
@@ -78,11 +77,11 @@ impl SourceAdapter for CrushAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        Ok(Some(scan_projects(&load_projects()?, Some(store), since_ts, include_events)?))
+        Ok(Some(scan_projects(&load_projects()?, Some(context), since_ts, include_events)?))
     }
 }
 
@@ -139,26 +138,14 @@ fn load_projects_from(path: Option<PathBuf>) -> anyhow::Result<Vec<ProjectRef>> 
 
 fn scan_projects(
     projects: &[ProjectRef],
-    store: Option<&Store>,
+    context: Option<&AdapterSyncContext>,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
-    let existing = match store {
-        Some(store) => store.session_meta_map("crush")?,
-        None => HashMap::new(),
-    };
-    let usage_state = match store {
-        Some(store) => store.usage_state_meta_map("crush")?,
-        None => HashMap::new(),
-    };
-    let event_state = match store {
-        Some(store) if include_events => store.event_state_meta_map("crush")?,
-        _ => HashMap::new(),
-    };
-    let metadata_state = match store {
-        Some(store) => store.metadata_state_meta_map("crush")?,
-        None => HashMap::new(),
-    };
+    let existing = context.map(AdapterSyncContext::session_meta);
+    let usage_state = context.map(AdapterSyncContext::usage_state);
+    let event_state = context.map(AdapterSyncContext::event_state);
+    let metadata_state = context.map(AdapterSyncContext::metadata_state);
 
     let mut sessions = Vec::new();
     let mut stats = SyncScanStats::default();
@@ -187,24 +174,24 @@ fn scan_projects(
                 stats.filtered_sessions += 1;
                 continue;
             }
-            if store.is_some()
-                && existing.get(&row.id).is_some_and(|old| {
+            if existing.is_some_and(|existing| {
+                existing.get(&row.id).is_some_and(|old| {
                     old.updated_at == Some(updated_at)
                         && crate::adapters::sync_state::session_state_is_current(
                             USAGE_PARSER_VERSION,
                             EVENT_PARSER_VERSION,
-                            usage_state.get(&row.id).copied(),
-                            event_state.get(&row.id).copied(),
+                            usage_state.and_then(|state| state.get(&row.id).copied()),
+                            event_state.and_then(|state| state.get(&row.id).copied()),
                             Some(updated_at),
                             include_events,
                         )
                         && crate::adapters::sync_state::metadata_state_is_current(
                             METADATA_PARSER_VERSION,
-                            metadata_state.get(&row.id).copied(),
+                            metadata_state.and_then(|state| state.get(&row.id).copied()),
                             Some(updated_at),
                         )
                 })
-            {
+            }) {
                 stats.skipped_sessions += 1;
                 continue;
             }
@@ -844,7 +831,7 @@ mod tests {
                 path: project.to_string_lossy().into_owned(),
                 data_dir: data_dir.to_string_lossy().into_owned(),
             }],
-            Some(&store),
+            Some(&AdapterSyncContext::from_store_for_test(&store, "crush").unwrap()),
             None,
             true,
         )
@@ -923,7 +910,7 @@ mod tests {
                 path: project.to_string_lossy().into_owned(),
                 data_dir: data_dir.to_string_lossy().into_owned(),
             }],
-            Some(&store),
+            Some(&AdapterSyncContext::from_store_for_test(&store, "crush").unwrap()),
             None,
             true,
         )

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::json_util::json_i64;
 use crate::adapters::paths::resolve_home_dir;
@@ -19,7 +20,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 pub(crate) struct CursorAdapter;
@@ -76,13 +76,13 @@ impl SourceAdapter for CursorAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let transcript_paths = collect_agent_transcript_paths();
         let mut result = if let Some(conn) = open_global_db()? {
-            scan_for_sync_conn(&conn, store, since_ts, include_events, &transcript_paths)?
+            scan_for_sync_conn(&conn, context, since_ts, include_events, &transcript_paths)?
         } else {
             SyncScanResult {
                 sessions: vec![],
@@ -90,9 +90,9 @@ impl SourceAdapter for CursorAdapter {
                 observations: Vec::new(),
             }
         };
-        let covered = ids_covered_by_ide(store, &result.sessions);
+        let covered = ids_covered_by_ide(context, &result.sessions);
         let store_result =
-            cli_store::scan_for_sync(store, since_ts, &covered, USAGE_PARSER_VERSION)?;
+            cli_store::scan_for_sync(context, since_ts, &covered, USAGE_PARSER_VERSION)?;
         merge_scan_results(&mut result, store_result);
         Ok(Some(result))
     }
@@ -100,20 +100,19 @@ impl SourceAdapter for CursorAdapter {
 
 fn scan_for_sync_conn(
     conn: &Connection,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
     transcript_paths: &HashMap<String, AgentTranscriptPath>,
 ) -> anyhow::Result<SyncScanResult> {
-    let existing = store.session_meta_map("cursor")?;
-    let existing_paths = store
-        .session_paths_for_source("cursor")?
-        .into_iter()
-        .map(|path| (path.source_id, path.source_file_path))
+    debug_assert_eq!(context.source(), "cursor");
+    let existing = context.session_meta();
+    let existing_paths = context
+        .session_paths()
+        .map(|path| (path.source_id.clone(), path.source_file_path.clone()))
         .collect::<HashMap<_, _>>();
-    let usage_state = store.usage_state_meta_map("cursor")?;
-    let event_state =
-        if include_events { store.event_state_meta_map("cursor")? } else { HashMap::new() };
+    let usage_state = context.usage_state();
+    let event_state = context.event_state();
     let global_mtime = global_db_mtime();
     let lookup = ComposerLookup::load(conn);
     let composer_ids = discover_composer_ids(conn)?;
@@ -1089,15 +1088,13 @@ fn append_cli_store_sessions(mut sessions: Vec<RawSession>) -> anyhow::Result<Ve
     Ok(sessions)
 }
 
-fn ids_covered_by_ide(store: &Store, emitted: &[RawSession]) -> HashSet<String> {
+fn ids_covered_by_ide(context: &AdapterSyncContext, emitted: &[RawSession]) -> HashSet<String> {
     let mut ids = emitted.iter().map(|session| session.source_id.clone()).collect::<HashSet<_>>();
-    if let Ok(paths) = store.session_paths_for_source("cursor") {
-        for path in paths {
-            let store_owned =
-                path.source_file_path.as_deref().is_some_and(|value| value.ends_with("store.db"));
-            if !store_owned {
-                ids.insert(path.source_id);
-            }
+    for path in context.session_paths() {
+        let store_owned =
+            path.source_file_path.as_deref().is_some_and(|value| value.ends_with("store.db"));
+        if !store_owned {
+            ids.insert(path.source_id.clone());
         }
     }
     ids
@@ -1245,6 +1242,7 @@ mod tests {
 
     use super::*;
     use crate::db::schema;
+    use crate::db::store::Store;
     use crate::types::{Session, TokenSource};
 
     fn temp_root(label: &str) -> PathBuf {
@@ -1458,7 +1456,7 @@ mod tests {
 
         let result = scan_for_sync_conn(
             &conn,
-            &store,
+            &AdapterSyncContext::from_store_for_test(&store, "cursor").unwrap(),
             Some(source_updated_at + 1),
             false,
             &transcript_paths,

--- a/src/adapters/cursor/cli_store.rs
+++ b/src/adapters/cursor/cli_store.rs
@@ -6,11 +6,11 @@ use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::json_i64;
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SyncScanResult};
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, Role, ThreadRole};
 
 const METADATA_PARSER_VERSION: u32 = 1;
@@ -47,7 +47,7 @@ pub(super) fn scan_uncovered(
 }
 
 pub(super) fn scan_for_sync(
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     covered: &HashSet<String>,
     usage_parser_version: u32,
@@ -61,8 +61,7 @@ pub(super) fn scan_for_sync(
     };
     let entries = collect_store_entries(&chats_dir, covered);
     file_scan::run_file_scan_with_options_and_mtime(
-        store,
-        "cursor",
+        context,
         since_ts,
         FileScanOptions {
             usage_parser_version: Some(usage_parser_version),

--- a/src/adapters/deepseek_harness.rs
+++ b/src/adapters/deepseek_harness.rs
@@ -11,12 +11,12 @@ use tracing::{debug, warn};
 use walkdir::WalkDir;
 
 use crate::{
+    adapters::AdapterSyncContext,
     adapters::{
         RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult,
         file_scan::{self, FileScanEntry},
         usage::usage_count,
     },
-    db::store::Store,
     types::{RawUsageEvent, Role},
 };
 
@@ -57,7 +57,7 @@ impl SourceAdapter for DeepSeekHarnessAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> Result<Option<SyncScanResult>> {
@@ -70,8 +70,7 @@ impl SourceAdapter for DeepSeekHarnessAdapter {
         };
 
         Ok(Some(file_scan::run_file_scan_with_options(
-            store,
-            self.id(),
+            context,
             since_ts,
             file_scan::FileScanOptions {
                 usage_parser_version: Some(USAGE_PARSER_VERSION),

--- a/src/adapters/file_scan.rs
+++ b/src/adapters/file_scan.rs
@@ -9,8 +9,9 @@ use crate::adapters::sync_state::{
     event_state_is_current_for_mtime, metadata_state_is_current_for_mtime,
     usage_state_is_current_for_mtime,
 };
-use crate::adapters::{RawSession, SourceObservation, SyncScanResult, SyncScanStats};
-use crate::db::store::Store;
+use crate::adapters::{
+    AdapterSyncContext, RawSession, SourceObservation, SyncScanResult, SyncScanStats,
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct FileScanOptions {
@@ -56,8 +57,7 @@ impl FileMetadataSnapshot {
 }
 
 pub(crate) fn run_file_scan<I, F>(
-    store: &Store,
-    source_id: &str,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     entries: I,
     parse_fn: F,
@@ -66,19 +66,11 @@ where
     I: IntoIterator<Item = FileScanEntry>,
     F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
 {
-    run_file_scan_with_options(
-        store,
-        source_id,
-        since_ts,
-        FileScanOptions::default(),
-        entries,
-        parse_fn,
-    )
+    run_file_scan_with_options(context, since_ts, FileScanOptions::default(), entries, parse_fn)
 }
 
 pub(crate) fn run_file_scan_with_options<I, F>(
-    store: &Store,
-    source_id: &str,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     options: FileScanOptions,
     entries: I,
@@ -89,8 +81,7 @@ where
     F: Fn(FileScanEntry, i64) -> Result<Option<RawSession>>,
 {
     run_file_scan_with_options_and_mtime(
-        store,
-        source_id,
+        context,
         since_ts,
         options,
         entries,
@@ -100,8 +91,7 @@ where
 }
 
 pub(crate) fn run_file_scan_with_options_and_mtime<I, F, M>(
-    store: &Store,
-    source_id: &str,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     options: FileScanOptions,
     entries: I,
@@ -114,8 +104,7 @@ where
     M: Fn(&FileScanEntry) -> Option<i64>,
 {
     run_file_scan_with_observations(
-        store,
-        source_id,
+        context,
         since_ts,
         options,
         entries,
@@ -125,8 +114,7 @@ where
 }
 
 pub(crate) fn run_file_scan_with_options_and_snapshot<I, F, S, T>(
-    store: &Store,
-    source_id: &str,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     options: FileScanOptions,
     entries: I,
@@ -141,8 +129,7 @@ where
 {
     let snapshot_fn = &snapshot_fn;
     run_file_scan_with_observations(
-        store,
-        source_id,
+        context,
         since_ts,
         options,
         entries,
@@ -153,7 +140,8 @@ where
             let stable = snapshot_fn(&revalidate_entry).as_ref() == Some(&before);
             if !stable {
                 warn!(
-                    "skipping unstable {source_id} session {}: source files changed while parsing ({})",
+                    "skipping unstable {} session {}: source files changed while parsing ({})",
+                    context.source(),
                     revalidate_entry.session_id,
                     revalidate_entry.stat_target.display()
                 );
@@ -164,8 +152,7 @@ where
 }
 
 fn run_file_scan_with_observations<I, F, S, T>(
-    store: &Store,
-    source_id: &str,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     options: FileScanOptions,
     entries: I,
@@ -177,19 +164,10 @@ where
     F: Fn(FileScanEntry, i64, FileScanSnapshot<T>) -> Result<(Option<RawSession>, bool)>,
     S: Fn(&FileScanEntry) -> Option<FileScanSnapshot<T>>,
 {
-    let existing = store.session_meta_map(source_id)?;
-    let usage_state = match options.usage_parser_version {
-        Some(_) => store.usage_state_meta_map(source_id)?,
-        None => Default::default(),
-    };
-    let event_state = match options.event_parser_version {
-        Some(_) => store.event_state_meta_map(source_id)?,
-        None => Default::default(),
-    };
-    let metadata_state = match options.metadata_parser_version {
-        Some(_) => store.metadata_state_meta_map(source_id)?,
-        None => Default::default(),
-    };
+    let existing = context.session_meta();
+    let usage_state = context.usage_state();
+    let event_state = context.event_state();
+    let metadata_state = context.metadata_state();
     let mut sessions = Vec::new();
     let mut observations = Vec::new();
     let mut stats = SyncScanStats::default();
@@ -277,6 +255,10 @@ mod tests {
         Store::open_in_memory().unwrap()
     }
 
+    fn sync_context(store: &Store) -> AdapterSyncContext {
+        AdapterSyncContext::from_store_for_test(store, "test-source").unwrap()
+    }
+
     fn make_session(
         id: &str,
         source_id: &str,
@@ -329,12 +311,11 @@ mod tests {
 
     #[test]
     fn empty_input_returns_empty_result() {
-        let store = setup_store();
-        let result =
-            run_file_scan(&store, "test-source", None, Vec::<FileScanEntry>::new(), |_, _| {
-                panic!("parse should not be called")
-            })
-            .unwrap();
+        let context = AdapterSyncContext::empty_for_test("test-source");
+        let result = run_file_scan(&context, None, Vec::<FileScanEntry>::new(), |_, _| {
+            panic!("parse should not be called")
+        })
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert!(result.observations.is_empty());
         assert_eq!(result.stats.skipped_sessions, 0);
@@ -351,7 +332,7 @@ mod tests {
             directory: None,
         };
 
-        let result = run_file_scan(&store, "test-source", None, vec![entry], |entry, mtime_ms| {
+        let result = run_file_scan(&sync_context(&store), None, vec![entry], |entry, mtime_ms| {
             Ok(Some(stub_raw_session(&entry.session_id, mtime_ms)))
         })
         .unwrap();
@@ -375,8 +356,7 @@ mod tests {
         store.insert_session(&make_session("s1", "sess-changing", Some(0), 1)).unwrap();
 
         let result = run_file_scan_with_options_and_snapshot(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions::default(),
             vec![entry],
@@ -401,8 +381,7 @@ mod tests {
             directory: None,
         };
         let retry = run_file_scan_with_options_and_snapshot(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions::default(),
             vec![entry],
@@ -433,7 +412,7 @@ mod tests {
             directory: None,
         };
 
-        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
+        let result = run_file_scan(&sync_context(&store), None, vec![entry], |_, _| {
             panic!("parse should not be called for skipped entry")
         })
         .unwrap();
@@ -462,7 +441,7 @@ mod tests {
         };
 
         let result =
-            run_file_scan(&store, "test-source", None, vec![entry], |_, _| Ok(None)).unwrap();
+            run_file_scan(&sync_context(&store), None, vec![entry], |_, _| Ok(None)).unwrap();
 
         assert!(result.sessions.is_empty());
         assert!(result.observations.is_empty());
@@ -482,8 +461,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: Some(1),
@@ -512,8 +490,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: Some(1),
@@ -542,8 +519,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: None,
@@ -572,8 +548,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: None,
@@ -605,8 +580,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: None,
@@ -633,8 +607,7 @@ mod tests {
             directory: None,
         };
         let result = run_file_scan_with_options(
-            &store,
-            "test-source",
+            &sync_context(&store),
             None,
             FileScanOptions {
                 usage_parser_version: None,
@@ -664,7 +637,7 @@ mod tests {
             directory: None,
         };
 
-        let result = run_file_scan(&store, "test-source", None, vec![entry], |entry, mtime_ms| {
+        let result = run_file_scan(&sync_context(&store), None, vec![entry], |entry, mtime_ms| {
             assert_eq!(mtime_ms, actual_mtime);
             Ok(Some(stub_raw_session(&entry.session_id, mtime_ms)))
         })
@@ -690,7 +663,7 @@ mod tests {
         };
 
         let result =
-            run_file_scan(&store, "test-source", Some(future_cutoff), vec![entry], |_, _| {
+            run_file_scan(&sync_context(&store), Some(future_cutoff), vec![entry], |_, _| {
                 panic!("parse should not be called for filtered entry")
             })
             .unwrap();
@@ -714,7 +687,7 @@ mod tests {
             directory: None,
         };
 
-        let result = run_file_scan(&store, "test-source", None, vec![entry], |_, _| {
+        let result = run_file_scan(&sync_context(&store), None, vec![entry], |_, _| {
             panic!("parse should not be called for missing stat target")
         })
         .unwrap();

--- a/src/adapters/goose.rs
+++ b/src/adapters/goose.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use rusqlite::types::Value as SqlValue;
@@ -6,13 +6,13 @@ use rusqlite::{Connection, Row};
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::opencode;
 use crate::adapters::{
     InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
     SyncScanOutput, SyncScanResult, SyncScanStats, first_timestamp, last_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 const SOURCE: &str = "goose";
@@ -96,12 +96,12 @@ impl SourceAdapter for GooseAdapter {
 
     fn scan_for_sync_output(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
         force: bool,
     ) -> anyhow::Result<Option<SyncScanOutput>> {
-        Ok(Some(scan_db(open_goose_db()?, Some(store), since_ts, include_events, force)?))
+        Ok(Some(scan_db(open_goose_db()?, Some(context), since_ts, include_events, force)?))
     }
 }
 
@@ -157,38 +157,26 @@ fn resolve_db_path_from(
 
 fn scan_db(
     opened: Option<(Connection, PathBuf)>,
-    store: Option<&Store>,
+    context: Option<&AdapterSyncContext>,
     since_ts: Option<i64>,
     include_events: bool,
     force: bool,
 ) -> anyhow::Result<SyncScanOutput> {
     let Some((conn, db_path)) = opened else {
-        return unavailable_scan_result(store);
+        return Ok(unavailable_scan_result(context));
     };
     let snapshot = conn.unchecked_transaction()?;
     if !has_table(&snapshot, "sessions") || !has_table(&snapshot, "messages") {
         debug!("Goose sessions.db missing required tables, skipping");
-        return unavailable_scan_result(store);
+        return Ok(unavailable_scan_result(context));
     }
 
-    let incremental_store = if force { None } else { store };
+    let incremental_context = if force { None } else { context };
     let since_ts = if force { None } else { since_ts };
-    let existing = match incremental_store {
-        Some(store) => store.session_meta_map(SOURCE)?,
-        None => HashMap::new(),
-    };
-    let usage_state = match incremental_store {
-        Some(store) => store.usage_state_meta_map(SOURCE)?,
-        None => HashMap::new(),
-    };
-    let event_state = match incremental_store {
-        Some(store) if include_events => store.event_state_meta_map(SOURCE)?,
-        _ => HashMap::new(),
-    };
-    let metadata_state = match incremental_store {
-        Some(store) => store.metadata_state_meta_map(SOURCE)?,
-        None => HashMap::new(),
-    };
+    let existing = incremental_context.map(AdapterSyncContext::session_meta);
+    let usage_state = incremental_context.map(AdapterSyncContext::usage_state);
+    let event_state = incremental_context.map(AdapterSyncContext::event_state);
+    let metadata_state = incremental_context.map(AdapterSyncContext::metadata_state);
 
     let (live, inventory_issues) = load_all_session_ids(&snapshot, &db_path)?;
     let rows = load_session_rows(&snapshot)?;
@@ -206,24 +194,24 @@ fn scan_db(
             stats.filtered_sessions += 1;
             continue;
         }
-        if incremental_store.is_some()
-            && existing.get(&row.id).is_some_and(|old| {
+        if existing.is_some_and(|existing| {
+            existing.get(&row.id).is_some_and(|old| {
                 old.updated_at == freshness
                     && crate::adapters::sync_state::session_state_is_current(
                         USAGE_PARSER_VERSION,
                         EVENT_PARSER_VERSION,
-                        usage_state.get(&row.id).copied(),
-                        event_state.get(&row.id).copied(),
+                        usage_state.and_then(|state| state.get(&row.id).copied()),
+                        event_state.and_then(|state| state.get(&row.id).copied()),
                         freshness,
                         include_events,
                     )
                     && crate::adapters::sync_state::metadata_state_is_current(
                         METADATA_PARSER_VERSION,
-                        metadata_state.get(&row.id).copied(),
+                        metadata_state.and_then(|state| state.get(&row.id).copied()),
                         freshness,
                     )
             })
-        {
+        }) {
             stats.skipped_sessions += 1;
             continue;
         }
@@ -249,23 +237,19 @@ fn scan_db(
     })
 }
 
-fn unavailable_scan_result(store: Option<&Store>) -> anyhow::Result<SyncScanOutput> {
+fn unavailable_scan_result(context: Option<&AdapterSyncContext>) -> SyncScanOutput {
     let result = SyncScanResult {
         sessions: Vec::new(),
         stats: SyncScanStats::default(),
         observations: Vec::new(),
     };
-    let has_history = match store {
-        Some(store) => !store.session_meta_map(SOURCE)?.is_empty(),
-        None => false,
-    };
-    if has_history {
-        return Ok(SyncScanOutput {
+    if context.is_some_and(AdapterSyncContext::has_existing_sessions) {
+        return SyncScanOutput {
             scan: result,
             reconcile: Some(ReconcilePlan::UnavailableInventory(Vec::new())),
-        });
+        };
     }
-    Ok(SyncScanOutput { scan: result, reconcile: None })
+    SyncScanOutput { scan: result, reconcile: None }
 }
 
 fn include_session_type(session_type: &str) -> bool {
@@ -1182,12 +1166,26 @@ mod tests {
             .unwrap();
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        let result = scan_db(
+            opened,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.scan.stats.skipped_sessions, 1);
         assert!(result.scan.sessions.is_empty());
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
-        let forced = scan_db(opened, Some(&store), None, true, true).unwrap();
+        let forced = scan_db(
+            opened,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            true,
+        )
+        .unwrap();
         assert_eq!(forced.scan.sessions.len(), 1);
         assert!(matches!(
             forced.reconcile,
@@ -1238,7 +1236,14 @@ mod tests {
             .unwrap();
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path.clone()));
-        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        let result = scan_db(
+            opened,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.scan.stats.skipped_sessions, 0);
         assert_eq!(result.scan.sessions.len(), 1);
         assert_eq!(result.scan.sessions[0].updated_at, Some(400_000));
@@ -1301,7 +1306,14 @@ mod tests {
         store.insert_session(&make_session("gone", Some(200_000), 1)).unwrap();
 
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
-        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        let result = scan_db(
+            opened,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
         let remaining = store.session_meta_map(SOURCE).unwrap();
         assert!(remaining.contains_key("keep"));
         assert!(remaining.contains_key("gone"));
@@ -1327,7 +1339,16 @@ mod tests {
         store.insert_session(&make_session("existing", Some(200_000), 1)).unwrap();
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
 
-        assert!(scan_db(opened, Some(&store), None, true, false).is_err());
+        assert!(
+            scan_db(
+                opened,
+                Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+                None,
+                true,
+                false
+            )
+            .is_err()
+        );
         assert!(store.session_meta(SOURCE, "existing").unwrap().is_some());
     }
 
@@ -1350,7 +1371,14 @@ mod tests {
         store.insert_session(&make_session("stale", Some(200_000), 1)).unwrap();
         let opened = opencode::open_readonly(&db_path).unwrap().map(|conn| (conn, db_path));
 
-        let result = scan_db(opened, Some(&store), None, true, false).unwrap();
+        let result = scan_db(
+            opened,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
 
         assert!(matches!(result.reconcile, Some(ReconcilePlan::PartialInventory(_))));
         assert!(result.scan.sessions.iter().any(|session| session.source_id == "keep"));
@@ -1362,7 +1390,14 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_session("existing", Some(200_000), 1)).unwrap();
 
-        let result = scan_db(None, Some(&store), None, true, false).unwrap();
+        let result = scan_db(
+            None,
+            Some(&AdapterSyncContext::from_store_for_test(&store, SOURCE).unwrap()),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
 
         assert!(matches!(result.reconcile, Some(ReconcilePlan::UnavailableInventory(_))));
         assert!(store.session_meta(SOURCE, "existing").unwrap().is_some());

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
@@ -13,7 +14,6 @@ use crate::adapters::{
     InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
     SyncScanOutput, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::Store;
 use crate::types::{RawUsageEvent, Role};
 
 const USAGE_PARSER_VERSION: u32 = 1;
@@ -60,7 +60,7 @@ impl SourceAdapter for GrokAdapter {
 
     fn scan_for_sync_output(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
         force: bool,
@@ -71,7 +71,7 @@ impl SourceAdapter for GrokAdapter {
                 stats: SyncScanStats::default(),
                 observations: Vec::new(),
             };
-            if store.session_meta_map("grok")?.is_empty() {
+            if !context.has_existing_sessions() {
                 return Ok(Some(SyncScanOutput { scan: result, reconcile: None }));
             }
             return Ok(Some(SyncScanOutput {
@@ -79,7 +79,7 @@ impl SourceAdapter for GrokAdapter {
                 reconcile: Some(ReconcilePlan::UnavailableInventory(Vec::new())),
             }));
         };
-        Ok(Some(scan_for_sync_impl(&sessions_dir, store, since_ts, force)?))
+        Ok(Some(scan_for_sync_impl(&sessions_dir, context, since_ts, force)?))
     }
 }
 
@@ -115,7 +115,7 @@ fn resolve_grok_sessions_dir() -> anyhow::Result<Option<PathBuf>> {
 
 fn scan_for_sync_impl(
     sessions_dir: &Path,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     force: bool,
 ) -> anyhow::Result<SyncScanOutput> {
@@ -137,8 +137,7 @@ fn scan_for_sync_impl(
         SyncScanResult { sessions, stats, observations: Vec::new() }
     } else {
         file_scan::run_file_scan_with_options(
-            store,
-            "grok",
+            context,
             since_ts,
             FileScanOptions {
                 usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -887,7 +886,13 @@ mod tests {
         fs::write(&not_directory, "not a directory").unwrap();
         let store = setup_store();
 
-        let result = scan_for_sync_impl(&not_directory, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &not_directory,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
 
         assert!(matches!(result.reconcile, Some(ReconcilePlan::UnavailableInventory(_))));
     }
@@ -921,7 +926,13 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(session_id, 1, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
 
         assert!(result.scan.sessions.is_empty());
         assert!(store.session_meta("grok", session_id).unwrap().is_some());
@@ -955,7 +966,13 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(subagent_id, 1, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
 
         assert!(store.session_meta_map("grok").unwrap().contains_key(subagent_id));
         assert_eq!(result.scan.sessions.len(), 1);
@@ -983,7 +1000,13 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_existing_session(session_id, mtime, 1)).unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             result.scan.sessions.len(),
             1,
@@ -1000,11 +1023,23 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&root, &store, None, false).unwrap();
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.scan.sessions.len(), 0);
         assert_eq!(result.scan.stats.skipped_sessions, 1);
 
-        let forced = scan_for_sync_impl(&root, &store, None, true).unwrap();
+        let forced = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(forced.scan.sessions.len(), 1);
         assert!(matches!(
             forced.reconcile,

--- a/src/adapters/kilo.rs
+++ b/src/adapters/kilo.rs
@@ -2,9 +2,9 @@ use std::path::{Path, PathBuf};
 
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::opencode;
 use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats};
-use crate::db::store::Store;
 
 pub(crate) struct KiloCodeAdapter;
 
@@ -37,7 +37,7 @@ impl SourceAdapter for KiloCodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -48,7 +48,7 @@ impl SourceAdapter for KiloCodeAdapter {
                 observations: Vec::new(),
             }));
         };
-        Ok(Some(opencode::scan_for_sync_conn(&conn, store, since_ts, "kilo-code", include_events)?))
+        Ok(Some(opencode::scan_for_sync_conn(&conn, context, since_ts, include_events)?))
     }
 }
 

--- a/src/adapters/kimi_code.rs
+++ b/src/adapters/kimi_code.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use tracing::warn;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed};
 use crate::adapters::paths::resolve_home_dir;
@@ -15,7 +16,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{RawUsageEvent, Role};
 
 pub(crate) struct KimiCodeAdapter;
@@ -57,7 +57,7 @@ impl SourceAdapter for KimiCodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -69,8 +69,7 @@ impl SourceAdapter for KimiCodeAdapter {
             }));
         };
         let result = file_scan::run_file_scan_with_options_and_snapshot(
-            store,
-            "kimi-code",
+            context,
             since_ts,
             kimi_scan_options(),
             collect_session_entries(&sessions_dir),
@@ -418,6 +417,7 @@ mod tests {
     use std::time::{Duration, UNIX_EPOCH};
 
     use super::*;
+    use crate::db::store::Store;
 
     fn fixture_state() -> &'static str {
         r#"{"id":"session_abc","cwd":"/repo","createdAt":1700000000000,"updatedAt":1700000060000,"title":"fix the bug","isCustomTitle":false,"archived":false}"#
@@ -471,13 +471,12 @@ mod tests {
     }
 
     fn run_kimi_snapshot_scan(
-        store: &Store,
+        context: &AdapterSyncContext,
         root: &Path,
         mutation: Option<SnapshotMutation>,
     ) -> SyncScanResult {
         file_scan::run_file_scan_with_options_and_snapshot(
-            store,
-            "kimi-code",
+            context,
             None,
             kimi_scan_options(),
             collect_session_entries(root),
@@ -600,7 +599,11 @@ mod tests {
                 )
                 .unwrap();
 
-            let result = run_kimi_snapshot_scan(&store, root.path(), Some(mutation));
+            let result = run_kimi_snapshot_scan(
+                &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
+                root.path(),
+                Some(mutation),
+            );
             assert!(result.sessions.is_empty(), "{mutation:?}");
             assert_eq!(result.stats.unstable_sessions, 1, "{mutation:?}");
             let indexed = store.list_recent_sessions(10).unwrap();
@@ -608,7 +611,11 @@ mod tests {
             assert_eq!(indexed[0].title, "prior indexed title", "{mutation:?}");
             assert_eq!(indexed[0].updated_at, Some(initial_mtime - 1), "{mutation:?}");
 
-            let retry = run_kimi_snapshot_scan(&store, root.path(), None);
+            let retry = run_kimi_snapshot_scan(
+                &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
+                root.path(),
+                None,
+            );
             assert_eq!(retry.sessions.len(), 1, "{mutation:?}");
             assert_eq!(retry.stats.unstable_sessions, 0, "{mutation:?}");
         }
@@ -648,8 +655,7 @@ mod tests {
             .unwrap();
 
         let backfill = file_scan::run_file_scan_with_options_and_snapshot(
-            &store,
-            "kimi-code",
+            &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
             None,
             kimi_scan_options(),
             collect_session_entries(root.path()),
@@ -670,8 +676,7 @@ mod tests {
             )
             .unwrap();
         let skipped = file_scan::run_file_scan_with_options_and_snapshot(
-            &store,
-            "kimi-code",
+            &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
             None,
             kimi_scan_options(),
             collect_session_entries(root.path()),
@@ -757,8 +762,7 @@ mod tests {
             .unwrap();
 
         let result = file_scan::run_file_scan_with_options_and_snapshot(
-            &store,
-            "kimi-code",
+            &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
             None,
             kimi_scan_options(),
             collect_session_entries(root.path()),

--- a/src/adapters/kiro.rs
+++ b/src/adapters/kiro.rs
@@ -6,13 +6,14 @@ use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SourceObservation, SyncScanResult,
     SyncScanStats, first_timestamp, last_timestamp,
 };
-use crate::db::store::{SessionPath, Store};
+use crate::db::store::SessionPath;
 use crate::types::Role;
 
 pub(crate) struct KiroAdapter;
@@ -46,14 +47,13 @@ impl SourceAdapter for KiroAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
         let mut result = if let Some(sessions_dir) = resolve_sessions_dir() {
             file_scan::run_file_scan_with_options(
-                store,
-                "kiro-cli",
+                context,
                 since_ts,
                 file_scan::FileScanOptions::default(),
                 collect_file_entries(&sessions_dir),
@@ -67,7 +67,7 @@ impl SourceAdapter for KiroAdapter {
             }
         };
 
-        let paths = store.session_paths_for_source("kiro-cli").unwrap_or_default();
+        let paths = context.session_paths().cloned().collect::<Vec<_>>();
         reconcile_file_source_ids(&mut result.sessions, &paths);
         let mut covered = covered_for_sqlite(&result.sessions, &result.observations, &paths);
         for session in scan_sqlite_sessions() {

--- a/src/adapters/mimo_code.rs
+++ b/src/adapters/mimo_code.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 use rusqlite::Connection;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::opencode;
 use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats};
-use crate::db::store::Store;
 
 pub(crate) struct MimoCodeAdapter;
 
@@ -39,7 +39,7 @@ impl SourceAdapter for MimoCodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -50,8 +50,7 @@ impl SourceAdapter for MimoCodeAdapter {
                 observations: Vec::new(),
             }));
         };
-        let mut result =
-            opencode::scan_for_sync_conn(&conn, store, since_ts, "mimo-code", include_events)?;
+        let mut result = opencode::scan_for_sync_conn(&conn, context, since_ts, include_events)?;
         result.sessions = drop_imported(&conn, result.sessions);
         Ok(Some(result))
     }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -27,11 +27,14 @@ pub(crate) mod sync_state;
 pub(crate) mod usage;
 pub(crate) mod zcode;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
 
-use crate::db::store::Store;
+use crate::db::store::{
+    EventSessionStateMeta, IndexedSessionMeta, MetadataSessionStateMeta, SessionPath,
+    UsageSessionStateMeta,
+};
 use crate::types::{ParentLink, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) trait SourceAdapter {
@@ -43,7 +46,7 @@ pub(crate) trait SourceAdapter {
     }
     fn scan_for_sync(
         &self,
-        _store: &Store,
+        _context: &AdapterSyncContext,
         _since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -51,7 +54,7 @@ pub(crate) trait SourceAdapter {
     }
     fn scan_for_sync_output(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
         force: bool,
@@ -60,12 +63,125 @@ pub(crate) trait SourceAdapter {
             return Ok(None);
         }
         Ok(self
-            .scan_for_sync(store, since_ts, include_events)?
+            .scan_for_sync(context, since_ts, include_events)?
             .map(|scan| SyncScanOutput { scan, reconcile: None }))
     }
     fn resume_command(&self, source_id: &str) -> Option<ResumeCommand>;
     fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
         None
+    }
+}
+
+pub(crate) struct AdapterSyncContext {
+    source: String,
+    session_meta: HashMap<String, IndexedSessionMeta>,
+    session_paths: HashMap<String, SessionPath>,
+    imported_ids: HashSet<String>,
+    usage_state: HashMap<String, UsageSessionStateMeta>,
+    event_state: HashMap<String, EventSessionStateMeta>,
+    metadata_state: HashMap<String, MetadataSessionStateMeta>,
+}
+
+pub(crate) struct AdapterSyncContextParts {
+    pub(crate) session_meta: HashMap<String, IndexedSessionMeta>,
+    pub(crate) session_paths: HashMap<String, SessionPath>,
+    pub(crate) imported_ids: HashSet<String>,
+    pub(crate) usage_state: HashMap<String, UsageSessionStateMeta>,
+    pub(crate) event_state: HashMap<String, EventSessionStateMeta>,
+    pub(crate) metadata_state: HashMap<String, MetadataSessionStateMeta>,
+}
+
+impl AdapterSyncContext {
+    pub(crate) fn new(
+        source: String,
+        session_meta: HashMap<String, IndexedSessionMeta>,
+        session_paths: HashMap<String, SessionPath>,
+        imported_ids: HashSet<String>,
+        usage_state: HashMap<String, UsageSessionStateMeta>,
+        event_state: HashMap<String, EventSessionStateMeta>,
+        metadata_state: HashMap<String, MetadataSessionStateMeta>,
+    ) -> Self {
+        Self {
+            source,
+            session_meta,
+            session_paths,
+            imported_ids,
+            usage_state,
+            event_state,
+            metadata_state,
+        }
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub(crate) fn session_meta(&self) -> &HashMap<String, IndexedSessionMeta> {
+        &self.session_meta
+    }
+
+    pub(crate) fn session_paths(&self) -> impl Iterator<Item = &SessionPath> {
+        self.session_paths.values()
+    }
+
+    pub(crate) fn has_existing_sessions(&self) -> bool {
+        !self.session_meta.is_empty()
+    }
+
+    pub(crate) fn usage_state(&self) -> &HashMap<String, UsageSessionStateMeta> {
+        &self.usage_state
+    }
+
+    pub(crate) fn event_state(&self) -> &HashMap<String, EventSessionStateMeta> {
+        &self.event_state
+    }
+
+    pub(crate) fn metadata_state(&self) -> &HashMap<String, MetadataSessionStateMeta> {
+        &self.metadata_state
+    }
+
+    pub(crate) fn into_parts(self) -> AdapterSyncContextParts {
+        AdapterSyncContextParts {
+            session_meta: self.session_meta,
+            session_paths: self.session_paths,
+            imported_ids: self.imported_ids,
+            usage_state: self.usage_state,
+            event_state: self.event_state,
+            metadata_state: self.metadata_state,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn empty_for_test(source: &str) -> Self {
+        Self::new(
+            source.to_string(),
+            HashMap::new(),
+            HashMap::new(),
+            HashSet::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_store_for_test(
+        store: &crate::db::store::Store,
+        source: &str,
+    ) -> anyhow::Result<Self> {
+        Ok(Self::new(
+            source.to_string(),
+            store.session_meta_map(source)?,
+            store
+                .session_paths_for_source(source)?
+                .into_iter()
+                .map(|path| (path.source_id.clone(), path))
+                .collect(),
+            store.imported_source_ids(source)?,
+            store.usage_state_meta_map(source)?,
+            store.event_state_meta_map(source)?,
+            store.metadata_state_meta_map(source)?,
+        ))
     }
 }
 

--- a/src/adapters/omp.rs
+++ b/src/adapters/omp.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use tracing::{debug, warn};
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::usage::{disjoint_output_and_reasoning, usage_count};
@@ -14,7 +15,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct OmpAdapter;
@@ -64,7 +64,7 @@ impl SourceAdapter for OmpAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -77,7 +77,7 @@ impl SourceAdapter for OmpAdapter {
             }));
         }
 
-        Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts, include_events)?))
+        Ok(Some(scan_for_sync_impl(&session_dirs, context, since_ts, include_events)?))
     }
 }
 
@@ -140,14 +140,13 @@ fn push_existing_unique_dir(dirs: &mut Vec<PathBuf>, seen: &mut HashSet<String>,
 
 fn scan_for_sync_impl(
     session_dirs: &[PathBuf],
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_omp_entries(session_dirs);
     file_scan::run_file_scan_with_options(
-        store,
-        "omp",
+        context,
         since_ts,
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -1157,7 +1156,13 @@ mod tests {
             )
             .unwrap();
 
-        let result = scan_for_sync_impl(&[session_dir], &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &[session_dir],
+            &AdapterSyncContext::from_store_for_test(&store, "omp").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -5,11 +5,11 @@ use rusqlite::{Connection, OpenFlags, params_from_iter};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
 };
-use crate::db::store::Store;
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
@@ -86,7 +86,7 @@ impl SourceAdapter for OpenCodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -98,7 +98,7 @@ impl SourceAdapter for OpenCodeAdapter {
             }));
         };
 
-        Ok(Some(scan_for_sync_conn(&conn, store, since_ts, self.id(), include_events)?))
+        Ok(Some(scan_for_sync_conn(&conn, context, since_ts, include_events)?))
     }
 }
 
@@ -640,36 +640,26 @@ fn display_json_value(value: &Value) -> String {
 
 pub(crate) fn scan_for_sync_conn(
     conn: &Connection,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
-    source_id: &str,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
-    scan_for_sync_conn_with_options(
-        conn,
-        store,
-        since_ts,
-        source_id,
-        include_events,
-        ScanOptions::default(),
-    )
+    scan_for_sync_conn_with_options(conn, context, since_ts, include_events, ScanOptions::default())
 }
 
 pub(crate) fn scan_for_sync_conn_with_options(
     conn: &Connection,
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
-    source_id: &str,
     include_events: bool,
     options: ScanOptions,
 ) -> anyhow::Result<SyncScanResult> {
     let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
     let sessions = load_session_rows(conn, since_ts)?;
-    let existing = store.session_meta_map(source_id)?;
-    let usage_state = store.usage_state_meta_map(source_id)?;
-    let event_state =
-        if include_events { store.event_state_meta_map(source_id)? } else { Default::default() };
-    let metadata_state = store.metadata_state_meta_map(source_id)?;
+    let existing = context.session_meta();
+    let usage_state = context.usage_state();
+    let event_state = context.event_state();
+    let metadata_state = context.metadata_state();
     let current_counts = load_message_counts(
         conn,
         &sessions.iter().map(|session| session.id.clone()).collect::<Vec<_>>(),
@@ -857,7 +847,13 @@ mod tests {
         mark_event_current(&store, "s1", Some(200));
         mark_metadata_current(&store, "s1");
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert!(result.sessions.is_empty());
         assert_eq!(result.stats.skipped_sessions, 1);
         drop(conn);
@@ -874,7 +870,13 @@ mod tests {
         mark_usage_current(&store, "s1", Some(200));
         mark_event_current(&store, "s1", Some(200));
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.stats.skipped_sessions, 0);
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].custom_title.as_deref(), Some("Test"));
@@ -893,7 +895,13 @@ mod tests {
         mark_usage_current(&store, "s1", Some(200));
         mark_metadata_current(&store, "s1");
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", false).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
         assert!(result.sessions.is_empty());
         assert_eq!(result.stats.skipped_sessions, 1);
         drop(conn);
@@ -912,7 +920,13 @@ mod tests {
         let store = setup_store();
         store.insert_session(&make_session("local-s1", "s1", Some(200), 1)).unwrap();
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.stats.skipped_sessions, 0);
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "s1");
@@ -934,7 +948,13 @@ mod tests {
         mark_event_current(&store, "s2", Some(150));
         mark_metadata_current(&store, "s2");
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.stats.skipped_sessions, 1);
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "s1");
@@ -950,7 +970,13 @@ mod tests {
         insert_session_with_message(&conn, "new", 220, 200, "new");
 
         let store = setup_store();
-        let result = scan_for_sync_conn(&conn, &store, Some(200), "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            Some(200),
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.stats.filtered_sessions, 1);
         assert_eq!(result.sessions.len(), 1);
@@ -984,7 +1010,13 @@ mod tests {
         .unwrap();
 
         let store = setup_store();
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", true).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "good");
@@ -1210,7 +1242,13 @@ mod tests {
         .unwrap();
         let store = setup_store();
 
-        let result = scan_for_sync_conn(&conn, &store, None, "opencode", false).unwrap();
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "opencode").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].messages.len(), 1);

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
 use crate::adapters::usage::{disjoint_output_and_reasoning, usage_count};
@@ -14,7 +15,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{ParentLink, ParentRelation, RawUsageEvent, Role, ThreadRole};
 
 pub(crate) struct PiAdapter;
@@ -64,7 +64,7 @@ impl SourceAdapter for PiAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -77,7 +77,7 @@ impl SourceAdapter for PiAdapter {
             }));
         }
 
-        Ok(Some(scan_for_sync_impl(&session_dirs, store, since_ts, include_events)?))
+        Ok(Some(scan_for_sync_impl(&session_dirs, context, since_ts, include_events)?))
     }
 }
 
@@ -181,14 +181,13 @@ fn push_existing_unique_dir(dirs: &mut Vec<PathBuf>, seen: &mut HashSet<String>,
 
 fn scan_for_sync_impl(
     session_dirs: &[PathBuf],
-    store: &Store,
+    context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
     let entries = collect_pi_entries(session_dirs);
     file_scan::run_file_scan_with_options(
-        store,
-        "pi",
+        context,
         since_ts,
         file_scan::FileScanOptions {
             usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -1199,8 +1198,13 @@ mod tests {
             )
             .unwrap();
 
-        let result =
-            scan_for_sync_impl(&[root.join("--tmp-pi-project--")], &store, None, true).unwrap();
+        let result = scan_for_sync_impl(
+            &[root.join("--tmp-pi-project--")],
+            &AdapterSyncContext::from_store_for_test(&store, "pi").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
 

--- a/src/adapters/qwen.rs
+++ b/src/adapters/qwen.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tracing::warn;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
@@ -13,7 +14,6 @@ use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp,
 };
-use crate::db::store::Store;
 use crate::types::{RawUsageEvent, Role};
 
 const USAGE_PARSER_VERSION: u32 = 2;
@@ -49,7 +49,7 @@ impl SourceAdapter for QwenAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -61,8 +61,7 @@ impl SourceAdapter for QwenAdapter {
             }));
         };
         Ok(Some(file_scan::run_file_scan_with_options(
-            store,
-            "qwen-code",
+            context,
             since_ts,
             FileScanOptions {
                 usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -354,6 +353,7 @@ fn parse_qwen_session(jsonl: &str, session_id: &str) -> Option<RawSession> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::store::Store;
 
     const SESSION_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -472,8 +472,7 @@ mod tests {
         crate::db::schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
         let first = file_scan::run_file_scan_with_options(
-            &store,
-            "qwen-code",
+            &AdapterSyncContext::from_store_for_test(&store, "qwen-code").unwrap(),
             None,
             FileScanOptions {
                 usage_parser_version: Some(USAGE_PARSER_VERSION),
@@ -513,8 +512,7 @@ mod tests {
             .unwrap();
 
         let second = file_scan::run_file_scan_with_options(
-            &store,
-            "qwen-code",
+            &AdapterSyncContext::from_store_for_test(&store, "qwen-code").unwrap(),
             None,
             FileScanOptions {
                 usage_parser_version: Some(USAGE_PARSER_VERSION),

--- a/src/adapters/roo.rs
+++ b/src/adapters/roo.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::cline;
 use crate::adapters::paths;
 use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult};
-use crate::db::store::Store;
 
 const EXTENSION_ID: &str = "rooveterinaryinc.roo-cline";
 
@@ -30,11 +30,11 @@ impl SourceAdapter for RooAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        Ok(Some(cline::scan_task_dirs_for_sync(&resolve_tasks_dirs(), store, since_ts, "roo")?))
+        Ok(Some(cline::scan_task_dirs_for_sync(&resolve_tasks_dirs(), context, since_ts)?))
     }
 }
 
@@ -68,7 +68,12 @@ mod tests {
     fn missing_tasks_dirs_sync_empty() {
         schema::register_sqlite_vec();
         let store = Store::open_in_memory().unwrap();
-        let result = cline::scan_task_dirs_for_sync(&[], &store, None, "roo").unwrap();
+        let result = cline::scan_task_dirs_for_sync(
+            &[],
+            &AdapterSyncContext::from_store_for_test(&store, "roo").unwrap(),
+            None,
+        )
+        .unwrap();
         assert!(result.sessions.is_empty());
         assert_eq!(result.stats.candidates, 0);
     }

--- a/src/adapters/zcode.rs
+++ b/src/adapters/zcode.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use tracing::debug;
 
+use crate::adapters::AdapterSyncContext;
 use crate::adapters::opencode;
 use crate::adapters::{RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats};
-use crate::db::store::Store;
 
 pub(crate) struct ZcodeAdapter;
 
@@ -41,7 +41,7 @@ impl SourceAdapter for ZcodeAdapter {
 
     fn scan_for_sync(
         &self,
-        store: &Store,
+        context: &AdapterSyncContext,
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
@@ -54,9 +54,8 @@ impl SourceAdapter for ZcodeAdapter {
         };
         Ok(Some(opencode::scan_for_sync_conn_with_options(
             &conn,
-            store,
+            context,
             since_ts,
-            "zcode",
             include_events,
             opencode::ScanOptions::ZCODE,
         )?))

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -375,7 +375,8 @@ impl SyncJob {
             self.stats.excluded_out += n;
         }
 
-        let Some(scan_result) = self.scan_sessions(adapter, label)? else {
+        let context = self.load_adapter_sync_context(source_id)?;
+        let Some(scan_result) = self.scan_sessions(adapter, label, &context)? else {
             return Ok(());
         };
         let adapters::SyncScanOutput {
@@ -383,7 +384,7 @@ impl SyncJob {
             reconcile,
         } = scan_result;
 
-        let mut existing = self.load_existing_state(source_id)?;
+        let mut existing = self.prepare_existing_state(source_id, context)?;
         let found = raw_sessions.len();
         for (done, raw) in raw_sessions.into_iter().enumerate() {
             self.progress.indexing(label, done, found);
@@ -400,7 +401,10 @@ impl SyncJob {
             )?;
             self.stats.excluded_out += n;
         }
-        self.reconcile_source(source_id, label, reconcile)?;
+        for source_id in &purged_excluded_ids {
+            existing.remove(source_id);
+        }
+        self.reconcile_source(source_id, label, reconcile, &mut existing)?;
 
         let touched = self.stats.touched() - touched_before;
         let elapsed_ms = started.elapsed().as_millis();
@@ -421,13 +425,14 @@ impl SyncJob {
         &mut self,
         adapter: &dyn adapters::SourceAdapter,
         label: &str,
+        context: &adapters::AdapterSyncContext,
     ) -> Result<Option<adapters::SyncScanOutput>> {
         if self.options.verbose {
             println!("Scanning {label}...");
         }
         let include_events = !self.options.usage_only || self.options.backfill_events;
         let optimized = match adapter.scan_for_sync_output(
-            &self.store,
+            context,
             self.since_ts,
             include_events,
             self.options.force,
@@ -526,10 +531,11 @@ impl SyncJob {
     }
 
     fn reconcile_source(
-        &self,
+        &mut self,
         source_id: &str,
         label: &str,
         reconcile: Option<adapters::ReconcilePlan>,
+        existing: &mut ExistingState,
     ) -> Result<()> {
         if !matches!(self.options.scope, ProjectScope::Global) {
             return Ok(());
@@ -545,17 +551,22 @@ impl SyncJob {
                 self.report_incomplete_inventory(label, "unavailable", &issues);
             }
             adapters::ReconcilePlan::CompleteLiveSet(live) => {
-                let existing = self.store.session_meta_map(source_id)?;
-                for source_id_to_delete in existing.keys().filter(|id| !live.contains(*id)) {
-                    self.store.delete_session_data(source_id, source_id_to_delete)?;
+                let stale = existing
+                    .meta
+                    .keys()
+                    .filter(|id| !live.contains(*id))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                for source_id_to_delete in stale {
+                    self.store.delete_session_data(source_id, &source_id_to_delete)?;
+                    existing.remove(&source_id_to_delete);
                 }
             }
             adapters::ReconcilePlan::ExactTombstones(source_ids) => {
-                let existing = self.store.session_meta_map(source_id)?;
-                for source_id_to_delete in
-                    source_ids.into_iter().filter(|id| existing.contains_key(id))
-                {
-                    self.store.delete_session_data(source_id, &source_id_to_delete)?;
+                for source_id_to_delete in source_ids {
+                    if existing.remove(&source_id_to_delete) {
+                        self.store.delete_session_data(source_id, &source_id_to_delete)?;
+                    }
                 }
             }
         }
@@ -583,14 +594,40 @@ impl SyncJob {
         }
     }
 
-    fn load_existing_state(&mut self, source_id: &str) -> Result<ExistingState> {
-        let meta = self.store.session_meta_map(source_id)?;
-        let mut paths = HashMap::new();
+    fn load_adapter_sync_context(&self, source_id: &str) -> Result<adapters::AdapterSyncContext> {
+        Ok(adapters::AdapterSyncContext::new(
+            source_id.to_string(),
+            self.store.session_meta_map(source_id)?,
+            self.store
+                .session_paths_for_source(source_id)?
+                .into_iter()
+                .map(|path| (path.source_id.clone(), path))
+                .collect(),
+            self.store.imported_source_ids(source_id)?,
+            self.store.usage_state_meta_map(source_id)?,
+            self.store.event_state_meta_map(source_id)?,
+            self.store.metadata_state_meta_map(source_id)?,
+        ))
+    }
+
+    fn prepare_existing_state(
+        &mut self,
+        source_id: &str,
+        context: adapters::AdapterSyncContext,
+    ) -> Result<ExistingState> {
+        let adapters::AdapterSyncContextParts {
+            session_meta: meta,
+            session_paths: mut paths,
+            imported_ids,
+            usage_state: usage_meta,
+            event_state: event_meta,
+            metadata_state: metadata_meta,
+        } = context.into_parts();
         // Backfilling identity for every session of a source is global
         // maintenance; a scoped run only writes identity for the sessions it
         // actually processes.
         let backfill_identity = matches!(self.options.scope, ProjectScope::Global);
-        for mut path in self.store.session_paths_for_source(source_id)? {
+        for path in paths.values_mut() {
             if backfill_identity
                 && path.directory.is_some()
                 && (path.repo_remote.is_none()
@@ -605,20 +642,7 @@ impl SyncJob {
                     path.repo_name = Some(repo.name.clone());
                 }
             }
-            paths.insert(path.source_id.clone(), path);
         }
-        let imported_ids = self.store.imported_source_ids(source_id)?;
-        let usage_meta = self.store.usage_state_meta_map(source_id)?;
-        let event_meta = if self.options.usage_only && !self.options.backfill_events {
-            Default::default()
-        } else {
-            self.store.event_state_meta_map(source_id)?
-        };
-        let metadata_meta = if self.options.usage_only {
-            Default::default()
-        } else {
-            self.store.metadata_state_meta_map(source_id)?
-        };
         Ok(ExistingState { meta, paths, imported_ids, usage_meta, event_meta, metadata_meta })
     }
 
@@ -1063,7 +1087,8 @@ pub(crate) fn persist_raw_session_for_conformance(
         AppConfig::default(),
         &[],
     )?;
-    let mut existing = job.load_existing_state(source)?;
+    let context = job.load_adapter_sync_context(source)?;
+    let mut existing = job.prepare_existing_state(source, context)?;
     job.process_raw_session(source, raw, &mut existing, &mut HashSet::new())?;
     Ok(job.store)
 }
@@ -1184,8 +1209,8 @@ mod tests {
 
     use crate::adapters::file_scan::{self, FileScanEntry};
     use crate::adapters::{
-        InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
-        SourceObservation, SyncScanOutput, SyncScanResult,
+        AdapterSyncContext, InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand,
+        SourceAdapter, SourceObservation, SyncScanOutput, SyncScanResult,
     };
     use crate::config::AppConfig;
     use crate::db::{
@@ -1269,7 +1294,7 @@ mod tests {
 
         fn scan_for_sync_output(
             &self,
-            _store: &Store,
+            _context: &AdapterSyncContext,
             _since_ts: Option<i64>,
             _include_events: bool,
             _force: bool,
@@ -1318,7 +1343,7 @@ mod tests {
 
         fn scan_for_sync_output(
             &self,
-            store: &Store,
+            context: &AdapterSyncContext,
             since_ts: Option<i64>,
             _include_events: bool,
             _force: bool,
@@ -1329,10 +1354,9 @@ mod tests {
                     stat_target: path.clone(),
                     directory: None,
                 };
-                let scan =
-                    file_scan::run_file_scan(store, "test", since_ts, vec![entry], |_, _| {
-                        anyhow::bail!("injected parse failure")
-                    })?;
+                let scan = file_scan::run_file_scan(context, since_ts, vec![entry], |_, _| {
+                    anyhow::bail!("injected parse failure")
+                })?;
                 return Ok(Some(SyncScanOutput { scan, reconcile: None }));
             }
             Ok(Some(SyncScanOutput {
@@ -1381,7 +1405,7 @@ mod tests {
 
         fn scan_for_sync(
             &self,
-            _store: &Store,
+            _context: &AdapterSyncContext,
             _since_ts: Option<i64>,
             _include_events: bool,
         ) -> anyhow::Result<Option<crate::adapters::SyncScanResult>> {
@@ -1751,6 +1775,7 @@ mod tests {
 
     #[test]
     fn skipped_observation_applies_path_exclusion_after_success() {
+        schema::register_sqlite_vec();
         let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ObservationAdapter {
             directory: None,
             include_session: false,
@@ -1837,6 +1862,21 @@ mod tests {
             assert!(job.store.session_meta("test", "keep").unwrap().is_some());
             assert!(job.store.session_meta("test", "stale").unwrap().is_none());
         }
+    }
+
+    #[test]
+    fn complete_live_set_keeps_session_written_during_same_source_run() {
+        let adapters: Vec<Box<dyn SourceAdapter>> = vec![Box::new(ReconcileAdapter {
+            plan: ReconcilePlan::CompleteLiveSet(HashSet::from(["new".to_string()])),
+            include_session: true,
+        })];
+        let (mut job, _) = scoped_job(ProjectScope::Global);
+        job.store.insert_session(&session("stale", "test", "stale")).unwrap();
+
+        job.run_with(&adapters, None).unwrap();
+
+        assert!(job.store.session_meta("test", "new").unwrap().is_some());
+        assert!(job.store.session_meta("test", "stale").unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
### What’s changed?

- Replace adapter access to the Recall store with an immutable, source-scoped sync context.
- Keep persistence, observations, and reconciliation owned by the sync layer.
- Remove duplicate source arguments from file-scan and shared adapter paths.
- Cover same-run writes during live-set reconciliation.

### Why

- Prevent adapters from gaining accidental database write capability while preserving incremental sync behavior.

### Verification

- `make check`