### PR TITLE
feat(mcp): exclude the current session from discovery

### DIFF
--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -24,6 +24,8 @@ Use MCP `list_recent_sessions` without a query, `search_sessions` with a query, 
 
 MCP search and recent hits expose `session_id` as Recall's index identity and `source_session_id` as the source tool's session identity. `get_session` returns both identities plus `first_message_seq` and `last_message_seq` for the messages represented in its text; both sequence fields are null when no messages are returned.
 
+For every MCP discovery call, generate a fresh high-entropy `invocation_nonce` literal and never reuse it. Recall prefers a verified host session ID and otherwise looks for that exact nonce in Codex or Claude Code discovery tool input. Treat `current_session.resolution: resolved` as proof that the named session was excluded before ranking and limit. When it is `unknown`, results are unchanged: do not guess the current session from time, project, recency, tool name, or result order.
+
 Use the equivalent CLI workflow when needed:
 
 ```bash
@@ -38,7 +40,7 @@ Search results are relevance-ranked and bounded. In a queried CLI listing, `--so
 
 ## Find Recent Work
 
-When the user asks what other agents recently did, call `list_recent_sessions` for the current project with no source filter and a limit of 10. Exclude the current conversation when identifiable and call `get_session` only for relevant candidates.
+When the user asks what other agents recently did, call `list_recent_sessions` for the current project with no source filter, a fresh `invocation_nonce`, and a limit of 10. Call `get_session` only for relevant candidates. If `current_session.resolution` is `unknown`, state that self-exclusion could not be verified.
 
 If MCP is unavailable, use:
 
@@ -60,14 +62,14 @@ Return the matching event rows with session, source, title, kind, target, and ti
 
 When Recall is invoked without a clear task, list the five most recent sessions in the current project and inspect their latest 12 messages. Do not broaden to all projects.
 
-With MCP, call `list_recent_sessions`, then `get_session` with `max_messages: 12` and `tail: true`. Without MCP, use:
+With MCP, call `list_recent_sessions` with a fresh `invocation_nonce`, then `get_session` with `max_messages: 12` and `tail: true`. Without MCP, use:
 
 ```bash
 recall session list --project /absolute/project/path --limit 5 --sort updated --format json
 recall session show --id <session-id> --format json --include metadata,messages --from-seq <calculated-sequence>
 ```
 
-Set `<calculated-sequence>` to `max(message_count - 12, 0)` from the list result. Offer at most three numbered candidates. Include only sessions whose ending contains an unanswered request, explicit remaining work, a blocker, or interrupted execution. Exclude completed and ambiguous sessions. Exclude the current session when identifiable; otherwise state that self-exclusion could not be verified. Treat the bounded list as candidates, not a complete inventory of unfinished work. A numeric reply selects the same candidate and continues it in the current agent.
+Set `<calculated-sequence>` to `max(message_count - 12, 0)` from the list result. Offer at most three numbered candidates. Include only sessions whose ending contains an unanswered request, explicit remaining work, a blocker, or interrupted execution. Exclude completed and ambiguous sessions. Trust self-exclusion only when `current_session.resolution` is `resolved`; otherwise state that it could not be verified. Treat the bounded list as candidates, not a complete inventory of unfinished work. A numeric reply selects the same candidate and continues it in the current agent.
 
 Do not launch native resume or app-open behavior unless the user explicitly requests it.
 

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -10,6 +10,10 @@ use walkdir::WalkDir;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::invocation_probe::{
+    InvocationProbeBudget, ProviderInvocationProbe, is_discovery_tool, nonce_matches_input,
+    probe_recent_files,
+};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
@@ -101,6 +105,83 @@ fn load_session_indexes(claude_dir: &Path) -> SessionIndexes {
 
 fn resolve_claude_dir() -> anyhow::Result<Option<PathBuf>> {
     resolve_home_dir(".claude", "~/.claude not found, skipping Claude Code")
+}
+
+pub(crate) fn probe_invocation_nonce(
+    nonce: &str,
+    budget: InvocationProbeBudget,
+) -> anyhow::Result<ProviderInvocationProbe> {
+    let Some(claude_dir) = resolve_claude_dir()? else {
+        return Ok(ProviderInvocationProbe {
+            source_ids: Vec::new(),
+            files_read: 0,
+            bytes_read: 0,
+            complete: true,
+        });
+    };
+    Ok(probe_invocation_nonce_in(&claude_dir, nonce, budget))
+}
+
+fn probe_invocation_nonce_in(
+    claude_dir: &Path,
+    nonce: &str,
+    budget: InvocationProbeBudget,
+) -> ProviderInvocationProbe {
+    probe_recent_files(
+        nonce,
+        collect_invocation_entries(claude_dir),
+        budget,
+        claude_invocation_input,
+    )
+}
+
+fn collect_invocation_entries(claude_dir: &Path) -> Vec<FileScanEntry> {
+    let mut entries = Vec::new();
+    for root in [claude_dir.join("projects"), claude_dir.join("transcripts")] {
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
+                || !path.is_file()
+            {
+                continue;
+            }
+            let Some(session_id) = transcript_source_id(path) else {
+                continue;
+            };
+            entries.push(FileScanEntry {
+                session_id,
+                stat_target: path.to_path_buf(),
+                directory: None,
+            });
+        }
+    }
+    entries
+}
+
+fn claude_invocation_input(value: &Value, nonce: &str) -> anyhow::Result<bool> {
+    if value.get("type").and_then(Value::as_str) != Some("assistant") {
+        return Ok(false);
+    }
+    let Some(content) =
+        value.get("message").and_then(|message| message.get("content")).and_then(Value::as_array)
+    else {
+        return Ok(false);
+    };
+    Ok(content.iter().any(|item| {
+        item.get("type").and_then(Value::as_str) == Some("tool_use")
+            && item.get("name").and_then(Value::as_str).is_some_and(is_discovery_tool)
+            && item.get("input").is_some_and(|input| nonce_matches_input(input, nonce))
+    }))
+}
+
+fn transcript_source_id(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .map(str::to_string)
 }
 
 fn scan_for_sync_impl(
@@ -200,9 +281,8 @@ fn collect_project_entries(claude_dir: &Path, indexes: &mut SessionIndexes) -> V
             if !file_path.is_file() {
                 continue;
             }
-            let session_id = match file_path.file_stem().and_then(|s| s.to_str()) {
-                Some(s) if !s.is_empty() => s.to_string(),
-                _ => continue,
+            let Some(session_id) = transcript_source_id(file_path) else {
+                continue;
             };
 
             let meta_cwd = indexes.live.get(&session_id).and_then(|m| m.cwd.clone());
@@ -270,9 +350,8 @@ fn collect_transcript_entries(claude_dir: &Path) -> Vec<FileScanEntry> {
         if !path.is_file() {
             continue;
         }
-        let session_id = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(s) if !s.is_empty() => s.to_string(),
-            _ => continue,
+        let Some(session_id) = transcript_source_id(path) else {
+            continue;
         };
 
         entries.push(FileScanEntry {
@@ -1256,6 +1335,69 @@ mod tests {
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].source_id, "sess-fresh");
         assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_accepts_only_discovery_tool_input_and_deduplicates_a_session() {
+        let root = temp_claude_root("invocation-probe");
+        let project = root.join("projects").join("-tmp-probe");
+        let path = write_user_jsonl(&project, "claude-session", "normal nonce-claude reference");
+        let call = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "mcp__recall__list_recent_sessions",
+                    "input": {"invocation_nonce": "nonce-claude"}
+                }]
+            }
+        });
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        writeln!(file, "{call}").unwrap();
+        writeln!(file, "{call}").unwrap();
+
+        let result =
+            probe_invocation_nonce_in(&root, "nonce-claude", InvocationProbeBudget::default());
+        assert!(result.complete);
+        assert_eq!(result.source_ids, vec!["claude-session".to_string()]);
+
+        let normal = probe_invocation_nonce_in(
+            &root,
+            "normal nonce-claude reference",
+            InvocationProbeBudget::default(),
+        );
+        assert!(normal.complete);
+        assert!(normal.source_ids.is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_reports_multiple_source_sessions_without_guessing() {
+        let root = temp_claude_root("invocation-probe-multiple");
+        let project = root.join("projects").join("-tmp-probe");
+        for session_id in ["claude-one", "claude-two"] {
+            let path = write_user_jsonl(&project, session_id, "ordinary");
+            let call = serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "name": "mcp__recall__search_sessions",
+                        "input": {"query": "history", "invocation_nonce": "nonce-shared"}
+                    }]
+                }
+            });
+            let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+            writeln!(file, "{call}").unwrap();
+        }
+
+        let result =
+            probe_invocation_nonce_in(&root, "nonce-shared", InvocationProbeBudget::default());
+        assert!(result.complete);
+        assert_eq!(result.source_ids.len(), 2);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -9,6 +9,10 @@ use walkdir::WalkDir;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
 use crate::adapters::file_scan::{self, FileScanEntry};
