### PR TITLE
Add Amp, OpenHands, Factory, and Aider source adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ One index across every AI coding CLI. Sync once, search everywhere, resume right
 | MiMo Code       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | ZCode           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Goose           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
+| Amp             |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
+| OpenHands       |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
+| Factory         |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
+| Aider           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   —    |      |
 
 ## Acknowledgements
 

--- a/src/adapters/aider.rs
+++ b/src/adapters/aider.rs
@@ -1,0 +1,336 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use crate::adapters::AdapterSyncContext;
+use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+};
+use crate::types::Role;
+
+const SOURCE: &str = "aider";
+const HISTORY_NAME: &str = ".aider.chat.history.md";
+
+pub(crate) struct AiderAdapter;
+
+impl SourceAdapter for AiderAdapter {
+    fn id(&self) -> &str {
+        SOURCE
+    }
+
+    fn label(&self) -> &str {
+        "AID"
+    }
+
+    fn resume_command(&self, _source_id: &str) -> Option<ResumeCommand> {
+        None
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let mut sessions = Vec::new();
+        for entry in collect_history_entries(&discovery_roots()) {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                continue;
+            };
+            if let Some(raw) = parse_history_entry(entry, mtime_ms)? {
+                sessions.push(raw);
+            }
+        }
+        Ok(sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        context: &AdapterSyncContext,
+        since_ts: Option<i64>,
+        _include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        Ok(Some(file_scan::run_file_scan_with_options(
+            context,
+            since_ts,
+            FileScanOptions::default(),
+            collect_history_entries(&discovery_roots()),
+            parse_history_entry,
+        )?))
+    }
+}
+
+fn discovery_roots() -> Vec<PathBuf> {
+    discovery_roots_from(std::env::current_dir().ok(), dirs::home_dir())
+}
+
+fn discovery_roots_from(cwd: Option<PathBuf>, home: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    if let Some(cwd) = cwd {
+        for dir in cwd_and_git_ancestors(&cwd) {
+            push_unique(&mut roots, &mut seen, dir);
+        }
+    }
+    if let Some(git_root) = home.map(|home| home.join("git"))
+        && git_root.is_dir()
+    {
+        for dir in bounded_git_layout_dirs(&git_root) {
+            push_unique(&mut roots, &mut seen, dir);
+        }
+    }
+    roots
+}
+
+fn cwd_and_git_ancestors(cwd: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut current = cwd.to_path_buf();
+    loop {
+        dirs.push(current.clone());
+        if current.join(".git").exists() {
+            break;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    dirs
+}
+
+fn bounded_git_layout_dirs(git_root: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![git_root.to_path_buf()];
+    let read = match fs::read_dir(git_root) {
+        Ok(read) => read,
+        Err(_) => return dirs,
+    };
+    for org in read.flatten() {
+        let org_path = org.path();
+        if !org_path.is_dir() {
+            continue;
+        }
+        dirs.push(org_path.clone());
+        let Ok(projects) = fs::read_dir(&org_path) else {
+            continue;
+        };
+        for project in projects.flatten() {
+            let project_path = project.path();
+            if project_path.is_dir() {
+                dirs.push(project_path);
+            }
+        }
+    }
+    dirs
+}
+
+fn push_unique(dirs: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, dir: PathBuf) {
+    if seen.insert(dir.clone()) {
+        dirs.push(dir);
+    }
+}
+
+fn collect_history_entries(roots: &[PathBuf]) -> Vec<FileScanEntry> {
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for root in roots {
+        let path = root.join(HISTORY_NAME);
+        if !path.is_file() {
+            continue;
+        }
+        let Ok(canonical) = path.canonicalize() else {
+            continue;
+        };
+        if !seen.insert(canonical.clone()) {
+            continue;
+        }
+        let session_id = root.to_string_lossy().into_owned();
+        entries.push(FileScanEntry {
+            session_id,
+            stat_target: canonical,
+            directory: Some(root.to_string_lossy().into_owned()),
+        });
+    }
+    entries
+}
+
+fn parse_history_entry(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<Option<RawSession>> {
+    match parse_history_file(&entry.stat_target, &entry.session_id, entry.directory, mtime_ms) {
+        Ok(raw) => Ok(raw),
+        Err(err) => {
+            warn!("failed to parse Aider history {}: {err}", entry.stat_target.display());
+            Ok(None)
+        }
+    }
+}
+
+fn parse_history_file(
+    path: &Path,
+    source_id: &str,
+    directory: Option<String>,
+    mtime_ms: i64,
+) -> anyhow::Result<Option<RawSession>> {
+    let text = fs::read_to_string(path)?;
+    parse_history_markdown(&text, source_id, directory, mtime_ms, path.to_str().map(str::to_string))
+}
+
+fn parse_history_markdown(
+    text: &str,
+    source_id: &str,
+    directory: Option<String>,
+    mtime_ms: i64,
+    source_path: Option<String>,
+) -> anyhow::Result<Option<RawSession>> {
+    let messages = split_chat_history_markdown(text);
+    if messages.is_empty() {
+        return Ok(None);
+    }
+    let started_at = session_start_ms(text).unwrap_or(mtime_ms);
+    let mut raw = RawSession::search_only(
+        source_id.to_string(),
+        directory,
+        started_at,
+        Some(mtime_ms),
+        None,
+        messages,
+    );
+    raw.source_file_path = source_path;
+    Ok(Some(raw))
+}
+
+fn split_chat_history_markdown(text: &str) -> Vec<RawMessage> {
+    let mut messages = Vec::new();
+    let mut user = Vec::new();
+    let mut assistant = Vec::new();
+    let mut tool = Vec::new();
+
+    fn flush(role: Role, lines: &mut Vec<String>, messages: &mut Vec<RawMessage>) {
+        let content = lines.join("").trim().to_string();
+        lines.clear();
+        if !content.is_empty() {
+            messages.push(RawMessage { role, content, timestamp: None });
+        }
+    }
+
+    for line in text.split_inclusive('\n') {
+        if line.starts_with("# ") {
+            continue;
+        }
+        if line.starts_with("> ") {
+            flush(Role::Assistant, &mut assistant, &mut messages);
+            flush(Role::User, &mut user, &mut messages);
+            tool.push(line[2..].to_string());
+            continue;
+        }
+        if line.starts_with("#### ") {
+            flush(Role::Assistant, &mut assistant, &mut messages);
+            tool.clear();
+            user.push(line[5..].to_string());
+            continue;
+        }
+        flush(Role::User, &mut user, &mut messages);
+        tool.clear();
+        assistant.push(line.to_string());
+    }
+    flush(Role::Assistant, &mut assistant, &mut messages);
+    flush(Role::User, &mut user, &mut messages);
+    messages
+}
+
+fn session_start_ms(text: &str) -> Option<i64> {
+    for line in text.lines() {
+        let Some(rest) = line.strip_prefix("# aider chat started at ") else {
+            continue;
+        };
+        let rest = rest.trim();
+        if rest.is_empty() {
+            continue;
+        }
+        if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(rest, "%Y-%m-%d %H:%M:%S") {
+            return Some(naive.and_utc().timestamp_millis());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/aider")
+    }
+
+    #[test]
+    fn resume_is_none() {
+        assert!(AiderAdapter.resume_command("/tmp/proj").is_none());
+    }
+
+    #[test]
+    fn official_format_uses_heading_for_user_and_skips_quotes() {
+        let text =
+            fs::read_to_string(fixtures_dir().join("official.aider.chat.history.md")).unwrap();
+        let session =
+            parse_history_markdown(&text, "/tmp/proj", Some("/tmp/proj".to_string()), 1, None)
+                .unwrap()
+                .unwrap();
+        assert_eq!(session.messages.len(), 4);
+        assert_eq!(session.messages[0].role, Role::User);
+        assert_eq!(
+            session.messages[0].content,
+            "Show me the failing query\nand the tenant predicate"
+        );
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content, "The query misses the tenant predicate.");
+        assert_eq!(session.messages[2].role, Role::User);
+        assert_eq!(session.messages[2].content, "also check tests");
+        assert_eq!(session.messages[3].role, Role::Assistant);
+        assert_eq!(session.messages[3].content, "Tests look fine.");
+        assert!(session.messages.iter().all(|message| !message.content.contains("Applied edit")));
+    }
+
+    #[test]
+    fn fad_style_blockquote_is_not_user() {
+        let text = fs::read_to_string(fixtures_dir().join("fad-blockquote-not-user.md")).unwrap();
+        let session = parse_history_markdown(&text, "/tmp/proj", None, 1, None).unwrap().unwrap();
+        assert!(session.messages.iter().all(|message| message.role != Role::User));
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].role, Role::Assistant);
+        assert_eq!(session.messages[0].content, "The assistant reply stays assistant.");
+        assert!(!session.messages.iter().any(|message| {
+            message.content.contains("FAD-style") || message.role == Role::User
+        }));
+    }
+
+    #[test]
+    fn discovery_uses_cwd_git_ancestors_and_home_git_only() {
+        let home = tempfile::tempdir().unwrap();
+        let repo = home.path().join("work/repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::write(repo.join(HISTORY_NAME), "#### hi\n\nok\n").unwrap();
+        fs::create_dir_all(home.path().join("git/samzong/Recall")).unwrap();
+        fs::write(home.path().join("git/samzong/Recall").join(HISTORY_NAME), "#### git layout\n")
+            .unwrap();
+        fs::create_dir_all(home.path().join("secret")).unwrap();
+        fs::write(home.path().join("secret").join(HISTORY_NAME), "#### leaked\n").unwrap();
+        fs::write(home.path().join(HISTORY_NAME), "#### home file\n").unwrap();
+
+        let roots = discovery_roots_from(Some(repo.clone()), Some(home.path().to_path_buf()));
+        let entries = collect_history_entries(&roots);
+        let ids: Vec<_> = entries.iter().map(|entry| entry.directory.clone()).collect();
+        assert!(ids.iter().any(|dir| dir.as_deref() == Some(repo.to_str().unwrap())));
+        assert!(ids.iter().any(|dir| {
+            dir.as_deref() == Some(home.path().join("git/samzong/Recall").to_str().unwrap())
+        }));
+        assert!(ids.iter().all(|dir| {
+            dir.as_deref() != Some(home.path().to_str().unwrap())
+                && dir.as_deref() != Some(home.path().join("secret").to_str().unwrap())
+        }));
+    }
+
+    #[test]
+    fn missing_home_git_is_not_walked() {
+        let home = tempfile::tempdir().unwrap();
+        let cwd = home.path().join("cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        let roots = discovery_roots_from(Some(cwd), Some(home.path().to_path_buf()));
+        assert!(collect_history_entries(&roots).is_empty());
+    }
+}

--- a/src/adapters/aider.rs
+++ b/src/adapters/aider.rs
@@ -6,9 +6,7 @@ use tracing::warn;
 
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
-use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-};
+use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult};
 use crate::types::Role;
 
 const SOURCE: &str = "aider";
@@ -213,16 +211,16 @@ fn split_chat_history_markdown(text: &str) -> Vec<RawMessage> {
         if line.starts_with("# ") {
             continue;
         }
-        if line.starts_with("> ") {
+        if let Some(rest) = line.strip_prefix("> ") {
             flush(Role::Assistant, &mut assistant, &mut messages);
             flush(Role::User, &mut user, &mut messages);
-            tool.push(line[2..].to_string());
+            tool.push(rest.to_string());
             continue;
         }
-        if line.starts_with("#### ") {
+        if let Some(rest) = line.strip_prefix("#### ") {
             flush(Role::Assistant, &mut assistant, &mut messages);
             tool.clear();
-            user.push(line[5..].to_string());
+            user.push(rest.to_string());
             continue;
         }
         flush(Role::User, &mut user, &mut messages);

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -159,7 +159,7 @@ fn is_amp_thread_file(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
-    if !name.ends_with(".json") || SKIP_NAMES.iter().any(|skip| *skip == name) {
+    if !name.ends_with(".json") || SKIP_NAMES.contains(&name) {
         return false;
     }
     let parent = path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str());
@@ -281,7 +281,7 @@ fn env_cwd(env: Option<&Value>) -> Option<String> {
     if let Some(cwd) = string_path(env.get("cwd")) {
         return Some(cwd);
     }
-    if let Some(cwd) = env.get("initial").and_then(env_cwd) {
+    if let Some(cwd) = env_cwd(env.get("initial")) {
         return Some(cwd);
     }
     let trees = env.get("trees").and_then(Value::as_array)?;
@@ -344,11 +344,10 @@ mod tests {
     fn resume_uses_threads_continue_and_json_id() {
         let command = AmpAdapter.resume_command("T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001").unwrap();
         assert_eq!(command.program, "amp");
-        assert_eq!(command.args, vec![
-            "threads",
-            "continue",
-            "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"
-        ]);
+        assert_eq!(
+            command.args,
+            vec!["threads", "continue", "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"]
+        );
     }
 
     #[test]

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -1,0 +1,485 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::adapters::AdapterSyncContext;
+use crate::adapters::json_util::{json_i64, rfc3339_ms};
+use crate::adapters::paths::vscode_extension_storage_dirs_from;
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+    first_timestamp, last_timestamp,
+};
+use crate::types::Role;
+
+const SOURCE: &str = "amp";
+const EXTENSION_ID: &str = "sourcegraph.amp";
+const MAX_THREAD_BYTES: u64 = 8 * 1024 * 1024;
+const SKIP_NAMES: &[&str] = &["config.json", "settings.json", "secrets.json"];
+
+pub(crate) struct AmpAdapter;
+
+impl SourceAdapter for AmpAdapter {
+    fn id(&self) -> &str {
+        SOURCE
+    }
+
+    fn label(&self) -> &str {
+        "AM"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "amp".to_string(),
+            args: vec!["threads".to_string(), "continue".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        Ok(scan_threads(&thread_roots(), None)?.sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        _context: &AdapterSyncContext,
+        since_ts: Option<i64>,
+        _include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        Ok(Some(scan_threads(&thread_roots(), since_ts)?))
+    }
+}
+
+fn thread_roots() -> Vec<PathBuf> {
+    thread_roots_from(
+        std::env::var("AMP_THREADS_DIR").ok(),
+        std::env::var("XDG_DATA_HOME").ok(),
+        dirs::home_dir(),
+        dirs::config_dir(),
+    )
+}
+
+fn thread_roots_from(
+    amp_threads_dir: Option<String>,
+    xdg_data_home: Option<String>,
+    home: Option<PathBuf>,
+    config_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(dir) = amp_threads_dir.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(dir);
+        if path.is_dir() {
+            roots.push(path);
+        }
+    }
+    let xdg = xdg_data_home
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home.map(|home| home.join(".local/share")));
+    if let Some(xdg) = xdg {
+        let path = xdg.join("amp/threads");
+        if path.is_dir() {
+            roots.push(path);
+        }
+    }
+    for storage in vscode_extension_storage_dirs_from(config_dir, EXTENSION_ID) {
+        for name in ["threads3", "threads"] {
+            let path = storage.join(name);
+            if path.is_dir() {
+                roots.push(path);
+            }
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn scan_threads(roots: &[PathBuf], since_ts: Option<i64>) -> anyhow::Result<SyncScanResult> {
+    let mut sessions = Vec::new();
+    let mut stats = SyncScanStats::default();
+    let mut by_id: HashMap<String, RawSession> = HashMap::new();
+
+    for path in collect_thread_files(roots) {
+        stats.candidates += 1;
+        let Ok(meta) = fs::metadata(&path) else {
+            stats.rejected_before_parse += 1;
+            continue;
+        };
+        if meta.len() > MAX_THREAD_BYTES {
+            debug!("skipping oversized Amp thread {}", path.display());
+            stats.rejected_before_parse += 1;
+            continue;
+        }
+        match parse_thread_file(&path) {
+            Ok(Some(raw)) => {
+                if since_ts.is_some_and(|cutoff| {
+                    last_timestamp(raw.updated_at, &raw.messages, &[], &[])
+                        .is_some_and(|updated| updated < cutoff)
+                }) {
+                    stats.filtered_sessions += 1;
+                    continue;
+                }
+                stats.parsed += 1;
+                by_id.entry(raw.source_id.clone()).or_insert(raw);
+            }
+            Ok(None) => {}
+            Err(err) => warn!("failed to parse Amp thread {}: {err}", path.display()),
+        }
+    }
+
+    sessions.extend(by_id.into_values());
+    Ok(SyncScanResult { sessions, stats, observations: Vec::new() })
+}
+
+fn collect_thread_files(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for root in roots {
+        let read = match fs::read_dir(root) {
+            Ok(read) => read,
+            Err(err) => {
+                debug!("cannot read Amp threads dir {}: {err}", root.display());
+                continue;
+            }
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.is_file() && is_amp_thread_file(&path) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn is_amp_thread_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !name.ends_with(".json") || SKIP_NAMES.iter().any(|skip| *skip == name) {
+        return false;
+    }
+    let parent = path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str());
+    if matches!(parent, Some("threads" | "threads3")) {
+        return true;
+    }
+    name == "thread.json"
+        || name.starts_with("conversation")
+        || name.starts_with("chat")
+        || name.starts_with("T-")
+}
+
+fn parse_thread_file(path: &Path) -> anyhow::Result<Option<RawSession>> {
+    let raw = fs::read_to_string(path)?;
+    let value: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!("failed to parse Amp JSON {}: {err}", path.display());
+            return Ok(None);
+        }
+    };
+    Ok(parse_thread_value(&value, path))
+}
+
+fn parse_thread_value(value: &Value, path: &Path) -> Option<RawSession> {
+    let doc = value.get("thread").filter(|thread| thread.is_object()).unwrap_or(value);
+    let source_id = doc
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .filter(|stem| *stem != "thread")
+                .map(|stem| stem.to_string())
+        })?;
+    let messages_value = doc.get("messages").or_else(|| value.get("messages"));
+    let messages = parse_messages(messages_value);
+    if messages.is_empty() {
+        return None;
+    }
+    let created = json_i64(doc.get("created")).or_else(|| rfc3339_ms(doc.get("created")));
+    let started_at = first_timestamp(created, &messages, &[], &[]).unwrap_or(0);
+    let updated_at = last_timestamp(created, &messages, &[], &[]);
+    let mut session = RawSession::search_only(
+        source_id,
+        env_cwd(doc.get("env")).or_else(|| env_cwd(value.get("env"))),
+        started_at,
+        updated_at,
+        None,
+        messages,
+    );
+    session.source_file_path = path.to_str().map(str::to_string);
+    session.custom_title = doc
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_string);
+    Some(session)
+}
+
+fn parse_messages(value: Option<&Value>) -> Vec<RawMessage> {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for item in items {
+        let Some(role) = parse_role(item.get("role").and_then(Value::as_str).unwrap_or("")) else {
+            continue;
+        };
+        let content = extract_text(item.get("content"));
+        if content.is_empty() {
+            continue;
+        }
+        let timestamp = json_i64(item.get("created"))
+            .or_else(|| rfc3339_ms(item.get("created")))
+            .or_else(|| json_i64(item.get("timestamp")))
+            .or_else(|| rfc3339_ms(item.get("timestamp")))
+            .or_else(|| json_i64(item.pointer("/meta/sentAt")));
+        messages.push(RawMessage { role, content, timestamp });
+    }
+    messages
+}
+
+fn parse_role(role: &str) -> Option<Role> {
+    match role {
+        "human" | "user" => Some(Role::User),
+        "agent" | "assistant" => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn extract_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Array(blocks)) => {
+            blocks.iter().filter_map(block_text).collect::<Vec<_>>().join("\n").trim().to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+fn block_text(block: &Value) -> Option<&str> {
+    if let Some(text) = block.as_str().map(str::trim).filter(|text| !text.is_empty()) {
+        return Some(text);
+    }
+    let kind = block.get("type").and_then(Value::as_str).unwrap_or("text");
+    if kind != "text" {
+        return None;
+    }
+    block.get("text").and_then(Value::as_str).map(str::trim).filter(|text| !text.is_empty())
+}
+
+fn env_cwd(env: Option<&Value>) -> Option<String> {
+    let env = env?;
+    if let Some(cwd) = string_path(env.get("cwd")) {
+        return Some(cwd);
+    }
+    if let Some(cwd) = env.get("initial").and_then(env_cwd) {
+        return Some(cwd);
+    }
+    let trees = env.get("trees").and_then(Value::as_array)?;
+    for tree in trees {
+        if let Some(cwd) = string_path(tree.get("cwd"))
+            .or_else(|| string_path(tree.get("path")))
+            .or_else(|| string_path(tree.get("fsPath")))
+            .or_else(|| file_uri_path(tree.get("uri")))
+        {
+            return Some(cwd);
+        }
+    }
+    None
+}
+
+fn string_path(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn file_uri_path(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(uri)) => {
+            let text = uri.trim();
+            if text.is_empty() {
+                None
+            } else if let Some(rest) = text.strip_prefix("file://") {
+                Some(rest.to_string())
+            } else {
+                Some(text.to_string())
+            }
+        }
+        Some(Value::Object(map)) => {
+            string_path(map.get("fsPath")).or_else(|| string_path(map.get("path")))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/amp")
+    }
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn resume_uses_threads_continue_and_json_id() {
+        let command = AmpAdapter.resume_command("T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001").unwrap();
+        assert_eq!(command.program, "amp");
+        assert_eq!(command.args, vec![
+            "threads",
+            "continue",
+            "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"
+        ]);
+    }
+
+    #[test]
+    fn missing_roots_are_empty() {
+        let roots = thread_roots_from(None, None, Some(PathBuf::from("/no/such/home")), None);
+        assert!(roots.is_empty());
+        let result = scan_threads(&roots, None).unwrap();
+        assert!(result.sessions.is_empty());
+    }
+
+    #[test]
+    fn amp_threads_dir_and_xdg_are_scanned_when_present() {
+        let root = tempfile::tempdir().unwrap();
+        let amp_dir = root.path().join("amp-threads");
+        let xdg = root.path().join("xdg");
+        fs::create_dir_all(&amp_dir).unwrap();
+        fs::create_dir_all(xdg.join("amp/threads")).unwrap();
+        let roots = thread_roots_from(
+            Some(amp_dir.to_string_lossy().into_owned()),
+            Some(xdg.to_string_lossy().into_owned()),
+            Some(PathBuf::from("/unused")),
+            None,
+        );
+        assert_eq!(roots, vec![amp_dir, xdg.join("amp/threads")]);
+    }
+
+    #[test]
+    fn vscode_threads3_and_threads_children_are_roots() {
+        let config = tempfile::tempdir().unwrap();
+        let storage =
+            config.path().join("Code").join("User").join("globalStorage").join(EXTENSION_ID);
+        fs::create_dir_all(storage.join("threads3")).unwrap();
+        fs::create_dir_all(storage.join("threads")).unwrap();
+        let roots = thread_roots_from(
+            None,
+            None,
+            Some(PathBuf::from("/unused")),
+            Some(config.path().to_path_buf()),
+        );
+        assert!(roots.contains(&storage.join("threads3")));
+        assert!(roots.contains(&storage.join("threads")));
+    }
+
+    #[test]
+    fn parse_prefers_object_id_over_filename_thread_json() {
+        let path = fixtures_dir().join("thread.json");
+        let session = parse_thread_file(&path).unwrap().unwrap();
+        assert_eq!(session.source_id, "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001");
+        assert_eq!(session.custom_title.as_deref(), Some("Amp thread title"));
+        assert_eq!(session.directory.as_deref(), Some("/tmp/amp-project"));
+        assert_eq!(session.started_at, 1_700_000_000_000);
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].role, Role::User);
+        assert_eq!(session.messages[0].content, "hello from amp");
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content, "hi back");
+    }
+
+    #[test]
+    fn parse_reads_thread_messages_wrapper() {
+        let path = fixtures_dir().join("wrapped-thread.json");
+        let session = parse_thread_file(&path).unwrap().unwrap();
+        assert_eq!(session.source_id, "T-0199cccc-dddd-7eee-8fff-000011112222");
+        assert_eq!(session.messages[0].content, "wrapped user");
+        assert_eq!(session.messages[1].content, "wrapped assistant");
+    }
+
+    #[test]
+    fn skips_secrets_and_settings() {
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/secrets.json")));
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/settings.json")));
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/config.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/T-abc.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/thread.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/conversation-1.json")));
+    }
+
+    #[test]
+    fn incremental_rereads_when_mtime_stale_and_size_grown() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("thread.json");
+        fs::copy(fixtures_dir().join("thread.json"), &path).unwrap();
+        let first_mtime = 1_700_000_000_000i64;
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH + Duration::from_millis(first_mtime as u64))
+            .unwrap();
+
+        let first = scan_threads(&[root.path().to_path_buf()], None).unwrap();
+        assert_eq!(first.sessions.len(), 1);
+        assert_eq!(first.sessions[0].messages.len(), 2);
+
+        let store = setup_store();
+        store
+            .insert_session(&Session {
+                id: "local-amp".to_string(),
+                source: SOURCE.to_string(),
+                source_id: "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001".to_string(),
+                title: "existing".to_string(),
+                directory: None,
+                repo_remote: None,
+                repo_slug: None,
+                repo_name: None,
+                started_at: first_mtime,
+                updated_at: Some(first_mtime),
+                message_count: 2,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: path.to_str().map(str::to_string),
+                is_import: false,
+            })
+            .unwrap();
+
+        let mut value: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        value["messages"].as_array_mut().unwrap().push(serde_json::json!({
+            "role": "human",
+            "content": [{ "type": "text", "text": "appended without mtime" }],
+            "created": 1700000003000u64
+        }));
+        fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH + Duration::from_millis(first_mtime as u64))
+            .unwrap();
+
+        let result = scan_threads(&[root.path().to_path_buf()], None).unwrap();
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].messages.len(), 3);
+        assert_eq!(result.sessions[0].messages[2].content, "appended without mtime");
+    }
+}

