### PR TITLE
Preserve structured tool event relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upgrade note
+
+Before using `recall powercontext backfill` with a Recall release that exports
+schema v6, run `recall ext upgrade powercontext` and verify that
+`recall ext list` shows version 0.1.1 or later. `recall-powercontext` 0.1.0
+accepts only schema v5.
 
 ## [0.5.8](https://github.com/samzong/Recall/compare/v0.5.7...v0.5.8) (2026-09-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "recall-powercontext"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -116,7 +116,7 @@ Core support in v0.1:
   `recall session list --query ... --format json`;
 - `recall session show` supports `--format json|jsonl`;
 - `recall export` emits JSONL, one session record per line, with export record
-  schema version 5, and supports `--include metadata,messages,usage,events`
+  schema version 6, and supports `--include metadata,messages,usage,events`
   for field projection. Export projections must include `messages`; `usage`
   and `events` are optional add-ons. `recall session list` and `recall export`
   also accept `--thread-role primary|subagent|unknown` to filter by topology;
@@ -124,8 +124,9 @@ Core support in v0.1:
   that need transcript data must pass `--messages` or
   `--include metadata,messages,usage,events`.
 - every session record carries `session.topology` (`thread_role` plus portable
-  `parents[]`); it is additive over schema v4 and does not affect
-  `protocol_version`. Import accepts records from schema v2 through v5.
+  `parents[]`), and event records carry nullable `tool_call_id`, `is_meta`, and
+  `visibility`; both are additive and do not affect `protocol_version`. Import
+  accepts records from schema v2 through v6.
 
 `protocol_version` is `2`. Version 2 changed the default scope: a command
 without `--project` now resolves its scope from the current directory instead

--- a/docs/session.md
+++ b/docs/session.md
@@ -549,10 +549,10 @@ match `excluded_paths` still runs, restricted to the current scope.
   unchanged.
 - Existing `recall export` remains the bulk export command.
 - Existing TUI shortcuts keep using the same internal session operations.
-- Export record schema is `v5`: `session.topology` is additive and does not
-  affect `protocol_version`. Import accepts `v2`-`v5`; pre-topology records
-  default to `thread_role = null` with no parent links, and `v5` round-trips
-  topology losslessly.
+- Export record schema is `v6`: event records add nullable `tool_call_id`,
+  `is_meta`, and `visibility` fields without affecting `protocol_version`.
+  Import accepts `v2`-`v6`; older records default the new event fields to null
+  and pre-topology records default to `thread_role = null` with no parent links.
 - `protocol_version` is `2`: the default scope of `recall search`,
   `recall session list`, and `recall export` now comes from the current
   directory. Scripts and extensions that relied on the flagless global scope

--- a/extensions/recall-powercontext/Cargo.toml
+++ b/extensions/recall-powercontext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall-powercontext"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 description = "Backfill Recall sessions into PowerContext Content Sources"

--- a/extensions/recall-powercontext/src/session.rs
+++ b/extensions/recall-powercontext/src/session.rs
@@ -1,7 +1,8 @@
 use anyhow::{Result, bail};
 use serde::Deserialize;
 
-pub const RECORD_SCHEMA_VERSION: u32 = 5;
+pub const MIN_RECORD_SCHEMA_VERSION: u32 = 5;
+pub const RECORD_SCHEMA_VERSION: u32 = 6;
 pub const MAX_SOURCE_ID_LENGTH: usize = 256;
 pub const MAX_CONTENT_LENGTH: usize = 200_000;
 