+use crate::adapters::invocation_probe::{
+    InvocationProbeBudget, ProviderInvocationProbe, is_discovery_tool, nonce_matches_input,
+    probe_recent_files,
+};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
 use crate::adapters::paths::resolve_home_dir;
 use crate::adapters::{
@@ -107,6 +111,168 @@ fn open_url_command(url: String) -> ResumeCommand {
 
 fn resolve_codex_dir() -> anyhow::Result<Option<PathBuf>> {
     resolve_home_dir(".codex", "~/.codex not found, skipping Codex")
+}
+
+pub(crate) fn probe_invocation_nonce(
+    nonce: &str,
+    budget: InvocationProbeBudget,
+) -> anyhow::Result<ProviderInvocationProbe> {
+    let Some(codex_dir) = resolve_codex_dir()? else {
+        return Ok(ProviderInvocationProbe {
+            source_ids: Vec::new(),
+            files_read: 0,
+            bytes_read: 0,
+            complete: true,
+        });
+    };
+    Ok(probe_invocation_nonce_in(&codex_dir, nonce, budget))
+}
+
+fn probe_invocation_nonce_in(
+    codex_dir: &Path,
+    nonce: &str,
+    budget: InvocationProbeBudget,
+) -> ProviderInvocationProbe {
+    let sessions_dir = codex_dir.join("sessions");
+    let archived_dir = codex_dir.join("archived_sessions");
+    probe_recent_files(
+        nonce,
+        collect_codex_entries(&[&sessions_dir, &archived_dir]),
+        budget,
+        codex_invocation_input,
+    )
+}
+
+fn codex_invocation_input(value: &Value, nonce: &str) -> anyhow::Result<bool> {
+    let Some(payload) = value.get("payload") else {
+        return Ok(false);
+    };
+    if value.get("type").and_then(Value::as_str) == Some("event_msg")
+        && payload.get("type").and_then(Value::as_str) == Some("item_completed")
+    {
+        let Some(item) = payload.get("item") else {
+            return Ok(false);
+        };
+        return Ok(item.get("type").and_then(Value::as_str) == Some("McpToolCall")
+            && item.get("tool").and_then(Value::as_str).is_some_and(is_discovery_tool)
+            && item.get("arguments").is_some_and(|input| nonce_matches_input(input, nonce)));
+    }
+    if value.get("type").and_then(Value::as_str) != Some("response_item") {
+        return Ok(false);
+    }
+    if !matches!(
+        payload.get("type").and_then(Value::as_str),
+        Some("function_call" | "custom_tool_call")
+    ) {
+        return Ok(false);
+    }
+    let Some(name) = payload.get("name").and_then(Value::as_str) else {
+        return Ok(false);
+    };
+    if payload.get("type").and_then(Value::as_str) == Some("custom_tool_call") && name == "exec" {
+        return Ok(payload
+            .get("input")
+            .and_then(Value::as_str)
+            .is_some_and(|input| codex_tool_wrapper_matches(input, nonce)));
+    }
+    if !is_discovery_tool(name) {
+        return Ok(false);
+    }
+    let Some(input) = payload.get("arguments").or_else(|| payload.get("input")) else {
+        return Ok(false);
+    };
+    match input {
+        Value::String(input) => {
+            let input: Value = serde_json::from_str(input)?;
+            Ok(nonce_matches_input(&input, nonce))
+        }
+        input => Ok(nonce_matches_input(input, nonce)),
+    }
+}
+
+fn codex_tool_wrapper_matches(input: &str, nonce: &str) -> bool {
+    let Some(tool_start) = input.find("tools.") else {
+        return false;
+    };
+    let tool = &input[tool_start + "tools.".len()..];
+    let name_end = tool
+        .find(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+        .unwrap_or(tool.len());
+    let name = &tool[..name_end];
+    if !is_discovery_tool(name) {
+        return false;
+    }
+    let Some(call) = tool[name_end..].trim_start().strip_prefix('(') else {
+        return false;
+    };
+    let Some(arguments) = call_arguments(call) else {
+        return false;
+    };
+    string_property_matches(arguments, "invocation_nonce", nonce)
+}
+
+fn call_arguments(input: &str) -> Option<&str> {
+    let mut depth = 1_usize;
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in input.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' | '`' => quote = Some(character),
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&input[..index]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn string_property_matches(input: &str, property: &str, expected: &str) -> bool {
+    input.match_indices(property).any(|(start, _)| {
+        let property_end = start + property.len();
+        let before = input[..start].chars().next_back();
+        let after = input[property_end..].chars().next();
+        if before.is_some_and(|character| character.is_ascii_alphanumeric() || character == '_')
+            || after.is_some_and(|character| character.is_ascii_alphanumeric() || character == '_')
+        {
+            return false;
+        }
+        let Some(value) = input[property_end..].trim_start().strip_prefix(':') else {
+            return false;
+        };
+        json_string(value.trim_start()).as_deref() == Some(expected)
+    })
+}
+
+fn json_string(input: &str) -> Option<String> {
+    if !input.starts_with('"') {
+        return None;
+    }
+    let mut escaped = false;
+    for (index, character) in input.char_indices().skip(1) {
+        if escaped {
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == '"' {
+            return serde_json::from_str(&input[..=index]).ok();
+        }
+    }
+    None
 }
 
 fn scan_for_sync_impl(
@@ -1920,6 +2086,123 @@ mod tests {
         assert_eq!(result.sessions[0].source_id, uuid);
         assert_eq!(result.sessions[0].source_file_path.as_deref(), path.to_str());
         assert_eq!(result.stats.skipped_sessions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_accepts_only_discovery_tool_input_and_deduplicates_a_session() {
+        let root = temp_codex_root("invocation-probe");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019c9c4f-a462-7cc1-99a5-4ab521648c91";
+        let path = write_codex_rollout(&sessions_dir, uuid, "normal nonce-codex reference");
+        let call = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "mcp__recall__search_sessions",
+                "arguments": serde_json::json!({
+                    "query": "history",
+                    "invocation_nonce": "nonce-codex"
+                }).to_string()
+            }
+        });
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        writeln!(file, "{call}").unwrap();
+        writeln!(file, "{call}").unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "item_completed",
+                    "item": {
+                        "type": "McpToolCall",
+                        "server": "recall",
+                        "tool": "search_sessions",
+                        "arguments": {
+                            "query": "history",
+                            "invocation_nonce": "nonce-codex"
+                        }
+                    }
+                }
+            })
+        )
+        .unwrap();
+
+        let result =
+            probe_invocation_nonce_in(&root, "nonce-codex", InvocationProbeBudget::default());
+        assert!(result.complete);
+        assert_eq!(result.source_ids, vec![uuid.to_string()]);
+
+        let normal = probe_invocation_nonce_in(
+            &root,
+            "normal nonce-codex reference",
+            InvocationProbeBudget::default(),
+        );
+        assert!(normal.complete);
+        assert!(normal.source_ids.is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_rejects_cross_session_nonce_reuse() {
+        let root = temp_codex_root("invocation-probe-multiple");
+        let sessions_dir = root.join("sessions");
+        for uuid in ["019c9c4f-a462-7cc1-99a5-4ab521648c91", "019c9c4f-a462-7cc1-99a5-4ab521648c92"]
+        {
+            let path = write_codex_rollout(&sessions_dir, uuid, "ordinary");
+            let call = serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "mcp__recall__list_recent_sessions",
+                    "input": {"invocation_nonce": "nonce-shared"}
+                }
+            });
+            let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+            writeln!(file, "{call}").unwrap();
+        }
+
+        let result =
+            probe_invocation_nonce_in(&root, "nonce-shared", InvocationProbeBudget::default());
+        assert!(result.complete);
+        assert_eq!(result.source_ids.len(), 2);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_accepts_codex_tool_wrapper_before_completion_event() {
+        let root = temp_codex_root("invocation-probe-wrapper");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019c9c4f-a462-7cc1-99a5-4ab521648c91";
+        let path = write_codex_rollout(&sessions_dir, uuid, "ordinary");
+        let call = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "input": "const r = await tools.mcp__recall__search_sessions({\n  query: \"history\",\n  invocation_nonce: \"nonce-wrapper\"\n});\ntext(r);"
+            }
+        });
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        writeln!(file, "{call}").unwrap();
+
+        let result =
+            probe_invocation_nonce_in(&root, "nonce-wrapper", InvocationProbeBudget::default());
+        assert!(result.complete);
+        assert_eq!(result.source_ids, vec![uuid.to_string()]);
+        assert!(!codex_tool_wrapper_matches(
+            "const r = await tools.exec_command({cmd: `tools.mcp__recall__search_sessions({invocation_nonce: \\\"nonce-wrapper\\\"})`});",
+            "nonce-wrapper"
+        ));
+        assert!(!codex_tool_wrapper_matches(
+            "const r = await tools.mcp__recall__search_sessions({query: \"history\"}); text(\"nonce-wrapper\");",
+            "nonce-wrapper"
+        ));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/invocation_probe.rs
+++ b/src/adapters/invocation_probe.rs
@@ -1,0 +1,376 @@
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::time::{Duration, SystemTime};
+
+use crate::adapters::file_scan::FileScanEntry;
+
+const MAX_FILES: usize = 64;
+const MAX_FILE_BYTES: usize = 256 * 1024;
+const MAX_TOTAL_BYTES: usize = 4 * 1024 * 1024;
+const RECENT_WINDOW: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InvocationProbeCandidate {
+    pub(crate) source: String,
+    pub(crate) source_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InvocationProbeResult {
+    pub(crate) candidates: Vec<InvocationProbeCandidate>,
+    pub(crate) files_read: usize,
+    pub(crate) bytes_read: usize,
+    pub(crate) complete: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderInvocationProbe {
+    pub(crate) source_ids: Vec<String>,
+    pub(crate) files_read: usize,
+    pub(crate) bytes_read: usize,
+    pub(crate) complete: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InvocationProbeBudget {
+    max_files: usize,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
+    recent_window: Duration,
+}
+
+impl InvocationProbeBudget {
+    fn remaining(self, files_read: usize, bytes_read: usize) -> Self {
+        Self {
+            max_files: self.max_files.saturating_sub(files_read),
+            max_file_bytes: self.max_file_bytes,
+            max_total_bytes: self.max_total_bytes.saturating_sub(bytes_read),
+            recent_window: self.recent_window,
+        }
+    }
+}
+
+impl Default for InvocationProbeBudget {
+    fn default() -> Self {
+        Self {
+            max_files: MAX_FILES,
+            max_file_bytes: MAX_FILE_BYTES,
+            max_total_bytes: MAX_TOTAL_BYTES,
+            recent_window: RECENT_WINDOW,
+        }
+    }
+}
+
+pub(crate) fn probe_invocation_nonce(nonce: &str) -> InvocationProbeResult {
+    if nonce.trim().is_empty() {
+        return InvocationProbeResult {
+            candidates: Vec::new(),
+            files_read: 0,
+            bytes_read: 0,
+            complete: true,
+        };
+    }
+    let mut result = InvocationProbeResult {
+        candidates: Vec::new(),
+        files_read: 0,
+        bytes_read: 0,
+        complete: true,
+    };
+    let mut budget = InvocationProbeBudget::default();
+    let codex = super::codex::probe_invocation_nonce(nonce, budget);
+    merge_provider_probe(&mut result, &mut budget, "codex", codex);
+    let claude = super::claude_code::probe_invocation_nonce(nonce, budget);
+    merge_provider_probe(&mut result, &mut budget, "claude-code", claude);
+    result
+}
+
+fn merge_provider_probe(
+    result: &mut InvocationProbeResult,
+    budget: &mut InvocationProbeBudget,
+    source: &str,
+    probe: anyhow::Result<ProviderInvocationProbe>,
+) {
+    match probe {
+        Ok(probe) => {
+            result.files_read += probe.files_read;
+            result.bytes_read += probe.bytes_read;
+            *budget = budget.remaining(probe.files_read, probe.bytes_read);
+            result.complete &= probe.complete;
+            result.candidates.extend(probe.source_ids.into_iter().map(|source_id| {
+                InvocationProbeCandidate { source: source.to_string(), source_id }
+            }));
+        }
+        Err(_) => result.complete = false,
+    }
+}
+
+pub(crate) fn probe_recent_files<F>(
+    nonce: &str,
+    entries: Vec<FileScanEntry>,
+    budget: InvocationProbeBudget,
+    confirms_input: F,
+) -> ProviderInvocationProbe
+where
+    F: Fn(&serde_json::Value, &str) -> anyhow::Result<bool>,
+{
+    let cutoff = SystemTime::now().checked_sub(budget.recent_window);
+    let mut recent = Vec::new();
+    let mut complete = true;
+    for entry in entries {
+        let metadata = match entry.stat_target.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                complete = false;
+                continue;
+            }
+        };
+        let modified = match metadata.modified() {
+            Ok(modified) => modified,
+            Err(_) => {
+                complete = false;
+                continue;
+            }
+        };
+        if cutoff.is_some_and(|cutoff| modified < cutoff) {
+            continue;
+        }
+        recent.push((modified, metadata.len(), entry));
+    }
+    recent.sort_by(|left, right| {
+        right.0.cmp(&left.0).then_with(|| left.2.stat_target.cmp(&right.2.stat_target))
+    });
+    if recent.len() > budget.max_files {
+        recent.truncate(budget.max_files);
+        complete = false;
+    }
+
+    let mut files_read: usize = 0;
+    let mut bytes_read: usize = 0;
+    let mut source_ids = BTreeSet::new();
+    for (_, file_len, entry) in recent {
+        let read_len = usize::try_from(file_len).unwrap_or(usize::MAX).min(budget.max_file_bytes);
+        if bytes_read.saturating_add(read_len) > budget.max_total_bytes {
+            complete = false;
+            break;
+        }
+        let mut file = match File::open(&entry.stat_target) {
+            Ok(file) => file,
+            Err(_) => {
+                complete = false;
+                continue;
+            }
+        };
+        let start = file_len.saturating_sub(read_len as u64);
+        if file.seek(SeekFrom::Start(start)).is_err() {
+            complete = false;
+            continue;
+        }
+        let mut bytes = Vec::with_capacity(read_len);
+        if file.take(read_len as u64).read_to_end(&mut bytes).is_err() {
+            complete = false;
+            continue;
+        }
+        files_read += 1;
+        bytes_read += bytes.len();
+        let text = match String::from_utf8(bytes) {
+            Ok(text) => text,
+            Err(_) => {
+                complete = false;
+                continue;
+            }
+        };
+        let text = if start == 0 {
+            text.as_str()
+        } else {
+            let Some(newline) = text.find('\n') else {
+                if text.contains(nonce) {
+                    complete = false;
+                }
+                continue;
+            };
+            let partial = &text[..newline];
+            if partial.contains(nonce) {
+                complete = false;
+            }
+            &text[newline + 1..]
+        };
+        if !text.contains(nonce) {
+            continue;
+        }
+        for line in text.lines().filter(|line| line.contains(nonce)) {
+            let value = match serde_json::from_str(line) {
+                Ok(value) => value,
+                Err(_) => {
+                    complete = false;
+                    continue;
+                }
+            };
+            match confirms_input(&value, nonce) {
+                Ok(true) => {
+                    source_ids.insert(entry.session_id.clone());
+                }
+                Ok(false) => {}
+                Err(_) => complete = false,
+            }
+        }
+    }
+    ProviderInvocationProbe {
+        source_ids: source_ids.into_iter().collect(),
+        files_read,
+        bytes_read,
+        complete,
+    }
+}
+
+pub(crate) fn is_discovery_tool(name: &str) -> bool {
+    matches!(name.rsplit("__").next(), Some("search_sessions" | "list_recent_sessions"))
+}
+
+pub(crate) fn nonce_matches_input(input: &serde_json::Value, nonce: &str) -> bool {
+    input.get("invocation_nonce").and_then(serde_json::Value::as_str) == Some(nonce)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    use super::*;
+
+    fn entry(path: PathBuf, session_id: &str) -> FileScanEntry {
+        FileScanEntry { session_id: session_id.to_string(), stat_target: path, directory: None }
+    }
+
+    fn confirms(value: &serde_json::Value, nonce: &str) -> anyhow::Result<bool> {
+        Ok(value.get("invocation_nonce").and_then(serde_json::Value::as_str) == Some(nonce))
+    }
+
+    #[test]
+    fn unreadable_damaged_truncated_and_over_budget_inputs_fail_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let damaged = root.path().join("damaged.jsonl");
+        fs::write(&damaged, "{nonce-damaged\n").unwrap();
+        let damaged_result = probe_recent_files(
+            "nonce-damaged",
+            vec![entry(damaged, "damaged")],
+            InvocationProbeBudget::default(),
+            confirms,
+        );
+        assert!(!damaged_result.complete);
+        assert!(damaged_result.source_ids.is_empty());
+
+        let missing = probe_recent_files(
+            "nonce",
+            vec![entry(root.path().join("missing.jsonl"), "missing")],
+            InvocationProbeBudget::default(),
+            confirms,
+        );
+        assert!(!missing.complete);
+
+        let truncated = root.path().join("truncated.jsonl");
+        fs::write(
+            &truncated,
+            format!("{}{{\"invocation_nonce\":\"nonce-cut\"}}\n", "x".repeat(64)),
+        )
+        .unwrap();
+        let truncated_result = probe_recent_files(
+            "nonce-cut",
+            vec![entry(truncated, "truncated")],
+            InvocationProbeBudget {
+                max_files: 1,
+                max_file_bytes: 32,
+                max_total_bytes: 32,
+                recent_window: RECENT_WINDOW,
+            },
+            confirms,
+        );
+        assert!(!truncated_result.complete);
+        assert!(truncated_result.source_ids.is_empty());
+
+        let first = root.path().join("first.jsonl");
+        let second = root.path().join("second.jsonl");
+        fs::write(&first, "{}\n").unwrap();
+        fs::write(&second, "{}\n").unwrap();
+        let over_budget = probe_recent_files(
+            "nonce",
+            vec![entry(first.clone(), "first"), entry(second.clone(), "second")],
+            InvocationProbeBudget {
+                max_files: 1,
+                max_file_bytes: MAX_FILE_BYTES,
+                max_total_bytes: MAX_TOTAL_BYTES,
+                recent_window: RECENT_WINDOW,
+            },
+            confirms,
+        );
+        assert!(!over_budget.complete);
+
+        let over_bytes = probe_recent_files(
+            "nonce",
+            vec![entry(first, "first"), entry(second, "second")],
+            InvocationProbeBudget {
+                max_files: 2,
+                max_file_bytes: MAX_FILE_BYTES,
+                max_total_bytes: 2,
+                recent_window: RECENT_WINDOW,
+            },
+            confirms,
+        );
+        assert!(!over_bytes.complete);
+        assert_eq!(over_bytes.bytes_read, 0);
+    }
+
+    #[test]
+    fn remaining_budget_caps_aggregate_provider_work() {
+        let budget = InvocationProbeBudget {
+            max_files: 4,
+            max_file_bytes: 32,
+            max_total_bytes: 96,
+            recent_window: RECENT_WINDOW,
+        };
+        let remaining = budget.remaining(3, 80);
+        assert_eq!(remaining.max_files, 1);
+        assert_eq!(remaining.max_file_bytes, 32);
+        assert_eq!(remaining.max_total_bytes, 16);
+    }
+
+    #[test]
+    fn fixed_fixture_probe_reports_stable_read_cost() {
+        let root = tempfile::tempdir().unwrap();
+        let nonce = "fixed-fixture-nonce";
+        let mut entries = Vec::new();
+        for index in 0..32 {
+            let path = root.path().join(format!("{index:02}.jsonl"));
+            let line = if index == 0 {
+                serde_json::json!({"invocation_nonce": nonce}).to_string()
+            } else {
+                serde_json::json!({"content": "x".repeat(4096)}).to_string()
+            };
+            fs::write(&path, format!("{line}\n")).unwrap();
+            entries.push(entry(path, &format!("session-{index:02}")));
+        }
+
+        let mut elapsed = Vec::new();
+        let mut costs = Vec::new();
+        for _ in 0..25 {
+            let start = Instant::now();
+            let result = probe_recent_files(
+                nonce,
+                entries.clone(),
+                InvocationProbeBudget::default(),
+                confirms,
+            );
+            elapsed.push(start.elapsed().as_micros());
+            costs.push((result.files_read, result.bytes_read));
+            assert!(result.complete);
+            assert_eq!(result.source_ids, vec!["session-00".to_string()]);
+        }
+        elapsed.sort_unstable();
+        assert!(costs.windows(2).all(|pair| pair[0] == pair[1]));
+        eprintln!(
+            "probe_cost runs=25 p50_us={} p95_us={} files={} bytes={}",
+            elapsed[12], elapsed[23], costs[0].0, costs[0].1
+        );
+    }
+}

--- a/src/adapters/invocation_probe.rs
+++ b/src/adapters/invocation_probe.rs
@@ -19,8 +19,6 @@ pub(crate) struct InvocationProbeCandidate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InvocationProbeResult {
     pub(crate) candidates: Vec<InvocationProbeCandidate>,
-    pub(crate) files_read: usize,
-    pub(crate) bytes_read: usize,
     pub(crate) complete: bool,
 }
 
@@ -64,19 +62,9 @@ impl Default for InvocationProbeBudget {
 
 pub(crate) fn probe_invocation_nonce(nonce: &str) -> InvocationProbeResult {
     if nonce.trim().is_empty() {
-        return InvocationProbeResult {
-            candidates: Vec::new(),
-            files_read: 0,
-            bytes_read: 0,
-            complete: true,
-        };
+        return InvocationProbeResult { candidates: Vec::new(), complete: true };
     }
-    let mut result = InvocationProbeResult {
-        candidates: Vec::new(),
-        files_read: 0,
-        bytes_read: 0,
-        complete: true,
-    };
+    let mut result = InvocationProbeResult { candidates: Vec::new(), complete: true };
     let mut budget = InvocationProbeBudget::default();
     let codex = super::codex::probe_invocation_nonce(nonce, budget);
     merge_provider_probe(&mut result, &mut budget, "codex", codex);
@@ -93,8 +81,6 @@ fn merge_provider_probe(
 ) {
     match probe {
         Ok(probe) => {
-            result.files_read += probe.files_read;
-            result.bytes_read += probe.bytes_read;
             *budget = budget.remaining(probe.files_read, probe.bytes_read);
             result.complete &= probe.complete;
             result.candidates.extend(probe.source_ids.into_iter().map(|source_id| {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod file_scan;
 pub(crate) mod gemini;
 pub(crate) mod goose;
 pub(crate) mod grok;
+pub(crate) mod invocation_probe;
 pub(crate) mod json_util;
 pub(crate) mod kilo;
 pub(crate) mod kimi_code;

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -178,6 +178,7 @@ pub(crate) fn run_search(query: &str) -> Result<()> {
         time_range: TimeRange::All,
         scope: ProjectScope::Global,
         thread_role: None,
+        excluded_session_id: None,
     };
 
     let t_search = Instant::now();
@@ -321,6 +322,7 @@ where
         time_range: TimeRange::All,
         scope: ProjectScope::Global,
         thread_role: None,
+        excluded_session_id: None,
     };
     let mut report = EvalReport { total: entries.len(), ..Default::default() };
 

--- a/src/bench_api.rs
+++ b/src/bench_api.rs
@@ -668,6 +668,7 @@ impl SearchIndex {
             time_range: TimeRange::All,
             scope: ProjectScope::Global,
             thread_role: None,
+            excluded_session_id: None,
         }
     }
 

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -21,6 +21,7 @@ pub(crate) struct SearchFilters {
     pub(crate) time_range: TimeRange,
     pub(crate) scope: ProjectScope,
     pub(crate) thread_role: Option<ThreadRoleFilter>,
+    pub(crate) excluded_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -172,6 +173,7 @@ impl<'a> SearchEngine<'a> {
             time_range: TimeRange::All,
             scope: query.scope.clone(),
             thread_role: None,
+            excluded_session_id: None,
         };
         apply_filters(&mut sql, &mut params, &mut param_idx, &filters);
 
@@ -327,7 +329,19 @@ impl<'a> SearchEngine<'a> {
         requested_k: usize,
     ) -> anyhow::Result<Vec<Hit>> {
         let blob = f32_slice_to_bytes(embedding);
-        let fetch_k = requested_k.clamp(1, SQLITE_VEC_MAX_K) as i64;
+        let excluded_vectors = match filters.excluded_session_id.as_deref() {
+            Some(session_id) => self.conn.query_row(
+                "SELECT COUNT(*)
+                 FROM message_vec mv
+                 JOIN messages m ON m.id = mv.message_id
+                 WHERE m.session_id = ?1",
+                rusqlite::params![session_id],
+                |row| row.get::<_, usize>(0),
+            )?,
+            None => 0,
+        };
+        let fetch_k =
+            requested_k.saturating_add(excluded_vectors).clamp(1, SQLITE_VEC_MAX_K) as i64;
 
         let mut sql = String::from(
             "SELECT m.session_id, MIN(mv.distance) AS best_distance
@@ -432,6 +446,11 @@ fn apply_filters(
     apply_project_scope(sql, params, param_idx, &filters.scope);
     if let Some(thread_role) = filters.thread_role {
         sql.push_str(thread_role.sql_predicate());
+    }
+    if let Some(excluded_session_id) = filters.excluded_session_id.as_deref() {
+        sql.push_str(&format!(" AND s.id != ?{}", *param_idx));
+        params.push(Box::new(excluded_session_id.to_string()));
+        *param_idx += 1;
     }
 }
 
@@ -594,6 +613,7 @@ mod tests {
             time_range: TimeRange::All,
             scope: ProjectScope::Global,
             thread_role: None,
+            excluded_session_id: None,
         };
         let engine = SearchEngine::new(&store.conn);
 

--- a/src/db/session_store.rs
+++ b/src/db/session_store.rs
@@ -515,6 +515,7 @@ impl Store {
             None,
             TimeRange::All,
             &ProjectScope::Global,
+            None,
             limit,
         )
     }
@@ -524,6 +525,7 @@ impl Store {
         sources: Option<&[String]>,
         time_range: TimeRange,
         scope: &ProjectScope,
+        excluded_session_id: Option<&str>,
         limit: usize,
     ) -> Result<Vec<Session>> {
         let mut sql = format!(
@@ -534,6 +536,11 @@ impl Store {
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         let mut param_idx = 1;
         apply_scope_filters(&mut sql, &mut params, &mut param_idx, sources, time_range, scope);
+        if let Some(excluded_session_id) = excluded_session_id {
+            sql.push_str(&format!(" AND s.id != ?{param_idx}"));
+            params.push(Box::new(excluded_session_id.to_string()));
+            param_idx += 1;
+        }
         sql.push_str(&format!(
             " ORDER BY COALESCE(updated_at, started_at) DESC, started_at DESC, source ASC, source_id ASC LIMIT ?{param_idx}"
         ));
@@ -1197,7 +1204,13 @@ mod topology_tests {
         );
 
         let mut ids = store
-            .list_recent_sessions_for_search_scope(None, TimeRange::All, &ProjectScope::Global, 100)
+            .list_recent_sessions_for_search_scope(
+                None,
+                TimeRange::All,
+                &ProjectScope::Global,
+                None,
+                100,
+            )
             .unwrap()
             .into_iter()
             .map(|s| s.source_id)
@@ -1251,6 +1264,7 @@ mod topology_tests {
                 None,
                 TimeRange::Today,
                 &ProjectScope::Global,
+                None,
                 100,
             )
             .unwrap()

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -120,6 +120,7 @@ fn no_filters() -> SearchFilters {
         time_range: TimeRange::All,
         scope: ProjectScope::Global,
         thread_role: None,
+        excluded_session_id: None,
     }
 }
 
@@ -876,6 +877,27 @@ fn semantic_adjacent_pages_follow_one_global_order() {
 }
 
 #[test]
+fn semantic_search_excludes_a_session_before_vector_and_hybrid_limits() {
+    let store = setup();
+    let embedding = seed_semantic_page_fixture(&store);
+    let engine = SearchEngine::new(&store.conn);
+
+    let mut vector_filters = no_filters();
+    vector_filters.excluded_session_id = Some("semantic-vec-fill".to_string());
+    let vector =
+        engine.hybrid_search("lexically-absent", Some(&embedding), &vector_filters, 1, 3).unwrap();
+    assert_eq!(vector.len(), 1);
+    assert_eq!(vector[0].session.id, "semantic-fts-04");
+
+    let mut hybrid_filters = no_filters();
+    hybrid_filters.excluded_session_id = Some("semantic-fts-04".to_string());
+    let hybrid =
+        engine.hybrid_search("semanticstable", Some(&embedding), &hybrid_filters, 2, 3).unwrap();
+    assert_eq!(hybrid.len(), 2);
+    assert!(hybrid.iter().all(|result| result.session.id != "semantic-fts-04"));
+}
+
+#[test]
 fn semantic_query_all_returns_complete_fts_set() {
     let store = setup();
     seed_semantic_boundary_sessions(&store, 10_001);
@@ -939,6 +961,7 @@ fn search_with_source_filter() {
         time_range: TimeRange::All,
         scope: ProjectScope::Global,
         thread_role: None,
+        excluded_session_id: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     assert_eq!(results.len(), 1);
@@ -1006,6 +1029,7 @@ fn search_with_directory_filter_respects_project_boundary() {
         time_range: TimeRange::All,
         scope: ProjectScope::Directory("/tmp/project".to_string()),
         thread_role: None,
+        excluded_session_id: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     let mut ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
@@ -1030,6 +1054,7 @@ fn recent_sessions_with_directory_filter_respects_project_boundary() {
             None,
             TimeRange::All,
             &ProjectScope::Directory("/tmp/project".to_string()),
+            None,
             10,
         )
         .unwrap();
@@ -1071,6 +1096,7 @@ fn search_with_repo_filter_matches_sibling_worktrees() {
             local_root: None,
         },
         thread_role: None,
+        excluded_session_id: None,
     };
     let results = engine.hybrid_search("parser", None, &filters, 10, 3).unwrap();
     let mut ids: Vec<String> = results.into_iter().map(|result| result.session.id).collect();
@@ -1166,7 +1192,7 @@ fn repository_scope_reaches_local_checkout_without_repo_identity() {
         local_root: Some("/repo/root".to_string()),
     };
     let mut ids = store
-        .list_recent_sessions_for_search_scope(None, TimeRange::All, &scope, 10)
+        .list_recent_sessions_for_search_scope(None, TimeRange::All, &scope, None, 10)
         .unwrap()
         .into_iter()
         .map(|session| session.source_id)
@@ -1236,7 +1262,7 @@ fn scope_predicate_matches_sql_and_rust_paths() {
 
     for scope in scopes {
         let mut sql_ids = store
-            .list_recent_sessions_for_search_scope(None, TimeRange::All, &scope, 100)
+            .list_recent_sessions_for_search_scope(None, TimeRange::All, &scope, None, 100)
             .unwrap()
             .into_iter()
             .map(|session| session.source_id)
@@ -2082,6 +2108,7 @@ fn hybrid_search_filters_by_thread_role_in_sql() {
         time_range: TimeRange::All,
         scope: ProjectScope::Global,
         thread_role,
+        excluded_session_id: None,
     };
     let source_ids = |results: Vec<crate::types::SearchResult>| {
         let mut ids = results.into_iter().map(|r| r.session.source_id).collect::<Vec<_>>();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1052,8 +1052,6 @@ mod tests {
                     source_id: (*source_id).to_string(),
                 })
                 .collect(),
-            files_read: candidates.len(),
-            bytes_read: candidates.len() * 100,
             complete,
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -55,6 +55,11 @@ struct SearchSessionsArgs {
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
     #[schemars(range(min = 1, max = 50))]
     limit: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Optional unique literal copied into this tool call so Recall can verify and exclude the invoking session when no host identity is available. It never affects relevance."
+    )]
+    invocation_nonce: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -87,6 +92,11 @@ struct ListRecentSessionsArgs {
     #[serde(default, deserialize_with = "deserialize_opt_u32")]
     #[schemars(range(min = 1, max = 50))]
     limit: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Optional unique literal copied into this tool call so Recall can verify and exclude the invoking session when no host identity is available."
+    )]
+    invocation_nonce: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -189,15 +199,12 @@ impl CurrentSessionContext {
         codex_thread: Option<&str>,
         codex_session: Option<&str>,
     ) -> Self {
-        if let Some(source_session_id) = verified_session_id(claude_session) {
-            return Self {
-                host_identity: Some(SourceSessionIdentity {
-                    source: "claude-code".to_string(),
-                    source_session_id: source_session_id.to_string(),
-                }),
-            };
-        }
-        let host_identity =
+        let claude_identity =
+            verified_session_id(claude_session).map(|source_session_id| SourceSessionIdentity {
+                source: "claude-code".to_string(),
+                source_session_id: source_session_id.to_string(),
+            });
+        let codex_identity =
             match (verified_session_id(codex_thread), verified_session_id(codex_session)) {
                 (Some(thread), Some(session)) if thread == session => Some(SourceSessionIdentity {
                     source: "codex".to_string(),
@@ -205,15 +212,47 @@ impl CurrentSessionContext {
                 }),
                 _ => None,
             };
+        let host_identity = match (claude_identity, codex_identity) {
+            (Some(identity), None) | (None, Some(identity)) => Some(identity),
+            _ => None,
+        };
         Self { host_identity }
     }
 
-    fn resolve(&self, store: &Store) -> CurrentSession {
-        let Some(identity) = self.host_identity.as_ref() else {
+    fn resolve(&self, store: &Store, invocation_nonce: Option<&str>) -> CurrentSession {
+        self.resolve_with_probe(
+            store,
+            invocation_nonce,
+            adapters::invocation_probe::probe_invocation_nonce,
+        )
+    }
+
+    fn resolve_with_probe<F>(
+        &self,
+        store: &Store,
+        invocation_nonce: Option<&str>,
+        probe: F,
+    ) -> CurrentSession
+    where
+        F: FnOnce(&str) -> adapters::invocation_probe::InvocationProbeResult,
+    {
+        if let Some(identity) = self.host_identity.as_ref()
+            && let Ok(Some(session)) =
+                store.get_session_by_source_id(&identity.source, &identity.source_session_id)
+        {
+            return CurrentSession::resolved(&session);
+        }
+        let Some(invocation_nonce) = invocation_nonce.filter(|value| !value.trim().is_empty())
+        else {
             return CurrentSession::unknown();
         };
+        let result = probe(invocation_nonce);
+        if !result.complete || result.candidates.len() != 1 {
+            return CurrentSession::unknown();
+        }
+        let candidate = &result.candidates[0];
         store
-            .get_session_by_source_id(&identity.source, &identity.source_session_id)
+            .get_session_by_source_id(&candidate.source, &candidate.source_id)
             .ok()
             .flatten()
             .as_ref()
@@ -364,7 +403,7 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "Search past AI coding sessions across Claude Code, Codex, OpenCode, Cursor, and other indexed tools. Use when the user asks whether they have seen an error, made a decision, or solved a similar problem before. Returns Recall session_id, source-native source_session_id, source, project, title, matched excerpt, and ISO-8601 timestamp.",
+        description = "Search past AI coding sessions across Claude Code, Codex, OpenCode, Cursor, and other indexed tools. Use when the user asks whether they have seen an error, made a decision, or solved a similar problem before. Pass a fresh invocation_nonce when the host does not expose a session ID. current_session.resolution is resolved only after exact Store verification; only then is that session excluded before ranking and limit. Unknown leaves results unchanged. Returns Recall session_id, source-native source_session_id, source, project, title, matched excerpt, and ISO-8601 timestamp.",
         annotations(
             title = "Search sessions",
             read_only_hint = true,
@@ -403,7 +442,7 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "List the most recently active indexed sessions, newest first. Use to browse what the user has been working on when there is no search query. Each hit has the same shape as search_sessions: Recall session_id, source-native source_session_id, source, project, title, excerpt (summary when present), and ISO-8601 timestamp.",
+        description = "List the most recently active indexed sessions, newest first. Use to browse what the user has been working on when there is no search query. Pass a fresh invocation_nonce when the host does not expose a session ID. current_session.resolution is resolved only after exact Store verification; only then is that session excluded before ordering and limit. Unknown leaves results unchanged. Each hit has the same shape as search_sessions: Recall session_id, source-native source_session_id, source, project, title, excerpt (summary when present), and ISO-8601 timestamp.",
         annotations(
             title = "List recent sessions",
             read_only_hint = true,
@@ -484,7 +523,7 @@ fn mcp_server_info() -> ServerInfo {
     ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
         .with_server_info(Implementation::new("recall", env!("CARGO_PKG_VERSION")))
         .with_instructions(
-            "Read-only memory over the local Recall session index. Search or list past coding sessions, look up which sessions touched a file, then fetch a session when you need the transcript. This server never writes, syncs, or mutates the index.",
+            "Read-only memory over the local Recall session index. Search or list past coding sessions, look up which sessions touched a file, then fetch a session when you need the transcript. Discovery tools report whether the current session was resolved and excluded; pass a fresh invocation_nonce when the host provides no session identity. Unknown resolution never guesses or changes results. This server never writes, syncs, waits for transcripts, or mutates the index.",
         )
 }
 
@@ -568,7 +607,7 @@ fn empty_events(message: impl Into<String>) -> EventList {
 fn search_sessions(
     index: &IndexState,
     args: &SearchSessionsArgs,
-) -> std::result::Result<HitList, HitList> {
+) -> std::result::Result<HitList, Box<HitList>> {
     search_sessions_with_context(index, args, &CurrentSessionContext::default())
 }
 
@@ -576,13 +615,13 @@ fn search_sessions_with_context(
     index: &IndexState,
     args: &SearchSessionsArgs,
     context: &CurrentSessionContext,
-) -> std::result::Result<HitList, HitList> {
+) -> std::result::Result<HitList, Box<HitList>> {
     match index {
-        IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
+        IndexState::Unavailable { message, .. } => Err(Box::new(empty_hits(message.clone()))),
         IndexState::Ready(store) => {
-            let current_session = context.resolve(store);
+            let current_session = context.resolve(store, args.invocation_nonce.as_deref());
             search_ready(store, args, &current_session)
-                .map_err(|message| empty_hits_with_current(message, current_session))
+                .map_err(|message| Box::new(empty_hits_with_current(message, current_session)))
         }
     }
 }
@@ -630,7 +669,7 @@ fn search_ready(
 fn list_recent_sessions(
     index: &IndexState,
     args: &ListRecentSessionsArgs,
-) -> std::result::Result<HitList, HitList> {
+) -> std::result::Result<HitList, Box<HitList>> {
     list_recent_sessions_with_context(index, args, &CurrentSessionContext::default())
 }
 
@@ -638,13 +677,13 @@ fn list_recent_sessions_with_context(
     index: &IndexState,
     args: &ListRecentSessionsArgs,
     context: &CurrentSessionContext,
-) -> std::result::Result<HitList, HitList> {
+) -> std::result::Result<HitList, Box<HitList>> {
     match index {
-        IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
+        IndexState::Unavailable { message, .. } => Err(Box::new(empty_hits(message.clone()))),
         IndexState::Ready(store) => {
-            let current_session = context.resolve(store);
+            let current_session = context.resolve(store, args.invocation_nonce.as_deref());
             list_ready(store, args, &current_session)
-                .map_err(|message| empty_hits_with_current(message, current_session))
+                .map_err(|message| Box::new(empty_hits_with_current(message, current_session)))
         }
     }
 }
@@ -1001,6 +1040,24 @@ mod tests {
         }
     }
 
+    fn probe_result(
+        candidates: &[(&str, &str)],
+        complete: bool,
+    ) -> adapters::invocation_probe::InvocationProbeResult {
+        adapters::invocation_probe::InvocationProbeResult {
+            candidates: candidates
+                .iter()
+                .map(|(source, source_id)| adapters::invocation_probe::InvocationProbeCandidate {
+                    source: (*source).to_string(),
+                    source_id: (*source_id).to_string(),
+                })
+                .collect(),
+            files_read: candidates.len(),
+            bytes_read: candidates.len() * 100,
+            complete,
+        }
+    }
+
     fn without_fields(value: impl Serialize, fields: &[&str]) -> Value {
         let mut value = to_json(value);
         let object = value.as_object_mut().unwrap();
@@ -1013,8 +1070,13 @@ mod tests {
     #[test]
     fn missing_index_is_a_tool_error() {
         let index = IndexState::Unavailable { path: None, message: MISSING_INDEX.to_string() };
-        let args =
-            SearchSessionsArgs { query: "error".into(), project: None, source: None, limit: None };
+        let args = SearchSessionsArgs {
+            query: "error".into(),
+            project: None,
+            source: None,
+            limit: None,
+            invocation_nonce: None,
+        };
         let list = search_sessions(&index, &args).expect_err("missing index");
         assert!(list.hits.is_empty());
         assert_eq!(list.message.as_deref(), Some(MISSING_INDEX));
@@ -1030,13 +1092,19 @@ mod tests {
             project: None,
             source: None,
             limit: None,
+            invocation_nonce: None,
         };
         let search = search_sessions(&index, &search_args).unwrap();
         assert!(search.hits.is_empty());
         assert_eq!(search.message.as_deref(), Some(EMPTY_INDEX));
         assert_eq!(json_result(search_sessions(&index, &search_args)).is_error, Some(false));
 
-        let list_args = ListRecentSessionsArgs { project: None, source: None, limit: None };
+        let list_args = ListRecentSessionsArgs {
+            project: None,
+            source: None,
+            limit: None,
+            invocation_nonce: None,
+        };
         let listed = list_recent_sessions(&index, &list_args).unwrap();
         assert!(listed.hits.is_empty());
         assert_eq!(listed.message.as_deref(), Some(EMPTY_INDEX));
@@ -1067,6 +1135,7 @@ mod tests {
                 project: None,
                 source: None,
                 limit: Some(80),
+                invocation_nonce: None,
             },
         )
         .unwrap();
@@ -1101,7 +1170,12 @@ mod tests {
 
         let list = list_recent_sessions(
             &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: Some(10) },
+            &ListRecentSessionsArgs {
+                project: None,
+                source: None,
+                limit: Some(10),
+                invocation_nonce: None,
+            },
         )
         .unwrap();
         assert_eq!(list.hits.len(), 2);
@@ -1140,14 +1214,18 @@ mod tests {
                 .is_none()
         );
         let claude_id = "604c4e71-f49c-4cc0-9388-88905fe65473";
-        let claude =
-            CurrentSessionContext::from_values(Some(claude_id), Some(codex_id), Some(codex_id));
+        let claude = CurrentSessionContext::from_values(Some(claude_id), None, None);
         assert_eq!(
             claude.host_identity,
             Some(SourceSessionIdentity {
                 source: "claude-code".to_string(),
                 source_session_id: claude_id.to_string(),
             })
+        );
+        assert!(
+            CurrentSessionContext::from_values(Some(claude_id), Some(codex_id), Some(codex_id))
+                .host_identity
+                .is_none()
         );
     }
 
@@ -1175,6 +1253,7 @@ mod tests {
                 project: None,
                 source: None,
                 limit: Some(1),
+                invocation_nonce: None,
             },
             &current_context,
         )
@@ -1191,6 +1270,7 @@ mod tests {
                 project: None,
                 source: None,
                 limit: Some(50),
+                invocation_nonce: None,
             },
             &current_context,
         )
@@ -1200,7 +1280,12 @@ mod tests {
 
         let recent = list_recent_sessions_with_context(
             &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: Some(1) },
+            &ListRecentSessionsArgs {
+                project: None,
+                source: None,
+                limit: Some(1),
+                invocation_nonce: None,
+            },
             &current_context,
         )
         .unwrap();
@@ -1210,7 +1295,12 @@ mod tests {
 
         let recent_fifty = list_recent_sessions_with_context(
             &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: Some(50) },
+            &ListRecentSessionsArgs {
+                project: None,
+                source: None,
+                limit: Some(50),
+                invocation_nonce: None,
+            },
             &current_context,
         )
         .unwrap();
@@ -1239,6 +1329,7 @@ mod tests {
                     project: None,
                     source: None,
                     limit: Some(1),
+                    invocation_nonce: None,
                 },
                 &current_context,
             )
@@ -1264,6 +1355,7 @@ mod tests {
                 project: Some("/tmp/other".into()),
                 source: Some("claude-code".into()),
                 limit: Some(1),
+                invocation_nonce: None,
             },
             &context("codex", "src-current"),
         )
@@ -1299,6 +1391,55 @@ mod tests {
     }
 
     #[test]
+    fn invocation_nonce_resolves_only_one_complete_indexed_candidate() {
+        let store = setup();
+        let mut current = session("current", "codex", "current", 10_000);
+        current.source_id = "nonce-source".to_string();
+        store.insert_session(&current).unwrap();
+        let context = CurrentSessionContext::default();
+
+        let resolved = context.resolve_with_probe(&store, Some("nonce"), |_| {
+            probe_result(&[("codex", "nonce-source")], true)
+        });
+        assert_eq!(resolved.resolution, CurrentSessionResolution::Resolved);
+        assert_eq!(resolved.session_id.as_deref(), Some("current"));
+
+        for result in [
+            probe_result(&[], true),
+            probe_result(&[("codex", "nonce-source"), ("claude-code", "other")], true),
+            probe_result(&[("codex", "nonce-source")], false),
+            probe_result(&[("codex", "unindexed")], true),
+            probe_result(&[("claude-code", "nonce-source")], true),
+        ] {
+            assert_eq!(
+                context.resolve_with_probe(&store, Some("nonce"), |_| result),
+                CurrentSession::unknown()
+            );
+        }
+        assert_eq!(
+            context.resolve_with_probe(&store, Some(" "), |_| {
+                panic!("blank nonce must not probe")
+            }),
+            CurrentSession::unknown()
+        );
+    }
+
+    #[test]
+    fn resolved_host_identity_skips_invocation_probe() {
+        let store = setup();
+        let mut current = session("current", "codex", "current", 10_000);
+        current.source_id = "host-source".to_string();
+        store.insert_session(&current).unwrap();
+
+        let resolved =
+            context("codex", "host-source").resolve_with_probe(&store, Some("nonce"), |_| {
+                panic!("resolved host identity must skip probing")
+            });
+        assert_eq!(resolved.resolution, CurrentSessionResolution::Resolved);
+        assert_eq!(resolved.session_id.as_deref(), Some("current"));
+    }
+
+    #[test]
     fn unknown_source_is_empty_not_a_crash() {
         let store = setup();
         store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
@@ -1309,6 +1450,7 @@ mod tests {
             project: None,
             source: Some("not-a-source".into()),
             limit: None,
+            invocation_nonce: None,
         };
         let list = search_sessions(&index, &args).expect_err("unknown source");
         assert!(list.hits.is_empty());
@@ -1543,7 +1685,12 @@ mod tests {
         index.ensure_open();
         let listed = list_recent_sessions(
             &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: None },
+            &ListRecentSessionsArgs {
+                project: None,
+                source: None,
+                limit: None,
+                invocation_nonce: None,
+            },
         )
         .unwrap();
         assert_eq!(listed.hits.len(), 1);
@@ -1560,7 +1707,12 @@ mod tests {
         let index = ready(store);
         let list = list_recent_sessions(
             &index,
-            &ListRecentSessionsArgs { project: None, source: None, limit: None },
+            &ListRecentSessionsArgs {
+                project: None,
+                source: None,
+                limit: None,
+                invocation_nonce: None,
+            },
         )
         .unwrap();
         let excerpt = list.hits[0].excerpt.as_deref().unwrap();
@@ -1597,6 +1749,7 @@ mod tests {
         let args: SearchSessionsArgs =
             serde_json::from_value(serde_json::json!({"query": "q", "limit": "12"})).unwrap();
         assert_eq!(args.limit, Some(12));
+        assert!(args.invocation_nonce.is_none());
         assert_eq!(clamp_limit(Some(80), 10, 50), 50);
         assert_eq!(clamp_limit(None, 10, 50), 10);
         assert_eq!(clamp_limit(Some(80), EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX), 50);
@@ -1626,8 +1779,18 @@ mod tests {
             .iter()
             .find(|tool| tool["name"] == "get_session")
             .expect("get_session capability");
+        let search_sessions = tools
+            .iter()
+            .find(|tool| tool["name"] == "search_sessions")
+            .expect("search_sessions capability");
+        let list_recent_sessions = tools
+            .iter()
+            .find(|tool| tool["name"] == "list_recent_sessions")
+            .expect("list_recent_sessions capability");
 
         assert!(get_session["inputSchema"]["properties"]["tail"].is_object());
+        assert!(search_sessions["inputSchema"]["properties"]["invocation_nonce"].is_object());
+        assert!(list_recent_sessions["inputSchema"]["properties"]["invocation_nonce"].is_object());
         assert!(get_session["description"].as_str().unwrap().contains("source_session_id"));
         assert!(get_session["description"].as_str().unwrap().contains("first_message_seq"));
         assert!(report.server.capabilities.tools.is_some());
@@ -1635,6 +1798,8 @@ mod tests {
         assert!(text.contains("get_session"));
         assert!(text.contains("Inputs: "));
         assert!(text.contains("tail"));
+        assert!(text.contains("invocation_nonce"));
+        assert!(text.contains("current_session.resolution"));
     }
 
     fn event(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -127,6 +127,103 @@ struct SessionHit {
 struct HitList {
     message: Option<String>,
     hits: Vec<SessionHit>,
+    current_session: CurrentSession,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CurrentSessionResolution {
+    Resolved,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct CurrentSession {
+    resolution: CurrentSessionResolution,
+    session_id: Option<String>,
+    source: Option<String>,
+    source_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceSessionIdentity {
+    source: String,
+    source_session_id: String,
+}
+
+#[derive(Clone, Default)]
+struct CurrentSessionContext {
+    host_identity: Option<SourceSessionIdentity>,
+}
+
+impl CurrentSession {
+    fn unknown() -> Self {
+        Self {
+            resolution: CurrentSessionResolution::Unknown,
+            session_id: None,
+            source: None,
+            source_session_id: None,
+        }
+    }
+
+    fn resolved(session: &Session) -> Self {
+        Self {
+            resolution: CurrentSessionResolution::Resolved,
+            session_id: Some(session.id.clone()),
+            source: Some(session.source.clone()),
+            source_session_id: Some(session.source_id.clone()),
+        }
+    }
+}
+
+impl CurrentSessionContext {
+    fn from_env() -> Self {
+        let claude = std::env::var("CLAUDE_CODE_SESSION_ID").ok();
+        let codex_thread = std::env::var("CODEX_THREAD_ID").ok();
+        let codex_session = std::env::var("CODEX_SESSION_ID").ok();
+        Self::from_values(claude.as_deref(), codex_thread.as_deref(), codex_session.as_deref())
+    }
+
+    fn from_values(
+        claude_session: Option<&str>,
+        codex_thread: Option<&str>,
+        codex_session: Option<&str>,
+    ) -> Self {
+        if let Some(source_session_id) = verified_session_id(claude_session) {
+            return Self {
+                host_identity: Some(SourceSessionIdentity {
+                    source: "claude-code".to_string(),
+                    source_session_id: source_session_id.to_string(),
+                }),
+            };
+        }
+        let host_identity =
+            match (verified_session_id(codex_thread), verified_session_id(codex_session)) {
+                (Some(thread), Some(session)) if thread == session => Some(SourceSessionIdentity {
+                    source: "codex".to_string(),
+                    source_session_id: thread.to_string(),
+                }),
+                _ => None,
+            };
+        Self { host_identity }
+    }
+
+    fn resolve(&self, store: &Store) -> CurrentSession {
+        let Some(identity) = self.host_identity.as_ref() else {
+            return CurrentSession::unknown();
+        };
+        store
+            .get_session_by_source_id(&identity.source, &identity.source_session_id)
+            .ok()
+            .flatten()
+            .as_ref()
+            .map(CurrentSession::resolved)
+            .unwrap_or_else(CurrentSession::unknown)
+    }
+}
+
+fn verified_session_id(value: Option<&str>) -> Option<&str> {
+    opt_trimmed(value).filter(|value| uuid::Uuid::try_parse(value).is_ok())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
@@ -187,6 +284,7 @@ enum IndexState {
 #[derive(Clone)]
 struct RecallMcp {
     index: Arc<Mutex<IndexState>>,
+    current_session: CurrentSessionContext,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
@@ -258,7 +356,11 @@ async fn serve(db: Option<PathBuf>) -> Result<()> {
 #[tool_router]
 impl RecallMcp {
     fn new(db: Option<&Path>) -> Self {
-        Self { index: Arc::new(Mutex::new(IndexState::open(db))), tool_router: Self::tool_router() }
+        Self {
+            index: Arc::new(Mutex::new(IndexState::open(db))),
+            current_session: CurrentSessionContext::from_env(),
+            tool_router: Self::tool_router(),
+        }
     }
 
     #[tool(
@@ -274,7 +376,11 @@ impl RecallMcp {
         &self,
         Parameters(args): Parameters<SearchSessionsArgs>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        Ok(json_result(search_sessions(&lock_index(&self.index), &args)))
+        Ok(json_result(search_sessions_with_context(
+            &lock_index(&self.index),
+            &args,
+            &self.current_session,
+        )))
     }
 
     #[tool(
@@ -309,7 +415,11 @@ impl RecallMcp {
         &self,
         Parameters(args): Parameters<ListRecentSessionsArgs>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        Ok(json_result(list_recent_sessions(&lock_index(&self.index), &args)))
+        Ok(json_result(list_recent_sessions_with_context(
+            &lock_index(&self.index),
+            &args,
+            &self.current_session,
+        )))
     }
 
     #[tool(
@@ -342,6 +452,7 @@ impl GetSessionBenchmark {
         Self {
             server: RecallMcp {
                 index: Arc::new(Mutex::new(IndexState::Ready(store))),
+                current_session: CurrentSessionContext::default(),
                 tool_router: RecallMcp::tool_router(),
             },
             max_messages,
@@ -438,40 +549,76 @@ fn to_json(value: impl Serialize) -> Value {
 }
 
 fn empty_hits(message: impl Into<String>) -> HitList {
-    HitList { message: Some(message.into()), hits: Vec::new() }
+    HitList {
+        message: Some(message.into()),
+        hits: Vec::new(),
+        current_session: CurrentSession::unknown(),
+    }
+}
+
+fn empty_hits_with_current(message: impl Into<String>, current_session: CurrentSession) -> HitList {
+    HitList { message: Some(message.into()), hits: Vec::new(), current_session }
 }
 
 fn empty_events(message: impl Into<String>) -> EventList {
     EventList { message: Some(message.into()), events: Vec::new() }
 }
 
+#[cfg(test)]
 fn search_sessions(
     index: &IndexState,
     args: &SearchSessionsArgs,
 ) -> std::result::Result<HitList, HitList> {
+    search_sessions_with_context(index, args, &CurrentSessionContext::default())
+}
+
+fn search_sessions_with_context(
+    index: &IndexState,
+    args: &SearchSessionsArgs,
+    context: &CurrentSessionContext,
+) -> std::result::Result<HitList, HitList> {
     match index {
         IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
-        IndexState::Ready(store) => search_ready(store, args).map_err(empty_hits),
+        IndexState::Ready(store) => {
+            let current_session = context.resolve(store);
+            search_ready(store, args, &current_session)
+                .map_err(|message| empty_hits_with_current(message, current_session))
+        }
     }
 }
 
-fn search_ready(store: &Store, args: &SearchSessionsArgs) -> std::result::Result<HitList, String> {
+fn search_ready(
+    store: &Store,
+    args: &SearchSessionsArgs,
+    current_session: &CurrentSession,
+) -> std::result::Result<HitList, String> {
     let (scope, sources) = resolve_filters(store, args.project.as_deref(), args.source.as_deref())?;
     let limit = clamp_limit(args.limit, SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX);
     let embedding = query_embedding(store, &args.query, |message| {
         tracing::info!("{message}");
     })
     .map_err(|error| error.to_string())?;
-    let filters = SearchFilters { sources, time_range: TimeRange::All, scope, thread_role: None };
+    let filters = SearchFilters {
+        sources,
+        time_range: TimeRange::All,
+        scope,
+        thread_role: None,
+        excluded_session_id: current_session.session_id.clone(),
+    };
     let results = SearchEngine::new(&store.conn)
         .hybrid_search(&args.query, embedding.as_deref(), &filters, limit, 3)
         .map_err(|error| error.to_string())?;
     if results.is_empty() {
         let message = if store_is_empty(store) { EMPTY_INDEX } else { SEARCH_EMPTY };
-        return Ok(HitList { message: Some(message.to_string()), hits: Vec::new() });
+        return Ok(HitList {
+            message: Some(message.to_string()),
+            hits: Vec::new(),
+            current_session: current_session.clone(),
+        });
     }
     Ok(HitList {
         message: None,
+        current_session: current_session.clone(),
         hits: results
             .into_iter()
             .map(|result| session_hit(&result.session, result.snippet))
@@ -479,31 +626,56 @@ fn search_ready(store: &Store, args: &SearchSessionsArgs) -> std::result::Result
     })
 }
 
+#[cfg(test)]
 fn list_recent_sessions(
     index: &IndexState,
     args: &ListRecentSessionsArgs,
 ) -> std::result::Result<HitList, HitList> {
+    list_recent_sessions_with_context(index, args, &CurrentSessionContext::default())
+}
+
+fn list_recent_sessions_with_context(
+    index: &IndexState,
+    args: &ListRecentSessionsArgs,
+    context: &CurrentSessionContext,
+) -> std::result::Result<HitList, HitList> {
     match index {
         IndexState::Unavailable { message, .. } => Err(empty_hits(message.clone())),
-        IndexState::Ready(store) => list_ready(store, args).map_err(empty_hits),
+        IndexState::Ready(store) => {
+            let current_session = context.resolve(store);
+            list_ready(store, args, &current_session)
+                .map_err(|message| empty_hits_with_current(message, current_session))
+        }
     }
 }
 
 fn list_ready(
     store: &Store,
     args: &ListRecentSessionsArgs,
+    current_session: &CurrentSession,
 ) -> std::result::Result<HitList, String> {
     let (scope, sources) = resolve_filters(store, args.project.as_deref(), args.source.as_deref())?;
     let limit = clamp_limit(args.limit, LIST_LIMIT_DEFAULT, LIST_LIMIT_MAX);
     let sessions = store
-        .list_recent_sessions_for_search_scope(sources.as_deref(), TimeRange::All, &scope, limit)
+        .list_recent_sessions_for_search_scope(
+            sources.as_deref(),
+            TimeRange::All,
+            &scope,
+            current_session.session_id.as_deref(),
+            limit,
+        )
         .map_err(|error| error.to_string())?;
     if sessions.is_empty() {
         let message = if store_is_empty(store) { EMPTY_INDEX } else { SEARCH_EMPTY };
-        return Ok(HitList { message: Some(message.to_string()), hits: Vec::new() });
+        return Ok(HitList {
+            message: Some(message.to_string()),
+            hits: Vec::new(),
+            current_session: current_session.clone(),
+        });
     }
     Ok(HitList {
         message: None,
+        current_session: current_session.clone(),
         hits: sessions
             .into_iter()
             .map(|session| {
@@ -820,6 +992,15 @@ mod tests {
         IndexState::Ready(store)
     }
 
+    fn context(source: &str, source_session_id: &str) -> CurrentSessionContext {
+        CurrentSessionContext {
+            host_identity: Some(SourceSessionIdentity {
+                source: source.to_string(),
+                source_session_id: source_session_id.to_string(),
+            }),
+        }
+    }
+
     fn without_fields(value: impl Serialize, fields: &[&str]) -> Value {
         let mut value = to_json(value);
         let object = value.as_object_mut().unwrap();
@@ -929,6 +1110,192 @@ mod tests {
         assert_eq!(list.hits[0].excerpt.as_deref(), Some("newer summary"));
         assert_eq!(list.hits[1].session_id, "old");
         assert_eq!(list.hits[1].source_session_id, "src-old");
+    }
+
+    #[test]
+    fn host_identity_requires_verified_source_native_values() {
+        let codex_id = "019c9c4f-a462-7cc1-99a5-4ab521648c91";
+        let codex = CurrentSessionContext::from_values(None, Some(codex_id), Some(codex_id));
+        assert_eq!(
+            codex.host_identity,
+            Some(SourceSessionIdentity {
+                source: "codex".to_string(),
+                source_session_id: codex_id.to_string(),
+            })
+        );
+        assert!(
+            CurrentSessionContext::from_values(None, Some("thread"), Some("session"))
+                .host_identity
+                .is_none()
+        );
+        assert!(
+            CurrentSessionContext::from_values(None, Some(codex_id), None).host_identity.is_none()
+        );
+        assert!(
+            CurrentSessionContext::from_values(None, Some(" "), Some(" ")).host_identity.is_none()
+        );
+        assert!(
+            CurrentSessionContext::from_values(None, Some("same"), Some("same"))
+                .host_identity
+                .is_none()
+        );
+        let claude_id = "604c4e71-f49c-4cc0-9388-88905fe65473";
+        let claude =
+            CurrentSessionContext::from_values(Some(claude_id), Some(codex_id), Some(codex_id));
+        assert_eq!(
+            claude.host_identity,
+            Some(SourceSessionIdentity {
+                source: "claude-code".to_string(),
+                source_session_id: claude_id.to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn resolved_current_session_is_excluded_before_search_and_recent_limits() {
+        let store = setup();
+        let mut current = session("000-current", "codex", "current", 100_000);
+        current.message_count = 1;
+        store.insert_session(&current).unwrap();
+        store.insert_messages(&[message("000-current", Role::User, "identityneedle", 0)]).unwrap();
+        for index in 0..50 {
+            let id = format!("history-{index:02}");
+            let mut stored = session(&id, "codex", "history", 50_000 - index);
+            stored.message_count = 1;
+            store.insert_session(&stored).unwrap();
+            store.insert_messages(&[message(&id, Role::User, "identityneedle", 0)]).unwrap();
+        }
+        let index = ready(store);
+        let current_context = context("codex", "src-000-current");
+
+        let first = search_sessions_with_context(
+            &index,
+            &SearchSessionsArgs {
+                query: "identityneedle".into(),
+                project: None,
+                source: None,
+                limit: Some(1),
+            },
+            &current_context,
+        )
+        .unwrap();
+        assert_eq!(first.hits.len(), 1);
+        assert_ne!(first.hits[0].session_id, "000-current");
+        assert_eq!(first.current_session.resolution, CurrentSessionResolution::Resolved);
+        assert_eq!(first.current_session.session_id.as_deref(), Some("000-current"));
+
+        let fifty = search_sessions_with_context(
+            &index,
+            &SearchSessionsArgs {
+                query: "identityneedle".into(),
+                project: None,
+                source: None,
+                limit: Some(50),
+            },
+            &current_context,
+        )
+        .unwrap();
+        assert_eq!(fifty.hits.len(), 50);
+        assert!(fifty.hits.iter().all(|hit| hit.session_id != "000-current"));
+
+        let recent = list_recent_sessions_with_context(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: Some(1) },
+            &current_context,
+        )
+        .unwrap();
+        assert_eq!(recent.hits.len(), 1);
+        assert_ne!(recent.hits[0].session_id, "000-current");
+        assert_eq!(recent.current_session.resolution, CurrentSessionResolution::Resolved);
+
+        let recent_fifty = list_recent_sessions_with_context(
+            &index,
+            &ListRecentSessionsArgs { project: None, source: None, limit: Some(50) },
+            &current_context,
+        )
+        .unwrap();
+        assert_eq!(recent_fifty.hits.len(), 50);
+        assert!(recent_fifty.hits.iter().all(|hit| hit.session_id != "000-current"));
+    }
+
+    #[test]
+    fn unresolved_or_mismatched_host_identity_keeps_discovery_complete() {
+        let store = setup();
+        let mut stored = session("current", "claude-code", "current", 10_000);
+        stored.source_id = "shared-source-id".to_string();
+        store.insert_session(&stored).unwrap();
+        store.insert_messages(&[message("current", Role::User, "mismatchneedle", 0)]).unwrap();
+        let index = ready(store);
+
+        for current_context in [
+            context("codex", "shared-source-id"),
+            context("codex", "not-indexed"),
+            CurrentSessionContext::from_values(None, Some("a"), Some("b")),
+        ] {
+            let result = search_sessions_with_context(
+                &index,
+                &SearchSessionsArgs {
+                    query: "mismatchneedle".into(),
+                    project: None,
+                    source: None,
+                    limit: Some(1),
+                },
+                &current_context,
+            )
+            .unwrap();
+            assert_eq!(result.current_session, CurrentSession::unknown());
+            assert_eq!(result.hits[0].session_id, "current");
+        }
+    }
+
+    #[test]
+    fn discovery_scope_does_not_change_exact_current_session_resolution() {
+        let store = setup();
+        let current = session("current", "codex", "current", 10_000);
+        store.insert_session(&current).unwrap();
+        let mut other = session("other", "claude-code", "other", 9_000);
+        other.directory = Some("/tmp/other".to_string());
+        store.insert_session(&other).unwrap();
+        store.insert_messages(&[message("other", Role::User, "scopeneedle", 0)]).unwrap();
+        let result = search_sessions_with_context(
+            &ready(store),
+            &SearchSessionsArgs {
+                query: "scopeneedle".into(),
+                project: Some("/tmp/other".into()),
+                source: Some("claude-code".into()),
+                limit: Some(1),
+            },
+            &context("codex", "src-current"),
+        )
+        .unwrap();
+        assert_eq!(result.current_session.resolution, CurrentSessionResolution::Resolved);
+        assert_eq!(result.hits[0].session_id, "other");
+    }
+
+    #[test]
+    fn exact_reads_remain_complete_for_the_resolved_current_session() {
+        let store = setup();
+        let mut current = session("current", "codex", "current", 10_000);
+        current.message_count = 1;
+        store.insert_session(&current).unwrap();
+        store.insert_messages(&[message("current", Role::User, "exact transcript", 0)]).unwrap();
+        persist_events(
+            &store,
+            "codex",
+            "current",
+            &[event(0, "file_write", Some("src/current.rs"), Some(10_000), None, None)],
+        );
+        let index = ready(store);
+
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "current".into(), max_messages: None, tail: false },
+        )
+        .unwrap();
+        assert_eq!(detail.messages, "[user] exact transcript");
+        let history = file_history(&index, &file_history_args("src/current.rs")).unwrap();
+        assert_eq!(history.events.len(), 1);
+        assert_eq!(history.events[0].session_id, "current");
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -47,7 +47,13 @@ pub(crate) fn run_search(
     let scope = store.resolve_scope(project_filter, repo_filter)?.announce();
     let embedding = query_embedding(&store, query, |message| println!("{message}"))?;
 
-    let filters = SearchFilters { sources: resolved_source, time_range, scope, thread_role: None };
+    let filters = SearchFilters {
+        sources: resolved_source,
+        time_range,
+        scope,
+        thread_role: None,
+        excluded_session_id: None,
+    };
 
     let results = engine.hybrid_search(query, embedding.as_deref(), &filters, 20, 3)?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -355,6 +355,7 @@ pub(crate) fn run_session_list(
             time_range,
             scope: scope.clone(),
             thread_role,
+            excluded_session_id: None,
         };
         let results = engine.hybrid_search_page(
             query,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -428,6 +428,7 @@ impl App {
                 source_ids.as_deref(),
                 self.time_filter,
                 &self.scope,
+                None,
                 200,
             )
             .unwrap_or_default();
@@ -2130,6 +2131,7 @@ impl App {
             time_range: self.time_filter,
             scope: self.scope.clone(),
             thread_role: None,
+            excluded_session_id: None,
         }
     }
 

--- a/src/tui/search_worker.rs
+++ b/src/tui/search_worker.rs
@@ -166,6 +166,7 @@ fn recent_sessions(store: &Store, request: &SearchRequest) -> anyhow::Result<Vec
         request.filters.sources.as_deref(),
         request.filters.time_range,
         &request.filters.scope,
+        None,
         SEARCH_LIMIT,
     )?;
     Ok(recent


### PR DESCRIPTION
## Problem

MCP discovery could return the actively invoking session as if it were independent historical evidence. Filtering that session after ranking would also let it consume the requested limit and influence hybrid ranking.

## Target invariant

- Resolve the invoking session only from a verified source-native host ID or one unique invocation nonce match that maps back to the existing Store.
- Exclude a resolved session before FTS, vector, hybrid, or recent-session limits are applied.
- Return current_session.resolution = unknown and leave results unchanged for missing, conflicting, unreadable, over-budget, ambiguous, or unindexed evidence.
- Keep get_session, file_history, CLI/TUI search, export, and the MCP read-only/no-sync boundary unchanged.

## Implementation

- Add additive current_session metadata to discovery responses and an internal query-level exclusion filter.
- Validate Claude Code and Codex host identities against exact source + source_id Store rows.
- Add bounded adapter-owned nonce probes for current Codex and Claude Code transcript formats, including the Codex pre-completion tool wrapper observed in a real invocation.
- Update MCP capabilities and the bundled Recall skill to generate a fresh nonce and trust exclusion only when resolution is resolved.

## Strongest alternative rejected

Filtering the current session from the returned HitList would be smaller, but the removed session would already have consumed the limit and participated in hybrid ranking. Query-level exclusion is required to preserve result count and ordering semantics.

## Verification

- make check — passed at 9d7b99f (audit, fmt, workspace clippy with -D warnings, and all workspace tests).
- Targeted nonce probe tests: 9 passed.
- MCP contract tests: 31 passed.
- Vector/hybrid pre-limit exclusion regression: passed.
- Bundled skill validator: passed.
- Fixed 32-file probe fixture, 25 runs on one machine: p50 760 µs, p95 839 µs, 127,484 bytes read.
- Real Codex 0.152.1 MCP smoke: the nonce was visible while the handler ran, resolved to the exact indexed source session, and that session was absent from hits.
- Real Claude Code 2.1.259 MCP smoke: the inherited Claude session ID matched the source transcript and Store row, and that session was absent from 50 requested recent hits.
- Independent T2 liability finder ran with Claude; its blocking clippy finding was fixed and reverified. Final liability verdict: ACCEPT_LOCAL. Final pre-ship verdict: PASS.

## Rollback and residual risk

Rollback is two ordinary reverts in reverse order. Future provider transcript formats may not match the bounded probes; that failure is intentionally fail-closed as unknown with unchanged discovery results.