--- a/src/adapters/factory.rs
+++ b/src/adapters/factory.rs
@@ -358,12 +358,10 @@ fn session_usage(
     let output_tokens = usage_count(usage, &["outputTokens", "output_tokens", "output"]);
     let cache_read_tokens =
         usage_count(usage, &["cacheReadTokens", "cache_read_tokens", "cache", "cacheRead"]);
-    let cache_write_tokens = usage_count(usage, &[
-        "cacheCreationTokens",
-        "cache_creation_tokens",
-        "cacheWriteTokens",
-        "cache_write",
-    ]);
+    let cache_write_tokens = usage_count(
+        usage,
+        &["cacheCreationTokens", "cache_creation_tokens", "cacheWriteTokens", "cache_write"],
+    );
     let reasoning_tokens =
         usage_count(usage, &["thinkingTokens", "thinking_tokens", "thinking", "reasoning"]);
     if input_tokens == 0

--- a/src/adapters/factory.rs
+++ b/src/adapters/factory.rs
@@ -1,0 +1,499 @@
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tracing::warn;
+use walkdir::WalkDir;
+
+use crate::adapters::AdapterSyncContext;
+use crate::adapters::events;
+use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
+use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
+use crate::adapters::usage::usage_count;
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+    first_timestamp,
+};
+use crate::types::{RawSessionEvent, RawUsageEvent, Role};
+
+const SOURCE: &str = "factory";
+const USAGE_PARSER_VERSION: u32 = 1;
+const EVENT_PARSER_VERSION: u32 = 1;
+
+pub(crate) struct FactoryAdapter;
+
+impl SourceAdapter for FactoryAdapter {
+    fn id(&self) -> &str {
+        SOURCE
+    }
+
+    fn label(&self) -> &str {
+        "FAC"
+    }
+
+    fn usage_parser_version(&self) -> Option<u32> {
+        Some(USAGE_PARSER_VERSION)
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "droid".to_string(),
+            args: vec!["--resume".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let mut sessions = Vec::new();
+        for entry in collect_session_entries(&sessions_dir()) {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                continue;
+            };
+            if let Some(raw) = parse_session_entry(entry, mtime_ms, true)? {
+                sessions.push(raw);
+            }
+        }
+        Ok(sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        context: &AdapterSyncContext,
+        since_ts: Option<i64>,
+        include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(root) = sessions_dir() else {
+            return Ok(Some(SyncScanResult {
+                sessions: Vec::new(),
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
+        };
+        Ok(Some(file_scan::run_file_scan_with_options(
+            context,
+            since_ts,
+            FileScanOptions {
+                usage_parser_version: Some(USAGE_PARSER_VERSION),
+                event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+                metadata_parser_version: None,
+            },
+            collect_session_entries(&Some(root)),
+            |entry, mtime_ms| parse_session_entry(entry, mtime_ms, include_events),
+        )?))
+    }
+}
+
+fn sessions_dir() -> Option<PathBuf> {
+    sessions_dir_from(dirs::home_dir())
+}
+
+fn sessions_dir_from(home: Option<PathBuf>) -> Option<PathBuf> {
+    let dir = home?.join(".factory/sessions");
+    dir.is_dir().then_some(dir)
+}
+
+fn collect_session_entries(root: &Option<PathBuf>) -> Vec<FileScanEntry> {
+    let Some(root) = root else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(session_id) = path.file_stem().and_then(|stem| stem.to_str()).map(str::to_string)
+        else {
+            continue;
+        };
+        entries.push(FileScanEntry {
+            session_id,
+            stat_target: path.to_path_buf(),
+            directory: None,
+        });
+    }
+    entries
+}
+
+fn parse_session_entry(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    match parse_session_file(&entry.stat_target, &entry.session_id, mtime_ms, include_events) {
+        Ok(raw) => Ok(raw),
+        Err(err) => {
+            warn!("failed to parse Factory session {}: {err}", entry.stat_target.display());
+            Ok(None)
+        }
+    }
+}
+
+fn parse_session_file(
+    path: &Path,
+    fallback_id: &str,
+    mtime_ms: i64,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    let file = fs::File::open(path)?;
+    let settings = read_settings(&settings_path(path));
+    parse_factory_jsonl(
+        BufReader::new(file).lines(),
+        fallback_id,
+        mtime_ms,
+        path.to_str().map(str::to_string),
+        settings.as_ref(),
+        include_events,
+    )
+}
+
+fn settings_path(jsonl: &Path) -> PathBuf {
+    let stem = jsonl.file_stem().and_then(|stem| stem.to_str()).unwrap_or_default();
+    jsonl.with_file_name(format!("{stem}.settings.json"))
+}
+
+fn read_settings(path: &Path) -> Option<Value> {
+    let raw = fs::read_to_string(path).ok()?;
+    match serde_json::from_str(&raw) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            warn!("failed to parse Factory settings {}: {err}", path.display());
+            None
+        }
+    }
+}
+
+fn parse_factory_jsonl(
+    lines: impl Iterator<Item = std::io::Result<String>>,
+    fallback_id: &str,
+    mtime_ms: i64,
+    source_path: Option<String>,
+    settings: Option<&Value>,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    let mut messages = Vec::new();
+    let mut events = Vec::new();
+    let mut source_id = fallback_id.to_string();
+    let mut directory = None;
+    let mut custom_title = None;
+
+    for item in jsonl_indexed(lines) {
+        let (_index, record) = item?;
+        take_meta(&record, &mut source_id, &mut directory, &mut custom_title);
+        let kind = record_kind(&record);
+        let timestamp =
+            json_i64(record.get("timestamp")).or_else(|| rfc3339_ms(record.get("timestamp")));
+        match kind {
+            "user" | "human" => {
+                if let Some(content) = record_text(&record) {
+                    messages.push(RawMessage { role: Role::User, content, timestamp });
+                }
+            }
+            "assistant" | "agent" => {
+                if let Some(content) = record_text(&record) {
+                    messages.push(RawMessage { role: Role::Assistant, content, timestamp });
+                }
+                if include_events {
+                    collect_tool_calls(&record, timestamp, source_path.as_deref(), &mut events);
+                }
+            }
+            "tool" | "tool_result" | "tool_use" if include_events => {
+                if kind == "tool_use" {
+                    collect_tool_calls(&record, timestamp, source_path.as_deref(), &mut events);
+                } else {
+                    events.push(events::tool_result_event(
+                        events::EventContext {
+                            event_seq: events.len() as u32,
+                            timestamp,
+                            source_path: source_path.clone(),
+                            source_event_id: json_opt(&record, &["id", "tool_use_id"]),
+                            message_seq: None,
+                            parser_version: EVENT_PARSER_VERSION,
+                        },
+                        json_opt(&record, &["name", "tool"]),
+                        record_text(&record),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if custom_title.is_none() {
+        custom_title = settings.and_then(|value| json_opt(value, &["title"]));
+    }
+
+    let usage_events = settings
+        .map(|value| session_usage(value, &source_id, mtime_ms, source_path.as_deref()))
+        .unwrap_or_default();
+    if messages.is_empty() && usage_events.is_empty() && events.is_empty() {
+        return Ok(None);
+    }
+
+    let started_at = first_timestamp(None, &messages, &usage_events, &events).unwrap_or(mtime_ms);
+    let mut raw =
+        RawSession::search_only(source_id, directory, started_at, Some(mtime_ms), None, messages)
+            .with_usage(usage_events, USAGE_PARSER_VERSION);
+    raw.source_file_path = source_path;
+    raw.custom_title = custom_title;
+    if include_events {
+        raw = raw.with_events(events, EVENT_PARSER_VERSION);
+    }
+    Ok(Some(raw))
+}
+
+fn take_meta(
+    record: &Value,
+    source_id: &mut String,
+    directory: &mut Option<String>,
+    custom_title: &mut Option<String>,
+) {
+    if let Some(id) = json_opt(record, &["sessionId", "session_id", "id"])
+        && record_kind(record).is_empty()
+    {
+        *source_id = id;
+    }
+    if directory.is_none() {
+        *directory = json_opt(record, &["cwd", "workingDirectory", "working_directory"]);
+    }
+    if custom_title.is_none() {
+        *custom_title = json_opt(record, &["title"]);
+    }
+}
+
+fn record_kind(record: &Value) -> &str {
+    record.get("type").or_else(|| record.get("role")).and_then(Value::as_str).unwrap_or("")
+}
+
+fn record_text(record: &Value) -> Option<String> {
+    extract_text(record.get("content"))
+        .or_else(|| extract_text(record.pointer("/message/content")))
+        .or_else(|| extract_text(record.get("text")))
+}
+
+fn extract_text(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(text)) => {
+            let text = text.trim();
+            if text.is_empty() { None } else { Some(text.to_string()) }
+        }
+        Some(Value::Array(blocks)) => {
+            let text = blocks.iter().filter_map(block_text).collect::<Vec<_>>().join("\n");
+            let text = text.trim();
+            if text.is_empty() { None } else { Some(text.to_string()) }
+        }
+        _ => None,
+    }
+}
+
+fn block_text(block: &Value) -> Option<&str> {
+    if let Some(text) = block.as_str().map(str::trim).filter(|text| !text.is_empty()) {
+        return Some(text);
+    }
+    let kind = block.get("type").and_then(Value::as_str).unwrap_or("text");
+    if kind != "text" {
+        return None;
+    }
+    block.get("text").and_then(Value::as_str).map(str::trim).filter(|text| !text.is_empty())
+}
+
+fn collect_tool_calls(
+    record: &Value,
+    timestamp: Option<i64>,
+    source_path: Option<&str>,
+    events_out: &mut Vec<RawSessionEvent>,
+) {
+    if record_kind(record) == "tool_use"
+        && let Some(name) = json_opt(record, &["name", "tool"])
+    {
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: source_path.map(str::to_string),
+                source_event_id: json_opt(record, &["id"]),
+                message_seq: None,
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name,
+            record.get("input").or_else(|| record.get("arguments")),
+        ));
+    }
+    let content = record.get("content").or_else(|| record.pointer("/message/content"));
+    let Some(Value::Array(blocks)) = content else {
+        return;
+    };
+    for block in blocks {
+        if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+            continue;
+        }
+        let Some(name) = json_opt(block, &["name", "tool"]) else {
+            continue;
+        };
+        events_out.push(events::tool_call_event(
+            events::EventContext {
+                event_seq: events_out.len() as u32,
+                timestamp,
+                source_path: source_path.map(str::to_string),
+                source_event_id: json_opt(block, &["id"]),
+                message_seq: None,
+                parser_version: EVENT_PARSER_VERSION,
+            },
+            name,
+            block.get("input").or_else(|| block.get("arguments")),
+        ));
+    }
+}
+
+fn session_usage(
+    settings: &Value,
+    session_id: &str,
+    timestamp: i64,
+    source_path: Option<&str>,
+) -> Vec<RawUsageEvent> {
+    let Some(usage) = settings.get("tokenUsage").or_else(|| settings.get("token_usage")) else {
+        return Vec::new();
+    };
+    let input_tokens = usage_count(usage, &["inputTokens", "input_tokens", "input"]);
+    let output_tokens = usage_count(usage, &["outputTokens", "output_tokens", "output"]);
+    let cache_read_tokens =
+        usage_count(usage, &["cacheReadTokens", "cache_read_tokens", "cache", "cacheRead"]);
+    let cache_write_tokens = usage_count(usage, &[
+        "cacheCreationTokens",
+        "cache_creation_tokens",
+        "cacheWriteTokens",
+        "cache_write",
+    ]);
+    let reasoning_tokens =
+        usage_count(usage, &["thinkingTokens", "thinking_tokens", "thinking", "reasoning"]);
+    if input_tokens == 0
+        && output_tokens == 0
+        && cache_read_tokens == 0
+        && cache_write_tokens == 0
+        && reasoning_tokens == 0
+    {
+        return Vec::new();
+    }
+    let model = json_opt(settings, &["model"]).unwrap_or_else(|| "unknown".to_string());
+    let provider = json_opt(settings, &["provider"]).unwrap_or_else(|| "factory".to_string());
+    let mut event = RawUsageEvent::observed(
+        format!("settings:{session_id}"),
+        0,
+        timestamp,
+        USAGE_PARSER_VERSION,
+    );
+    event.model = model;
+    event.provider = provider;
+    event.input_tokens = input_tokens;
+    event.output_tokens = output_tokens;
+    event.cache_read_tokens = cache_read_tokens;
+    event.cache_write_tokens = cache_write_tokens;
+    event.reasoning_tokens = reasoning_tokens;
+    event.source_path = source_path.map(str::to_string);
+    event.raw_usage_json = Some(usage.to_string());
+    vec![event]
+}
+
+fn json_opt(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/factory")
+    }
+
+    fn fixture_session() -> PathBuf {
+        fixtures_dir()
+            .join("-Users-alice-Dev-myproject")
+            .join("11111111-2222-4333-8444-555555555555.jsonl")
+    }
+
+    #[test]
+    fn resume_uses_droid_flag() {
+        let command =
+            FactoryAdapter.resume_command("11111111-2222-4333-8444-555555555555").unwrap();
+        assert_eq!(command.program, "droid");
+        assert_eq!(command.args, vec!["--resume", "11111111-2222-4333-8444-555555555555"]);
+    }
+
+    #[test]
+    fn missing_sessions_dir_is_empty() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(sessions_dir_from(Some(home.path().to_path_buf())).is_none());
+        assert!(collect_session_entries(&None).is_empty());
+    }
+
+    #[test]
+    fn only_factory_sessions_are_walked() {
+        let home = tempfile::tempdir().unwrap();
+        fs::create_dir_all(home.path().join(".factory/other")).unwrap();
+        fs::write(home.path().join(".factory/settings.json"), "{}").unwrap();
+        fs::create_dir_all(home.path().join(".factory/sessions")).unwrap();
+        assert_eq!(
+            sessions_dir_from(Some(home.path().to_path_buf())).unwrap(),
+            home.path().join(".factory/sessions")
+        );
+        assert!(
+            collect_session_entries(&sessions_dir_from(Some(home.path().to_path_buf()))).is_empty()
+        );
+    }
+
+    #[test]
+    fn scan_reads_slug_jsonl_and_settings_token_usage() {
+        let home = tempfile::tempdir().unwrap();
+        let dest = home.path().join(".factory/sessions/-Users-alice-Dev-myproject");
+        fs::create_dir_all(&dest).unwrap();
+        fs::copy(fixture_session(), dest.join("11111111-2222-4333-8444-555555555555.jsonl"))
+            .unwrap();
+        fs::copy(
+            fixtures_dir()
+                .join("-Users-alice-Dev-myproject")
+                .join("11111111-2222-4333-8444-555555555555.settings.json"),
+            dest.join("11111111-2222-4333-8444-555555555555.settings.json"),
+        )
+        .unwrap();
+
+        let entries = collect_session_entries(&sessions_dir_from(Some(home.path().to_path_buf())));
+        assert_eq!(entries.len(), 1);
+        let session =
+            parse_session_entry(entries.into_iter().next().unwrap(), 99, true).unwrap().unwrap();
+        assert_eq!(session.source_id, "11111111-2222-4333-8444-555555555555");
+        assert_eq!(session.directory.as_deref(), Some("/Users/alice/Dev/myproject"));
+        assert_eq!(session.custom_title.as_deref(), Some("Fix auth"));
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "fix the login");
+        assert_eq!(session.messages[1].content, "looking at auth.py");
+        assert_eq!(session.events.len(), 2);
+        assert_eq!(session.events[0].name.as_deref(), Some("read"));
+        assert_eq!(session.events[0].target.as_deref(), Some("/Users/alice/Dev/myproject/auth.py"));
+        assert_eq!(session.events[1].kind, "tool_result");
+        assert_eq!(session.usage_events.len(), 1);
+        assert_eq!(session.usage_events[0].model, "claude-sonnet-4");
+        assert_eq!(session.usage_events[0].input_tokens, 100);
+        assert_eq!(session.usage_events[0].output_tokens, 40);
+        assert_eq!(session.usage_events[0].cache_read_tokens, 10);
+        assert_eq!(session.usage_events[0].cache_write_tokens, 5);
+        assert_eq!(session.usage_events[0].reasoning_tokens, 8);
+    }
+
+    #[test]
+    fn settings_json_is_not_a_session() {
+        let home = tempfile::tempdir().unwrap();
+        let dest = home.path().join(".factory/sessions/proj");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(
+            dest.join("sess.settings.json"),
+            r#"{"model":"x","tokenUsage":{"inputTokens":1}}"#,
+        )
+        .unwrap();
+        assert!(collect_session_entries(&Some(home.path().join(".factory/sessions"))).is_empty());
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod aider;
+pub(crate) mod amp;
 pub(crate) mod antigravity;
 pub(crate) mod claude_code;
 pub(crate) mod cline;
@@ -8,6 +10,7 @@ pub(crate) mod crush;
 pub(crate) mod cursor;
 pub(crate) mod deepseek_harness;
 pub(crate) mod events;
+pub(crate) mod factory;
 pub(crate) mod file_scan;
 pub(crate) mod gemini;
 pub(crate) mod goose;
@@ -20,6 +23,7 @@ pub(crate) mod kiro;
 pub(crate) mod mimo_code;
 pub(crate) mod omp;
 pub(crate) mod opencode;
+pub(crate) mod openhands;
 pub(crate) mod paths;
 pub(crate) mod pi;
 pub(crate) mod qwen;
@@ -369,6 +373,10 @@ pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(mimo_code::MimoCodeAdapter),
         Box::new(zcode::ZcodeAdapter),
         Box::new(goose::GooseAdapter),
+        Box::new(amp::AmpAdapter),
+        Box::new(openhands::OpenHandsAdapter),
+        Box::new(factory::FactoryAdapter),
+        Box::new(aider::AiderAdapter),
     ]
 }
 