@@ -99,9 +100,9 @@ pub enum CaptureItem {
 pub fn parse_export_line(line: &str, line_no: usize) -> Result<ExportRecord> {
     let record: ExportRecord = serde_json::from_str(line)
         .map_err(|error| anyhow::anyhow!("failed to parse export JSONL line {line_no}: {error}"))?;
-    if record.schema_version != RECORD_SCHEMA_VERSION {
+    if !(MIN_RECORD_SCHEMA_VERSION..=RECORD_SCHEMA_VERSION).contains(&record.schema_version) {
         bail!(
-            "unsupported export schema_version {} on line {line_no}; expected {RECORD_SCHEMA_VERSION}",
+            "unsupported export schema_version {} on line {line_no}; expected {MIN_RECORD_SCHEMA_VERSION}..={RECORD_SCHEMA_VERSION}",
             record.schema_version
         );
     }
@@ -199,10 +200,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_schema_other_than_five() {
-        let line = r#"{"schema_version":4,"record_type":"session","session":{"id":"s","source":"codex"},"messages":[]}"#;
-        let error = parse_export_line(line, 1).unwrap_err().to_string();
-        assert!(error.contains("schema_version 4"), "{error}");
+    fn accepts_five_and_six_but_rejects_versions_outside_the_supported_range() {
+        for version in [5, 6] {
+            let line = format!(
+                r#"{{"schema_version":{version},"record_type":"session","session":{{"id":"s","source":"codex"}},"messages":[]}}"#
+            );
+            parse_export_line(&line, 1).unwrap();
+        }
+        for version in [4, 7] {
+            let line = format!(
+                r#"{{"schema_version":{version},"record_type":"session","session":{{"id":"s","source":"codex"}},"messages":[]}}"#
+            );
+            let error = parse_export_line(&line, 1).unwrap_err().to_string();
+            assert!(error.contains(&format!("schema_version {version}")), "{error}");
+        }
     }
 
     #[test]

--- a/extensions/recall-powercontext/tests/backfill_cli.rs
+++ b/extensions/recall-powercontext/tests/backfill_cli.rs
@@ -13,7 +13,7 @@ fn adapter_jsonl() -> String {
         .enumerate()
         .map(|(idx, adapter)| {
             format!(
-                r#"{{"schema_version":5,"record_type":"session","session":{{"id":"s{idx}","source":"{adapter}","source_id":"raw-{idx}","title":"{adapter}","started_at":1000,"updated_at":1100,"message_count":1,"topology":{{"thread_role":"primary","parents":[]}}}},"messages":[{{"seq":0,"role":"user","content":"prompt from {adapter}"}}]}}"#
+                r#"{{"schema_version":6,"record_type":"session","session":{{"id":"s{idx}","source":"{adapter}","source_id":"raw-{idx}","title":"{adapter}","started_at":1000,"updated_at":1100,"message_count":1,"topology":{{"thread_role":"primary","parents":[]}}}},"messages":[{{"seq":0,"role":"user","content":"prompt from {adapter}"}}]}}"#
             )
         })
         .collect::<Vec<_>>()

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -24,6 +24,8 @@ Use MCP `list_recent_sessions` without a query, `search_sessions` with a query, 
 
 MCP search and recent hits expose `session_id` as Recall's index identity and `source_session_id` as the source tool's session identity. `get_session` returns both identities plus `first_message_seq` and `last_message_seq` for the messages represented in its text; both sequence fields are null when no messages are returned.
 
+Set `include_events: true` on `get_session` only when tool relationships, file operations, meta records, or other structured evidence is needed. The opt-in payload returns at most 50 events anchored to the returned message range plus unanchored events. Each event string field is capped at 200 characters and all event string fields at 10,000 characters total; check `returned_events` and `events_truncated` before treating it as complete. Events expose only sequence, timestamp, kind, actor, name, status, target, message anchor, source event ID, tool call ID, meta, visibility, and short summary fields. They never include raw arguments, raw results, source paths, or parser internals.
+
 For every MCP discovery call, generate a fresh high-entropy `invocation_nonce` literal and never reuse it. Recall prefers a verified host session ID and otherwise looks for that exact nonce in Codex or Claude Code discovery tool input. Treat `current_session.resolution: resolved` as proof that the named session was excluded before ranking and limit. When it is `unknown`, results are unchanged: do not guess the current session from time, project, recency, tool name, or result order.
 
 Use the equivalent CLI workflow when needed:

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -25,7 +25,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 pub(crate) struct ClaudeCodeAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 5;
-const EVENT_PARSER_VERSION: u32 = 3;
+const EVENT_PARSER_VERSION: u32 = 4;
 const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for ClaudeCodeAdapter {
@@ -378,7 +378,7 @@ fn parse_claude_session_file(
         }
     };
 
-    if parsed.messages.is_empty() && parsed.usage_events.is_empty() {
+    if parsed.messages.is_empty() && parsed.usage_events.is_empty() && parsed.events.is_empty() {
         return Ok(None);
     }
 
@@ -387,7 +387,7 @@ fn parse_claude_session_file(
         meta.and_then(|m| m.started_at),
         &parsed.messages,
         &parsed.usage_events,
-        &[],
+        &parsed.events,
     )
     .unwrap_or(0);
     let directory =
@@ -464,6 +464,7 @@ pub(crate) fn parse_conversation_jsonl(
     let mut first_ts: Option<i64> = None;
     let mut last_ts: Option<i64> = None;
     let mut session_id: Option<String> = None;
+    let mut last_visible_message_seq: Option<u32> = None;
     let source_path = path.to_string_lossy().to_string();
 
     for item in jsonl_indexed(reader.lines()) {
@@ -510,9 +511,11 @@ pub(crate) fn parse_conversation_jsonl(
             _ => continue,
         }
 
-        let is_machinery = v.get("isCompactSummary").and_then(|b| b.as_bool()).unwrap_or(false)
-            || v.get("isSidechain").and_then(|b| b.as_bool()).unwrap_or(false)
-            || v.get("isMeta").and_then(|b| b.as_bool()).unwrap_or(false);
+        let is_compact_summary =
+            v.get("isCompactSummary").and_then(Value::as_bool).unwrap_or(false);
+        let is_sidechain = v.get("isSidechain").and_then(Value::as_bool).unwrap_or(false);
+        let is_meta = v.get("isMeta").and_then(Value::as_bool);
+        let is_machinery = is_compact_summary || is_sidechain || is_meta == Some(true);
 
         let role = if msg_type == "user" { Role::User } else { Role::Assistant };
 
@@ -545,7 +548,21 @@ pub(crate) fn parse_conversation_jsonl(
             }
         }
 
-        if is_machinery {
+        if is_compact_summary || is_meta == Some(true) {
+            if include_events {
+                collect_claude_meta_event(
+                    message.get("content"),
+                    role,
+                    timestamp,
+                    &source_path,
+                    line_index,
+                    &mut events,
+                );
+            }
+            continue;
+        }
+
+        if is_sidechain {
             continue;
         }
 
@@ -561,17 +578,24 @@ pub(crate) fn parse_conversation_jsonl(
         if include_events {
             collect_claude_content_events(
                 message.get("content"),
-                role.clone(),
-                timestamp,
-                &source_path,
-                line_index,
-                message_seq,
+                ClaudeContentEventContext {
+                    role: role.clone(),
+                    timestamp,
+                    source_path: &source_path,
+                    line_index,
+                    prior_message_seq: last_visible_message_seq,
+                    current_message_seq: message_seq,
+                    is_meta,
+                },
                 &mut events,
             );
         }
 
         if !text.is_empty() {
             messages.push(RawMessage { role, content: text, timestamp });
+        }
+        if claude_content_has_visible_text(message.get("content")) {
+            last_visible_message_seq = message_seq;
         }
     }
 
@@ -611,55 +635,134 @@ fn claude_topology(
     (Some(ThreadRole::Subagent), parents)
 }
 
-fn collect_claude_content_events(
-    content: Option<&Value>,
+struct ClaudeContentEventContext<'a> {
     role: Role,
     timestamp: Option<i64>,
-    source_path: &str,
+    source_path: &'a str,
     line_index: usize,
-    message_seq: Option<u32>,
+    prior_message_seq: Option<u32>,
+    current_message_seq: Option<u32>,
+    is_meta: Option<bool>,
+}
+
+fn collect_claude_content_events(
+    content: Option<&Value>,
+    context: ClaudeContentEventContext<'_>,
     events_out: &mut Vec<RawSessionEvent>,
 ) {
     let Some(Value::Array(arr)) = content else {
         return;
     };
+    let mut message_seq = context.prior_message_seq;
     for (item_index, item) in arr.iter().enumerate() {
         match item.get("type").and_then(|t| t.as_str()) {
-            Some("tool_use") if role == Role::Assistant => {
+            Some("text") => {
+                if item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty()) {
+                    message_seq = context.current_message_seq;
+                }
+            }
+            Some("tool_use") if context.role == Role::Assistant => {
                 let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
-                events_out.push(events::tool_call_event(
+                let mut event = events::tool_call_event(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
-                        timestamp,
-                        source_path: Some(source_path.to_string()),
-                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        timestamp: context.timestamp,
+                        source_path: Some(context.source_path.to_string()),
+                        source_event_id: Some(format!("{}:{item_index}", context.line_index)),
                         message_seq,
                         parser_version: EVENT_PARSER_VERSION,
                     },
                     name,
                     item.get("input"),
-                ));
+                );
+                event.tool_call_id = claude_tool_call_id(item.get("id"));
+                event.is_meta = context.is_meta;
+                events_out.push(event);
             }
             Some("tool_result") => {
                 let summary = item.get("content").map(|content| match content {
                     Value::String(text) => text.to_string(),
                     other => other.to_string(),
                 });
-                events_out.push(events::tool_result_event(
+                let mut event = events::tool_result_event(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
-                        timestamp,
-                        source_path: Some(source_path.to_string()),
-                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        timestamp: context.timestamp,
+                        source_path: Some(context.source_path.to_string()),
+                        source_event_id: Some(format!("{}:{item_index}", context.line_index)),
                         message_seq,
                         parser_version: EVENT_PARSER_VERSION,
                     },
-                    item.get("tool_use_id").and_then(|id| id.as_str()).map(String::from),
+                    item.get("name").and_then(Value::as_str).map(String::from),
                     summary,
-                ));
+                );
+                event.tool_call_id = claude_tool_call_id(item.get("tool_use_id"));
+                event.is_meta = context.is_meta;
+                events_out.push(event);
             }
             _ => {}
         }
+    }
+}
+
+fn claude_tool_call_id(value: Option<&Value>) -> Option<String> {
+    value.and_then(Value::as_str).map(str::trim).filter(|id| !id.is_empty()).map(String::from)
+}
+
+fn claude_content_has_visible_text(content: Option<&Value>) -> bool {
+    match content {
+        Some(Value::String(text)) => !text.is_empty(),
+        Some(Value::Array(items)) => items.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("text")
+                && item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty())
+        }),
+        _ => false,
+    }
+}
+
+fn collect_claude_meta_event(
+    content: Option<&Value>,
+    role: Role,
+    timestamp: Option<i64>,
+    source_path: &str,
+    line_index: usize,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let summary = claude_visible_content(content);
+    if summary.is_empty() {
+        return;
+    }
+    events_out.push(RawSessionEvent {
+        event_seq: events_out.len() as u32,
+        timestamp,
+        kind: "message".to_string(),
+        actor: role.as_str().to_string(),
+        name: None,
+        status: None,
+        target: None,
+        message_seq: None,
+        summary: Some(events::bounded_summary(summary)),
+        source_path: Some(source_path.to_string()),
+        source_event_id: Some(line_index.to_string()),
+        tool_call_id: None,
+        is_meta: Some(true),
+        visibility: None,
+        attrs_json: None,
+        parser_version: EVENT_PARSER_VERSION,
+    });
+}
+
+fn claude_visible_content(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
     }
 }
 
@@ -852,10 +955,19 @@ mod tests {
         let raw = parse_claude_session_file(entry, mtime, &indexes, true).unwrap().unwrap();
 
         assert_eq!(raw.events.len(), 2);
+        assert_eq!(raw.messages.len(), 2);
         assert_eq!(raw.events[0].kind, "file_read");
         assert_eq!(raw.events[0].name.as_deref(), Some("Read"));
         assert_eq!(raw.events[0].target.as_deref(), Some("src/main.rs"));
+        assert_eq!(raw.events[0].message_seq, None);
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("0:0"));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("tool-1"));
         assert_eq!(raw.events[1].kind, "tool_result");
+        assert_eq!(raw.events[1].name, None);
+        assert_eq!(raw.events[1].message_seq, None);
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("1:0"));
+        assert_eq!(raw.events[1].tool_call_id.as_deref(), Some("tool-1"));
+        assert_eq!(raw.event_parser_version, Some(EVENT_PARSER_VERSION));
 
         let entry = FileScanEntry {
             session_id: "tool-session".to_string(),
@@ -866,6 +978,189 @@ mod tests {
 
         assert!(raw.events.is_empty());
         assert_eq!(raw.event_parser_version, None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_claude_session_preserves_relationships_meta_and_source_order_anchors() {
+        let root = temp_claude_root("event-relationships");
+        let project = root.join("projects").join("-tmp-foo");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("event-relationships.jsonl");
+        let lines = [
+            serde_json::json!({
+                "type": "user",
+                "timestamp": "2026-04-13T10:00:00Z",
+                "message": {"content": "Inspect the repository"}
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool-before",
+                            "name": "Read",
+                            "input": {"path": "Cargo.toml"}
+                        },
+                        {"type": "text", "text": "I found the manifest."},
+                        {
+                            "type": "tool_use",
+                            "id": "tool-after",
+                            "name": "Read",
+                            "input": {"path": "src/lib.rs"}
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "   ",
+                            "name": "Read",
+                            "input": {"path": "src/main.rs"}
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": 42,
+                            "name": "Read",
+                            "input": {"path": "src/cli.rs"}
+                        }
+                    ]
+                }
+            }),
+            serde_json::json!({
+                "type": "user",
+                "timestamp": "2026-04-13T10:00:02Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-after",
+                            "name": "Read result",
+                            "content": "library body"
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-before",
+                            "content": "manifest body"
+                        },
+                        {"type": "tool_result", "tool_use_id": "", "content": "empty id"},
+                        {"type": "tool_result", "tool_use_id": false, "content": "wrong id"}
+                    ]
+                }
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "isMeta": false,
+                "timestamp": "2026-04-13T10:00:03Z",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Continue."},
+                        {
+                            "type": "tool_use",
+                            "id": "tool-explicit-false",
+                            "name": "Glob",
+                            "input": {"pattern": "src/**/*.rs"}
+                        }
+                    ]
+                }
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "isMeta": true,
+                "timestamp": "2026-04-13T10:00:04Z",
+                "message": {"content": [{"type": "text", "text": "汉".repeat(5000)}]}
+            }),
+            serde_json::json!({
+                "type": "user",
+                "isCompactSummary": true,
+                "timestamp": "2026-04-13T10:00:05Z",
+                "message": {"content": "Compacted context"}
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "isSidechain": true,
+                "timestamp": "2026-04-13T10:00:06Z",
+                "message": {"content": "Hidden sidechain"}
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "isMeta": true,
+                "isSidechain": true,
+                "timestamp": "2026-04-13T10:00:07Z",
+                "message": {"content": "Explicit sidechain metadata"}
+            }),
+        ];
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+
+        let parsed = parse_conversation_jsonl(&path, 0, true).unwrap();
+
+        assert_eq!(parsed.messages.len(), 4);
+        assert!(parsed.messages.iter().all(|message| message.content != "Hidden sidechain"));
+        assert_eq!(parsed.usage_events.len(), 0);
+        assert_eq!(parsed.events.len(), 12);
+        assert_eq!(parsed.events[0].message_seq, Some(0));
+        assert_eq!(parsed.events[0].tool_call_id.as_deref(), Some("tool-before"));
+        assert_eq!(parsed.events[1].message_seq, Some(1));
+        assert_eq!(parsed.events[1].tool_call_id.as_deref(), Some("tool-after"));
+        assert_eq!(parsed.events[2].tool_call_id, None);
+        assert_eq!(parsed.events[3].tool_call_id, None);
+        assert_eq!(parsed.events[4].name.as_deref(), Some("Read result"));
+        assert_eq!(parsed.events[4].tool_call_id.as_deref(), Some("tool-after"));
+        assert_eq!(parsed.events[5].name, None);
+        assert_eq!(parsed.events[5].tool_call_id.as_deref(), Some("tool-before"));
+        assert_eq!(parsed.events[6].tool_call_id, None);
+        assert_eq!(parsed.events[7].tool_call_id, None);
+        assert_eq!(parsed.events[8].source_event_id.as_deref(), Some("3:1"));
+        assert_eq!(parsed.events[8].message_seq, Some(3));
+        assert_eq!(parsed.events[8].is_meta, Some(false));
+        assert_eq!(parsed.events[9].source_event_id.as_deref(), Some("4"));
+        assert_eq!(parsed.events[9].is_meta, Some(true));
+        assert_eq!(parsed.events[9].visibility, None);
+        let summary = parsed.events[9].summary.as_deref().unwrap();
+        assert!(summary.ends_with('…'));
+        assert!(summary.len() <= 4099);
+        assert_eq!(parsed.events[10].source_event_id.as_deref(), Some("5"));
+        assert_eq!(parsed.events[10].summary.as_deref(), Some("Compacted context"));
+        assert_eq!(parsed.events[10].is_meta, Some(true));
+        assert_eq!(parsed.events[11].summary.as_deref(), Some("Explicit sidechain metadata"));
+        assert_eq!(parsed.events[11].is_meta, Some(true));
+        assert_eq!(parsed.events[11].visibility, None);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_claude_session_file_keeps_meta_event_only_transcript() {
+        let root = temp_claude_root("meta-event-only");
+        let project = root.join("projects").join("-tmp-foo");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("meta-event-only.jsonl");
+        let line = serde_json::json!({
+            "type": "assistant",
+            "isCompactSummary": true,
+            "timestamp": "2026-04-13T10:00:00Z",
+            "message": {"content": "Compacted context"}
+        });
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(file, "{line}").unwrap();
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+        let entry = FileScanEntry {
+            session_id: "meta-event-only".to_string(),
+            stat_target: path,
+            directory: Some("/tmp/foo".to_string()),
+        };
+
+        let raw = parse_claude_session_file(entry, mtime, &SessionIndexes::default(), true)
+            .unwrap()
+            .unwrap();
+
+        assert!(raw.messages.is_empty());
+        assert!(raw.usage_events.is_empty());
+        assert_eq!(raw.events.len(), 1);
+        assert_eq!(raw.started_at, 1_776_074_400_000);
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -1286,6 +1581,63 @@ mod tests {
         .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_reparses_unchanged_session_with_stale_event_parser() {
+        let root = temp_claude_root("event-parser-backfill");
+        let project = root.join("projects").join("-tmp-proj");
+        let path = write_user_jsonl(&project, "sess-event-backfill", "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session("sess-event-backfill", mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "claude-code",
+                "sess-event-backfill",
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "claude-code",
+                "sess-event-backfill",
+                &[],
+                EVENT_PARSER_VERSION - 1,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "claude-code",
+                "sess-event-backfill",
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions[0].event_parser_version, Some(EVENT_PARSER_VERSION));
+        assert_eq!(result.sessions[0].messages.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "hello");
+        assert!(result.sessions[0].usage_events.is_empty());
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -24,7 +24,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 pub(crate) struct CodexAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 5;
-const EVENT_PARSER_VERSION: u32 = 3;
+const EVENT_PARSER_VERSION: u32 = 4;
 const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CodexAdapter {
@@ -445,6 +445,7 @@ pub(crate) fn parse_codex_session_with_options(
     let mut forked_child_waiting_for_turn_context = false;
     let mut forked_child_inherited_baseline: Option<CodexUsageTotals> = None;
     let mut forked_child_inherited_reported_total: Option<i64> = None;
+    let mut last_visible_message_seq: Option<u32> = None;
     let source_path = path.to_string_lossy().to_string();
 
     for item in jsonl_indexed(reader.lines()) {
@@ -574,7 +575,12 @@ pub(crate) fn parse_codex_session_with_options(
                                 && !text.is_empty()
                             {
                                 let ts = parse_timestamp(&v);
-                                push_codex_message(&mut messages, Role::User, text.to_string(), ts);
+                                last_visible_message_seq = push_codex_message(
+                                    &mut messages,
+                                    Role::User,
+                                    text.to_string(),
+                                    ts,
+                                );
                             }
                         }
                         "agent_message" => {
@@ -582,7 +588,7 @@ pub(crate) fn parse_codex_session_with_options(
                                 && !text.is_empty()
                             {
                                 let ts = parse_timestamp(&v);
-                                push_codex_message(
+                                last_visible_message_seq = push_codex_message(
                                     &mut messages,
                                     Role::Assistant,
                                     text.to_string(),
@@ -595,36 +601,52 @@ pub(crate) fn parse_codex_session_with_options(
                 }
             }
             "response_item" => {
-                if let Some(payload) = v.get("payload")
-                    && payload.get("type").and_then(|t| t.as_str()) == Some("message")
-                    && payload.get("role").and_then(|r| r.as_str()) == Some("assistant")
-                {
-                    let text = extract_content_array(payload.get("content"));
-                    let message_seq =
-                        if text.is_empty() { None } else { Some(messages.len() as u32) };
-                    if include_events {
-                        collect_codex_content_events(
-                            payload.get("content"),
-                            parse_timestamp(&v),
+                if let Some(payload) = v.get("payload") {
+                    let timestamp = parse_timestamp(&v);
+                    let payload_type = payload.get("type").and_then(|t| t.as_str());
+                    let role = payload.get("role").and_then(|r| r.as_str());
+                    if payload_type == Some("message") && role == Some("assistant") {
+                        let text = extract_content_array(payload.get("content"));
+                        let message_seq = if text.is_empty() {
+                            None
+                        } else {
+                            push_codex_message(&mut messages, Role::Assistant, text, timestamp)
+                        };
+                        if include_events {
+                            collect_codex_content_events(
+                                payload.get("content"),
+                                timestamp,
+                                &source_path,
+                                line_index,
+                                last_visible_message_seq,
+                                message_seq,
+                                &mut events,
+                            );
+                        }
+                        if codex_content_has_visible_text(payload.get("content")) {
+                            last_visible_message_seq = message_seq;
+                        }
+                    } else if include_events
+                        && payload_type == Some("message")
+                        && matches!(role, Some("developer" | "system"))
+                    {
+                        collect_codex_meta_event(
+                            payload,
+                            timestamp,
                             &source_path,
                             line_index,
-                            message_seq,
+                            &mut events,
+                        );
+                    } else if include_events {
+                        collect_codex_response_item_event(
+                            payload,
+                            timestamp,
+                            &source_path,
+                            line_index,
+                            last_visible_message_seq,
                             &mut events,
                         );
                     }
-                    if !text.is_empty() {
-                        let ts = parse_timestamp(&v);
-                        push_codex_message(&mut messages, Role::Assistant, text, ts);
-                    }
-                }
-                if include_events && let Some(payload) = v.get("payload") {
-                    collect_codex_response_item_event(
-                        payload,
-                        parse_timestamp(&v),
-                        &source_path,
-                        line_index,
-                        &mut events,
-                    );
                 }
             }
             _ => {}
@@ -681,16 +703,14 @@ fn collect_codex_response_item_event(
     timestamp: Option<i64>,
     source_path: &str,
     line_index: usize,
+    message_seq: Option<u32>,
     events_out: &mut Vec<RawSessionEvent>,
 ) {
     let Some(payload_type) = payload.get("type").and_then(|t| t.as_str()) else {
         return;
     };
-    let source_event_id = payload
-        .get("call_id")
-        .and_then(|id| id.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| line_index.to_string());
+    let source_event_id = Some(line_index.to_string());
+    let tool_call_id = codex_tool_call_id(payload);
 
     if payload_type.ends_with("_output") {
         let mut event = events::tool_result_event(
@@ -698,14 +718,15 @@ fn collect_codex_response_item_event(
                 event_seq: events_out.len() as u32,
                 timestamp,
                 source_path: Some(source_path.to_string()),
-                source_event_id: Some(source_event_id),
-                message_seq: None,
+                source_event_id,
+                message_seq,
                 parser_version: EVENT_PARSER_VERSION,
             },
             payload.get("name").and_then(|name| name.as_str()).map(String::from),
             codex_output_summary(payload),
         );
         event.status = payload.get("status").and_then(|status| status.as_str()).map(String::from);
+        event.tool_call_id = tool_call_id;
         events_out.push(event);
         return;
     }
@@ -722,14 +743,15 @@ fn collect_codex_response_item_event(
                             event_seq: events_out.len() as u32,
                             timestamp,
                             source_path: Some(source_path.to_string()),
-                            source_event_id: Some(source_event_id.clone()),
-                            message_seq: None,
+                            source_event_id: source_event_id.clone(),
+                            message_seq,
                             parser_version: EVENT_PARSER_VERSION,
                         },
                         name.clone(),
                         target,
                     );
                     event.status = status.clone();
+                    event.tool_call_id = tool_call_id.clone();
                     events_out.push(event);
                 }
                 return;
@@ -741,8 +763,8 @@ fn collect_codex_response_item_event(
                     event_seq: events_out.len() as u32,
                     timestamp,
                     source_path: Some(source_path.to_string()),
-                    source_event_id: Some(source_event_id.clone()),
-                    message_seq: None,
+                    source_event_id: source_event_id.clone(),
+                    message_seq,
                     parser_version: EVENT_PARSER_VERSION,
                 },
                 name,
@@ -753,8 +775,8 @@ fn collect_codex_response_item_event(
                     event_seq: events_out.len() as u32,
                     timestamp,
                     source_path: Some(source_path.to_string()),
-                    source_event_id: Some(source_event_id),
-                    message_seq: None,
+                    source_event_id,
+                    message_seq,
                     parser_version: EVENT_PARSER_VERSION,
                 },
                 name,
@@ -762,8 +784,18 @@ fn collect_codex_response_item_event(
             ),
         };
         event.status = status;
+        event.tool_call_id = tool_call_id;
         events_out.push(event);
     }
+}
+
+fn codex_tool_call_id(payload: &Value) -> Option<String> {
+    payload
+        .get("call_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(String::from)
 }
 
 fn codex_call_name(payload_type: &str, payload: &Value) -> String {
@@ -799,18 +831,25 @@ fn collect_codex_content_events(
     timestamp: Option<i64>,
     source_path: &str,
     line_index: usize,
-    message_seq: Option<u32>,
+    prior_message_seq: Option<u32>,
+    current_message_seq: Option<u32>,
     events_out: &mut Vec<RawSessionEvent>,
 ) {
     let Some(Value::Array(arr)) = content else {
         return;
     };
+    let mut message_seq = prior_message_seq;
     for (item_index, item) in arr.iter().enumerate() {
         match item.get("type").and_then(|t| t.as_str()) {
+            Some("text" | "output_text") => {
+                if item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty()) {
+                    message_seq = current_message_seq;
+                }
+            }
             Some("function_call") => {
                 let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
                 let args = item.get("arguments").and_then(|a| a.as_str());
-                events_out.push(events::tool_call_event_from_text(
+                let mut event = events::tool_call_event_from_text(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
                         timestamp,
@@ -821,11 +860,13 @@ fn collect_codex_content_events(
                     },
                     name,
                     args,
-                ));
+                );
+                event.tool_call_id = codex_tool_call_id(item);
+                events_out.push(event);
             }
             Some("function_call_output") => {
                 let output = item.get("output").and_then(|o| o.as_str()).map(String::from);
-                events_out.push(events::tool_result_event(
+                let mut event = events::tool_result_event(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
                         timestamp,
@@ -836,11 +877,75 @@ fn collect_codex_content_events(
                     },
                     None,
                     output,
-                ));
+                );
+                event.tool_call_id = codex_tool_call_id(item);
+                events_out.push(event);
             }
             _ => {}
         }
     }
+}
+
+fn codex_content_has_visible_text(content: Option<&Value>) -> bool {
+    let Some(Value::Array(items)) = content else {
+        return false;
+    };
+    items.iter().any(|item| {
+        matches!(item.get("type").and_then(Value::as_str), Some("text" | "output_text"))
+            && item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty())
+    })
+}
+
+fn collect_codex_meta_event(
+    payload: &Value,
+    timestamp: Option<i64>,
+    source_path: &str,
+    line_index: usize,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    let Some(actor) = payload.get("role").and_then(Value::as_str) else {
+        return;
+    };
+    let summary = codex_visible_content(payload.get("content"));
+    if summary.is_empty() {
+        return;
+    }
+    events_out.push(RawSessionEvent {
+        event_seq: events_out.len() as u32,
+        timestamp,
+        kind: "message".to_string(),
+        actor: actor.to_string(),
+        name: None,
+        status: None,
+        target: None,
+        message_seq: None,
+        summary: Some(events::bounded_summary(summary)),
+        source_path: Some(source_path.to_string()),
+        source_event_id: Some(line_index.to_string()),
+        tool_call_id: None,
+        is_meta: Some(true),
+        visibility: None,
+        attrs_json: None,
+        parser_version: EVENT_PARSER_VERSION,
+    });
+}
+
+fn codex_visible_content(content: Option<&Value>) -> String {
+    let Some(Value::Array(items)) = content else {
+        return String::new();
+    };
+    items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("text" | "output_text" | "input_text")
+            )
+        })
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn extract_content_array(content: Option<&Value>) -> String {
@@ -1103,13 +1208,15 @@ fn push_codex_message(
     role: Role,
     content: String,
     timestamp: Option<i64>,
-) {
+) -> Option<u32> {
     if role == Role::Assistant
         && messages.last().is_some_and(|m| m.role == Role::Assistant && m.content == content)
     {
-        return;
+        return messages.len().checked_sub(1).map(|seq| seq as u32);
     }
+    let seq = messages.len() as u32;
     messages.push(RawMessage { role, content, timestamp });
+    Some(seq)
 }
 
 #[cfg(test)]
@@ -1273,20 +1380,26 @@ mod tests {
         assert_eq!(raw.events[0].kind, "command");
         assert_eq!(raw.events[0].name.as_deref(), Some("exec_command"));
         assert_eq!(raw.events[0].target.as_deref(), Some("sed -n '1,220p' CLAUDE.md"));
-        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("call_123"));
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1"));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("call_123"));
         assert_eq!(raw.events[1].kind, "tool_result");
-        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("call_123"));
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("2"));
+        assert_eq!(raw.events[1].tool_call_id.as_deref(), Some("call_123"));
         assert_eq!(raw.events[2].kind, "file_write");
         assert_eq!(raw.events[2].name.as_deref(), Some("apply_patch"));
         assert_eq!(raw.events[2].status.as_deref(), Some("completed"));
         assert_eq!(raw.events[2].target.as_deref(), Some("src/lib.rs"));
-        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("call_patch"));
+        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("3"));
+        assert_eq!(raw.events[2].tool_call_id.as_deref(), Some("call_patch"));
         assert_eq!(raw.events[3].kind, "file_write");
         assert_eq!(raw.events[3].name.as_deref(), Some("apply_patch"));
         assert_eq!(raw.events[3].target.as_deref(), Some("docs/new.md"));
         assert_eq!(raw.events[3].event_seq, 3);
+        assert_eq!(raw.events[3].source_event_id.as_deref(), Some("3"));
+        assert_eq!(raw.events[3].tool_call_id.as_deref(), Some("call_patch"));
         assert_eq!(raw.events[4].kind, "tool_result");
-        assert_eq!(raw.events[4].source_event_id.as_deref(), Some("call_patch"));
+        assert_eq!(raw.events[4].source_event_id.as_deref(), Some("4"));
+        assert_eq!(raw.events[4].tool_call_id.as_deref(), Some("call_patch"));
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -1369,6 +1482,141 @@ mod tests {
         assert!(raw.messages.is_empty());
         assert_eq!(raw.events[0].kind, "command");
         assert_eq!(raw.events[0].message_seq, None);
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1:0"));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("call_empty"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_preserves_event_relationships_and_source_order_anchors() {
+        let root = temp_codex_root("event-relationships");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2395";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let lines = [
+            serde_json::json!({
+                "type": "session_meta",
+                "timestamp": "2026-04-13T10:00:00Z",
+                "payload": {"id": uuid, "cwd": "/tmp/foo"}
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": "{\"command\":\"pwd\"}",
+                    "call_id": "call_start"
+                }
+            }),
+            serde_json::json!({
+                "type": "event_msg",
+                "timestamp": "2026-04-13T10:00:02Z",
+                "payload": {"type": "user_message", "message": "Inspect the repository"}
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:03Z",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_start",
+                    "output": "/tmp/foo"
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:04Z",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "function_call",
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"Cargo.toml\"}",
+                            "call_id": "call_before"
+                        },
+                        {"type": "output_text", "text": "I found the manifest."},
+                        {
+                            "type": "function_call",
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"src/lib.rs\"}",
+                            "call_id": "call_after"
+                        },
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_after",
+                            "output": "library body"
+                        }
+                    ]
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:05Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": "{\"command\":\"git status\"}"
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:06Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": "{\"command\":\"git diff\"}",
+                    "call_id": "   "
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:07Z",
+                "payload": {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "汉".repeat(5000)}]
+                }
+            }),
+        ];
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+
+        assert_eq!(raw.messages.len(), 2);
+        assert_eq!(raw.usage_events.len(), 0);
+        assert_eq!(raw.events.len(), 8);
+        assert_eq!(raw.events[0].message_seq, None);
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1"));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("call_start"));
+        assert_eq!(raw.events[1].message_seq, Some(0));
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("3"));
+        assert_eq!(raw.events[1].tool_call_id.as_deref(), Some("call_start"));
+        assert_eq!(raw.events[2].message_seq, Some(0));
+        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("4:0"));
+        assert_eq!(raw.events[2].tool_call_id.as_deref(), Some("call_before"));
+        assert_eq!(raw.events[3].message_seq, Some(1));
+        assert_eq!(raw.events[3].tool_call_id.as_deref(), Some("call_after"));
+        assert_eq!(raw.events[4].message_seq, Some(1));
+        assert_eq!(raw.events[4].tool_call_id.as_deref(), Some("call_after"));
+        assert_eq!(raw.events[5].source_event_id.as_deref(), Some("5"));
+        assert_eq!(raw.events[5].tool_call_id, None);
+        assert_eq!(raw.events[6].source_event_id.as_deref(), Some("6"));
+        assert_eq!(raw.events[6].tool_call_id, None);
+        assert_eq!(raw.events[7].kind, "message");
+        assert_eq!(raw.events[7].actor, "developer");
+        assert_eq!(raw.events[7].message_seq, None);
+        assert_eq!(raw.events[7].is_meta, Some(true));
+        assert_eq!(raw.events[7].visibility, None);
+        let summary = raw.events[7].summary.as_deref().unwrap();
+        assert!(summary.ends_with('…'));
+        assert!(summary.len() <= 4099);
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -1455,13 +1703,16 @@ mod tests {
         assert_eq!(raw.events[0].name.as_deref(), Some("web_search"));
         assert_eq!(raw.events[0].target.as_deref(), Some("rust sqlite json_extract"));
         assert_eq!(raw.events[0].status.as_deref(), Some("completed"));
-        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("web_123"));
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1"));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("web_123"));
         assert_eq!(raw.events[1].kind, "search");
         assert_eq!(raw.events[1].name.as_deref(), Some("tool_search"));
         assert_eq!(raw.events[1].target.as_deref(), Some("serena initial_instructions"));
