### PR TITLE
refactor(rx): simplify launcher internals

### DIFF
--- a/crates/rx/src/args.rs
+++ b/crates/rx/src/args.rs
@@ -55,13 +55,8 @@ pub(crate) enum ProvidersCommand {
     Login { provider: Option<String> },
     Logout { provider: Option<String> },
     Use { provider: Option<String> },
-    Models(ModelsCommand),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ModelsCommand {
-    Help,
-    Update { provider: Option<String> },
+    ModelsHelp,
+    ModelsUpdate { provider: Option<String> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -197,7 +192,7 @@ fn parse_providers(args: &[OsString]) -> Result<ProvidersCommand> {
         None if args.is_empty() => Ok(ProvidersCommand::Help),
         Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ProvidersCommand::Help),
         Some("list") if args.len() == 1 => Ok(ProvidersCommand::List),
-        Some("models") => Ok(ProvidersCommand::Models(parse_models(&args[1..])?)),
+        Some("models") => parse_models(&args[1..]),
         Some(command @ ("login" | "logout" | "use")) => {
             let provider = parse_provider_argument(command, &args[1..])?;
             Ok(match command {
@@ -220,11 +215,11 @@ fn parse_providers(args: &[OsString]) -> Result<ProvidersCommand> {
     }
 }
 
-fn parse_models(args: &[OsString]) -> Result<ModelsCommand> {
+fn parse_models(args: &[OsString]) -> Result<ProvidersCommand> {
     match args.first().and_then(|arg| arg.to_str()) {
-        None if args.is_empty() => Ok(ModelsCommand::Help),
-        Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ModelsCommand::Help),
-        Some("update") => Ok(ModelsCommand::Update {
+        None if args.is_empty() => Ok(ProvidersCommand::ModelsHelp),
+        Some("-h" | "--help" | "help") if args.len() <= 1 => Ok(ProvidersCommand::ModelsHelp),
+        Some("update") => Ok(ProvidersCommand::ModelsUpdate {
             provider: parse_provider_argument("models update", &args[1..])?,
         }),
         Some(command) => {

--- a/crates/rx/src/catalog.rs
+++ b/crates/rx/src/catalog.rs
@@ -48,7 +48,7 @@ fn has_version_suffix(url: &str) -> bool {
     })
 }
 
-pub(crate) fn fetch_get(url: &str, headers: &[(&str, String)]) -> Result<String> {
+fn fetch_get(url: &str, headers: &[(&str, String)]) -> Result<String> {
     let (status, body) = fetch(url, headers)?;
     if !(200..300).contains(&status) {
         bail!("HTTP {status}: {}", truncate(&body, 300));
@@ -121,7 +121,13 @@ pub(crate) fn load_opencode_models(
     allow_fetch: bool,
 ) -> Result<BTreeMap<String, Value>> {
     ensure(paths, provider_id, base_url, key, allow_fetch)?;
-    read_json_object(artifact_path(paths, provider_id, "opencode.json"))
+    let path = artifact_path(paths, provider_id, "opencode.json");
+    if !path.is_file() {
+        return Ok(BTreeMap::new());
+    }
+    let body =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
 }
 
 pub(crate) fn load_pi_models(
@@ -132,7 +138,13 @@ pub(crate) fn load_pi_models(
     allow_fetch: bool,
 ) -> Result<Vec<Value>> {
     ensure(paths, provider_id, base_url, key, allow_fetch)?;
-    read_json_array(artifact_path(paths, provider_id, "pi.json"))
+    let path = artifact_path(paths, provider_id, "pi.json");
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let body =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
 }
 
 pub(crate) fn load_listed_models(
@@ -284,7 +296,8 @@ fn has_stale_catalog(paths: &Paths, provider_id: &str, endpoint: &str) -> bool {
 }
 
 fn complete_cache_meta(paths: &Paths, provider_id: &str, endpoint: &str) -> Option<CacheMeta> {
-    let meta = read_meta(paths, provider_id)?;
+    let body = fs::read_to_string(artifact_path(paths, provider_id, "meta.json")).ok()?;
+    let meta: CacheMeta = serde_json::from_str(&body).ok()?;
     if meta.endpoint != endpoint || meta.format != CATALOG_FORMAT {
         return None;
     }
@@ -292,11 +305,6 @@ fn complete_cache_meta(paths: &Paths, provider_id: &str, endpoint: &str) -> Opti
         .into_iter()
         .all(|suffix| artifact_path(paths, provider_id, suffix).is_file())
         .then_some(meta)
-}
-
-fn read_meta(paths: &Paths, provider_id: &str) -> Option<CacheMeta> {
-    let body = fs::read_to_string(artifact_path(paths, provider_id, "meta.json")).ok()?;
-    serde_json::from_str(&body).ok()
 }
 
 fn catalog_has_models(path: &Path) -> bool {
@@ -307,24 +315,6 @@ fn catalog_has_models(path: &Path) -> bool {
         return false;
     };
     value.get("models").and_then(Value::as_array).is_some_and(|models| !models.is_empty())
-}
-
-fn read_json_object(path: PathBuf) -> Result<BTreeMap<String, Value>> {
-    if !path.is_file() {
-        return Ok(BTreeMap::new());
-    }
-    let body =
-        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
-}
-
-fn read_json_array(path: PathBuf) -> Result<Vec<Value>> {
-    if !path.is_file() {
-        return Ok(Vec::new());
-    }
-    let body =
-        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
 }
 
 fn catalogs_dir(paths: &Paths) -> PathBuf {

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -389,9 +389,26 @@ fn merge_seed(document: &mut Value, caches: &SeedCaches) {
     let mut catalog_marker =
         object.get(RX_SEEDED_CATALOG_KEY).and_then(Value::as_object).cloned().unwrap_or_default();
     merge_tool_search_denylist(object, caches, &mut catalog_marker);
-    merge_model_options(object, caches, &mut catalog_marker);
-    merge_model_access(object, caches, &mut catalog_marker);
-    merge_costs(object, caches, &mut catalog_marker);
+    reconcile_array_cache(
+        object,
+        &mut catalog_marker,
+        MODEL_OPTIONS_CACHE_KEY,
+        "value",
+        model_option_values(caches),
+    );
+    reconcile_array_cache(
+        object,
+        &mut catalog_marker,
+        MODEL_ACCESS_CACHE_KEY,
+        "apiName",
+        model_access_values(caches),
+    );
+    reconcile_object_cache(
+        object,
+        &mut catalog_marker,
+        MODEL_COSTS_CACHE_KEY,
+        &caches.additional_model_costs,
+    );
     merge_compact_windows(object, caches, &mut catalog_marker);
     catalog_marker.insert("provider_id".to_string(), json!(caches.provider_id));
     catalog_marker.insert("version".to_string(), json!(1));
@@ -491,42 +508,6 @@ fn merge_tool_search_denylist(
     legacy_owned.sort();
     object.insert(RX_SEEDED_DENYLIST_KEY.to_string(), json!(legacy_owned));
     marker.insert(TOOL_SEARCH_DENYLIST_MARKER_KEY.to_string(), Value::Object(next_marker));
-}
-
-fn merge_model_options(
-    object: &mut serde_json::Map<String, Value>,
-    caches: &SeedCaches,
-    marker: &mut serde_json::Map<String, Value>,
-) {
-    reconcile_array_cache(
-        object,
-        marker,
-        MODEL_OPTIONS_CACHE_KEY,
-        "value",
-        model_option_values(caches),
-    );
-}
-
-fn merge_model_access(
-    object: &mut serde_json::Map<String, Value>,
-    caches: &SeedCaches,
-    marker: &mut serde_json::Map<String, Value>,
-) {
-    reconcile_array_cache(
-        object,
-        marker,
-        MODEL_ACCESS_CACHE_KEY,
-        "apiName",
-        model_access_values(caches),
-    );
-}
-
-fn merge_costs(
-    object: &mut serde_json::Map<String, Value>,
-    caches: &SeedCaches,
-    marker: &mut serde_json::Map<String, Value>,
-) {
-    reconcile_object_cache(object, marker, MODEL_COSTS_CACHE_KEY, &caches.additional_model_costs);
 }
 
 fn merge_compact_windows(

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -95,7 +95,7 @@ pub(crate) struct SeedCaches {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SeedOutcome {
-    Seeded { model_count: usize },
+    Seeded,
     Fallback,
 }
 
@@ -105,17 +105,17 @@ pub(crate) fn try_seed_user_catalog(
     base_url: &str,
     api_key: &str,
     env: &EnvLookup,
-) -> Result<SeedOutcome> {
+) -> SeedOutcome {
     let caches = match catalog::load_claude_seed(paths, provider_id, base_url, api_key) {
         Ok(Some(caches)) if !caches.additional_model_options.is_empty() => caches,
-        _ => return Ok(SeedOutcome::Fallback),
+        _ => return SeedOutcome::Fallback,
     };
     let config_path = claude_config_path(env);
     match write_seed(&config_path, &caches) {
-        Ok(()) => Ok(SeedOutcome::Seeded { model_count: caches.additional_model_options.len() }),
+        Ok(()) => SeedOutcome::Seeded,
         Err(error) => {
             eprintln!("[rx] catalog seed skipped: {error:#}");
-            Ok(SeedOutcome::Fallback)
+            SeedOutcome::Fallback
         }
     }
 }
@@ -323,11 +323,15 @@ fn claude_config_path(env: &EnvLookup) -> PathBuf {
     }
 }
 
-fn write_seed(path: &Path, caches: &SeedCaches) -> Result<()> {
+pub(crate) fn write_seed(path: &Path, caches: &SeedCaches) -> Result<()> {
     write_seed_with_hook(path, caches, |_| {})
 }
 
-fn write_seed_with_hook<F>(path: &Path, caches: &SeedCaches, mut after_read: F) -> Result<()>
+pub(crate) fn write_seed_with_hook<F>(
+    path: &Path,
+    caches: &SeedCaches,
+    mut after_read: F,
+) -> Result<()>
 where
     F: FnMut(usize),
 {
@@ -356,23 +360,6 @@ where
         }
     }
     bail!("{} changed repeatedly while seeding catalog", path.display())
-}
-
-#[cfg(test)]
-pub(crate) fn write_seed_for_test(path: &Path, caches: &SeedCaches) -> Result<()> {
-    write_seed(path, caches)
-}
-
-#[cfg(test)]
-pub(crate) fn write_seed_with_hook_for_test<F>(
-    path: &Path,
-    caches: &SeedCaches,
-    after_read: F,
-) -> Result<()>
-where
-    F: FnMut(usize),
-{
-    write_seed_with_hook(path, caches, after_read)
 }
 
 fn read_config_document(path: &Path) -> Result<(Value, Option<Vec<u8>>)> {

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -132,24 +132,20 @@ pub(crate) fn seed_from_openai_body(
     if let Ok(models) = parse_user_catalog(body)
         && !models.is_empty()
     {
-        let models = apply_fallback_context(provider_id, models);
+        let fallback_context = catalog::fallback_context(provider_id);
+        let models = models
+            .into_iter()
+            .map(|model| UserModel {
+                context_length: Some(model.context_length.unwrap_or(fallback_context)),
+                ..model
+            })
+            .collect::<Vec<_>>();
         let seed = with_provider(provider_id, build_seed(&models));
         if !seed.additional_model_options.is_empty() {
             return seed;
         }
     }
     seed_from_listed(provider_id, fallback)
-}
-
-fn apply_fallback_context(provider_id: &str, models: Vec<UserModel>) -> Vec<UserModel> {
-    let fallback = catalog::fallback_context(provider_id);
-    models
-        .into_iter()
-        .map(|model| UserModel {
-            context_length: Some(model.context_length.unwrap_or(fallback)),
-            ..model
-        })
-        .collect()
 }
 
 fn with_provider(provider_id: &str, mut caches: SeedCaches) -> SeedCaches {
@@ -173,12 +169,12 @@ fn from_listed_models(provider_id: &str, models: &[ListedModel]) -> Vec<UserMode
         .collect()
 }
 
-pub(crate) fn parse_user_catalog(body: &str) -> Result<Vec<UserModel>> {
+fn parse_user_catalog(body: &str) -> Result<Vec<UserModel>> {
     let value: Value = serde_json::from_str(body).context("catalog response is not JSON")?;
     parse_user_catalog_value(&value)
 }
 
-pub(crate) fn parse_user_catalog_value(value: &Value) -> Result<Vec<UserModel>> {
+fn parse_user_catalog_value(value: &Value) -> Result<Vec<UserModel>> {
     let Some(data) = value.get("data").and_then(Value::as_array) else {
         bail!("catalog JSON has no data array");
     };

--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -7,10 +7,10 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
-pub struct Paths {
-    pub dir: PathBuf,
-    pub config: PathBuf,
-    pub keys: PathBuf,
+pub(crate) struct Paths {
+    pub(crate) dir: PathBuf,
+    pub(crate) config: PathBuf,
+    pub(crate) keys: PathBuf,
 }
 
 impl Paths {
@@ -85,10 +85,6 @@ pub(crate) fn load_or_default(paths: &Paths) -> Result<RxConfig> {
     Ok(load(paths)?.unwrap_or_default())
 }
 
-fn ensure_provider_entry<'a>(config: &'a mut RxConfig, id: &str) -> &'a mut ProviderConfig {
-    config.provider.entry(id.to_string()).or_default()
-}
-
 pub(crate) fn stored_providers(paths: &Paths) -> Result<BTreeSet<String>> {
     Ok(load_keys(paths)?.values.keys().cloned().collect())
 }
@@ -110,7 +106,7 @@ pub(crate) fn login(paths: &Paths, provider: &str, key: String) -> Result<()> {
     let mut config = load_or_default(paths)?;
     crate::provider::resolve(provider, config.provider.get(provider))?;
     let mut keys = load_keys(paths)?;
-    let entry = ensure_provider_entry(&mut config, provider);
+    let entry = config.provider.entry(provider.to_string()).or_default();
     entry.auth = AuthMode::ApiKey;
     keys.values.insert(provider.to_string(), key);
     config.default_provider = Some(provider.to_string());

--- a/crates/rx/src/dsh.rs
+++ b/crates/rx/src/dsh.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use serde_yaml::{Mapping, Value};
 
-use crate::catalog;
+use crate::catalog::{self, openai_base};
 use crate::config::Paths;
-use crate::launch::{EnvLookup, openai_base};
+use crate::launch::EnvLookup;
 use crate::provider::{ModelProtocol, Provider, ReasoningControl, Setup};
 
 pub(crate) const PROFILE: &str = "dsh-tui";

--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -211,14 +211,7 @@ fn target(profile: &GatewayProfile, key: String) -> ProviderTarget {
         default_model: None,
         claude_default_model: None,
     };
-    ProviderTarget {
-        provider_id: profile.provider_id.clone(),
-        base_url: profile.endpoint.clone(),
-        claude_url: crate::provider::claude_base(&provider),
-        provider,
-        key,
-        model: None,
-    }
+    ProviderTarget { provider, key, model: None }
 }
 
 fn validate_route_args(harness: Harness, passthrough: &[OsString]) -> Result<()> {

--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -84,7 +84,7 @@ pub(crate) fn run(passthrough: Vec<OsString>, env: &EnvLookup) -> Result<()> {
                 request.gateway.credential_env
             )
         })?;
-    let target = target(&request.gateway, key)?;
+    let target = target(&request.gateway, key);
     let paths = Paths::in_dir(request.state_dir);
     let launch_request = LaunchRequest { harness, provider: None, passthrough };
     let install_env = EnvLookup::real_with(install_overrides(request.install_policy));
@@ -199,7 +199,7 @@ fn prepare_state(environment: &HashMap<String, String>) -> Result<()> {
     Ok(())
 }
 
-fn target(profile: &GatewayProfile, key: String) -> Result<ProviderTarget> {
+fn target(profile: &GatewayProfile, key: String) -> ProviderTarget {
     let provider = Provider {
         id: profile.provider_id.clone(),
         name: profile.name.clone(),
@@ -211,14 +211,14 @@ fn target(profile: &GatewayProfile, key: String) -> Result<ProviderTarget> {
         default_model: None,
         claude_default_model: None,
     };
-    Ok(ProviderTarget {
+    ProviderTarget {
         provider_id: profile.provider_id.clone(),
         base_url: profile.endpoint.clone(),
         claude_url: crate::provider::claude_base(&provider),
         provider,
         key,
         model: None,
-    })
+    }
 }
 
 fn validate_route_args(harness: Harness, passthrough: &[OsString]) -> Result<()> {

--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -342,6 +342,12 @@ mod tests {
     }
 
     #[test]
+    fn host_entrypoint_rejects_malformed_requests() {
+        let env = EnvLookup::isolated(HashMap::from([(REQUEST_ENV.to_string(), "{".to_string())]));
+        assert!(run(Vec::new(), &env).is_err());
+    }
+
+    #[test]
     fn hosted_request_allows_missing_harness() {
         assert!(parse_request(&request(None)).unwrap().harness.is_none());
         assert_eq!(

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -199,19 +199,6 @@ fn ensure_dsh(env: &EnvLookup) -> Result<PathBuf> {
     }
     offer_install("DeepSeek Harness", &crate::dsh::install_hint(), env)?;
     ensure_pnpm()?;
-    install_dsh_packages()?;
-    let path = lookup_program("dsh").ok_or_else(|| {
-        anyhow::anyhow!(
-            "DeepSeek Harness finished installing but dsh was not found. Add npm's global bin to PATH, then retry."
-        )
-    })?;
-    if !crate::dsh::profile_ready(env) {
-        install_dsh_profile(&path, env)?;
-    }
-    Ok(path)
-}
-
-fn install_dsh_packages() -> Result<()> {
     let cmd = crate::dsh::npm_install_cmd();
     eprintln!("[rx] {cmd}");
     run_npm(
@@ -224,7 +211,15 @@ fn install_dsh_packages() -> Result<()> {
         ],
         &cmd,
     )?;
-    Ok(())
+    let path = lookup_program("dsh").ok_or_else(|| {
+        anyhow::anyhow!(
+            "DeepSeek Harness finished installing but dsh was not found. Add npm's global bin to PATH, then retry."
+        )
+    })?;
+    if !crate::dsh::profile_ready(env) {
+        install_dsh_profile(&path, env)?;
+    }
+    Ok(path)
 }
 
 fn ensure_pnpm() -> Result<()> {

--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -146,7 +146,7 @@ fn executable_extensions() -> Option<OsString> {
     None
 }
 
-pub(crate) fn extra_bin_dirs() -> Vec<PathBuf> {
+fn extra_bin_dirs() -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };

--- a/crates/rx/src/kimi.rs
+++ b/crates/rx/src/kimi.rs
@@ -48,7 +48,7 @@ pub(crate) fn prepare(
     env: &EnvLookup,
     passthrough: &[OsString],
 ) -> Result<LaunchPlan> {
-    let provider_id = target.provider_id.as_str();
+    let provider_id = target.provider.id.as_str();
     let provider_alias = format!("rx-{provider_id}");
     let model_prefix = format!("{provider_alias}/");
     let (requested_model, mut args) = take_model(passthrough)?;
@@ -60,7 +60,7 @@ pub(crate) fn prepare(
     let mut models = match catalog::load_listed_models(
         paths,
         provider_id,
-        &target.base_url,
+        &target.provider.endpoint,
         &target.key,
         allow_fetch,
     ) {
@@ -166,7 +166,7 @@ fn desired_catalog(
 ) -> OwnedCatalog {
     let provider = OwnedProvider {
         alias: provider_alias.to_string(),
-        base_url: catalog::openai_base(&target.base_url),
+        base_url: catalog::openai_base(&target.provider.endpoint),
         api_key_sha256: key_hash(&target.key),
     };
     let models = models
@@ -178,7 +178,7 @@ fn desired_catalog(
                 model: model.id.clone(),
                 max_context_size: model
                     .context_length
-                    .unwrap_or_else(|| catalog::fallback_context(&target.provider_id)),
+                    .unwrap_or_else(|| catalog::fallback_context(&target.provider.id)),
                 display_name: model.name.clone(),
             };
             (alias, entry)
@@ -441,15 +441,9 @@ mod tests {
     use super::*;
 
     fn target(key: &str) -> ProviderTarget {
-        let provider = crate::provider::find("tokener").unwrap().clone();
-        ProviderTarget {
-            provider_id: "tokener".to_string(),
-            base_url: "https://provider.test".to_string(),
-            claude_url: "https://provider.test".to_string(),
-            provider,
-            key: key.to_string(),
-            model: None,
-        }
+        let mut provider = crate::provider::find("tokener").unwrap().clone();
+        provider.endpoint = "https://provider.test".to_string();
+        ProviderTarget { provider, key: key.to_string(), model: None }
     }
 
     fn listed(id: &str, name: &str, context: i64) -> ListedModel {

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -6,15 +6,13 @@ use std::process::{Command, Stdio};
 use anyhow::{Result, bail};
 
 use crate::args::{self, Harness, LaunchRequest};
-use crate::catalog;
+use crate::catalog::{self, anthropic_base, openai_base};
 use crate::claude_catalog::{self, SeedOutcome};
 use crate::config::{AuthMode, Paths};
 use crate::provider::{Provider, Setup};
 
-pub(crate) use crate::catalog::{anthropic_base, openai_base};
-
 #[derive(Debug, Clone, Default)]
-pub struct EnvLookup {
+pub(crate) struct EnvLookup {
     overrides: HashMap<String, String>,
     real: bool,
 }
@@ -46,11 +44,11 @@ impl EnvLookup {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LaunchPlan {
-    pub program: PathBuf,
-    pub args: Vec<OsString>,
-    pub env_set: Vec<(String, String)>,
-    pub stderr_note: Option<String>,
+pub(crate) struct LaunchPlan {
+    pub(crate) program: PathBuf,
+    pub(crate) args: Vec<OsString>,
+    pub(crate) env_set: Vec<(String, String)>,
+    pub(crate) stderr_note: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -155,7 +153,7 @@ pub(crate) fn plan_target(
                 &target.base_url,
                 &target.key,
                 env,
-            )?
+            )
         } else {
             SeedOutcome::Fallback
         };
@@ -165,7 +163,7 @@ pub(crate) fn plan_target(
             apply_yolo(request, &mut plan, env);
             return Ok(plan);
         }
-        if matches!(seed, SeedOutcome::Seeded { .. }) {
+        if seed == SeedOutcome::Seeded {
             let mut plan = inject_claude_generated_seeded(
                 request,
                 &target.provider.env,
@@ -318,35 +316,14 @@ fn resolve_key(
     }
 }
 
-fn inject_claude_openrouter(
+pub(crate) fn inject_claude_openrouter(
     request: &LaunchRequest,
     base_url: &str,
     key: &str,
     model: Option<&str>,
     seed: SeedOutcome,
 ) -> LaunchPlan {
-    inject_claude_openrouter_impl(request, base_url, key, model, seed)
-}
-
-#[cfg(test)]
-pub(crate) fn inject_claude_openrouter_for_test(
-    request: &LaunchRequest,
-    base_url: &str,
-    key: &str,
-    model: Option<&str>,
-    seed: SeedOutcome,
-) -> LaunchPlan {
-    inject_claude_openrouter_impl(request, base_url, key, model, seed)
-}
-
-fn inject_claude_openrouter_impl(
-    request: &LaunchRequest,
-    base_url: &str,
-    key: &str,
-    model: Option<&str>,
-    seed: SeedOutcome,
-) -> LaunchPlan {
-    let seeded = matches!(seed, SeedOutcome::Seeded { .. });
+    let seeded = seed == SeedOutcome::Seeded;
     let mut args = request.passthrough.clone();
     if seeded && !claude_catalog::user_passes_settings(&request.passthrough) {
         args.insert(
@@ -364,7 +341,7 @@ fn inject_claude_openrouter_impl(
             "[rx] provider catalog seed failed; falling back to provider model discovery"
                 .to_string(),
         ),
-        SeedOutcome::Seeded { .. } => None,
+        SeedOutcome::Seeded => None,
     };
     LaunchPlan {
         program: PathBuf::from("claude"),
@@ -423,7 +400,7 @@ fn claude_openrouter_env(
     env_set
 }
 
-fn inject_claude_generated_seeded(
+pub(crate) fn inject_claude_generated_seeded(
     request: &LaunchRequest,
     env_key: &str,
     base_url: &str,
@@ -444,17 +421,6 @@ fn inject_claude_generated_seeded(
         env_set: claude_generated_seeded_env(env_key, base_url, key, model),
         stderr_note: None,
     }
-}
-
-#[cfg(test)]
-pub(crate) fn inject_claude_generated_seeded_for_test(
-    request: &LaunchRequest,
-    env_key: &str,
-    base_url: &str,
-    key: &str,
-    model: Option<&str>,
-) -> LaunchPlan {
-    inject_claude_generated_seeded(request, env_key, base_url, key, model)
 }
 
 fn claude_generated_seeded_env(

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -510,8 +510,6 @@ fn inject(
             })
         }
         Harness::OpenCode => {
-            let provider_id =
-                if provider.setup == Setup::Generated { provider_id } else { provider.id.as_str() };
             let mut env_set = vec![(provider.env.clone(), key.to_string())];
             env_set.push((
                 "OPENCODE_CONFIG_CONTENT".to_string(),
@@ -544,8 +542,6 @@ fn inject(
             })
         }
         Harness::Pi => {
-            let provider_id =
-                if provider.setup == Setup::Generated { provider_id } else { provider.id.as_str() };
             crate::pi::prepare(provider_id, provider, base_url, key, paths, env)?;
             Ok(LaunchPlan {
                 program: PathBuf::from("pi"),

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -53,10 +53,7 @@ pub(crate) struct LaunchPlan {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProviderTarget {
-    pub provider_id: String,
     pub provider: Provider,
-    pub base_url: String,
-    pub claude_url: String,
     pub key: String,
     pub model: Option<String>,
 }
@@ -102,14 +99,7 @@ pub(crate) fn configured_provider(
     let auth = entry.map(|entry| entry.auth).unwrap_or(AuthMode::ApiKey);
     let key = resolve_key(&provider, auth, paths, env)?;
     let model = entry.and_then(|entry| entry.model.clone());
-    Ok(ProviderResolution::Target(Box::new(ProviderTarget {
-        provider_id,
-        base_url: provider.endpoint.clone(),
-        claude_url: crate::provider::claude_base(&provider),
-        provider,
-        key,
-        model,
-    })))
+    Ok(ProviderResolution::Target(Box::new(ProviderTarget { provider, key, model })))
 }
 
 pub(crate) fn plan(request: &LaunchRequest, paths: &Paths, env: &EnvLookup) -> Result<LaunchPlan> {
@@ -140,6 +130,8 @@ pub(crate) fn plan_target(
     env: &EnvLookup,
     target: &ProviderTarget,
 ) -> Result<LaunchPlan> {
+    let provider_id = target.provider.id.as_str();
+    let base_url = target.provider.endpoint.as_str();
     let model = target.model.as_deref().or(match request.harness {
         Harness::Claude => target.provider.claude_default_model,
         Harness::Codex => target.provider.default_model,
@@ -147,27 +139,22 @@ pub(crate) fn plan_target(
     });
     if matches!(request.harness, Harness::Claude) {
         let seed = if env.is_real() {
-            claude_catalog::try_seed_user_catalog(
-                paths,
-                &target.provider_id,
-                &target.base_url,
-                &target.key,
-                env,
-            )
+            claude_catalog::try_seed_user_catalog(paths, provider_id, base_url, &target.key, env)
         } else {
             SeedOutcome::Fallback
         };
         if target.provider.setup == Setup::OpenRouter {
-            let mut plan =
-                inject_claude_openrouter(request, &target.claude_url, &target.key, model, seed);
+            let claude_url = crate::provider::claude_base(&target.provider);
+            let mut plan = inject_claude_openrouter(request, &claude_url, &target.key, model, seed);
             apply_yolo(request, &mut plan, env);
             return Ok(plan);
         }
         if seed == SeedOutcome::Seeded {
+            let claude_url = crate::provider::claude_base(&target.provider);
             let mut plan = inject_claude_generated_seeded(
                 request,
                 &target.provider.env,
-                &target.claude_url,
+                &claude_url,
                 &target.key,
                 model,
             );
@@ -476,15 +463,15 @@ fn inject(
     target: &ProviderTarget,
     model: Option<&str>,
 ) -> Result<LaunchPlan> {
-    let provider_id = target.provider_id.as_str();
     let provider = &target.provider;
-    let base_url = target.base_url.as_str();
+    let provider_id = provider.id.as_str();
+    let base_url = provider.endpoint.as_str();
     let key = target.key.as_str();
     match request.harness {
         Harness::Claude => Ok(LaunchPlan {
             program: PathBuf::from("claude"),
             args: request.passthrough.clone(),
-            env_set: claude_env(&provider.env, &target.claude_url, key, model),
+            env_set: claude_env(&provider.env, &crate::provider::claude_base(provider), key, model),
             stderr_note: None,
         }),
         Harness::Codex => {

--- a/crates/rx/src/lib.rs
+++ b/crates/rx/src/lib.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use anyhow::Result;
 
 use args::{Command, LaunchRequest, argv0_harness, parse, rewrite_argv0};
-pub use config::Paths;
+use config::Paths;
 use launch::{EnvLookup, plan};
 
 pub(crate) const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -29,7 +29,7 @@ pub fn run(raw_args: impl IntoIterator<Item = impl Into<OsString>>) -> Result<()
     run_with(raw_args.into_iter().map(Into::into).collect(), &Paths::user()?, &EnvLookup::real())
 }
 
-pub fn run_with(raw_args: Vec<OsString>, paths: &Paths, env: &EnvLookup) -> Result<()> {
+fn run_with(raw_args: Vec<OsString>, paths: &Paths, env: &EnvLookup) -> Result<()> {
     let command = if raw_args.first().and_then(|argv0| argv0_harness(argv0)).is_some() {
         parse(&rewrite_argv0(raw_args.clone()))?
     } else {
@@ -83,7 +83,7 @@ fn launch_request(
     launch::exec(&plan)
 }
 
-pub fn help_text() -> &'static str {
+fn help_text() -> &'static str {
     "\
 rx — launch agent harnesses through a configured AI provider
 

--- a/crates/rx/src/opencode.rs
+++ b/crates/rx/src/opencode.rs
@@ -5,8 +5,9 @@ use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
 use crate::catalog;
+use crate::catalog::openai_base;
 use crate::config::Paths;
-use crate::launch::{EnvLookup, openai_base};
+use crate::launch::EnvLookup;
 use crate::provider::{Provider, Setup};
 
 pub(crate) fn config_content(

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -9,8 +9,9 @@ use serde_json::{Value, json};
 
 use crate::args;
 use crate::catalog;
+use crate::catalog::openai_base;
 use crate::config::Paths;
-use crate::launch::{EnvLookup, openai_base};
+use crate::launch::EnvLookup;
 use crate::opencode;
 use crate::provider::{Provider, Setup};
 

--- a/crates/rx/src/pi.rs
+++ b/crates/rx/src/pi.rs
@@ -23,7 +23,7 @@ const PI_ENV_CLEAR: &[&str] = &[
     "GEMINI_API_KEY",
 ];
 
-pub(crate) fn global_agent_dir(env: &EnvLookup) -> Result<PathBuf> {
+fn global_agent_dir(env: &EnvLookup) -> Result<PathBuf> {
     // PI_CODING_AGENT_DIR is authoritative for pi's configuration location
     // (see src/adapters/pi.rs); providers must land where the launched
     // process will actually read them.
@@ -53,10 +53,6 @@ pub(crate) fn global_agent_dir(env: &EnvLookup) -> Result<PathBuf> {
     Ok(home.join(".pi").join("agent"))
 }
 
-pub(crate) fn recall_pi_dir(paths: &Paths) -> PathBuf {
-    paths.dir.join("pi")
-}
-
 pub(crate) fn prepare(
     provider_id: &str,
     provider: &Provider,
@@ -73,7 +69,7 @@ pub(crate) fn prepare(
         }
         return Ok(());
     }
-    let recall_dir = recall_pi_dir(paths);
+    let recall_dir = paths.dir.join("pi");
     fs::create_dir_all(&recall_dir)
         .with_context(|| format!("failed to create {}", recall_dir.display()))?;
     write_json_atomic(&recall_dir.join(format!("{provider_id}-provider.json")), &document)?;

--- a/crates/rx/src/provider.rs
+++ b/crates/rx/src/provider.rs
@@ -220,7 +220,6 @@ fn from_snapshot(provider: SnapshotProvider) -> Provider {
         "openrouter" => {
             (Setup::OpenRouter, Some("~openai/gpt-latest"), Some("~anthropic/claude-sonnet-latest"))
         }
-        "tokener" => (Setup::Generated, None, None),
         _ => (Setup::Generated, None, None),
     };
     Provider {

--- a/crates/rx/src/provider.rs
+++ b/crates/rx/src/provider.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use anyhow::{Result, bail};
@@ -190,9 +190,8 @@ pub(crate) fn claude_base(provider: &Provider) -> String {
 
 pub(crate) fn available(config: &RxConfig) -> Result<Vec<Provider>> {
     let mut providers = catalog().to_vec();
-    let known: BTreeSet<String> = providers.iter().map(|provider| provider.id.clone()).collect();
     for (id, entry) in &config.provider {
-        if !known.contains(id.as_str()) && entry.base_url.is_some() {
+        if find(id).is_none() && entry.base_url.is_some() {
             providers.push(resolve(id, Some(entry))?);
         }
     }

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -12,7 +12,7 @@ use ratatui::{
     widgets::{Paragraph, Wrap},
 };
 
-use crate::args::{ModelsCommand, ProvidersCommand};
+use crate::args::ProvidersCommand;
 use crate::catalog;
 use crate::config::{AuthMode, Paths};
 use crate::launch::{self, EnvLookup};
@@ -300,7 +300,13 @@ pub(crate) fn run(command: ProvidersCommand, paths: &Paths, env: &EnvLookup) -> 
         ProvidersCommand::Login { provider } => login(paths, env, provider.as_deref()),
         ProvidersCommand::Logout { provider } => logout(paths, env, provider.as_deref()),
         ProvidersCommand::Use { provider } => use_provider(paths, env, provider.as_deref()),
-        ProvidersCommand::Models(command) => models(command, paths, env),
+        ProvidersCommand::ModelsHelp => {
+            print!("{}", models_help());
+            Ok(())
+        }
+        ProvidersCommand::ModelsUpdate { provider } => {
+            update_models(paths, env, provider.as_deref())
+        }
     }
 }
 
@@ -322,16 +328,6 @@ pub(crate) fn models_help() -> &'static str {
         "Usage:\n",
         "  rx providers models update [provider]\n\n",
     )
-}
-
-fn models(command: ModelsCommand, paths: &Paths, env: &EnvLookup) -> Result<()> {
-    match command {
-        ModelsCommand::Help => {
-            print!("{}", models_help());
-            Ok(())
-        }
-        ModelsCommand::Update { provider } => update_models(paths, env, provider.as_deref()),
-    }
 }
 
 fn update_models(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Result<()> {

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -908,6 +908,19 @@ mod tests {
     }
 
     #[test]
+    fn picker_ignores_enter_without_a_matching_provider() {
+        let mut app = App::new(Action::Use, vec![state("openrouter", "OpenRouter", true, true)]);
+        app.query = "missing".to_string();
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(!app.exit);
+        assert_eq!(app.step, Step::Provider);
+        assert!(app.selected.is_none());
+        assert!(app.outcome.is_none());
+    }
+
+    #[test]
     fn direct_login_starts_at_the_api_key_step() {
         let mut app = App::login_for_provider(
             vec![

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -360,9 +360,13 @@ fn update_models(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Res
                 bail!("no API key for provider '{id}'; run: rx providers login {id}")
             }
         };
-        let count =
-            catalog::update_models(paths, &target.provider_id, &target.base_url, &target.key)?;
-        println!("{}: {count} models", target.provider_id);
+        let count = catalog::update_models(
+            paths,
+            &target.provider.id,
+            &target.provider.endpoint,
+            &target.key,
+        )?;
+        println!("{}: {count} models", target.provider.id);
     }
     Ok(())
 }

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -76,8 +76,6 @@ struct App {
 
 impl App {
     fn new(action: Action, providers: Vec<ProviderState>) -> Self {
-        let mut providers = providers;
-        sort_provider_states(&mut providers);
         let mut app = Self {
             action,
             step: Step::Provider,
@@ -153,14 +151,15 @@ impl App {
     }
 
     fn handle_provider_key(&mut self, key: KeyEvent) {
-        let count = self.filtered_providers().len();
+        let filtered = self.filtered_providers();
+        let count = filtered.len();
         match key.code {
             KeyCode::Up if count > 0 => {
                 self.cursor = self.cursor.checked_sub(1).unwrap_or(count - 1);
             }
             KeyCode::Down if count > 0 => self.cursor = (self.cursor + 1) % count,
             KeyCode::Enter if count > 0 => {
-                self.selected = self.filtered_providers().get(self.cursor).copied();
+                self.selected = filtered.get(self.cursor).copied();
                 self.api_key.clear();
                 self.validation_error = false;
                 match self.action {
@@ -850,16 +849,15 @@ mod tests {
 
     #[test]
     fn picker_pins_openrouter_and_tokener_then_configured_then_alpha() {
-        let app = App::new(
-            Action::Login,
-            vec![
-                state("zenmux", "Zenmux", true, false),
-                state("tokener", "Tokener", false, false),
-                state("abacus", "Abacus", false, false),
-                state("openrouter", "OpenRouter", false, false),
-                state("deepseek", "DeepSeek", true, false),
-            ],
-        );
+        let mut states = vec![
+            state("zenmux", "Zenmux", true, false),
+            state("tokener", "Tokener", false, false),
+            state("abacus", "Abacus", false, false),
+            state("openrouter", "OpenRouter", false, false),
+            state("deepseek", "DeepSeek", true, false),
+        ];
+        sort_provider_states(&mut states);
+        let app = App::new(Action::Login, states);
         let names = app
             .filtered_providers()
             .into_iter()

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::args::{
     Command, CompletionShell, CompletionsCommand, Harness, LaunchRequest, ProviderIdFilter,
@@ -36,6 +37,25 @@ fn temp_paths() -> (tempfile::TempDir, Paths) {
     (dir, paths)
 }
 
+fn accept_connection(listener: &TcpListener) -> TcpStream {
+    listener.set_nonblocking(true).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false).unwrap();
+                return stream;
+            }
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock && Instant::now() < deadline =>
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("test server did not receive a connection: {error}"),
+        }
+    }
+}
+
 fn serve_openai_models(body: &str) -> (String, thread::JoinHandle<()>) {
     serve_openai_models_times(body, 1)
 }
@@ -46,7 +66,7 @@ fn serve_openai_models_times(body: &str, times: usize) -> (String, thread::JoinH
     let body = body.to_string();
     let server = thread::spawn(move || {
         for _ in 0..times {
-            let (mut stream, _) = listener.accept().unwrap();
+            let mut stream = accept_connection(&listener);
             let mut request = [0; 2048];
             let size = stream.read(&mut request).unwrap();
             let req = String::from_utf8_lossy(&request[..size]);
@@ -66,7 +86,7 @@ fn serve_openai_error(status: u16) -> (String, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_connection(&listener);
         let mut request = [0; 2048];
         let _ = stream.read(&mut request);
         write!(
@@ -83,7 +103,7 @@ fn serve_openai_models_then_error(body: &str, status: u16) -> (String, thread::J
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     let body = body.to_string();
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_connection(&listener);
         let mut request = [0; 2048];
         let size = stream.read(&mut request).unwrap();
         let req = String::from_utf8_lossy(&request[..size]);
@@ -94,7 +114,7 @@ fn serve_openai_models_then_error(body: &str, status: u16) -> (String, thread::J
             body.len()
         )
         .unwrap();
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_connection(&listener);
         let mut request = [0; 2048];
         let _ = stream.read(&mut request);
         write!(
@@ -315,6 +335,27 @@ fn completion_ids_list_configured_and_known() {
     for id in known {
         assert_ne!(id, "none");
     }
+}
+
+#[test]
+fn available_providers_include_only_complete_custom_entries_once() {
+    let config: crate::config::RxConfig = toml::from_str(
+        r#"
+[provider.openrouter]
+base_url = "https://proxy.example.com/v1"
+
+[provider.complete]
+base_url = "https://complete.example.com/v1"
+
+[provider.incomplete]
+env = "INCOMPLETE_API_KEY"
+"#,
+    )
+    .unwrap();
+    let available = crate::provider::available(&config).unwrap();
+    assert_eq!(available.iter().filter(|provider| provider.id == "openrouter").count(), 1);
+    assert!(available.iter().any(|provider| provider.id == "complete"));
+    assert!(!available.iter().any(|provider| provider.id == "incomplete"));
 }
 
 #[test]
@@ -1399,7 +1440,7 @@ fn pi_tokener_writes_recall_cache() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_connection(&listener);
         let mut request = [0; 1024];
         let size = stream.read(&mut request).unwrap();
         assert!(String::from_utf8_lossy(&request[..size]).starts_with("GET /v1/models "));
@@ -1695,7 +1736,7 @@ model = "gpt-prod"
     assert_eq!(codex.env_set, vec![("TOKENER_DEV_API_KEY".to_string(), "sk-dev".to_string())]);
 
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let mut stream = accept_connection(&listener);
         let mut request = [0; 2048];
         let size = stream.read(&mut request).unwrap();
         let req = String::from_utf8_lossy(&request[..size]);
@@ -2190,6 +2231,82 @@ fn claude_seed_uses_openai_models_and_merges_from_cache() {
         serde_json::from_str(&fs::read_to_string(config_dir.path().join(".claude.json")).unwrap())
             .unwrap();
     assert_eq!(document["additionalModelOptionsCache"][0]["value"], "claude-sonnet-5");
+}
+
+#[test]
+fn empty_claude_catalog_does_not_claim_seeded_discovery() {
+    let (_dir, paths) = temp_paths();
+    let config_dir = tempfile::tempdir().unwrap();
+    let (base_url, server) = serve_openai_models(r#"{"data":[]}"#);
+    let env = EnvLookup::isolated(HashMap::from([(
+        "CLAUDE_CONFIG_DIR".to_string(),
+        config_dir.path().display().to_string(),
+    )]));
+    let outcome =
+        crate::claude_catalog::try_seed_user_catalog(&paths, "lab", &base_url, "sk-test", &env);
+    server.join().unwrap();
+    assert_eq!(outcome, crate::claude_catalog::SeedOutcome::Fallback);
+    assert!(!config_dir.path().join(".claude.json").exists());
+}
+
+#[test]
+fn empty_cached_claude_seed_falls_back_without_writing_config() {
+    let (_dir, paths) = temp_paths();
+    let config_dir = tempfile::tempdir().unwrap();
+    let (base_url, server) = serve_openai_models(r#"{"data":[{"id":"claude-test"}]}"#);
+    crate::catalog::prepare_codex_catalog(&paths, "lab", &base_url, "sk-test").unwrap().unwrap();
+    server.join().unwrap();
+    fs::write(
+        paths.dir.join("catalogs/lab.claude.json"),
+        serde_json::to_vec(&crate::claude_catalog::SeedCaches::default()).unwrap(),
+    )
+    .unwrap();
+    let env = EnvLookup::isolated(HashMap::from([(
+        "CLAUDE_CONFIG_DIR".to_string(),
+        config_dir.path().display().to_string(),
+    )]));
+
+    let outcome =
+        crate::claude_catalog::try_seed_user_catalog(&paths, "lab", &base_url, "sk-test", &env);
+
+    assert_eq!(outcome, crate::claude_catalog::SeedOutcome::Fallback);
+    assert!(!config_dir.path().join(".claude.json").exists());
+}
+
+#[test]
+fn real_claude_plan_uses_seeded_generated_route() {
+    let (_dir, paths) = temp_paths();
+    let config_dir = tempfile::tempdir().unwrap();
+    let (base_url, server) = serve_openai_models(r#"{"data":[{"id":"claude-test"}]}"#);
+    fs::write(
+        &paths.config,
+        format!(
+            "[provider.lab]\nbase_url = \"{base_url}\"\nenv = \"LAB_API_KEY\"\nauth = \"env\"\n"
+        ),
+    )
+    .unwrap();
+    let env = EnvLookup::real_with(HashMap::from([
+        ("CLAUDE_CONFIG_DIR".to_string(), config_dir.path().display().to_string()),
+        ("LAB_API_KEY".to_string(), "sk-test".to_string()),
+        ("RX_NO_YOLO".to_string(), "1".to_string()),
+    ]));
+    let plan = launch::plan(
+        &LaunchRequest {
+            harness: Harness::Claude,
+            provider: Some("lab".to_string()),
+            passthrough: os(&["fix it"]),
+        },
+        &paths,
+        &env,
+    )
+    .unwrap();
+    server.join().unwrap();
+    assert_eq!(plan.args[0], "--settings");
+    assert_eq!(plan.args[2], "fix it");
+    assert!(
+        plan.env_set.iter().any(|(key, value)| key == "ANTHROPIC_AUTH_TOKEN" && value == "sk-test")
+    );
+    assert!(config_dir.path().join(".claude.json").is_file());
 }
 
 #[test]

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -364,18 +364,13 @@ fn homebrew_managed_rx_requires_brew_upgrade() {
         "/srv/custom-brew/Cellar/recall/0.5.1/bin/rx",
     ] {
         assert_eq!(
-            crate::update::self_update_blocker_for_test(Path::new(path)),
+            crate::update::self_update_blocker(Path::new(path)),
             Some(crate::update::HOMEBREW_UPDATE_HINT)
         );
     }
+    assert_eq!(crate::update::self_update_blocker(Path::new("/Users/x/.cargo/bin/rx")), None);
     assert_eq!(
-        crate::update::self_update_blocker_for_test(Path::new("/Users/x/.cargo/bin/rx")),
-        None
-    );
-    assert_eq!(
-        crate::update::self_update_blocker_for_test(Path::new(
-            "/opt/homebrew/Cellar/other/0.5.1/bin/rx"
-        )),
+        crate::update::self_update_blocker(Path::new("/opt/homebrew/Cellar/other/0.5.1/bin/rx")),
         None
     );
 }
@@ -392,11 +387,11 @@ fn homebrew_managed_rx_is_detected_through_bin_symlink() {
     std::os::unix::fs::symlink(&cellar_rx, &linked_rx).unwrap();
 
     assert_eq!(
-        crate::update::self_update_blocker_for_test(&linked_rx),
+        crate::update::self_update_blocker(&linked_rx),
         Some(crate::update::HOMEBREW_UPDATE_HINT)
     );
     assert_eq!(
-        crate::update::homebrew_launch_update_notice_for_test(&linked_rx, "0.6.0"),
+        crate::update::homebrew_launch_update_notice(&linked_rx, "0.6.0"),
         Some("rx 0.6.0 is available — run `brew upgrade recall`".to_string())
     );
 }
@@ -418,7 +413,7 @@ fn claude_seed_replaces_wrong_typed_growthbook_cache() {
     let config_path = dir.path().join(".claude.json");
     fs::write(&config_path, r#"{"cachedGrowthBookFeatures": null}"#).unwrap();
     let caches = crate::claude_catalog::SeedCaches::default();
-    crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &caches).unwrap();
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
     assert!(document["cachedGrowthBookFeatures"].is_object());
@@ -643,7 +638,7 @@ fn bundled_providers_match_the_admission_list() {
     assert_eq!(zai.env, "ZHIPU_API_KEY");
     assert_eq!(zai.anthropic_base.as_deref(), Some("https://api.z.ai/api/anthropic"));
     assert_eq!(crate::provider::claude_base(zai), "https://api.z.ai/api/anthropic");
-    assert_eq!(launch::openai_base(&zai.endpoint), "https://api.z.ai/api/paas/v4");
+    assert_eq!(crate::catalog::openai_base(&zai.endpoint), "https://api.z.ai/api/paas/v4");
     let zhipu = crate::provider::find("zhipuai").unwrap();
     assert_eq!(zhipu.endpoint, "https://open.bigmodel.cn/api/paas/v4");
     assert_eq!(zhipu.anthropic_base.as_deref(), Some("https://open.bigmodel.cn/api/anthropic"));
@@ -1800,14 +1795,23 @@ base_url = "https://provider.test/v1"
 #[test]
 fn url_helpers_strip_or_add_v1() {
     assert_eq!(
-        launch::anthropic_base("https://openrouter.ai/api/v1/"),
+        crate::catalog::anthropic_base("https://openrouter.ai/api/v1/"),
         "https://openrouter.ai/api"
     );
-    assert_eq!(launch::openai_base("https://api.tokener.dev"), "https://api.tokener.dev/v1");
-    assert_eq!(launch::openai_base("https://openrouter.ai/api/v1"), "https://openrouter.ai/api/v1");
-    assert_eq!(launch::openai_base("https://api.z.ai/api/paas/v4"), "https://api.z.ai/api/paas/v4");
     assert_eq!(
-        launch::openai_base("https://api.z.ai/api/coding/paas/v4/"),
+        crate::catalog::openai_base("https://api.tokener.dev"),
+        "https://api.tokener.dev/v1"
+    );
+    assert_eq!(
+        crate::catalog::openai_base("https://openrouter.ai/api/v1"),
+        "https://openrouter.ai/api/v1"
+    );
+    assert_eq!(
+        crate::catalog::openai_base("https://api.z.ai/api/paas/v4"),
+        "https://api.z.ai/api/paas/v4"
+    );
+    assert_eq!(
+        crate::catalog::openai_base("https://api.z.ai/api/coding/paas/v4/"),
         "https://api.z.ai/api/coding/paas/v4"
     );
 }
@@ -2166,10 +2170,9 @@ fn claude_seed_uses_openai_models_and_merges_from_cache() {
         &base_url,
         "sk-test",
         &env,
-    )
-    .unwrap();
+    );
     server.join().unwrap();
-    assert!(matches!(first, crate::claude_catalog::SeedOutcome::Seeded { model_count: 1 }));
+    assert_eq!(first, crate::claude_catalog::SeedOutcome::Seeded);
     let cached: crate::claude_catalog::SeedCaches = serde_json::from_str(
         &fs::read_to_string(paths.dir.join("catalogs/openrouter.claude.json")).unwrap(),
     )
@@ -2181,9 +2184,8 @@ fn claude_seed_uses_openai_models_and_merges_from_cache() {
         &base_url,
         "sk-test",
         &env,
-    )
-    .unwrap();
-    assert!(matches!(second, crate::claude_catalog::SeedOutcome::Seeded { model_count: 1 }));
+    );
+    assert_eq!(second, crate::claude_catalog::SeedOutcome::Seeded);
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(config_dir.path().join(".claude.json")).unwrap())
             .unwrap();
@@ -2198,7 +2200,7 @@ fn debug_is_not_a_harness() {
 
 #[test]
 fn generated_provider_seeded_plan_uses_auth_token_and_settings() {
-    let plan = launch::inject_claude_generated_seeded_for_test(
+    let plan = launch::inject_claude_generated_seeded(
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("tokener".to_string()),
@@ -2267,7 +2269,7 @@ fn openrouter_seed_writes_claude_json() {
         supported_efforts: vec![],
         pricing: None,
     }]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &caches).unwrap();
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
     let options = document["additionalModelOptionsCache"].as_array().unwrap();
@@ -2291,7 +2293,7 @@ fn claude_seed_replaces_previous_provider_catalog_without_dropping_unowned_entri
         r#"{"data":[{"id":"google/gemini-3.7-flash","name":"Gemini","context_length":200000}]}"#,
     )
     .unwrap();
-    crate::claude_catalog::write_seed_for_test(
+    crate::claude_catalog::write_seed(
         &config_path,
         &crate::claude_catalog::seed_from_listed("openrouter", &openrouter),
     )
@@ -2321,7 +2323,7 @@ fn claude_seed_replaces_previous_provider_catalog_without_dropping_unowned_entri
         r#"{"data":[{"id":"claude-sonnet-5","name":"Sonnet 5","context_length":200000}]}"#,
     )
     .unwrap();
-    crate::claude_catalog::write_seed_for_test(
+    crate::claude_catalog::write_seed(
         &config_path,
         &crate::claude_catalog::seed_from_listed("tokener", &tokener),
     )
@@ -2365,7 +2367,7 @@ fn claude_seed_first_run_preserves_preexisting_catalog_entries() {
         r#"{"data":[{"id":"claude-sonnet-5","name":"Sonnet 5","context_length":200000}]}"#,
     )
     .unwrap();
-    crate::claude_catalog::write_seed_for_test(
+    crate::claude_catalog::write_seed(
         &config_path,
         &crate::claude_catalog::seed_from_listed("openrouter", &models),
     )
@@ -2426,7 +2428,7 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
             }),
         },
     ]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &first_seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &first_seed).unwrap();
 
     let second_seed = crate::claude_catalog::build_seed(&[crate::claude_catalog::UserModel {
         id: "anthropic/claude-current".to_string(),
@@ -2442,7 +2444,7 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
             web_search: None,
         }),
     }]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &second_seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &second_seed).unwrap();
 
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2490,7 +2492,7 @@ fn claude_seed_reclaims_modified_owned_payloads_and_preserves_unowned() {
             web_search: None,
         }),
     }]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
 
     let mut document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2512,12 +2514,9 @@ fn claude_seed_reclaims_modified_owned_payloads_and_preserves_unowned() {
     document["autoCompactWindowsCache"]["claude-edited"] = serde_json::json!(123_456);
     fs::write(&config_path, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
 
-    crate::claude_catalog::write_seed_for_test(
-        &config_path,
-        &crate::claude_catalog::SeedCaches::default(),
-    )
-    .unwrap();
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &crate::claude_catalog::SeedCaches::default())
+        .unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
 
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2555,7 +2554,7 @@ fn claude_seed_recreates_deleted_owned_payloads() {
             web_search: None,
         }),
     }]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
 
     let mut document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2575,8 +2574,8 @@ fn claude_seed_recreates_deleted_owned_payloads() {
         .retain(|entry| entry != "openai/deleted");
     fs::write(&config_path, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
 
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
 
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2622,12 +2621,9 @@ fn claude_seed_does_not_claim_unmarked_matching_identity() {
         supported_efforts: vec![],
         pricing: None,
     }]);
-    crate::claude_catalog::write_seed_for_test(&config_path, &seed).unwrap();
-    crate::claude_catalog::write_seed_for_test(
-        &config_path,
-        &crate::claude_catalog::SeedCaches::default(),
-    )
-    .unwrap();
+    crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
+    crate::claude_catalog::write_seed(&config_path, &crate::claude_catalog::SeedCaches::default())
+        .unwrap();
 
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
@@ -2665,7 +2661,7 @@ fn concurrent_claude_seed_writes_leave_one_complete_catalog() {
         }]);
         writers.push(thread::spawn(move || {
             barrier.wait();
-            crate::claude_catalog::write_seed_for_test(&path, &caches).unwrap();
+            crate::claude_catalog::write_seed(&path, &caches).unwrap();
         }));
     }
     for writer in writers {
@@ -2710,7 +2706,7 @@ fn claude_seed_remerges_external_config_changes() {
         pricing: None,
     }]);
     let external_path = config_path.clone();
-    crate::claude_catalog::write_seed_with_hook_for_test(&config_path, &caches, |attempt| {
+    crate::claude_catalog::write_seed_with_hook(&config_path, &caches, |attempt| {
         if attempt == 0 {
             fs::write(&external_path, r#"{"external":"keep"}"#).unwrap();
         }
@@ -2734,7 +2730,7 @@ fn claude_seed_errors_on_non_object_config_root_instead_of_panicking() {
     let config_path = dir.path().join(".claude.json");
     fs::write(&config_path, r#"["not", "an", "object"]"#).unwrap();
     let caches = crate::claude_catalog::SeedCaches::default();
-    let error = crate::claude_catalog::write_seed_for_test(&config_path, &caches).unwrap_err();
+    let error = crate::claude_catalog::write_seed(&config_path, &caches).unwrap_err();
     assert!(error.to_string().contains("not a JSON object"));
     // The original file is preserved.
     assert_eq!(fs::read_to_string(&config_path).unwrap(), r#"["not", "an", "object"]"#);
@@ -2742,7 +2738,7 @@ fn claude_seed_errors_on_non_object_config_root_instead_of_panicking() {
 
 #[test]
 fn openrouter_seeded_plan_injects_settings() {
-    let plan = launch::inject_claude_openrouter_for_test(
+    let plan = launch::inject_claude_openrouter(
         &LaunchRequest {
             harness: Harness::Claude,
             provider: Some("openrouter".to_string()),
@@ -2751,7 +2747,7 @@ fn openrouter_seeded_plan_injects_settings() {
         "https://openrouter.ai/api",
         "sk-or-test",
         Some("~anthropic/claude-sonnet-latest"),
-        crate::claude_catalog::SeedOutcome::Seeded { model_count: 2 },
+        crate::claude_catalog::SeedOutcome::Seeded,
     );
     assert_eq!(plan.args[0], "--settings");
     assert!(arg_str(&plan.args[1]).contains("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"));
@@ -2792,9 +2788,8 @@ fn live_openrouter_seed_populates_claude_json() {
         "https://openrouter.ai/api",
         &env.get("OPENROUTER_API_KEY").unwrap(),
         &env,
-    )
-    .unwrap();
-    assert!(matches!(outcome, crate::claude_catalog::SeedOutcome::Seeded { .. }));
+    );
+    assert_eq!(outcome, crate::claude_catalog::SeedOutcome::Seeded);
     let document: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(dir.path().join(".claude.json")).unwrap())
             .unwrap();

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 
 use crate::args::{
-    Command, CompletionShell, CompletionsCommand, Harness, LaunchRequest, ModelsCommand,
-    ProviderIdFilter, ProvidersCommand, UpdateCommand, parse, rewrite_argv0,
+    Command, CompletionShell, CompletionsCommand, Harness, LaunchRequest, ProviderIdFilter,
+    ProvidersCommand, UpdateCommand, parse, rewrite_argv0,
 };
 use crate::config::{self, Paths};
 use crate::launch::{self, EnvLookup};
@@ -548,17 +548,17 @@ fn providers_commands_parse() {
     );
     assert_eq!(
         parse_line(&["rx", "providers", "models"]),
-        Command::Providers(ProvidersCommand::Models(ModelsCommand::Help))
+        Command::Providers(ProvidersCommand::ModelsHelp)
     );
     assert_eq!(
         parse_line(&["rx", "providers", "models", "update"]),
-        Command::Providers(ProvidersCommand::Models(ModelsCommand::Update { provider: None }))
+        Command::Providers(ProvidersCommand::ModelsUpdate { provider: None })
     );
     assert_eq!(
         parse_line(&["rx", "providers", "models", "update", "openrouter"]),
-        Command::Providers(ProvidersCommand::Models(ModelsCommand::Update {
+        Command::Providers(ProvidersCommand::ModelsUpdate {
             provider: Some("openrouter".to_string()),
-        }))
+        })
     );
 }
 
@@ -942,7 +942,7 @@ fn use_none_skips_implicit_openrouter() {
 fn models_update_rejects_none_provider() {
     let (_dir, paths) = temp_paths();
     let error = crate::providers::run(
-        ProvidersCommand::Models(ModelsCommand::Update { provider: Some("none".to_string()) }),
+        ProvidersCommand::ModelsUpdate { provider: Some("none".to_string()) },
         &paths,
         &EnvLookup::isolated(HashMap::new()),
     )
@@ -2030,7 +2030,7 @@ fn providers_models_update_command_fetches_configured_provider() {
     fs::write(&paths.config, format!("[provider.lab]\nbase_url = \"{base_url}\"\n")).unwrap();
     config::login(&paths, "lab", "sk-test".to_string()).unwrap();
     crate::providers::run(
-        ProvidersCommand::Models(ModelsCommand::Update { provider: Some("lab".to_string()) }),
+        ProvidersCommand::ModelsUpdate { provider: Some("lab".to_string()) },
         &paths,
         &EnvLookup::isolated(HashMap::new()),
     )

--- a/crates/rx/src/update.rs
+++ b/crates/rx/src/update.rs
@@ -302,13 +302,13 @@ fn ensure_self_update_allowed(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn self_update_blocker(path: &Path) -> Option<&'static str> {
+pub(crate) fn self_update_blocker(path: &Path) -> Option<&'static str> {
     homebrew_update_hint(path).or_else(|| {
         fs::canonicalize(path).ok().and_then(|resolved| homebrew_update_hint(&resolved))
     })
 }
 
-fn homebrew_launch_update_notice(path: &Path, latest: &str) -> Option<String> {
+pub(crate) fn homebrew_launch_update_notice(path: &Path, latest: &str) -> Option<String> {
     self_update_blocker(path)
         .map(|_| format!("rx {latest} is available — run `brew upgrade recall`"))
 }
@@ -325,16 +325,6 @@ fn homebrew_update_hint(path: &Path) -> Option<&'static str> {
         .windows(2)
         .any(|pair| pair[0] == OsStr::new("Cellar") && pair[1] == OsStr::new("recall"))
         .then_some(HOMEBREW_UPDATE_HINT)
-}
-
-#[cfg(test)]
-pub(crate) fn self_update_blocker_for_test(path: &Path) -> Option<&'static str> {
-    self_update_blocker(path)
-}
-
-#[cfg(test)]
-pub(crate) fn homebrew_launch_update_notice_for_test(path: &Path, latest: &str) -> Option<String> {
-    homebrew_launch_update_notice(path, latest)
 }
 
 fn http_get(url: &str, headers: &[(&str, &str)]) -> Result<String> {


### PR DESCRIPTION
### What's changed?

- Flatten single-use wrappers and remove redundant provider, catalog, launch, and command state.
- Preserve automatic updates, automatic harness installation, provider routing, and native argument passthrough.
- Add behavior-level coverage for custom provider admission, Claude catalog seeding, malformed host requests, and empty provider-picker results.

### Why

- Reduce internal complexity and maintenance surface without changing the user-visible launcher contract.

### Validation

- make check
- cargo test -p rx: 147 passed, 1 ignored live-network test
- 42-case differential matrix against main: 0 differences
- Isolated DSH auto-install, profile install, and launch end-to-end probe