@@ -397,6 +405,8 @@ pub(crate) fn source_supports_event_backfill(source_id: &str) -> bool {
             | "mimo-code"
             | "zcode"
             | "goose"
+            | "openhands"
+            | "factory"
     )
 }
 
@@ -416,4 +426,17 @@ pub(crate) fn dashboard_source_labels() -> Vec<(String, String)> {
         .filter(|adapter| adapter_supports_usage_dashboard(adapter.as_ref(), true))
         .map(|adapter| (adapter.id().to_string(), adapter.label().to_string()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_adapters;
+
+    #[test]
+    fn all_adapters_includes_amp_openhands_factory_aider() {
+        let ids: Vec<_> = all_adapters().iter().map(|adapter| adapter.id().to_string()).collect();
+        for id in ["amp", "openhands", "factory", "aider"] {
+            assert!(ids.iter().any(|existing| existing == id), "{id} missing from all_adapters()");
+        }
+    }
 }

--- a/src/adapters/openhands.rs
+++ b/src/adapters/openhands.rs
@@ -142,12 +142,7 @@ fn parse_conversation_entry(
     mtime_ms: i64,
     include_events: bool,
 ) -> anyhow::Result<Option<RawSession>> {
-    let dir = if entry.stat_target.file_name().and_then(|name| name.to_str()) == Some("events") {
-        entry.stat_target.parent().map(Path::to_path_buf)
-    } else {
-        entry.stat_target.parent().map(Path::to_path_buf)
-    };
-    let Some(dir) = dir else {
+    let Some(dir) = entry.stat_target.parent().map(Path::to_path_buf) else {
         return Ok(None);
     };
     match parse_conversation_dir(&dir, &entry.session_id, mtime_ms, include_events) {
@@ -278,10 +273,9 @@ fn parse_docs_messages(value: &Value) -> Vec<RawMessage> {
         let Some(role) = parse_role(item.get("role").and_then(Value::as_str).unwrap_or("")) else {
             continue;
         };
-        let content = extract_text(item.get("content"));
-        if content.is_empty() {
+        let Some(content) = extract_text(item.get("content")) else {
             continue;
-        }
+        };
         messages.push(RawMessage { role, content, timestamp: event_timestamp(item) });
     }
     messages

--- a/src/adapters/openhands.rs
+++ b/src/adapters/openhands.rs
@@ -1,0 +1,595 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::adapters::AdapterSyncContext;
+use crate::adapters::events;
+use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
+use crate::adapters::json_util::{json_i64, rfc3339_ms};
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+    first_timestamp, last_timestamp,
+};
+use crate::types::{RawSessionEvent, Role};
+
+const SOURCE: &str = "openhands";
+const EVENT_PARSER_VERSION: u32 = 1;
+
+pub(crate) struct OpenHandsAdapter;
+
+impl SourceAdapter for OpenHandsAdapter {
+    fn id(&self) -> &str {
+        SOURCE
+    }
+
+    fn label(&self) -> &str {
+        "OH"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "openhands".to_string(),
+            args: vec!["--resume".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        let mut sessions = Vec::new();
+        for entry in collect_conversation_entries(&conversations_dir()) {
+            if let Some(raw) = parse_conversation_entry(entry, 0, true)? {
+                sessions.push(raw);
+            }
+        }
+        Ok(sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        context: &AdapterSyncContext,
+        since_ts: Option<i64>,
+        include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        let Some(root) = conversations_dir() else {
+            return Ok(Some(SyncScanResult {
+                sessions: Vec::new(),
+                stats: SyncScanStats::default(),
+                observations: Vec::new(),
+            }));
+        };
+        Ok(Some(file_scan::run_file_scan_with_options(
+            context,
+            since_ts,
+            FileScanOptions {
+                usage_parser_version: None,
+                event_parser_version: include_events.then_some(EVENT_PARSER_VERSION),
+                metadata_parser_version: None,
+            },
+            collect_conversation_entries(&Some(root)),
+            |entry, mtime_ms| parse_conversation_entry(entry, mtime_ms, include_events),
+        )?))
+    }
+}
+
+fn conversations_dir() -> Option<PathBuf> {
+    conversations_dir_from(
+        std::env::var("OH_PERSISTENCE_DIR").ok(),
+        std::env::var("FILE_STORE_PATH").ok(),
+        dirs::home_dir(),
+    )
+}
+
+fn conversations_dir_from(
+    oh_persistence_dir: Option<String>,
+    file_store_path: Option<String>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let persistence = oh_persistence_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            file_store_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| home.map(|home| home.join(".openhands")))?;
+    let dir = persistence.join("conversations");
+    dir.is_dir().then_some(dir)
+}
+
+fn collect_conversation_entries(root: &Option<PathBuf>) -> Vec<FileScanEntry> {
+    let Some(root) = root else {
+        return Vec::new();
+    };
+    let read = match fs::read_dir(root) {
+        Ok(read) => read,
+        Err(err) => {
+            debug!("cannot read OpenHands conversations {}: {err}", root.display());
+            return Vec::new();
+        }
+    };
+    let mut entries = Vec::new();
+    for entry in read.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(source_id) = path.file_name().and_then(|name| name.to_str()).map(str::to_string)
+        else {
+            continue;
+        };
+        let events_dir = path.join("events");
+        let conversation_json = path.join("conversation.json");
+        let stat_target = if events_dir.is_dir() {
+            events_dir
+        } else if conversation_json.is_file() {
+            conversation_json
+        } else {
+            continue;
+        };
+        entries.push(FileScanEntry { session_id: source_id, stat_target, directory: None });
+    }
+    entries
+}
+
+fn parse_conversation_entry(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    let dir = if entry.stat_target.file_name().and_then(|name| name.to_str()) == Some("events") {
+        entry.stat_target.parent().map(Path::to_path_buf)
+    } else {
+        entry.stat_target.parent().map(Path::to_path_buf)
+    };
+    let Some(dir) = dir else {
+        return Ok(None);
+    };
+    match parse_conversation_dir(&dir, &entry.session_id, mtime_ms, include_events) {
+        Ok(raw) => Ok(raw),
+        Err(err) => {
+            warn!("failed to parse OpenHands conversation {}: {err}", dir.display());
+            Ok(None)
+        }
+    }
+}
+
+fn parse_conversation_dir(
+    dir: &Path,
+    source_id: &str,
+    mtime_ms: i64,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    let events_dir = dir.join("events");
+    if events_dir.is_dir() {
+        return parse_sdk_layout(dir, &events_dir, source_id, mtime_ms, include_events);
+    }
+    let conversation_json = dir.join("conversation.json");
+    if conversation_json.is_file() {
+        return parse_docs_layout(&conversation_json, source_id, mtime_ms);
+    }
+    Ok(None)
+}
+
+fn parse_sdk_layout(
+    dir: &Path,
+    events_dir: &Path,
+    source_id: &str,
+    mtime_ms: i64,
+    include_events: bool,
+) -> anyhow::Result<Option<RawSession>> {
+    let base = read_json(&dir.join("base_state.json")).unwrap_or(Value::Null);
+    let directory = json_path(&base, &["workspace", "cwd", "working_directory"]);
+    let title = json_string(&base, &["title", "name"]);
+    let mut messages = Vec::new();
+    let mut events = Vec::new();
+    for path in list_event_files(events_dir) {
+        let value = match read_json(&path) {
+            Some(value) => value,
+            None => continue,
+        };
+        let kind = event_kind(&value);
+        let timestamp = event_timestamp(&value);
+        match kind {
+            "SystemPromptEvent" => {}
+            "MessageEvent" => {
+                if let Some(role) = message_role(&value)
+                    && let Some(content) = message_text(&value)
+                {
+                    messages.push(RawMessage { role, content, timestamp });
+                }
+            }
+            "ActionEvent" if include_events => {
+                if let Some(event) = action_event(&value, timestamp, events.len() as u32, &path) {
+                    events.push(event);
+                }
+            }
+            "ObservationEvent" if include_events => {
+                events.push(events::tool_result_event(
+                    event_context(&value, timestamp, events.len() as u32, &path),
+                    json_string(&value, &["tool_name", "name"]),
+                    observation_summary(&value),
+                ));
+            }
+            _ => {}
+        }
+    }
+    if messages.is_empty() && events.is_empty() {
+        return Ok(None);
+    }
+    let started_at = first_timestamp(event_timestamp(&base), &messages, &[], &events).unwrap_or(0);
+    let updated_at = last_timestamp(Some(mtime_ms), &messages, &[], &events).or(Some(mtime_ms));
+    let mut raw = RawSession::search_only(
+        source_id.to_string(),
+        directory,
+        started_at,
+        updated_at,
+        None,
+        messages,
+    );
+    raw.source_file_path = dir.to_str().map(str::to_string);
+    raw.custom_title = title;
+    if include_events {
+        raw = raw.with_events(events, EVENT_PARSER_VERSION);
+    }
+    Ok(Some(raw))
+}
+
+fn parse_docs_layout(
+    path: &Path,
+    source_id: &str,
+    mtime_ms: i64,
+) -> anyhow::Result<Option<RawSession>> {
+    let Some(value) = read_json(path) else {
+        return Ok(None);
+    };
+    let id =
+        json_string(&value, &["id", "conversation_id"]).unwrap_or_else(|| source_id.to_string());
+    let messages = parse_docs_messages(&value);
+    if messages.is_empty() {
+        return Ok(None);
+    }
+    let started_at =
+        first_timestamp(event_timestamp(&value), &messages, &[], &[]).unwrap_or(mtime_ms);
+    let mut raw = RawSession::search_only(
+        id,
+        json_path(&value, &["workspace", "cwd", "working_directory"]),
+        started_at,
+        Some(mtime_ms),
+        None,
+        messages,
+    );
+    raw.source_file_path = path.to_str().map(str::to_string);
+    raw.custom_title = json_string(&value, &["title", "name"]);
+    Ok(Some(raw))
+}
+
+fn parse_docs_messages(value: &Value) -> Vec<RawMessage> {
+    let Some(items) = value.get("messages").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for item in items {
+        let Some(role) = parse_role(item.get("role").and_then(Value::as_str).unwrap_or("")) else {
+            continue;
+        };
+        let content = extract_text(item.get("content"));
+        if content.is_empty() {
+            continue;
+        }
+        messages.push(RawMessage { role, content, timestamp: event_timestamp(item) });
+    }
+    messages
+}
+
+fn list_event_files(events_dir: &Path) -> Vec<PathBuf> {
+    let read = match fs::read_dir(events_dir) {
+        Ok(read) => read,
+        Err(err) => {
+            debug!("cannot read OpenHands events {}: {err}", events_dir.display());
+            return Vec::new();
+        }
+    };
+    let mut files: Vec<(u64, String, PathBuf)> = Vec::new();
+    for entry in read.flatten() {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default().to_string();
+        files.push((event_ordinal(&name).unwrap_or(u64::MAX), name, path));
+    }
+    files.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    files.into_iter().map(|(_, _, path)| path).collect()
+}
+
+fn event_ordinal(name: &str) -> Option<u64> {
+    let stem = name.strip_suffix(".json")?;
+    let rest = stem.strip_prefix("event-").or_else(|| stem.strip_prefix("event_"))?;
+    rest.split(['-', '_']).next()?.parse().ok()
+}
+
+fn event_kind(value: &Value) -> &str {
+    value
+        .get("kind")
+        .or_else(|| value.get("type"))
+        .or_else(|| value.get("event_type"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+}
+
+fn event_timestamp(value: &Value) -> Option<i64> {
+    json_i64(value.get("timestamp"))
+        .or_else(|| rfc3339_ms(value.get("timestamp")))
+        .or_else(|| json_i64(value.get("created_at")))
+        .or_else(|| rfc3339_ms(value.get("created_at")))
+}
+
+fn message_role(value: &Value) -> Option<Role> {
+    let source = value.get("source").and_then(Value::as_str).unwrap_or("");
+    match source {
+        "user" => Some(Role::User),
+        "agent" => Some(Role::Assistant),
+        _ => {
+            let role = value
+                .pointer("/llm_message/role")
+                .or_else(|| value.pointer("/message/role"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            parse_role(role)
+        }
+    }
+}
+
+fn message_text(value: &Value) -> Option<String> {
+    let content = extract_text(value.pointer("/llm_message/content"))
+        .or_else(|| extract_text(value.pointer("/message/content")))
+        .or_else(|| extract_text(value.get("content")))
+        .or_else(|| extract_text(value.get("text")));
+    let content = content?;
+    if content.is_empty() { None } else { Some(content) }
+}
+
+fn parse_role(role: &str) -> Option<Role> {
+    match role {
+        "user" | "human" => Some(Role::User),
+        "assistant" | "agent" => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn extract_text(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(text)) => {
+            let text = text.trim();
+            if text.is_empty() { None } else { Some(text.to_string()) }
+        }
+        Some(Value::Array(blocks)) => {
+            let text = blocks.iter().filter_map(block_text).collect::<Vec<_>>().join("\n");
+            let text = text.trim();
+            if text.is_empty() { None } else { Some(text.to_string()) }
+        }
+        _ => None,
+    }
+}
+
+fn block_text(block: &Value) -> Option<&str> {
+    if let Some(text) = block.as_str().map(str::trim).filter(|text| !text.is_empty()) {
+        return Some(text);
+    }
+    let kind = block.get("type").and_then(Value::as_str).unwrap_or("text");
+    if kind != "text" {
+        return None;
+    }
+    block.get("text").and_then(Value::as_str).map(str::trim).filter(|text| !text.is_empty())
+}
+
+fn action_event(
+    value: &Value,
+    timestamp: Option<i64>,
+    event_seq: u32,
+    path: &Path,
+) -> Option<RawSessionEvent> {
+    let name = json_string(value, &["tool_name", "name"])
+        .or_else(|| {
+            json_string(value.pointer("/action").unwrap_or(&Value::Null), &["kind", "name"])
+        })
+        .filter(|name| !name.is_empty())?;
+    let args = value.get("action").or_else(|| value.get("tool_call")).or_else(|| value.get("args"));
+    Some(events::tool_call_event(event_context(value, timestamp, event_seq, path), name, args))
+}
+
+fn observation_summary(value: &Value) -> Option<String> {
+    extract_text(value.get("content"))
+        .or_else(|| extract_text(value.pointer("/observation/content")))
+}
+
+fn event_context(
+    value: &Value,
+    timestamp: Option<i64>,
+    event_seq: u32,
+    path: &Path,
+) -> events::EventContext {
+    events::EventContext {
+        event_seq,
+        timestamp,
+        source_path: path.to_str().map(str::to_string),
+        source_event_id: json_string(value, &["id"]),
+        message_seq: None,
+        parser_version: EVENT_PARSER_VERSION,
+    }
+}
+
+fn json_string(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn json_path(value: &Value, keys: &[&str]) -> Option<String> {
+    json_string(value, keys)
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(_) => return None,
+    };
+    match serde_json::from_str(&raw) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            warn!("failed to parse OpenHands JSON {}: {err}", path.display());
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/openhands")
+    }
+
+    fn copy_tree(from: &Path, to: &Path) {
+        for entry in walkdir::WalkDir::new(from).into_iter().filter_map(Result::ok) {
+            let relative = entry.path().strip_prefix(from).unwrap();
+            let dest = to.join(relative);
+            if entry.file_type().is_dir() {
+                fs::create_dir_all(&dest).unwrap();
+            } else if entry.file_type().is_file() {
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent).unwrap();
+                }
+                fs::copy(entry.path(), dest).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn resume_uses_official_flag() {
+        let command = OpenHandsAdapter.resume_command("abc123def456").unwrap();
+        assert_eq!(command.program, "openhands");
+        assert_eq!(command.args, vec!["--resume", "abc123def456"]);
+    }
+
+    #[test]
+    fn default_root_is_home_openhands_conversations() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(conversations_dir_from(None, None, Some(home.path().to_path_buf())).is_none());
+        fs::create_dir_all(home.path().join(".openhands/conversations")).unwrap();
+        let resolved = conversations_dir_from(None, None, Some(home.path().to_path_buf())).unwrap();
+        assert_eq!(resolved, home.path().join(".openhands/conversations"));
+    }
+
+    #[test]
+    fn oh_persistence_dir_wins_over_file_store_path() {
+        let root = tempfile::tempdir().unwrap();
+        let persistence = root.path().join("oh");
+        fs::create_dir_all(persistence.join("conversations")).unwrap();
+        fs::create_dir_all(root.path().join("legacy/conversations")).unwrap();
+        let resolved = conversations_dir_from(
+            Some(persistence.to_string_lossy().into_owned()),
+            Some(root.path().join("legacy").to_string_lossy().into_owned()),
+            Some(PathBuf::from("/unused")),
+        )
+        .unwrap();
+        assert_eq!(resolved, persistence.join("conversations"));
+    }
+
+    #[test]
+    fn file_store_path_is_legacy_fallback() {
+        let root = tempfile::tempdir().unwrap();
+        let legacy = root.path().join("legacy");
+        fs::create_dir_all(legacy.join("conversations")).unwrap();
+        let resolved = conversations_dir_from(
+            None,
+            Some(legacy.to_string_lossy().into_owned()),
+            Some(PathBuf::from("/unused")),
+        )
+        .unwrap();
+        assert_eq!(resolved, legacy.join("conversations"));
+    }
+
+    #[test]
+    fn sdk_layout_sorts_by_numeric_ordinal_not_lex() {
+        assert!(
+            event_ordinal("event-100000-ddd.json").unwrap()
+                > event_ordinal("event-99999-ccc.json").unwrap()
+        );
+        assert!(
+            "event-100000-ddd.json".to_string() < "event-99999-ccc.json".to_string(),
+            "lex order would invert 100000 vs 99999"
+        );
+        let session =
+            parse_conversation_dir(&fixtures_dir().join("sdk-layout"), "sdk-conv-1", 1, true)
+                .unwrap()
+                .unwrap();
+        assert_eq!(session.source_id, "sdk-conv-1");
+        assert_eq!(session.directory.as_deref(), Some("/tmp/oh-sdk"));
+        assert_eq!(session.custom_title.as_deref(), Some("SDK conversation"));
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "first user turn");
+        assert_eq!(session.messages[1].content, "ordinal 99999 assistant");
+        assert_eq!(session.events.len(), 2);
+        assert_eq!(session.events[0].name.as_deref(), Some("terminal"));
+        assert_eq!(session.events[0].kind, "tool_call");
+        assert_eq!(session.events[1].kind, "tool_result");
+    }
+
+    #[test]
+    fn docs_layout_conversation_json_is_used_only_without_events() {
+        let session =
+            parse_conversation_dir(&fixtures_dir().join("docs-layout"), "abc123def456", 9, false)
+                .unwrap()
+                .unwrap();
+        assert_eq!(session.source_id, "abc123def456");
+        assert_eq!(session.directory.as_deref(), Some("/tmp/oh-docs"));
+        assert_eq!(session.messages[0].content, "Fix the login bug in auth.py");
+        assert_eq!(session.messages[1].content, "Looking at auth.py now");
+        assert!(session.events.is_empty());
+    }
+
+    #[test]
+    fn events_dir_wins_over_stale_conversation_json() {
+        let root = tempfile::tempdir().unwrap();
+        let conv = root.path().join("mixed");
+        copy_tree(&fixtures_dir().join("sdk-layout"), &conv);
+        fs::copy(
+            fixtures_dir().join("docs-layout/conversation.json"),
+            conv.join("conversation.json"),
+        )
+        .unwrap();
+        let session = parse_conversation_dir(&conv, "mixed", 1, true).unwrap().unwrap();
+        assert_eq!(session.messages[0].content, "first user turn");
+        assert_ne!(session.messages[0].content, "Fix the login bug in auth.py");
+    }
+
+    #[test]
+    fn missing_conversations_dir_is_empty() {
+        let entries = collect_conversation_entries(&None);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn collect_identifies_events_or_conversation_json() {
+        let root = tempfile::tempdir().unwrap();
+        copy_tree(&fixtures_dir().join("sdk-layout"), &root.path().join("sdk-conv-1"));
+        copy_tree(&fixtures_dir().join("docs-layout"), &root.path().join("abc123def456"));
+        fs::create_dir_all(root.path().join("empty")).unwrap();
+        let mut ids: Vec<_> = collect_conversation_entries(&Some(root.path().to_path_buf()))
+            .into_iter()
+            .map(|entry| entry.session_id)
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec!["abc123def456", "sdk-conv-1"]);
+    }
+}

--- a/src/adapters/openhands.rs
+++ b/src/adapters/openhands.rs
@@ -520,7 +520,7 @@ mod tests {
                 > event_ordinal("event-99999-ccc.json").unwrap()
         );
         assert!(
-            "event-100000-ddd.json".to_string() < "event-99999-ccc.json".to_string(),
+            "event-100000-ddd.json" < "event-99999-ccc.json",
             "lex order would invert 100000 vs 99999"
         );
         let session =

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -27,7 +27,11 @@ pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
     vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
 }
 
-pub(crate) fn vscode_extension_task_dirs_from(
+pub(crate) fn vscode_extension_storage_dirs(extension_id: &str) -> Vec<PathBuf> {
+    vscode_extension_storage_dirs_from(dirs::config_dir(), extension_id)
+}
+
+pub(crate) fn vscode_extension_storage_dirs_from(
     config_dir: Option<PathBuf>,
     extension_id: &str,
 ) -> Vec<PathBuf> {
@@ -36,14 +40,18 @@ pub(crate) fn vscode_extension_task_dirs_from(
     };
     VSCODE_HOSTS
         .iter()
-        .map(|host| {
-            config_dir
-                .join(host)
-                .join("User")
-                .join("globalStorage")
-                .join(extension_id)
-                .join("tasks")
-        })
+        .map(|host| config_dir.join(host).join("User").join("globalStorage").join(extension_id))
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+pub(crate) fn vscode_extension_task_dirs_from(
+    config_dir: Option<PathBuf>,
+    extension_id: &str,
+) -> Vec<PathBuf> {
+    vscode_extension_storage_dirs_from(config_dir, extension_id)
+        .into_iter()
+        .map(|dir| dir.join("tasks"))
         .filter(|path| path.is_dir())
         .collect()
 }
@@ -120,5 +128,23 @@ mod tests {
             "saoudrizwan.claude-dev",
         );
         assert_eq!(dirs, vec![oss]);
+    }
+
+    #[test]
+    fn storage_dirs_include_cursor_and_skip_missing_hosts() {
+        let root = tempfile::tempdir().unwrap();
+        let cursor =
+            root.path().join("Cursor").join("User").join("globalStorage").join("sourcegraph.amp");
+        let code =
+            root.path().join("Code").join("User").join("globalStorage").join("sourcegraph.amp");
+        fs::create_dir_all(&cursor).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        fs::create_dir_all(
+            root.path().join("VSCodium").join("User").join("globalStorage").join("other"),
+        )
+        .unwrap();
+        let dirs =
+            vscode_extension_storage_dirs_from(Some(root.path().to_path_buf()), "sourcegraph.amp");
+        assert_eq!(dirs, vec![code, cursor]);
     }
 }

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -27,10 +27,6 @@ pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
     vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
 }
 
-pub(crate) fn vscode_extension_storage_dirs(extension_id: &str) -> Vec<PathBuf> {
-    vscode_extension_storage_dirs_from(dirs::config_dir(), extension_id)
-}
-
 pub(crate) fn vscode_extension_storage_dirs_from(
     config_dir: Option<PathBuf>,
     extension_id: &str,

--- a/tests/fixtures/aider/fad-blockquote-not-user.md
+++ b/tests/fixtures/aider/fad-blockquote-not-user.md
@@ -1,0 +1,5 @@
+# aider chat started at 2026-07-17 09:00:00
+
+> this is a FAD-style user line and must not be Role::User
+
+The assistant reply stays assistant.

--- a/tests/fixtures/aider/official.aider.chat.history.md
+++ b/tests/fixtures/aider/official.aider.chat.history.md
@@ -1,0 +1,12 @@
+# aider chat started at 2026-07-17 09:00:00
+
+#### Show me the failing query
+#### and the tenant predicate
+
+The query misses the tenant predicate.
+
+> Applied edit to query.go
+
+#### also check tests
+
+Tests look fine.

--- a/tests/fixtures/amp/thread.json
+++ b/tests/fixtures/amp/thread.json
@@ -1,0 +1,26 @@
+{
+  "v": 3,
+  "id": "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001",
+  "created": 1700000000000,
+  "title": "Amp thread title",
+  "env": {
+    "trees": [
+      { "cwd": "/tmp/amp-project" }
+    ]
+  },
+  "messages": [
+    {
+      "role": "human",
+      "content": [{ "type": "text", "text": "hello from amp" }],
+      "created": 1700000001000
+    },
+    {
+      "role": "agent",
+      "content": [
+        { "type": "text", "text": "hi back" },
+        { "type": "tool_use", "name": "bash", "input": { "cmd": "ls" } }
+      ],
+      "created": 1700000002000
+    }
+  ]
+}

--- a/tests/fixtures/amp/wrapped-thread.json
+++ b/tests/fixtures/amp/wrapped-thread.json
@@ -1,0 +1,19 @@
+{
+  "thread": {
+    "id": "T-0199cccc-dddd-7eee-8fff-000011112222",
+    "created": 1700000100000,
+    "title": "Wrapped thread",
+    "messages": [
+      {
+        "role": "user",
+        "content": "wrapped user",
+        "created": 1700000101000
+      },
+      {
+        "role": "assistant",
+        "content": "wrapped assistant",
+        "created": 1700000102000
+      }
+    ]
+  }
+}

--- a/tests/fixtures/factory/-Users-alice-Dev-myproject/11111111-2222-4333-8444-555555555555.jsonl
+++ b/tests/fixtures/factory/-Users-alice-Dev-myproject/11111111-2222-4333-8444-555555555555.jsonl
@@ -1,0 +1,5 @@
+{"sessionId":"11111111-2222-4333-8444-555555555555","title":"Fix auth","cwd":"/Users/alice/Dev/myproject"}
+{"role":"user","content":"fix the login","timestamp":1700000001000}
+{"role":"assistant","content":"looking at auth.py","timestamp":1700000002000}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"call-1","name":"read","input":{"path":"/Users/alice/Dev/myproject/auth.py"}}]},"timestamp":1700000003000}
+{"role":"tool","content":"export function login","timestamp":1700000004000}

--- a/tests/fixtures/factory/-Users-alice-Dev-myproject/11111111-2222-4333-8444-555555555555.settings.json
+++ b/tests/fixtures/factory/-Users-alice-Dev-myproject/11111111-2222-4333-8444-555555555555.settings.json
@@ -1,0 +1,10 @@
+{
+  "model": "claude-sonnet-4",
+  "tokenUsage": {
+    "inputTokens": 100,
+    "outputTokens": 40,
+    "cacheReadTokens": 10,
+    "cacheCreationTokens": 5,
+    "thinkingTokens": 8
+  }
+}

--- a/tests/fixtures/openhands/docs-layout/conversation.json
+++ b/tests/fixtures/openhands/docs-layout/conversation.json
@@ -1,0 +1,18 @@
+{
+  "id": "abc123def456",
+  "title": "Fix the login bug",
+  "created_at": "2026-01-01T00:00:00Z",
+  "workspace": "/tmp/oh-docs",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Fix the login bug in auth.py",
+      "timestamp": "2026-01-01T00:00:01Z"
+    },
+    {
+      "role": "assistant",
+      "content": "Looking at auth.py now",
+      "timestamp": "2026-01-01T00:00:02Z"
+    }
+  ]
+}