-        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("tool_search_123"));
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("2"));
+        assert_eq!(raw.events[1].tool_call_id.as_deref(), Some("tool_search_123"));
         assert_eq!(raw.events[2].kind, "tool_result");
-        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("tool_search_123"));
+        assert_eq!(raw.events[2].source_event_id.as_deref(), Some("3"));
+        assert_eq!(raw.events[2].tool_call_id.as_deref(), Some("tool_search_123"));
         assert!(raw.events[2].summary.as_deref().unwrap_or("").contains("mcp__serena"));
 
         let _ = fs::remove_dir_all(&root);
@@ -1940,6 +2191,64 @@ mod tests {
         .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert_eq!(result.stats.skipped_sessions, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_reparses_unchanged_session_with_stale_event_parser() {
+        let root = temp_codex_root("event-parser-backfill");
+        let sessions_dir = root.join("sessions");
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b237d";
+        let path = write_codex_rollout(&sessions_dir, uuid, "hello");
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session(uuid, mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "codex",
+                uuid,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "codex",
+                uuid,
+                &[],
+                EVENT_PARSER_VERSION - 1,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "codex",
+                uuid,
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(METADATA_PARSER_VERSION),
+                },
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "codex").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions[0].event_parser_version, Some(EVENT_PARSER_VERSION));
+        assert_eq!(result.sessions[0].messages.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "hello");
+        assert!(result.sessions[0].usage_events.is_empty());
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -25,7 +25,7 @@ use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 pub(crate) struct CursorAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 2;
-const EVENT_PARSER_VERSION: u32 = 2;
+const EVENT_PARSER_VERSION: u32 = 3;
 
 #[derive(Debug, Clone)]
 struct ComposerMeta {
@@ -348,7 +348,7 @@ fn parse_composer_session(
             let message_seq = (messages.len() - 1) as u32;
             collect_bubble_tool_events(
                 bubble,
-                bubble_id.unwrap_or("unknown"),
+                bubble_id,
                 &source_path,
                 timestamp,
                 message_seq,
@@ -614,7 +614,7 @@ fn render_bubble_content(bubble: &Value, role: &Role) -> String {
 
 fn collect_bubble_tool_events(
     bubble: &Value,
-    bubble_id: &str,
+    bubble_id: Option<&str>,
     source_path: &str,
     timestamp: Option<i64>,
     message_seq: u32,
@@ -624,10 +624,11 @@ fn collect_bubble_tool_events(
         return;
     };
     let name = tool_data.get("name").and_then(|value| value.as_str()).unwrap_or("tool").to_string();
-    let source_event_id = Some(bubble_id.to_string());
+    let source_event_id = cursor_native_id(bubble_id);
+    let tool_call_id = source_event_id.clone();
 
     if let Some(params) = tool_data.get("params") {
-        events_out.push(events::tool_call_event(
+        let mut event = events::tool_call_event(
             events::EventContext {
                 event_seq: events_out.len() as u32,
                 timestamp,
@@ -638,11 +639,13 @@ fn collect_bubble_tool_events(
             },
             name.clone(),
             Some(params),
-        ));
+        );
+        event.tool_call_id = tool_call_id.clone();
+        events_out.push(event);
     } else if let Some(raw_args) = tool_data.get("rawArgs") {
         match raw_args {
             Value::String(text) => {
-                events_out.push(events::tool_call_event_from_text(
+                let mut event = events::tool_call_event_from_text(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
                         timestamp,
@@ -653,10 +656,12 @@ fn collect_bubble_tool_events(
                     },
                     name.clone(),
                     Some(text.as_str()),
-                ));
+                );
+                event.tool_call_id = tool_call_id.clone();
+                events_out.push(event);
             }
             other => {
-                events_out.push(events::tool_call_event(
+                let mut event = events::tool_call_event(
                     events::EventContext {
                         event_seq: events_out.len() as u32,
                         timestamp,
@@ -667,11 +672,13 @@ fn collect_bubble_tool_events(
                     },
                     name.clone(),
                     Some(other),
-                ));
+                );
+                event.tool_call_id = tool_call_id.clone();
+                events_out.push(event);
             }
         }
     } else {
-        events_out.push(events::tool_call_event(
+        let mut event = events::tool_call_event(
             events::EventContext {
                 event_seq: events_out.len() as u32,
                 timestamp,
@@ -682,12 +689,14 @@ fn collect_bubble_tool_events(
             },
             name.clone(),
             None,
-        ));
+        );
+        event.tool_call_id = tool_call_id.clone();
+        events_out.push(event);
     }
 
     if let Some(result) = tool_data.get("result") {
         let summary = render_json_fragment(result).filter(|text| !text.is_empty());
-        events_out.push(events::tool_result_event(
+        let mut event = events::tool_result_event(
             events::EventContext {
                 event_seq: events_out.len() as u32,
                 timestamp,
@@ -698,8 +707,14 @@ fn collect_bubble_tool_events(
             },
             Some(name),
             summary,
-        ));
+        );
+        event.tool_call_id = tool_call_id;
+        events_out.push(event);
     }
+}
+
+fn cursor_native_id(value: Option<&str>) -> Option<String> {
+    value.map(str::trim).filter(|id| !id.is_empty() && *id != "unknown").map(String::from)
 }
 
 fn render_legacy_bubble(value: &Value, role: &Role) -> String {
@@ -863,6 +878,7 @@ fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<O
     let reader = BufReader::new(file);
     let mut messages = Vec::new();
     let mut session_events = Vec::new();
+    let mut last_visible_message_seq: Option<u32> = None;
     let source_path = path.display().to_string();
 
     for (line_index, line) in reader.lines().enumerate() {
@@ -886,21 +902,26 @@ fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<O
             continue;
         };
         let is_user = matches!(role, Role::User);
+        let content = render_transcript_content_items(items, is_user);
+        let current_message_seq =
+            if content.is_empty() { None } else { Some(messages.len() as u32) };
         if include_events && matches!(role, Role::Assistant) {
-            let message_seq = if messages.is_empty() { None } else { Some(messages.len() as u32) };
             collect_transcript_content_events(
                 items,
                 &source_path,
                 line_index,
-                message_seq,
+                last_visible_message_seq,
+                current_message_seq,
                 &mut session_events,
             );
         }
-        let content = render_transcript_content_items(items, is_user);
         if content.is_empty() {
             continue;
         }
         messages.push(RawMessage { role, content, timestamp: None });
+        if transcript_content_has_visible_text(items) {
+            last_visible_message_seq = current_message_seq;
+        }
     }
 
     if messages.is_empty() && session_events.is_empty() {
@@ -923,31 +944,65 @@ fn parse_agent_transcript(path: &Path, include_events: bool) -> anyhow::Result<O
     Ok(Some(session))
 }
 
+#[cfg(test)]
+pub(crate) fn parse_conformance_fixture(
+    path: &Path,
+    source_id: &str,
+) -> anyhow::Result<Option<RawSession>> {
+    let mut raw = parse_agent_transcript(path, true)?;
+    if let Some(session) = raw.as_mut() {
+        session.source_id = source_id.to_string();
+    }
+    Ok(raw)
+}
+
 fn collect_transcript_content_events(
     items: &[Value],
     source_path: &str,
     line_index: usize,
-    message_seq: Option<u32>,
+    prior_message_seq: Option<u32>,
+    current_message_seq: Option<u32>,
     events_out: &mut Vec<RawSessionEvent>,
 ) {
+    let mut message_seq = prior_message_seq;
     for (item_index, item) in items.iter().enumerate() {
-        if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
-            continue;
+        match item.get("type").and_then(|t| t.as_str()) {
+            Some("text") => {
+                if item
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| !text.trim().is_empty())
+                {
+                    message_seq = current_message_seq;
+                }
+            }
+            Some("tool_use") => {
+                let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
+                let mut event = events::tool_call_event(
+                    events::EventContext {
+                        event_seq: events_out.len() as u32,
+                        timestamp: None,
+                        source_path: Some(source_path.to_string()),
+                        source_event_id: Some(format!("{line_index}:{item_index}")),
+                        message_seq,
+                        parser_version: EVENT_PARSER_VERSION,
+                    },
+                    name,
+                    item.get("input"),
+                );
+                event.tool_call_id = cursor_native_id(item.get("id").and_then(Value::as_str));
+                events_out.push(event);
+            }
+            _ => {}
         }
-        let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool").to_string();
-        events_out.push(events::tool_call_event(
-            events::EventContext {
-                event_seq: events_out.len() as u32,
-                timestamp: None,
-                source_path: Some(source_path.to_string()),
-                source_event_id: Some(format!("{line_index}:{item_index}")),
-                message_seq,
-                parser_version: EVENT_PARSER_VERSION,
-            },
-            name,
-            item.get("input"),
-        ));
     }
+}
+
+fn transcript_content_has_visible_text(items: &[Value]) -> bool {
+    items.iter().any(|item| {
+        item.get("type").and_then(Value::as_str) == Some("text")
+            && item.get("text").and_then(Value::as_str).is_some_and(|text| !text.trim().is_empty())
+    })
 }
 
 fn render_transcript_content_items(items: &[Value], is_user: bool) -> String {
@@ -1470,6 +1525,73 @@ mod tests {
     }
 
     #[test]
+    fn incremental_scan_reparses_current_session_with_stale_event_parser() {
+        schema::register_sqlite_vec();
+        let root = temp_root("event-parser-backfill");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        let store = Store::open_in_memory().unwrap();
+        let source_updated_at = 1_700_000_100_000_i64;
+        store
+            .insert_session(&Session {
+                id: uuid::Uuid::new_v4().to_string(),
+                source: "cursor".to_string(),
+                source_id: composer_id.clone(),
+                title: "Usage review".to_string(),
+                directory: Some("/Users/x/project".to_string()),
+                repo_remote: None,
+                repo_slug: None,
+                repo_name: None,
+                started_at: 1_700_000_000_000,
+                updated_at: Some(source_updated_at),
+                message_count: 1,
+                entrypoint: Some("chat".to_string()),
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: None,
+                is_import: false,
+            })
+            .unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "cursor",
+                &composer_id,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(source_updated_at),
+            )
+            .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "cursor",
+                &composer_id,
+                &[],
+                EVENT_PARSER_VERSION - 1,
+                Some(source_updated_at),
+            )
+            .unwrap();
+
+        let result = scan_for_sync_conn(
+            &conn,
+            &AdapterSyncContext::from_store_for_test(&store, "cursor").unwrap(),
+            None,
+            true,
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions[0].event_parser_version, Some(EVENT_PARSER_VERSION));
+        assert_eq!(result.sessions[0].messages.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "hello cursor");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn parse_composer_session_prefers_bubble_usage_over_context_breakdown() {
         let root = temp_root("bubble-usage");
         let composer_id = uuid::Uuid::new_v4().to_string();
@@ -1557,7 +1679,71 @@ mod tests {
         assert_eq!(parsed.events.len(), 2);
         assert_eq!(parsed.events[0].kind, "search");
         assert_eq!(parsed.events[0].name.as_deref(), Some("grep"));
+        assert_eq!(parsed.events[0].source_event_id.as_deref(), Some(bubble_id.as_str()));
+        assert_eq!(parsed.events[0].tool_call_id.as_deref(), Some(bubble_id.as_str()));
         assert_eq!(parsed.events[1].kind, "tool_result");
+        assert_eq!(parsed.events[1].source_event_id.as_deref(), Some(bubble_id.as_str()));
+        assert_eq!(parsed.events[1].tool_call_id.as_deref(), Some(bubble_id.as_str()));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn composer_tool_events_do_not_invent_missing_bubble_relationships() {
+        let bubble = serde_json::json!({
+            "toolFormerData": {
+                "name": "grep",
+                "rawArgs": "{\"pattern\":\"usage\"}",
+                "result": "match"
+            }
+        });
+        for bubble_id in [None, Some(""), Some("unknown")] {
+            let mut events = Vec::new();
+            collect_bubble_tool_events(&bubble, bubble_id, "composer:test", None, 0, &mut events);
+            assert_eq!(events.len(), 2);
+            assert!(events.iter().all(|event| event.source_event_id.is_none()));
+            assert!(events.iter().all(|event| event.tool_call_id.is_none()));
+        }
+    }
+
+    #[test]
+    fn parse_composer_legacy_map_preserves_messages_without_guessing_events() {
+        let root = temp_root("legacy-map");
+        let composer_id = uuid::Uuid::new_v4().to_string();
+        let bubble_id = uuid::Uuid::new_v4().to_string();
+        let conn = seed_global_db(&root, &composer_id, &bubble_id);
+        conn.execute(
+            "DELETE FROM cursorDiskKV WHERE key = ?1",
+            [format!("bubbleId:{composer_id}:{bubble_id}")],
+        )
+        .unwrap();
+        let composer_data = serde_json::json!({
+            "composerId": composer_id,
+            "createdAt": 1_700_000_000_000_i64,
+            "lastUpdatedAt": 1_700_000_100_000_i64,
+            "fullConversationHeadersOnly": [{"bubbleId": bubble_id, "type": 2}],
+            "conversationMap": {
+                bubble_id.clone(): {
+                    "text": "Legacy assistant message",
+                    "toolFormerData": {
+                        "name": "grep",
+                        "rawArgs": "{\"pattern\":\"usage\"}"
+                    }
+                }
+            }
+        });
+        conn.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+            rusqlite::params![composer_data.to_string(), format!("composerData:{composer_id}")],
+        )
+        .unwrap();
+
+        let meta = load_composer_meta(&conn, &composer_id, &ComposerLookup::load(&conn));
+        let parsed = parse_composer_session(&conn, &composer_id, &meta, true).unwrap().unwrap();
+
+        assert_eq!(parsed.messages.len(), 1);
+        assert_eq!(parsed.messages[0].content, "Legacy assistant message");
+        assert!(parsed.events.is_empty());
+
         let _ = fs::remove_dir_all(root);
     }
 
@@ -1570,13 +1756,22 @@ mod tests {
             &jsonl_path,
             &[
                 r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nhello\n</user_query>"}]}}"#,
-                r#"{"role":"assistant","message":{"content":[{"type":"text","text":"searching"},{"type":"tool_use","name":"Glob","input":{"glob_pattern":"*.rs"}}]}}"#,
+                r#"{"role":"assistant","message":{"content":[{"type":"tool_use","id":"tool-before","name":"Glob","input":{"glob_pattern":"*.toml"}},{"type":"text","text":"searching"},{"type":"tool_use","id":"tool-after","name":"Glob","input":{"glob_pattern":"*.rs"}},{"type":"tool_use","id":"","name":"Glob","input":{"glob_pattern":"*.md"}},{"type":"tool_use","id":"unknown","name":"Glob","input":{"glob_pattern":"*.json"}},{"type":"tool_use","id":42,"name":"Glob","input":{"glob_pattern":"*.lock"}}]}}"#,
             ],
         );
         let raw = parse_agent_transcript(&jsonl_path, true).unwrap().unwrap();
-        assert_eq!(raw.events.len(), 1);
+        assert_eq!(raw.events.len(), 5);
         assert_eq!(raw.events[0].kind, "search");
         assert_eq!(raw.events[0].name.as_deref(), Some("Glob"));
+        assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1:0"));
+        assert_eq!(raw.events[0].message_seq, Some(0));
+        assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("tool-before"));
+        assert_eq!(raw.events[1].source_event_id.as_deref(), Some("1:2"));
+        assert_eq!(raw.events[1].message_seq, Some(1));
+        assert_eq!(raw.events[1].tool_call_id.as_deref(), Some("tool-after"));
+        assert_eq!(raw.events[2].tool_call_id, None);
+        assert_eq!(raw.events[3].tool_call_id, None);
+        assert_eq!(raw.events[4].tool_call_id, None);
         assert_eq!(raw.event_parser_version, Some(EVENT_PARSER_VERSION));
         let _ = fs::remove_dir_all(root);
     }

--- a/src/adapters/events.rs
+++ b/src/adapters/events.rs
@@ -37,6 +37,9 @@ pub(crate) fn tool_call_event(
         summary,
         source_path: context.source_path,
         source_event_id: context.source_event_id,
+        tool_call_id: None,
+        is_meta: None,
+        visibility: None,
         attrs_json: args.map(|value| value.to_string()),
         parser_version: context.parser_version,
     }
@@ -66,6 +69,9 @@ pub(crate) fn tool_call_event_from_text(
         summary,
         source_path: context.source_path,
         source_event_id: context.source_event_id,
+        tool_call_id: None,
+        is_meta: None,
+        visibility: None,
         attrs_json: parsed.map(|value| value.to_string()),
         parser_version: context.parser_version,
     }
@@ -88,6 +94,9 @@ pub(crate) fn tool_result_event(
         summary: summary.map(cap_tool_result_summary),
         source_path: context.source_path,
         source_event_id: context.source_event_id,
+        tool_call_id: None,
+        is_meta: None,
+        visibility: None,
         attrs_json: None,
         parser_version: context.parser_version,
     }
@@ -111,6 +120,9 @@ pub(crate) fn file_write_event(
         summary: Some(summary),
         source_path: context.source_path,
         source_event_id: context.source_event_id,
+        tool_call_id: None,
+        is_meta: None,
+        visibility: None,
         attrs_json: None,
         parser_version: context.parser_version,
     }

--- a/src/adapters/events.rs
+++ b/src/adapters/events.rs
@@ -91,7 +91,7 @@ pub(crate) fn tool_result_event(
         status: None,
         target: None,
         message_seq: context.message_seq,
-        summary: summary.map(cap_tool_result_summary),
+        summary: summary.map(bounded_summary),
         source_path: context.source_path,
         source_event_id: context.source_event_id,
         tool_call_id: None,
@@ -232,7 +232,7 @@ fn non_empty(text: &str) -> Option<String> {
     if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
 }
 
-fn cap_tool_result_summary(summary: String) -> String {
+pub(crate) fn bounded_summary(summary: String) -> String {
     if summary.len() <= TOOL_RESULT_SUMMARY_MAX_BYTES {
         return summary;
     }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -378,6 +378,9 @@ fn parse_part_events(
                     summary: None,
                     source_path: None,
                     source_event_id: Some(part_id.to_string()),
+                    tool_call_id: None,
+                    is_meta: None,
+                    visibility: None,
                     attrs_json,
                     parser_version: EVENT_PARSER_VERSION,
                 }];
@@ -397,6 +400,9 @@ fn parse_part_events(
                     message_seq: None,
                     source_path: None,
                     source_event_id: Some(part_id.to_string()),
+                    tool_call_id: None,
+                    is_meta: None,
+                    visibility: None,
                     attrs_json: attrs_json.clone(),
                     parser_version: EVENT_PARSER_VERSION,
                 })

--- a/src/db/event_store.rs
+++ b/src/db/event_store.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use rusqlite::OptionalExtension;
 
 use super::store::{EventSessionStateMeta, Store};
-use crate::types::{RawSessionEvent, SessionEventRecord};
+use crate::types::{EvidenceVisibility, RawSessionEvent, SessionEventRecord};
 
 impl Store {
     pub(crate) fn event_state_meta_map(
@@ -72,7 +72,8 @@ impl Store {
     ) -> Result<Vec<SessionEventRecord>> {
         let mut stmt = self.conn.prepare(
             "SELECT event_seq, timestamp, kind, actor, name, status, target,
-                    message_seq, summary, source_path, source_event_id, attrs_json, parser_version
+                    message_seq, summary, source_path, source_event_id, tool_call_id,
+                    is_meta, visibility, attrs_json, parser_version
              FROM session_events
              WHERE session_id = ?1
              ORDER BY event_seq ASC",
@@ -90,8 +91,14 @@ impl Store {
                 summary: row.get(8)?,
                 source_path: row.get(9)?,
                 source_event_id: row.get(10)?,
-                attrs_json: row.get(11)?,
-                parser_version: row.get(12)?,
+                tool_call_id: row.get(11)?,
+                is_meta: row.get(12)?,
+                visibility: row
+                    .get::<_, Option<String>>(13)?
+                    .as_deref()
+                    .and_then(EvidenceVisibility::parse),
+                attrs_json: row.get(14)?,
+                parser_version: row.get(15)?,
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
@@ -114,11 +121,12 @@ pub(crate) fn replace_session_events(
         "INSERT INTO session_events (
             session_id, source, source_id, event_seq, timestamp,
             kind, actor, name, status, target, message_seq, summary,
-            source_path, source_event_id, attrs_json, parser_version, created_at
+            source_path, source_event_id, tool_call_id, is_meta, visibility,
+            attrs_json, parser_version, created_at
          )
          VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-            ?12, ?13, ?14, ?15, ?16, ?17
+            ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20
          )",
     )?;
     for event in session_events {
@@ -137,6 +145,9 @@ pub(crate) fn replace_session_events(
             event.summary,
             event.source_path,
             event.source_event_id,
+            event.tool_call_id,
+            event.is_meta,
+            event.visibility.map(EvidenceVisibility::as_str),
             event.attrs_json,
             event.parser_version,
             created_at,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,6 +1,7 @@
 use rusqlite::{Connection, OptionalExtension};
 
-const SCHEMA_VERSION: i64 = 12;
+const V12_SCHEMA_VERSION: i64 = 12;
+const SCHEMA_VERSION: i64 = 13;
 
 #[allow(clippy::missing_transmute_annotations)]
 pub(crate) fn register_sqlite_vec() {
@@ -46,8 +47,12 @@ pub(crate) fn init(conn: &Connection) -> anyhow::Result<()> {
     if version < 11 {
         migrate_v11(conn)?;
     }
-    if version < SCHEMA_VERSION || fts_needs_trigram_rebuild(conn)? {
+    if version < V12_SCHEMA_VERSION || fts_needs_trigram_rebuild(conn)? {
         migrate_v12(conn)?;
+    }
+    let version = read_schema_version(conn)?;
+    if version < SCHEMA_VERSION {
+        migrate_v13(conn)?;
     }
     Ok(())
 }
@@ -414,7 +419,7 @@ fn migrate_v12_with_lock<T>(
     acquire_lock: impl FnOnce() -> anyhow::Result<Option<T>>,
 ) -> anyhow::Result<()> {
     if !fts_needs_trigram_rebuild(conn)? {
-        if read_schema_version(conn)? < SCHEMA_VERSION {
+        if read_schema_version(conn)? < V12_SCHEMA_VERSION {
             conn.execute_batch("PRAGMA user_version = 12;")?;
         }
         return Ok(());
@@ -433,7 +438,7 @@ fn migrate_v12_with_lock<T>(
     };
 
     if !fts_needs_trigram_rebuild(conn)? {
-        if read_schema_version(conn)? < SCHEMA_VERSION {
+        if read_schema_version(conn)? < V12_SCHEMA_VERSION {
             conn.execute_batch("PRAGMA user_version = 12;")?;
         }
         return Ok(());
@@ -442,7 +447,8 @@ fn migrate_v12_with_lock<T>(
     eprintln!("Upgrading search index (one-time; may take a minute on large databases)...");
     let started = std::time::Instant::now();
     let version = read_schema_version(conn)?;
-    let version_update = if version < SCHEMA_VERSION { "PRAGMA user_version = 12;" } else { "" };
+    let version_update =
+        if version < V12_SCHEMA_VERSION { "PRAGMA user_version = 12;" } else { "" };
     add_column_if_missing(
         conn,
         "ALTER TABLE messages ADD COLUMN trigram_indexed INTEGER
@@ -456,6 +462,23 @@ fn migrate_v12_with_lock<T>(
     if file_backed {
         conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
         eprintln!("Search index upgraded in {:.0?}.", started.elapsed());
+    }
+    Ok(())
+}
+
+fn migrate_v13(conn: &Connection) -> anyhow::Result<()> {
+    let version = read_schema_version(conn)?;
+    for stmt in [
+        "ALTER TABLE session_events ADD COLUMN tool_call_id TEXT",
+        "ALTER TABLE session_events ADD COLUMN is_meta INTEGER
+         CHECK (is_meta IN (0, 1) OR is_meta IS NULL)",
+        "ALTER TABLE session_events ADD COLUMN visibility TEXT
+         CHECK (visibility IN ('visible', 'hidden', 'inactive') OR visibility IS NULL)",
+    ] {
+        add_column_if_missing(conn, stmt)?;
+    }
+    if version >= V12_SCHEMA_VERSION {
+        conn.execute_batch("PRAGMA user_version = 13;")?;
     }
     Ok(())
 }
@@ -560,6 +583,7 @@ mod tests {
             PRAGMA user_version = 5;",
         )
         .unwrap();
+        migrate_v5(&conn).unwrap();
 
         init(&conn).unwrap();
 
@@ -585,6 +609,8 @@ mod tests {
             PRAGMA user_version = 6;",
         )
         .unwrap();
+        migrate_v5(&conn).unwrap();
+        conn.execute_batch("PRAGMA user_version = 6;").unwrap();
 
         init(&conn).unwrap();
 
@@ -609,6 +635,8 @@ mod tests {
             PRAGMA user_version = 7;",
         )
         .unwrap();
+        migrate_v5(&conn).unwrap();
+        conn.execute_batch("PRAGMA user_version = 7;").unwrap();
 
         init(&conn).unwrap();
 
@@ -636,6 +664,8 @@ mod tests {
             PRAGMA user_version = 8;",
         )
         .unwrap();
+        migrate_v5(&conn).unwrap();
+        conn.execute_batch("PRAGMA user_version = 8;").unwrap();
 
         init(&conn).unwrap();
 
@@ -906,6 +936,18 @@ mod tests {
         assert_eq!(schema_version(&conn).unwrap(), 11);
         assert!(!has_trigram_fts(&conn).unwrap());
 
+        migrate_v13(&conn).unwrap();
+        assert_eq!(schema_version(&conn).unwrap(), 11);
+        let structured_columns: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('session_events')
+                 WHERE name IN ('tool_call_id', 'is_meta', 'visibility')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(structured_columns, 3);
+
         conn.execute_batch(
             "INSERT INTO sessions (id, source, source_id, title, started_at)
              VALUES ('s1', 'cursor', 'c1', 'usage audit', 0);",
@@ -926,6 +968,8 @@ mod tests {
 
         migrate_v12_with_lock(&store.conn, true, || Ok::<Option<()>, anyhow::Error>(Some(())))
             .unwrap();
+        assert_eq!(schema_version(&store.conn).unwrap(), V12_SCHEMA_VERSION);
+        migrate_v13(&store.conn).unwrap();
         assert_eq!(schema_version(&store.conn).unwrap(), SCHEMA_VERSION);
         assert!(has_trigram_fts(&store.conn).unwrap());
         let hits: i64 = store
@@ -938,6 +982,119 @@ mod tests {
             )
             .unwrap();
         assert_eq!(hits, 1, "messages written during deferral must join the rebuilt index");
+    }
+
+    #[test]
+    fn migrate_v13_adds_structured_event_columns_to_existing_v12_db() {
+        type EventRow = (
+            i64,
+            Option<i64>,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+        );
+
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        migrate_v1(&conn).unwrap();
+        migrate_v2(&conn).unwrap();
+        migrate_v3(&conn).unwrap();
+        migrate_v4(&conn).unwrap();
+        migrate_v5(&conn).unwrap();
+        migrate_v6(&conn).unwrap();
+        migrate_v7(&conn).unwrap();
+        migrate_v8(&conn).unwrap();
+        migrate_v9(&conn).unwrap();
+        migrate_v10(&conn).unwrap();
+        migrate_v11(&conn).unwrap();
+        migrate_v12(&conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO sessions (id, source, source_id, title, started_at)
+             VALUES ('s1', 'codex', 'source-1', 'existing', 1000);
+             INSERT INTO session_events (
+                session_id, source, source_id, event_seq, timestamp, kind, actor,
+                name, status, target, message_seq, summary, source_path,
+                source_event_id, attrs_json, parser_version, created_at
+             ) VALUES (
+                's1', 'codex', 'source-1', 7, 1234, 'file_write', 'assistant',
+                'apply_patch', 'completed', 'src/lib.rs', 3, 'updated file',
+                '/tmp/session.jsonl', 'line:7', '{\"path\":\"src/lib.rs\"}', 4, 2000
+             );",
+        )
+        .unwrap();
+        let before: EventRow = conn
+            .query_row(
+                "SELECT event_seq, timestamp, kind, actor, name, status, target,
+                        message_seq, summary, source_path, source_event_id, parser_version
+                 FROM session_events WHERE session_id = 's1'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
+                        row.get(9)?,
+                        row.get(10)?,
+                        row.get(11)?,
+                    ))
+                },
+            )
+            .unwrap();
+
+        init(&conn).unwrap();
+
+        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
+        let after: EventRow = conn
+            .query_row(
+                "SELECT event_seq, timestamp, kind, actor, name, status, target,
+                        message_seq, summary, source_path, source_event_id, parser_version
+                 FROM session_events WHERE session_id = 's1'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
+                        row.get(9)?,
+                        row.get(10)?,
+                        row.get(11)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(after, before);
+        let structured: (Option<String>, Option<bool>, Option<String>) = conn
+            .query_row(
+                "SELECT tool_call_id, is_meta, visibility FROM session_events WHERE session_id = 's1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(structured, (None, None, None));
+        assert!(conn.execute("UPDATE session_events SET is_meta = 2", []).is_err());
+        assert!(conn.execute("UPDATE session_events SET visibility = 'unknown'", []).is_err());
+
+        init(&conn).unwrap();
+        assert_eq!(schema_version(&conn).unwrap(), SCHEMA_VERSION);
     }
 
     #[test]

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -675,6 +675,9 @@ mod tests {
             summary: Some(format!("{kind} {target}")),
             source_path: None,
             source_event_id: None,
+            tool_call_id: None,
+            is_meta: None,
+            visibility: None,
             attrs_json: Some(r#"{"secret":"nope"}"#.to_string()),
             parser_version: 1,
         }

--- a/src/export.rs
+++ b/src/export.rs
@@ -12,7 +12,7 @@ use crate::types::{
     Message, Role, Session, SessionEventRecord, SessionTopology, SessionUsageEventRecord,
 };
 
-pub(crate) const RECORD_SCHEMA_VERSION: u32 = 5;
+pub(crate) const RECORD_SCHEMA_VERSION: u32 = 6;
 const RECORD_TYPE: &str = "session";
 const EXPORT_IN_MEMORY_DB_LIMIT: usize = 8 * 1024 * 1024;
 
@@ -168,6 +168,9 @@ struct ExportEvent {
     summary: Option<String>,
     source_path: Option<String>,
     source_event_id: Option<String>,
+    tool_call_id: Option<String>,
+    is_meta: Option<bool>,
+    visibility: Option<crate::types::EvidenceVisibility>,
     attrs_json: Option<String>,
     parser_version: u32,
 }
@@ -363,6 +366,9 @@ impl From<SessionEventRecord> for ExportEvent {
             summary: event.summary,
             source_path: event.source_path,
             source_event_id: event.source_event_id,
+            tool_call_id: event.tool_call_id,
+            is_meta: event.is_meta,
+            visibility: event.visibility,
             attrs_json: event.attrs_json,
             parser_version: event.parser_version,
         }

--- a/src/import.rs
+++ b/src/import.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 
 use crate::db::store::{SessionTopologyWrite, Store};
 use crate::types::{
-    Message, ParentLink, RawSessionEvent, RawUsageEvent, Role, Session, TokenSource,
+    EvidenceVisibility, Message, ParentLink, RawSessionEvent, RawUsageEvent, Role, Session,
+    TokenSource,
 };
 
 const RECORD_TYPE: &str = "session";
@@ -148,6 +149,12 @@ struct ImportEvent {
     #[serde(default)]
     source_event_id: Option<String>,
     #[serde(default)]
+    tool_call_id: Option<String>,
+    #[serde(default)]
+    is_meta: Option<bool>,
+    #[serde(default)]
+    visibility: Option<EvidenceVisibility>,
+    #[serde(default)]
     attrs_json: Option<String>,
     #[serde(default)]
     parser_version: u32,
@@ -173,7 +180,7 @@ pub(crate) fn import_jsonl<R: BufRead>(
         if record.record_type != RECORD_TYPE {
             bail!("line {line_no}: unsupported record_type '{}'", record.record_type);
         }
-        if !matches!(record.schema_version, 2..=5) {
+        if !matches!(record.schema_version, 2..=6) {
             bail!("line {line_no}: unsupported schema_version {}", record.schema_version);
         }
 
@@ -282,6 +289,9 @@ fn persist_record(store: &Store, record: ImportRecord, line_no: usize) -> Result
             summary: e.summary,
             source_path: e.source_path,
             source_event_id: e.source_event_id,
+            tool_call_id: e.tool_call_id,
+            is_meta: e.is_meta,
+            visibility: e.visibility,
             attrs_json: e.attrs_json,
             parser_version: e.parser_version,
         })
@@ -404,6 +414,9 @@ mod tests {
             summary: Some("ran ls".to_string()),
             source_path: Some("/home/origin/raw.jsonl".to_string()),
             source_event_id: Some("ev-1".to_string()),
+            tool_call_id: Some("call-1".to_string()),
+            is_meta: Some(false),
+            visibility: Some(EvidenceVisibility::Visible),
             attrs_json: Some("{\"exit_code\":0}".to_string()),
             parser_version: 5,
         }
@@ -606,6 +619,10 @@ mod tests {
         let bad_type = r#"{"schema_version":3,"record_type":"snapshot","session":{"source":"codex","source_id":"x","title":"t","started_at":0}}"#;
         let err = import_jsonl(&store, false, bad_type.as_bytes()).unwrap_err();
         assert!(err.to_string().contains("record_type"), "unexpected error: {err}");
+
+        let bad_visibility = r#"{"schema_version":6,"record_type":"session","session":{"source":"codex","source_id":"x","title":"t","started_at":0},"events":[{"event_seq":0,"kind":"tool","actor":"assistant","visibility":"unknown"}]}"#;
+        let err = import_jsonl(&store, false, bad_visibility.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("unknown variant"), "unexpected error: {err}");
     }
 
     #[test]
@@ -620,6 +637,30 @@ mod tests {
             .query_row("SELECT parser_version FROM usage_events", [], |row| row.get(0))
             .unwrap();
         assert_eq!(parser_version, 0, "missing v3 fields must default to 0");
+        let events = store
+            .list_session_events_for_session(
+                &store.get_session_by_source_id("codex", "v2-1").unwrap().unwrap().id,
+            )
+            .unwrap();
+        assert_eq!(events[0].tool_call_id, None);
+        assert_eq!(events[0].is_meta, None);
+        assert_eq!(events[0].visibility, None);
+    }
+
+    #[test]
+    fn accepts_schema_version_5_without_v6_event_fields() {
+        let store = setup();
+        let v5 = r#"{"schema_version":5,"record_type":"session","session":{"source":"claude-code","source_id":"v5-1","title":"V5","started_at":100},"events":[{"event_seq":0,"timestamp":101,"kind":"tool_result","actor":"tool","source_event_id":"2:0","parser_version":3}]}"#;
+        let summary = import_jsonl(&store, false, v5.as_bytes()).unwrap();
+        assert_eq!(summary, ImportSummary { total: 1, imported: 1, skipped: 0 });
+
+        let session = store.get_session_by_source_id("claude-code", "v5-1").unwrap().unwrap();
+        let events = store.list_session_events_for_session(&session.id).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source_event_id.as_deref(), Some("2:0"));
+        assert_eq!(events[0].tool_call_id, None);
+        assert_eq!(events[0].is_meta, None);
+        assert_eq!(events[0].visibility, None);
     }
 
     #[test]

--- a/src/integration/regression.rs
+++ b/src/integration/regression.rs
@@ -83,6 +83,9 @@ fn make_session_event(kind: &str, name: Option<&str>, target: Option<&str>) -> R
         summary: Some("event summary".to_string()),
         source_path: Some("/tmp/source.jsonl".to_string()),
         source_event_id: Some("42".to_string()),
+        tool_call_id: Some("call-42".to_string()),
+        is_meta: Some(false),
+        visibility: Some(crate::types::EvidenceVisibility::Visible),
         attrs_json: Some(r#"{"path":"src/main.rs"}"#.to_string()),
         parser_version: 1,
     }
@@ -281,6 +284,10 @@ fn persist_session_writes_session_events_and_state() {
     assert_eq!(loaded[0].kind, "file_read");
     assert_eq!(loaded[0].name.as_deref(), Some("read_file"));
     assert_eq!(loaded[0].target.as_deref(), Some("src/main.rs"));
+    assert_eq!(loaded[0].source_event_id.as_deref(), Some("42"));
+    assert_eq!(loaded[0].tool_call_id.as_deref(), Some("call-42"));
+    assert_eq!(loaded[0].is_meta, Some(false));
+    assert_eq!(loaded[0].visibility, Some(crate::types::EvidenceVisibility::Visible));
 }
 
 #[test]
@@ -330,7 +337,7 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     let lines: Vec<_> = text.lines().collect();
     assert_eq!(lines.len(), 1);
     let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(value["schema_version"], 5);
+    assert_eq!(value["schema_version"], 6);
     assert_eq!(value["record_type"], "session");
     assert_eq!(value["session"]["source"], "codex");
     assert_eq!(value["session"]["source_id"], "raw1");
@@ -360,6 +367,10 @@ fn export_jsonl_emits_session_messages_and_usage_events() {
     assert_eq!(value["events"][0]["name"], "read_file");
     assert_eq!(value["events"][0]["target"], "src/main.rs");
     assert_eq!(value["events"][0]["message_seq"], 1);
+    assert_eq!(value["events"][0]["source_event_id"], "42");
+    assert_eq!(value["events"][0]["tool_call_id"], "call-42");
+    assert_eq!(value["events"][0]["is_meta"], false);
+    assert_eq!(value["events"][0]["visibility"], "visible");
     assert_eq!(value["events"][0]["parser_version"], 1);
     assert_eq!(value["events"][0]["attrs_json"], r#"{"path":"src/main.rs"}"#);
 }

--- a/src/integration/roundtrip_conformance.rs
+++ b/src/integration/roundtrip_conformance.rs
@@ -101,6 +101,9 @@ fn expected_contract(source: &str, raw: &RawSession) -> Value {
                 "summary": event.summary,
                 "source_path": event.source_path,
                 "source_event_id": event.source_event_id,
+                "tool_call_id": event.tool_call_id,
+                "is_meta": event.is_meta,
+                "visibility": event.visibility,
                 "attrs_json": event.attrs_json,
                 "parser_version": event.parser_version,
             })

--- a/src/integration/roundtrip_conformance.rs
+++ b/src/integration/roundtrip_conformance.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
 
-use crate::adapters::{RawSession, claude_code, codex, kimi_code};
+use crate::adapters::{RawSession, claude_code, codex, cursor, kimi_code};
 use crate::db::schema;
 use crate::db::search::TimeRange;
 use crate::db::store::Store;
@@ -239,6 +239,43 @@ fn codex_single_file_round_trip() {
     assert_roundtrip("codex", || {
         codex::parse_codex_session_with_options(&path, true)?
             .context("Codex fixture was not parsed")
+    });
+}
+
+#[test]
+fn cursor_agent_transcript_round_trip() {
+    let root = tempfile::tempdir().unwrap();
+    let source_id = "019a4c01-e8f4-7270-bdab-7f19273b2502";
+    let path = root.path().join(format!("{source_id}.jsonl"));
+    write_jsonl(
+        &path,
+        &[
+            json!({
+                "role": "user",
+                "message": {
+                    "content": [{"type": "text", "text": "Inspect the Cursor transcript"}]
+                }
+            }),
+            json!({
+                "role": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Reading the parser."},
+                        {
+                            "type": "tool_use",
+                            "id": "cursor-tool-contract",
+                            "name": "Read",
+                            "input": {"path": "src/adapters/cursor.rs"}
+                        }
+                    ]
+                }
+            }),
+        ],
+    );
+
+    assert_roundtrip("cursor", || {
+        cursor::parse_conformance_fixture(&path, source_id)?
+            .context("Cursor fixture was not parsed")
     });
 }
 

--- a/src/integration/roundtrip_conformance.rs
+++ b/src/integration/roundtrip_conformance.rs
@@ -214,6 +214,25 @@ fn codex_single_file_round_trip() {
                 "timestamp": "2026-04-13T10:00:02Z",
                 "payload": {"type": "agent_message", "message": "The mapping is intact."}
             }),
+            json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:03Z",
+                "payload": {
+                    "type": "function_call",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"src/db/events.rs\"}",
+                    "call_id": "call_conformance"
+                }
+            }),
+            json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:04Z",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_conformance",
+                    "output": "event store mapping"
+                }
+            }),
         ],
     );
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1820,6 +1820,9 @@ mod tests {
             summary: summary.map(str::to_string),
             source_path: None,
             source_event_id: None,
+            tool_call_id: None,
+            is_meta: None,
+            visibility: None,
             attrs_json: Some(r#"{"token":"secret-value"}"#.to_string()),
             parser_version: 1,
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -18,7 +18,7 @@ use crate::db::search::{SearchEngine, SearchFilters, SessionEventQuery, TimeRang
 use crate::db::store::Store;
 use crate::project_scope::ProjectScope;
 use crate::query::{query_embedding, resolve_source_filter};
-use crate::types::{Message, Role, Session};
+use crate::types::{EvidenceVisibility, Message, Role, Session, SessionEventRecord};
 
 const SEARCH_LIMIT_DEFAULT: u32 = 10;
 const SEARCH_LIMIT_MAX: u32 = 50;
@@ -30,6 +30,9 @@ const FILE_HISTORY_KINDS: [&str; 2] = ["file_write", "file_read"];
 const GET_MAX_MESSAGES_DEFAULT: u32 = 50;
 const GET_MESSAGE_CHAR_CAP: usize = 2_000;
 const GET_RESPONSE_CHAR_CAP: usize = 32_000;
+const GET_EVENT_LIMIT: usize = 50;
+const GET_EVENT_FIELD_CHAR_CAP: usize = 200;
+const GET_EVENT_TEXT_CHAR_CAP: usize = 10_000;
 const EXCERPT_CHAR_CAP: usize = 200;
 
 const MISSING_INDEX: &str =
@@ -76,6 +79,11 @@ struct GetSessionArgs {
         description = "Return the newest messages instead of the oldest, preserving sequence order."
     )]
     tail: bool,
+    #[serde(default)]
+    #[schemars(
+        description = "Include up to 50 structured events anchored to the returned message range, plus unanchored events. Each event string field is capped at 200 characters and all event string fields at 10000 characters total. Defaults to false."
+    )]
+    include_events: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -301,6 +309,29 @@ struct SessionDetail {
     last_message_seq: Option<u32>,
     truncated: bool,
     messages: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    events: Option<Vec<SessionEventDetail>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    returned_events: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    events_truncated: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+struct SessionEventDetail {
+    event_seq: u32,
+    timestamp: Option<String>,
+    kind: String,
+    actor: String,
+    name: Option<String>,
+    status: Option<String>,
+    target: Option<String>,
+    message_seq: Option<u32>,
+    source_event_id: Option<String>,
+    tool_call_id: Option<String>,
+    is_meta: Option<bool>,
+    visibility: Option<EvidenceVisibility>,
+    summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -423,7 +454,7 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Returns metadata, including source-native source_session_id and the first_message_seq and last_message_seq represented by the response, plus messages as plain text in sequence order.",
+        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Set include_events only when structured evidence is needed; it returns at most 50 events anchored to the returned message range plus unanchored events, caps each event string field at 200 characters and all event string fields at 10000 characters total, and never returns raw arguments, results, source paths, or parser internals. Returns metadata, including source-native source_session_id and the first_message_seq and last_message_seq represented by the response, plus messages as plain text in sequence order.",
         annotations(
             title = "Get session",
             read_only_hint = true,
@@ -506,6 +537,7 @@ impl GetSessionBenchmark {
                 session_id: "claude-code:session-0".to_string(),
                 max_messages: Some(self.max_messages),
                 tail: self.tail,
+                include_events: false,
             }))
             .expect("benchmark get_session");
         serde_json::to_vec(&result).expect("serialize benchmark get_session")
@@ -809,6 +841,17 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
     let messages = store.get_messages(&session.id).map_err(|error| error.to_string())?;
     let (text, returned, truncated, first_message_seq, last_message_seq) =
         render_messages(&messages, max_messages, args.tail);
+    let (events, returned_events, events_truncated) = if args.include_events {
+        let records = store
+            .list_session_events_for_session(&session.id)
+            .map_err(|error| error.to_string())?;
+        let (events, truncated) =
+            render_session_events(records, first_message_seq, last_message_seq, args.tail);
+        let returned = events.len();
+        (Some(events), Some(returned), Some(truncated))
+    } else {
+        (None, None, None)
+    };
     Ok(SessionDetail {
         message: None,
         session_id: Some(session.id.clone()),
@@ -824,6 +867,9 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
         last_message_seq,
         truncated,
         messages: text,
+        events,
+        returned_events,
+        events_truncated,
     })
 }
 
@@ -843,7 +889,121 @@ fn empty_detail(message: Option<String>) -> SessionDetail {
         last_message_seq: None,
         truncated: false,
         messages: String::new(),
+        events: None,
+        returned_events: None,
+        events_truncated: None,
     }
+}
+
+fn render_session_events(
+    records: Vec<SessionEventRecord>,
+    first_message_seq: Option<u32>,
+    last_message_seq: Option<u32>,
+    tail: bool,
+) -> (Vec<SessionEventDetail>, bool) {
+    let total_records = records.len();
+    let filtered = records
+        .iter()
+        .filter(|event| match event.message_seq {
+            None => true,
+            Some(message_seq) => first_message_seq
+                .zip(last_message_seq)
+                .is_some_and(|(first, last)| message_seq >= first && message_seq <= last),
+        })
+        .collect::<Vec<_>>();
+    let mut truncated = filtered.len() != total_records;
+    let selected = if tail {
+        filtered.iter().rev().take(GET_EVENT_LIMIT).copied().collect::<Vec<_>>()
+    } else {
+        filtered.iter().take(GET_EVENT_LIMIT).copied().collect::<Vec<_>>()
+    };
+    if selected.len() != filtered.len() {
+        truncated = true;
+    }
+
+    let mut details = Vec::new();
+    let mut text_chars = 0;
+    for record in selected {
+        let (detail, fields_truncated) = session_event_detail(record);
+        let detail_chars = session_event_text_chars(&detail);
+        if text_chars + detail_chars > GET_EVENT_TEXT_CHAR_CAP {
+            truncated = true;
+            break;
+        }
+        text_chars += detail_chars;
+        truncated |= fields_truncated;
+        details.push(detail);
+    }
+    details.sort_by_key(|event| match event.message_seq {
+        Some(message_seq) => (0_u8, message_seq, event.event_seq),
+        None => (1_u8, 0, event.event_seq),
+    });
+    (details, truncated)
+}
+
+fn session_event_detail(record: &SessionEventRecord) -> (SessionEventDetail, bool) {
+    let (kind, kind_truncated) = truncate_chars(&record.kind, GET_EVENT_FIELD_CHAR_CAP);
+    let (actor, actor_truncated) = truncate_chars(&record.actor, GET_EVENT_FIELD_CHAR_CAP);
+    let (name, name_truncated) = truncate_event_field(record.name.as_deref());
+    let (status, status_truncated) = truncate_event_field(record.status.as_deref());
+    let (target, target_truncated) = truncate_event_field(record.target.as_deref());
+    let (source_event_id, source_event_id_truncated) =
+        truncate_event_field(record.source_event_id.as_deref());
+    let (tool_call_id, tool_call_id_truncated) =
+        truncate_event_field(record.tool_call_id.as_deref());
+    let (summary, summary_truncated) = truncate_event_field(record.summary.as_deref());
+    (
+        SessionEventDetail {
+            event_seq: record.event_seq,
+            timestamp: record.timestamp.map(iso8601),
+            kind,
+            actor,
+            name,
+            status,
+            target,
+            message_seq: record.message_seq,
+            source_event_id,
+            tool_call_id,
+            is_meta: record.is_meta,
+            visibility: record.visibility,
+            summary,
+        },
+        kind_truncated
+            || actor_truncated
+            || name_truncated
+            || status_truncated
+            || target_truncated
+            || source_event_id_truncated
+            || tool_call_id_truncated
+            || summary_truncated,
+    )
+}
+
+fn truncate_event_field(value: Option<&str>) -> (Option<String>, bool) {
+    match value {
+        Some(value) => {
+            let (value, truncated) = truncate_chars(value, GET_EVENT_FIELD_CHAR_CAP);
+            (Some(value), truncated)
+        }
+        None => (None, false),
+    }
+}
+
+fn session_event_text_chars(event: &SessionEventDetail) -> usize {
+    event.kind.chars().count()
+        + event.actor.chars().count()
+        + optional_text_chars(event.timestamp.as_deref())
+        + optional_text_chars(event.name.as_deref())
+        + optional_text_chars(event.status.as_deref())
+        + optional_text_chars(event.target.as_deref())
+        + optional_text_chars(event.source_event_id.as_deref())
+        + optional_text_chars(event.tool_call_id.as_deref())
+        + event.visibility.map(|value| value.as_str().chars().count()).unwrap_or(0)
+        + optional_text_chars(event.summary.as_deref())
+}
+
+fn optional_text_chars(value: Option<&str>) -> usize {
+    value.map(|value| value.chars().count()).unwrap_or(0)
 }
 
 fn resolve_filters(
@@ -1379,7 +1539,12 @@ mod tests {
 
         let detail = get_session(
             &index,
-            &GetSessionArgs { session_id: "current".into(), max_messages: None, tail: false },
+            &GetSessionArgs {
+                session_id: "current".into(),
+                max_messages: None,
+                tail: false,
+                include_events: false,
+            },
         )
         .unwrap();
         assert_eq!(detail.messages, "[user] exact transcript");
@@ -1473,7 +1638,12 @@ mod tests {
 
         let detail = get_session(
             &index,
-            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(1), tail: false },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: Some(1),
+                tail: false,
+                include_events: false,
+            },
         )
         .unwrap();
         assert_eq!(detail.session_id.as_deref(), Some("s1"));
@@ -1504,7 +1674,12 @@ mod tests {
             .unwrap();
         let detail = get_session(
             &ready(store),
-            &GetSessionArgs { session_id: "s1".into(), max_messages: None, tail: false },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: None,
+                tail: false,
+                include_events: false,
+            },
         )
         .unwrap();
 
@@ -1540,7 +1715,12 @@ mod tests {
         store.insert_session(&stored).unwrap();
         let detail = get_session(
             &ready(store),
-            &GetSessionArgs { session_id: "s1".into(), max_messages: None, tail: false },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: None,
+                tail: false,
+                include_events: false,
+            },
         )
         .unwrap();
 
@@ -1570,7 +1750,12 @@ mod tests {
 
         let detail = get_session(
             &index,
-            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(2), tail: true },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: Some(2),
+                tail: true,
+                include_events: false,
+            },
         )
         .unwrap();
 
@@ -1602,7 +1787,12 @@ mod tests {
 
         let detail = get_session(
             &index,
-            &GetSessionArgs { session_id: "s1".into(), max_messages: Some(20), tail: true },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: Some(20),
+                tail: true,
+                include_events: false,
+            },
         )
         .unwrap();
 
@@ -1618,11 +1808,220 @@ mod tests {
     }
 
     #[test]
+    fn get_session_without_events_preserves_json_bytes_and_skips_event_read() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
+        store.insert_messages(&[message("s1", Role::User, "hello", 0)]).unwrap();
+        store.conn.execute_batch("DROP TABLE session_events").unwrap();
+        let args = GetSessionArgs {
+            session_id: "s1".into(),
+            max_messages: None,
+            tail: false,
+            include_events: false,
+        };
+
+        let index = ready(store);
+        let detail = get_session(&index, &args).unwrap();
+        let bytes = serde_json::to_vec(&detail).unwrap();
+
+        assert_eq!(
+            bytes,
+            br#"{"message":null,"session_id":"s1","source_session_id":"src-s1","source":"codex","project":"/tmp/demo","title":"title","summary":"title summary","timestamp":"1970-01-01T00:00:01.000Z","message_count":1,"returned_messages":1,"first_message_seq":0,"last_message_seq":0,"truncated":false,"messages":"[user] hello"}"#
+        );
+        assert!(detail.events.is_none());
+        assert!(detail.returned_events.is_none());
+        assert!(detail.events_truncated.is_none());
+        let event_error = get_session(&index, &GetSessionArgs { include_events: true, ..args })
+            .expect_err("include_events must read the event table");
+        assert!(event_error.contains("session_events"));
+    }
+
+    #[test]
+    fn get_session_events_follow_returned_message_range_and_preserve_null_anchors() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "events", 1_000);
+        stored.message_count = 4;
+        store.insert_session(&stored).unwrap();
+        store
+            .insert_messages(&[
+                message("s1", Role::User, "zero", 0),
+                message("s1", Role::Assistant, "one", 1),
+                message("s1", Role::User, "two", 2),
+                message("s1", Role::Assistant, "three", 3),
+            ])
+            .unwrap();
+        let mut events = (0..5)
+            .map(|seq| event(seq, "tool_call", None, Some(1_700_000_000_000), None, None))
+            .collect::<Vec<_>>();
+        events[0].message_seq = Some(0);
+        events[1].message_seq = None;
+        events[2].message_seq = Some(2);
+        events[2].source_event_id = Some("line:2".to_string());
+        events[2].tool_call_id = Some("call-2".to_string());
+        events[2].is_meta = Some(false);
+        events[2].visibility = Some(EvidenceVisibility::Visible);
+        events[3].message_seq = Some(3);
+        events[4].message_seq = None;
+        persist_events(&store, "codex", "s1", &events);
+        let index = ready(store);
+
+        let head = get_session(
+            &index,
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: Some(2),
+                tail: false,
+                include_events: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            head.events.as_ref().unwrap().iter().map(|event| event.event_seq).collect::<Vec<_>>(),
+            vec![0, 1, 4]
+        );
+        assert_eq!(head.returned_events, Some(3));
+        assert_eq!(head.events_truncated, Some(true));
+
+        let tail = get_session(
+            &index,
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: Some(2),
+                tail: true,
+                include_events: true,
+            },
+        )
+        .unwrap();
+        let returned = tail.events.as_ref().unwrap();
+        assert_eq!(
+            returned.iter().map(|event| event.event_seq).collect::<Vec<_>>(),
+            vec![2, 3, 1, 4]
+        );
+        assert_eq!(returned[0].timestamp.as_deref(), Some("2023-11-14T22:13:20.000Z"));
+        assert_eq!(returned[0].source_event_id.as_deref(), Some("line:2"));
+        assert_eq!(returned[0].tool_call_id.as_deref(), Some("call-2"));
+        assert_eq!(returned[0].is_meta, Some(false));
+        assert_eq!(returned[0].visibility, Some(EvidenceVisibility::Visible));
+        assert_eq!(tail.returned_events, Some(4));
+        assert_eq!(tail.events_truncated, Some(true));
+        let value = serde_json::to_value(&tail).unwrap();
+        let serialized = value.to_string();
+        assert!(!serialized.contains("attrs_json"));
+        assert!(!serialized.contains("source_path"));
+        assert!(!serialized.contains("parser_version"));
+        assert!(!serialized.contains("secret-value"));
+    }
+
+    #[test]
+    fn get_session_events_apply_head_and_tail_event_caps() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "event cap", 1_000);
+        stored.message_count = 0;
+        store.insert_session(&stored).unwrap();
+        let events = (0..55)
+            .map(|seq| {
+                let mut event = event(seq, "tool_call", None, None, None, None);
+                event.message_seq = None;
+                event
+            })
+            .collect::<Vec<_>>();
+        persist_events(&store, "codex", "s1", &events);
+        let index = ready(store);
+
+        for (tail, first, last) in [(false, 0, 49), (true, 5, 54)] {
+            let detail = get_session(
+                &index,
+                &GetSessionArgs {
+                    session_id: "s1".into(),
+                    max_messages: None,
+                    tail,
+                    include_events: true,
+                },
+            )
+            .unwrap();
+            let events = detail.events.unwrap();
+            assert_eq!(events.len(), GET_EVENT_LIMIT);
+            assert_eq!(events.first().unwrap().event_seq, first);
+            assert_eq!(events.last().unwrap().event_seq, last);
+            assert_eq!(detail.returned_events, Some(GET_EVENT_LIMIT));
+            assert_eq!(detail.events_truncated, Some(true));
+        }
+    }
+
+    #[test]
+    fn get_session_events_bound_unicode_fields_and_total_text() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "event text cap", 1_000);
+        stored.message_count = 0;
+        store.insert_session(&stored).unwrap();
+        let long = "汉".repeat(GET_EVENT_FIELD_CHAR_CAP + 50);
+        let events = (0..GET_EVENT_LIMIT as u32)
+            .map(|seq| {
+                let mut event = event(seq, "tool_call", None, None, Some(&long), None);
+                event.message_seq = None;
+                event.target = Some(long.clone());
+                event
+            })
+            .collect::<Vec<_>>();
+        persist_events(&store, "codex", "s1", &events);
+
+        let detail = get_session(
+            &ready(store),
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: None,
+                tail: false,
+                include_events: true,
+            },
+        )
+        .unwrap();
+        let events = detail.events.unwrap();
+        assert!(events.len() < GET_EVENT_LIMIT);
+        assert_eq!(detail.returned_events, Some(events.len()));
+        assert_eq!(detail.events_truncated, Some(true));
+        assert!(events.iter().all(|event| {
+            let summary = event.summary.as_deref().unwrap();
+            summary.chars().count() == GET_EVENT_FIELD_CHAR_CAP && summary.ends_with('…')
+        }));
+        assert!(
+            events.iter().map(session_event_text_chars).sum::<usize>() <= GET_EVENT_TEXT_CHAR_CAP
+        );
+    }
+
+    #[test]
+    fn get_session_include_events_returns_explicit_empty_payload() {
+        let store = setup();
+        let mut stored = session("s1", "codex", "no events", 1_000);
+        stored.message_count = 0;
+        store.insert_session(&stored).unwrap();
+
+        let detail = get_session(
+            &ready(store),
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: None,
+                tail: false,
+                include_events: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(detail.events, Some(Vec::new()));
+        assert_eq!(detail.returned_events, Some(0));
+        assert_eq!(detail.events_truncated, Some(false));
+    }
+
+    #[test]
     fn get_session_missing_id_is_a_tool_error() {
         let store = setup();
         store.insert_session(&session("s1", "codex", "title", 1_000)).unwrap();
         let index = ready(store);
-        let args = GetSessionArgs { session_id: "missing".into(), max_messages: None, tail: false };
+        let args = GetSessionArgs {
+            session_id: "missing".into(),
+            max_messages: None,
+            tail: false,
+            include_events: false,
+        };
         let error = get_session(&index, &args).expect_err("missing session");
         assert!(error.contains(SESSION_NOT_FOUND));
         assert_eq!(
@@ -1729,7 +2128,12 @@ mod tests {
         let index = ready(store);
         let detail = get_session(
             &index,
-            &GetSessionArgs { session_id: "s1".into(), max_messages: None, tail: false },
+            &GetSessionArgs {
+                session_id: "s1".into(),
+                max_messages: None,
+                tail: false,
+                include_events: false,
+            },
         )
         .unwrap();
         assert!(detail.truncated);
@@ -1752,6 +2156,9 @@ mod tests {
         assert_eq!(clamp_limit(None, 10, 50), 10);
         assert_eq!(clamp_limit(Some(80), EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX), 50);
         assert_eq!(clamp_limit(None, EVENT_LIMIT_DEFAULT, EVENT_LIMIT_MAX), 20);
+        let get_args: GetSessionArgs =
+            serde_json::from_value(serde_json::json!({"session_id": "s1"})).unwrap();
+        assert!(!get_args.include_events);
     }
 
     #[test]
@@ -1787,15 +2194,22 @@ mod tests {
             .expect("list_recent_sessions capability");
 
         assert!(get_session["inputSchema"]["properties"]["tail"].is_object());
+        assert!(get_session["inputSchema"]["properties"]["include_events"].is_object());
         assert!(search_sessions["inputSchema"]["properties"]["invocation_nonce"].is_object());
         assert!(list_recent_sessions["inputSchema"]["properties"]["invocation_nonce"].is_object());
         assert!(get_session["description"].as_str().unwrap().contains("source_session_id"));
         assert!(get_session["description"].as_str().unwrap().contains("first_message_seq"));
+        let description = get_session["description"].as_str().unwrap();
+        assert!(description.contains("50 events"));
+        assert!(description.contains("200 characters"));
+        assert!(description.contains("10000 characters"));
+        assert!(description.contains("never returns raw arguments"));
         assert!(report.server.capabilities.tools.is_some());
         let text = render_capabilities(&report);
         assert!(text.contains("get_session"));
         assert!(text.contains("Inputs: "));
         assert!(text.contains("tail"));
+        assert!(text.contains("include_events"));
         assert!(text.contains("invocation_nonce"));
         assert!(text.contains("current_session.resolution"));
     }

--- a/src/skill_audit.rs
+++ b/src/skill_audit.rs
@@ -516,6 +516,9 @@ mod tests {
             summary: None,
             source_path: None,
             source_event_id: None,
+            tool_call_id: None,
+            is_meta: None,
+            visibility: None,
             attrs_json: None,
             parser_version: 1,
         };
@@ -571,6 +574,9 @@ mod tests {
             summary: None,
             source_path: None,
             source_event_id: None,
+            tool_call_id: None,
+            is_meta: None,
+            visibility: None,
             attrs_json: Some(r#"{"skill":"commit"}"#.to_string()),
             parser_version: 1,
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -180,6 +180,33 @@ pub(crate) struct RawUsageEvent {
     pub(crate) raw_usage_json: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum EvidenceVisibility {
+    Visible,
+    Hidden,
+    Inactive,
+}
+
+impl EvidenceVisibility {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Visible => "visible",
+            Self::Hidden => "hidden",
+            Self::Inactive => "inactive",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "visible" => Some(Self::Visible),
+            "hidden" => Some(Self::Hidden),
+            "inactive" => Some(Self::Inactive),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RawSessionEvent {
     pub(crate) event_seq: u32,
@@ -193,6 +220,9 @@ pub(crate) struct RawSessionEvent {
     pub(crate) summary: Option<String>,
     pub(crate) source_path: Option<String>,
     pub(crate) source_event_id: Option<String>,
+    pub(crate) tool_call_id: Option<String>,
+    pub(crate) is_meta: Option<bool>,
+    pub(crate) visibility: Option<EvidenceVisibility>,
     pub(crate) attrs_json: Option<String>,
     pub(crate) parser_version: u32,
 }
@@ -228,6 +258,9 @@ pub(crate) struct SessionEventRecord {
     pub(crate) summary: Option<String>,
     pub(crate) source_path: Option<String>,
     pub(crate) source_event_id: Option<String>,
+    pub(crate) tool_call_id: Option<String>,
+    pub(crate) is_meta: Option<bool>,
+    pub(crate) visibility: Option<EvidenceVisibility>,
     pub(crate) attrs_json: Option<String>,
     pub(crate) parser_version: u32,
 }


### PR DESCRIPTION
## Summary

Recall already stores structured session events, but the existing fields mix event provenance with tool-call correlation. Codex can correlate with `call_id`, Claude stores event position in `source_event_id` while overloading `name` with `tool_use_id`, and Cursor sometimes persists the literal `unknown`. MCP cannot read the resulting session timeline.

This change adds one additive event contract across storage, export/import, Codex, Claude Code, Cursor, and MCP:

- `source_event_id` remains source-native event provenance.
- `tool_call_id` is populated only from a stable source-native correlation ID.
- `is_meta` and `visibility` remain nullable when the source does not prove the semantic.
- Missing IDs are never reconstructed from adjacency, timestamps, or transcript positions.
- MCP events are opt-in, bounded, and exclude raw arguments, results, paths, parser internals, and `attrs_json`.

## Data and compatibility

- Adds idempotent schema v13 columns: `tool_call_id`, `is_meta`, and `visibility`.
- Preserves old event bytes and maps all new fields to `null` for existing rows.
- Keeps v13 columns available when the v12 trigram rebuild is deferred without advancing `user_version`, so the rebuild still retries later.
- Emits export schema v6 and imports v2 through v6.
- Keeps CLI JSON/JSONL changes additive; `protocol_version` is unchanged.
- Releases `recall-powercontext` 0.1.1 with v5-v6 export compatibility. The extension release must complete before the later core release; the changelog tells existing users to run `recall ext upgrade powercontext`.

## Provider evidence

- Codex parser v4 preserves source `call_id` relationships for function, custom, tool-search, web-search, and patch-derived events. Event provenance remains line/item based. Explicit developer/system records become bounded meta events, including the observed `input_text` payload shape.
- Claude Code parser v4 preserves `tool_use.id` / `tool_result.tool_use_id`, leaves result names unset unless the source supplies a real tool name, and keeps `isMeta`, compact-summary, and sidechain semantics separate.
- Cursor parser v3 preserves real composer bubble IDs and source-native CLI tool IDs, removes invented `unknown` identities, and leaves legacy paths relation-free when the source has no proof.
- Source-order message anchors use only preceding visible transcript messages; pure-tool transcripts remain valid without invented anchors.

## MCP contract

`get_session` adds `include_events`, defaulting to `false`. The default response remains byte-for-byte unchanged and does not read the event table. Opt-in responses expose only the documented public fields, with:

- 50-event cap;
- 200 Unicode characters per string field;
- 10,000 total event-string characters;
- message-range filtering plus preserved null anchors;
- deterministic head/tail selection and ordering;
- explicit `returned_events` and `events_truncated` fields only when events are requested.

## Rejected alternatives

- A canonical messages/tool-calls/tool-results union would force a broad migration across every adapter, search, TUI, and historical record.
- Pairing missing call/results by adjacency would turn ordering coincidence into persisted fact.
- A separate MCP event tool would duplicate session lookup, caps, errors, and client-side joins while still requiring the same storage contract.

## Verification

- `make check` passed: audit, fmt, clippy with `-D warnings`, and workspace tests. The audit gate reported only its three existing allowed warnings.
- Provider parser, backfill, round-trip conformance, schema migration, import/export, extension, and sync coverage passed in the workspace gate.
- `cargo test mcp::tests`: 36 passed.
- `cargo test --features bench mcp_get_session`: 2 passed.
- Two final `cargo bench --features bench --bench recall mcp_get_session` runs produced median microseconds:
  - long head: 150.1 / 138.5
  - long tail: 136.6 / 140.9
  - medium: 63.60 / 64.93
  - short: 22.74 / 22.87
- `recall-powercontext` 0.1.1 manifest and host release package were verified; local aarch64 archive SHA-256: `569eb50c0267ee092477bae45a1e3d6e9a97cc131c2b0fa713d5d5a3db729285`.
- Mirror plan/review/ship completed with `PASS WITH RESIDUAL RISK`.
- Liability Review T2 completed against diff fingerprint `0666e4d34ed635b5d8e33a1ad631b39d4e534264` with a different-agent Cursor cold review and zero findings.
- Pre-Ship passed for the final MCP commit fingerprint `dde75a8289059edc73bd7ed863a8a37507b466a1`.

## Risks and rollback

The remaining bounded risk is an unobserved provider schema variant or production-scale historical backfill behavior. Parser-version backfill, source-native-only IDs, nullable semantics, migration fixtures, and full workspace coverage constrain that risk.

Before a core release, verify that `recall-powercontext` 0.1.1 is published in the catalog. Before release, rollback is a normal revert of this PR. After schema v13 has been applied, the added nullable columns are non-destructive and an older binary can ignore them; do not feed export schema v6 records to an older importer or `recall-powercontext` 0.1.0.