--- a/tests/fixtures/openhands/sdk-layout/base_state.json
+++ b/tests/fixtures/openhands/sdk-layout/base_state.json
@@ -1,0 +1,5 @@
+{
+  "id": "sdk-conv-1",
+  "title": "SDK conversation",
+  "workspace": "/tmp/oh-sdk"
+}

--- a/tests/fixtures/openhands/sdk-layout/events/event-00000-aaa11111-1111-4111-8111-111111111111.json
+++ b/tests/fixtures/openhands/sdk-layout/events/event-00000-aaa11111-1111-4111-8111-111111111111.json
@@ -1,0 +1,10 @@
+{
+  "kind": "SystemPromptEvent",
+  "id": "sys-1",
+  "timestamp": "2026-01-01T00:00:00Z",
+  "source": "agent",
+  "system_prompt": {
+    "role": "system",
+    "content": "You are OpenHands."
+  }
+}

--- a/tests/fixtures/openhands/sdk-layout/events/event-00001-bbb22222-2222-4222-8222-222222222222.json
+++ b/tests/fixtures/openhands/sdk-layout/events/event-00001-bbb22222-2222-4222-8222-222222222222.json
@@ -1,0 +1,10 @@
+{
+  "kind": "MessageEvent",
+  "id": "msg-user-1",
+  "timestamp": "2026-01-01T00:00:01Z",
+  "source": "user",
+  "llm_message": {
+    "role": "user",
+    "content": [{ "type": "text", "text": "first user turn" }]
+  }
+}

--- a/tests/fixtures/openhands/sdk-layout/events/event-100000-ddd44444-4444-4444-8444-444444444444.json
+++ b/tests/fixtures/openhands/sdk-layout/events/event-100000-ddd44444-4444-4444-8444-444444444444.json
@@ -1,0 +1,8 @@
+{
+  "kind": "ActionEvent",
+  "id": "act-1",
+  "timestamp": "2026-01-01T00:00:03Z",
+  "source": "agent",
+  "tool_name": "terminal",
+  "action": { "command": "ls /tmp/oh-sdk" }
+}

--- a/tests/fixtures/openhands/sdk-layout/events/event-100001-eee55555-5555-4555-8555-555555555555.json
+++ b/tests/fixtures/openhands/sdk-layout/events/event-100001-eee55555-5555-4555-8555-555555555555.json
@@ -1,0 +1,8 @@
+{
+  "kind": "ObservationEvent",
+  "id": "obs-1",
+  "timestamp": "2026-01-01T00:00:04Z",
+  "source": "environment",
+  "tool_name": "terminal",
+  "content": "auth.py\n"
+}

--- a/tests/fixtures/openhands/sdk-layout/events/event-99999-ccc33333-3333-4333-8333-333333333333.json
+++ b/tests/fixtures/openhands/sdk-layout/events/event-99999-ccc33333-3333-4333-8333-333333333333.json
@@ -1,0 +1,10 @@
+{
+  "kind": "MessageEvent",
+  "id": "msg-agent-1",
+  "timestamp": "2026-01-01T00:00:02Z",
+  "source": "agent",
+  "llm_message": {
+    "role": "assistant",
+    "content": [{ "type": "text", "text": "ordinal 99999 assistant" }]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add four in-tree `SourceAdapter`s and register them in `all_adapters()`.

## Amp
- Discovers `$AMP_THREADS_DIR`, `$XDG_DATA_HOME/amp/threads` or `~/.local/share/amp/threads`, and VS Code-family `globalStorage/sourcegraph.amp/{threads,threads3}`.
- Prefers JSON `id` over filename (`thread.json` collisions).
- Incremental scan always re-reads within an 8 MiB cap (Amp does not bump mtime). Test locks mtime-stale / size-grown.
- Resume: `amp threads continue <id>`. Missing roots are an empty success. Does not read `secrets.json`.

## OpenHands
- Persistence root follows OpenHands: `OH_PERSISTENCE_DIR`, then `FILE_STORE_PATH`, then `~/.openhands`, plus `/conversations`.
- Primary layout: `base_state.json` + `events/event-NNNNN-<uuid>.json`, sorted by numeric ordinal (not lex).
- `conversation.json` is parsed only when a dir has that file and no `events/`.
- Resume: `openhands --resume <id>`.

## Factory
- Walks only `~/.factory/sessions/**/*.jsonl` with sibling `{uuid}.settings.json`.
- Parses `tokenUsage` (input/output/cache/thinking), not just model.
- Resume: `droid --resume <sessionId>`.

## Aider
- Official `split_chat_history_markdown` roles: `#### ` user, `> ` tool (not user), remaining assistant.
- Negative fixture: FAD-style `> user` must not become `Role::User`.
- Discovery is cwd + git ancestors + `~/git/*` / `~/git/*/*` only. Resume is `None`.

Fixtures live under `tests/fixtures/{amp,openhands,factory,aider}/`. Tools do not need to be installed.

Verified: `cargo clippy --workspace --all-targets --features bench -- -D warnings` (includes the OpenHands lex-vs-numeric sort assertion, now comparing string literals). Unit test `sdk_layout_sorts_by_numeric_ordinal_not_lex` still passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e817d764-6309-4a38-b9ec-7e243b02d4f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e817d764-6309-4a38-b9ec-7e243b02d4f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

