### PR TITLE
Add Amp source adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ One index across every AI coding CLI. Sync once, search everywhere, resume right
 | ZCode           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Goose           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
 | Droid           |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |   ✅   |
+| Amp             |     ✅    |     ✅     |        ✅        |        ✅       |        ✅       |   ✅   |      |
 
 ## Acknowledgements
 

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::json_util::{json_i64, rfc3339_ms};
-use crate::adapters::paths::vscode_extension_storage_dirs_from;
+use crate::adapters::paths::{file_uri_to_path, vscode_extension_storage_dirs_from};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
@@ -278,7 +278,9 @@ fn block_text(block: &Value) -> Option<&str> {
 
 fn env_cwd(env: Option<&Value>) -> Option<String> {
     let env = env?;
-    if let Some(cwd) = string_path(env.get("cwd")) {
+    if let Some(cwd) =
+        string_path(env.get("cwd")).or_else(|| file_uri_value_to_path(env.get("workingDirectory")))
+    {
         return Some(cwd);
     }
     if let Some(cwd) = env_cwd(env.get("initial")) {
@@ -286,11 +288,17 @@ fn env_cwd(env: Option<&Value>) -> Option<String> {
     }
     let trees = env.get("trees").and_then(Value::as_array)?;
     for tree in trees {
-        if let Some(cwd) = string_path(tree.get("cwd")) {
+        if let Some(cwd) =
+            string_path(tree.get("cwd")).or_else(|| file_uri_value_to_path(tree.get("uri")))
+        {
             return Some(cwd);
         }
     }
     None
+}
+
+fn file_uri_value_to_path(value: Option<&Value>) -> Option<String> {
+    value.and_then(Value::as_str).and_then(file_uri_to_path)
 }
 
 fn string_path(value: Option<&Value>) -> Option<String> {
@@ -384,6 +392,16 @@ mod tests {
         assert_eq!(session.source_id, "T-0199cccc-dddd-7eee-8fff-000011112222");
         assert_eq!(session.messages[0].content, "wrapped user");
         assert_eq!(session.messages[1].content, "wrapped assistant");
+    }
+
+    #[test]
+    fn env_cwd_falls_back_to_current_amp_tree_uri() {
+        let env = serde_json::json!({
+            "initial": {
+                "trees": [{"uri": "file:///tmp/amp%20project"}]
+            }
+        });
+        assert_eq!(env_cwd(Some(&env)).as_deref(), Some("/tmp/amp project"));
     }
 
     #[test]

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -286,11 +286,7 @@ fn env_cwd(env: Option<&Value>) -> Option<String> {
     }
     let trees = env.get("trees").and_then(Value::as_array)?;
     for tree in trees {
-        if let Some(cwd) = string_path(tree.get("cwd"))
-            .or_else(|| string_path(tree.get("path")))
-            .or_else(|| string_path(tree.get("fsPath")))
-            .or_else(|| file_uri_path(tree.get("uri")))
-        {
+        if let Some(cwd) = string_path(tree.get("cwd")) {
             return Some(cwd);
         }
     }
@@ -305,39 +301,13 @@ fn string_path(value: Option<&Value>) -> Option<String> {
         .map(str::to_string)
 }
 
-fn file_uri_path(value: Option<&Value>) -> Option<String> {
-    match value {
-        Some(Value::String(uri)) => {
-            let text = uri.trim();
-            if text.is_empty() {
-                None
-            } else if let Some(rest) = text.strip_prefix("file://") {
-                Some(rest.to_string())
-            } else {
-                Some(text.to_string())
-            }
-        }
-        Some(Value::Object(map)) => {
-            string_path(map.get("fsPath")).or_else(|| string_path(map.get("path")))
-        }
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{schema, store::Store};
-    use crate::types::Session;
     use std::time::{Duration, UNIX_EPOCH};
 
     fn fixtures_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/amp")
-    }
-
-    fn setup_store() -> Store {
-        schema::register_sqlite_vec();
-        Store::open_in_memory().unwrap()
     }
 
     #[test]
@@ -439,29 +409,6 @@ mod tests {
         let first = scan_threads(&[root.path().to_path_buf()], None).unwrap();
         assert_eq!(first.sessions.len(), 1);
         assert_eq!(first.sessions[0].messages.len(), 2);
-
-        let store = setup_store();
-        store
-            .insert_session(&Session {
-                id: "local-amp".to_string(),
-                source: SOURCE.to_string(),
-                source_id: "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001".to_string(),
-                title: "existing".to_string(),
-                directory: None,
-                repo_remote: None,
-                repo_slug: None,
-                repo_name: None,
-                started_at: first_mtime,
-                updated_at: Some(first_mtime),
-                message_count: 2,
-                entrypoint: None,
-                custom_title: None,
-                summary: None,
-                duration_minutes: None,
-                source_file_path: path.to_str().map(str::to_string),
-                is_import: false,
-            })
-            .unwrap();
 
         let mut value: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         value["messages"].as_array_mut().unwrap().push(serde_json::json!({

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -1,0 +1,484 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tracing::{debug, warn};
+
+use crate::adapters::AdapterSyncContext;
+use crate::adapters::json_util::{json_i64, rfc3339_ms};
+use crate::adapters::paths::vscode_extension_storage_dirs_from;
+use crate::adapters::{
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
+    first_timestamp, last_timestamp,
+};
+use crate::types::Role;
+
+const SOURCE: &str = "amp";
+const EXTENSION_ID: &str = "sourcegraph.amp";
+const MAX_THREAD_BYTES: u64 = 8 * 1024 * 1024;
+const SKIP_NAMES: &[&str] = &["config.json", "settings.json", "secrets.json"];
+
+pub(crate) struct AmpAdapter;
+
+impl SourceAdapter for AmpAdapter {
+    fn id(&self) -> &str {
+        SOURCE
+    }
+
+    fn label(&self) -> &str {
+        "AM"
+    }
+
+    fn resume_command(&self, source_id: &str) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "amp".to_string(),
+            args: vec!["threads".to_string(), "continue".to_string(), source_id.to_string()],
+        })
+    }
+
+    fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
+        Ok(scan_threads(&thread_roots(), None)?.sessions)
+    }
+
+    fn scan_for_sync(
+        &self,
+        _context: &AdapterSyncContext,
+        since_ts: Option<i64>,
+        _include_events: bool,
+    ) -> anyhow::Result<Option<SyncScanResult>> {
+        Ok(Some(scan_threads(&thread_roots(), since_ts)?))
+    }
+}
+
+fn thread_roots() -> Vec<PathBuf> {
+    thread_roots_from(
+        std::env::var("AMP_THREADS_DIR").ok(),
+        std::env::var("XDG_DATA_HOME").ok(),
+        dirs::home_dir(),
+        dirs::config_dir(),
+    )
+}
+
+fn thread_roots_from(
+    amp_threads_dir: Option<String>,
+    xdg_data_home: Option<String>,
+    home: Option<PathBuf>,
+    config_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(dir) = amp_threads_dir.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(dir);
+        if path.is_dir() {
+            roots.push(path);
+        }
+    }
+    let xdg = xdg_data_home
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home.map(|home| home.join(".local/share")));
+    if let Some(xdg) = xdg {
+        let path = xdg.join("amp/threads");
+        if path.is_dir() {
+            roots.push(path);
+        }
+    }
+    for storage in vscode_extension_storage_dirs_from(config_dir, EXTENSION_ID) {
+        for name in ["threads3", "threads"] {
+            let path = storage.join(name);
+            if path.is_dir() {
+                roots.push(path);
+            }
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn scan_threads(roots: &[PathBuf], since_ts: Option<i64>) -> anyhow::Result<SyncScanResult> {
+    let mut sessions = Vec::new();
+    let mut stats = SyncScanStats::default();
+    let mut by_id: HashMap<String, RawSession> = HashMap::new();
+
+    for path in collect_thread_files(roots) {
+        stats.candidates += 1;
+        let Ok(meta) = fs::metadata(&path) else {
+            stats.rejected_before_parse += 1;
+            continue;
+        };
+        if meta.len() > MAX_THREAD_BYTES {
+            debug!("skipping oversized Amp thread {}", path.display());
+            stats.rejected_before_parse += 1;
+            continue;
+        }
+        match parse_thread_file(&path) {
+            Ok(Some(raw)) => {
+                if since_ts.is_some_and(|cutoff| {
+                    last_timestamp(raw.updated_at, &raw.messages, &[], &[])
+                        .is_some_and(|updated| updated < cutoff)
+                }) {
+                    stats.filtered_sessions += 1;
+                    continue;
+                }
+                stats.parsed += 1;
+                by_id.entry(raw.source_id.clone()).or_insert(raw);
+            }
+            Ok(None) => {}
+            Err(err) => warn!("failed to parse Amp thread {}: {err}", path.display()),
+        }
+    }
+
+    sessions.extend(by_id.into_values());
+    Ok(SyncScanResult { sessions, stats, observations: Vec::new() })
+}
+
+fn collect_thread_files(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for root in roots {
+        let read = match fs::read_dir(root) {
+            Ok(read) => read,
+            Err(err) => {
+                debug!("cannot read Amp threads dir {}: {err}", root.display());
+                continue;
+            }
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.is_file() && is_amp_thread_file(&path) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn is_amp_thread_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !name.ends_with(".json") || SKIP_NAMES.contains(&name) {
+        return false;
+    }
+    let parent = path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str());
+    if matches!(parent, Some("threads" | "threads3")) {
+        return true;
+    }
+    name == "thread.json"
+        || name.starts_with("conversation")
+        || name.starts_with("chat")
+        || name.starts_with("T-")
+}
+
+fn parse_thread_file(path: &Path) -> anyhow::Result<Option<RawSession>> {
+    let raw = fs::read_to_string(path)?;
+    let value: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(err) => {
+            warn!("failed to parse Amp JSON {}: {err}", path.display());
+            return Ok(None);
+        }
+    };
+    Ok(parse_thread_value(&value, path))
+}
+
+fn parse_thread_value(value: &Value, path: &Path) -> Option<RawSession> {
+    let doc = value.get("thread").filter(|thread| thread.is_object()).unwrap_or(value);
+    let source_id = doc
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .filter(|stem| *stem != "thread")
+                .map(|stem| stem.to_string())
+        })?;
+    let messages_value = doc.get("messages").or_else(|| value.get("messages"));
+    let messages = parse_messages(messages_value);
+    if messages.is_empty() {
+        return None;
+    }
+    let created = json_i64(doc.get("created")).or_else(|| rfc3339_ms(doc.get("created")));
+    let started_at = first_timestamp(created, &messages, &[], &[]).unwrap_or(0);
+    let updated_at = last_timestamp(created, &messages, &[], &[]);
+    let mut session = RawSession::search_only(
+        source_id,
+        env_cwd(doc.get("env")).or_else(|| env_cwd(value.get("env"))),
+        started_at,
+        updated_at,
+        None,
+        messages,
+    );
+    session.source_file_path = path.to_str().map(str::to_string);
+    session.custom_title = doc
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_string);
+    Some(session)
+}
+
+fn parse_messages(value: Option<&Value>) -> Vec<RawMessage> {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for item in items {
+        let Some(role) = parse_role(item.get("role").and_then(Value::as_str).unwrap_or("")) else {
+            continue;
+        };
+        let content = extract_text(item.get("content"));
+        if content.is_empty() {
+            continue;
+        }
+        let timestamp = json_i64(item.get("created"))
+            .or_else(|| rfc3339_ms(item.get("created")))
+            .or_else(|| json_i64(item.get("timestamp")))
+            .or_else(|| rfc3339_ms(item.get("timestamp")))
+            .or_else(|| json_i64(item.pointer("/meta/sentAt")));
+        messages.push(RawMessage { role, content, timestamp });
+    }
+    messages
+}
+
+fn parse_role(role: &str) -> Option<Role> {
+    match role {
+        "human" | "user" => Some(Role::User),
+        "agent" | "assistant" => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn extract_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Array(blocks)) => {
+            blocks.iter().filter_map(block_text).collect::<Vec<_>>().join("\n").trim().to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+fn block_text(block: &Value) -> Option<&str> {
+    if let Some(text) = block.as_str().map(str::trim).filter(|text| !text.is_empty()) {
+        return Some(text);
+    }
+    let kind = block.get("type").and_then(Value::as_str).unwrap_or("text");
+    if kind != "text" {
+        return None;
+    }
+    block.get("text").and_then(Value::as_str).map(str::trim).filter(|text| !text.is_empty())
+}
+
+fn env_cwd(env: Option<&Value>) -> Option<String> {
+    let env = env?;
+    if let Some(cwd) = string_path(env.get("cwd")) {
+        return Some(cwd);
+    }
+    if let Some(cwd) = env_cwd(env.get("initial")) {
+        return Some(cwd);
+    }
+    let trees = env.get("trees").and_then(Value::as_array)?;
+    for tree in trees {
+        if let Some(cwd) = string_path(tree.get("cwd"))
+            .or_else(|| string_path(tree.get("path")))
+            .or_else(|| string_path(tree.get("fsPath")))
+            .or_else(|| file_uri_path(tree.get("uri")))
+        {
+            return Some(cwd);
+        }
+    }
+    None
+}
+
+fn string_path(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn file_uri_path(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(uri)) => {
+            let text = uri.trim();
+            if text.is_empty() {
+                None
+            } else if let Some(rest) = text.strip_prefix("file://") {
+                Some(rest.to_string())
+            } else {
+                Some(text.to_string())
+            }
+        }
+        Some(Value::Object(map)) => {
+            string_path(map.get("fsPath")).or_else(|| string_path(map.get("path")))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{schema, store::Store};
+    use crate::types::Session;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn fixtures_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/amp")
+    }
+
+    fn setup_store() -> Store {
+        schema::register_sqlite_vec();
+        Store::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn resume_uses_threads_continue_and_json_id() {
+        let command = AmpAdapter.resume_command("T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001").unwrap();
+        assert_eq!(command.program, "amp");
+        assert_eq!(
+            command.args,
+            vec!["threads", "continue", "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001"]
+        );
+    }
+
+    #[test]
+    fn missing_roots_are_empty() {
+        let roots = thread_roots_from(None, None, Some(PathBuf::from("/no/such/home")), None);
+        assert!(roots.is_empty());
+        let result = scan_threads(&roots, None).unwrap();
+        assert!(result.sessions.is_empty());
+    }
+
+    #[test]
+    fn amp_threads_dir_and_xdg_are_scanned_when_present() {
+        let root = tempfile::tempdir().unwrap();
+        let amp_dir = root.path().join("amp-threads");
+        let xdg = root.path().join("xdg");
+        fs::create_dir_all(&amp_dir).unwrap();
+        fs::create_dir_all(xdg.join("amp/threads")).unwrap();
+        let roots = thread_roots_from(
+            Some(amp_dir.to_string_lossy().into_owned()),
+            Some(xdg.to_string_lossy().into_owned()),
+            Some(PathBuf::from("/unused")),
+            None,
+        );
+        assert_eq!(roots, vec![amp_dir, xdg.join("amp/threads")]);
+    }
+
+    #[test]
+    fn vscode_threads3_and_threads_children_are_roots() {
+        let config = tempfile::tempdir().unwrap();
+        let storage =
+            config.path().join("Code").join("User").join("globalStorage").join(EXTENSION_ID);
+        fs::create_dir_all(storage.join("threads3")).unwrap();
+        fs::create_dir_all(storage.join("threads")).unwrap();
+        let roots = thread_roots_from(
+            None,
+            None,
+            Some(PathBuf::from("/unused")),
+            Some(config.path().to_path_buf()),
+        );
+        assert!(roots.contains(&storage.join("threads3")));
+        assert!(roots.contains(&storage.join("threads")));
+    }
+
+    #[test]
+    fn parse_prefers_object_id_over_filename_thread_json() {
+        let path = fixtures_dir().join("thread.json");
+        let session = parse_thread_file(&path).unwrap().unwrap();
+        assert_eq!(session.source_id, "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001");
+        assert_eq!(session.custom_title.as_deref(), Some("Amp thread title"));
+        assert_eq!(session.directory.as_deref(), Some("/tmp/amp-project"));
+        assert_eq!(session.started_at, 1_700_000_000_000);
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].role, Role::User);
+        assert_eq!(session.messages[0].content, "hello from amp");
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content, "hi back");
+    }
+
+    #[test]
+    fn parse_reads_thread_messages_wrapper() {
+        let path = fixtures_dir().join("wrapped-thread.json");
+        let session = parse_thread_file(&path).unwrap().unwrap();
+        assert_eq!(session.source_id, "T-0199cccc-dddd-7eee-8fff-000011112222");
+        assert_eq!(session.messages[0].content, "wrapped user");
+        assert_eq!(session.messages[1].content, "wrapped assistant");
+    }
+
+    #[test]
+    fn skips_secrets_and_settings() {
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/secrets.json")));
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/settings.json")));
+        assert!(!is_amp_thread_file(Path::new("/tmp/threads/config.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/T-abc.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/thread.json")));
+        assert!(is_amp_thread_file(Path::new("/tmp/threads/conversation-1.json")));
+    }
+
+    #[test]
+    fn incremental_rereads_when_mtime_stale_and_size_grown() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("thread.json");
+        fs::copy(fixtures_dir().join("thread.json"), &path).unwrap();
+        let first_mtime = 1_700_000_000_000i64;
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH + Duration::from_millis(first_mtime as u64))
+            .unwrap();
+
+        let first = scan_threads(&[root.path().to_path_buf()], None).unwrap();
+        assert_eq!(first.sessions.len(), 1);
+        assert_eq!(first.sessions[0].messages.len(), 2);
+
+        let store = setup_store();
+        store
+            .insert_session(&Session {
+                id: "local-amp".to_string(),
+                source: SOURCE.to_string(),
+                source_id: "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001".to_string(),
+                title: "existing".to_string(),
+                directory: None,
+                repo_remote: None,
+                repo_slug: None,
+                repo_name: None,
+                started_at: first_mtime,
+                updated_at: Some(first_mtime),
+                message_count: 2,
+                entrypoint: None,
+                custom_title: None,
+                summary: None,
+                duration_minutes: None,
+                source_file_path: path.to_str().map(str::to_string),
+                is_import: false,
+            })
+            .unwrap();
+
+        let mut value: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        value["messages"].as_array_mut().unwrap().push(serde_json::json!({
+            "role": "human",
+            "content": [{ "type": "text", "text": "appended without mtime" }],
+            "created": 1700000003000u64
+        }));
+        fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH + Duration::from_millis(first_mtime as u64))
+            .unwrap();
+
+        let result = scan_threads(&[root.path().to_path_buf()], None).unwrap();
+        assert_eq!(result.stats.skipped_sessions, 0);
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].messages.len(), 3);
+        assert_eq!(result.sessions[0].messages[2].content, "appended without mtime");
+    }
+}

--- a/src/adapters/amp.rs
+++ b/src/adapters/amp.rs
@@ -205,7 +205,7 @@ fn parse_thread_value(value: &Value, path: &Path) -> Option<RawSession> {
     }
     let created = json_i64(doc.get("created")).or_else(|| rfc3339_ms(doc.get("created")));
     let started_at = first_timestamp(created, &messages, &[], &[]).unwrap_or(0);
-    let updated_at = last_timestamp(created, &messages, &[], &[]);
+    let updated_at = last_timestamp(None, &messages, &[], &[]);
     let mut session = RawSession::search_only(
         source_id,
         env_cwd(doc.get("env")).or_else(|| env_cwd(value.get("env"))),
@@ -369,6 +369,7 @@ mod tests {
         assert_eq!(session.custom_title.as_deref(), Some("Amp thread title"));
         assert_eq!(session.directory.as_deref(), Some("/tmp/amp-project"));
         assert_eq!(session.started_at, 1_700_000_000_000);
+        assert_eq!(session.updated_at, Some(1_700_000_002_000));
         assert_eq!(session.messages.len(), 2);
         assert_eq!(session.messages[0].role, Role::User);
         assert_eq!(session.messages[0].content, "hello from amp");

--- a/src/adapters/copilot_chat.rs
+++ b/src/adapters/copilot_chat.rs
@@ -9,6 +9,7 @@ use tracing::debug;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::json_i64;
+use crate::adapters::paths::file_uri_to_path;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, first_timestamp,
 };
@@ -140,49 +141,6 @@ fn workspace_folder(path: &Path) -> Option<String> {
     let content = fs::read_to_string(path).ok()?;
     let value: Value = serde_json::from_str(&content).ok()?;
     file_uri_to_path(value.get("folder").and_then(|folder| folder.as_str())?)
-}
-
-fn file_uri_to_path(uri: &str) -> Option<String> {
-    let rest = uri.strip_prefix("file://")?;
-    let decoded = percent_decode(rest)?;
-    if cfg!(windows)
-        && let Some(drive) = decoded.strip_prefix('/')
-        && drive.len() >= 2
-        && drive.as_bytes()[1] == b':'
-    {
-        return Some(drive.to_string());
-    }
-    Some(decoded)
-}
-
-fn percent_decode(input: &str) -> Option<String> {
-    let bytes = input.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'%' {
-            if index + 2 >= bytes.len() {
-                return None;
-            }
-            let hi = from_hex(bytes[index + 1])?;
-            let lo = from_hex(bytes[index + 2])?;
-            out.push((hi << 4) | lo);
-            index += 3;
-        } else {
-            out.push(bytes[index]);
-            index += 1;
-        }
-    }
-    String::from_utf8(out).ok()
-}
-
-fn from_hex(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
 }
 
 fn parse_chat_session_for_entry(
@@ -626,15 +584,6 @@ mod tests {
         assert_eq!(sess.directory.as_deref(), Some("/Users/x/git/foo bar"));
 
         let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn file_uri_to_path_decodes_and_keeps_posix_absolute() {
-        assert_eq!(
-            file_uri_to_path("file:///Users/x/git/foo%20bar").as_deref(),
-            Some("/Users/x/git/foo bar")
-        );
-        assert_eq!(file_uri_to_path("https://example.com"), None);
     }
 
     #[test]

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod amp;
 pub(crate) mod antigravity;
 pub(crate) mod claude_code;
 pub(crate) mod cline;
@@ -371,6 +372,7 @@ pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {
         Box::new(zcode::ZcodeAdapter),
         Box::new(goose::GooseAdapter),
         Box::new(droid::DroidAdapter),
+        Box::new(amp::AmpAdapter),
     ]
 }
 
@@ -418,4 +420,15 @@ pub(crate) fn dashboard_source_labels() -> Vec<(String, String)> {
         .filter(|adapter| adapter_supports_usage_dashboard(adapter.as_ref(), true))
         .map(|adapter| (adapter.id().to_string(), adapter.label().to_string()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_adapters;
+
+    #[test]
+    fn all_adapters_includes_amp() {
+        let ids: Vec<_> = all_adapters().iter().map(|adapter| adapter.id().to_string()).collect();
+        assert!(ids.iter().any(|id| id == "amp"), "amp missing from all_adapters()");
+    }
 }

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -23,6 +23,49 @@ pub(crate) fn resolve_home_dir(
     Ok(Some(dir))
 }
 
+pub(crate) fn file_uri_to_path(uri: &str) -> Option<String> {
+    let rest = uri.strip_prefix("file://")?;
+    let decoded = percent_decode(rest)?;
+    if cfg!(windows)
+        && let Some(drive) = decoded.strip_prefix('/')
+        && drive.len() >= 2
+        && drive.as_bytes()[1] == b':'
+    {
+        return Some(drive.to_string());
+    }
+    Some(decoded)
+}
+
+fn percent_decode(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = from_hex(bytes[index + 1])?;
+            let lo = from_hex(bytes[index + 2])?;
+            out.push((hi << 4) | lo);
+            index += 3;
+        } else {
+            out.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn from_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
     vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
 }
@@ -67,6 +110,15 @@ mod tests {
     #[test]
     fn missing_config_dir_returns_empty() {
         assert!(vscode_extension_task_dirs_from(None, "saoudrizwan.claude-dev").is_empty());
+    }
+
+    #[test]
+    fn file_uri_path_decodes_percent_escapes() {
+        assert_eq!(
+            file_uri_to_path("file:///Users/x/git/foo%20bar").as_deref(),
+            Some("/Users/x/git/foo bar")
+        );
+        assert_eq!(file_uri_to_path("https://example.com"), None);
     }
 
     #[test]

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -27,7 +27,7 @@ pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
     vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
 }
 
-pub(crate) fn vscode_extension_task_dirs_from(
+pub(crate) fn vscode_extension_storage_dirs_from(
     config_dir: Option<PathBuf>,
     extension_id: &str,
 ) -> Vec<PathBuf> {
@@ -36,14 +36,18 @@ pub(crate) fn vscode_extension_task_dirs_from(
     };
     VSCODE_HOSTS
         .iter()
-        .map(|host| {
-            config_dir
-                .join(host)
-                .join("User")
-                .join("globalStorage")
-                .join(extension_id)
-                .join("tasks")
-        })
+        .map(|host| config_dir.join(host).join("User").join("globalStorage").join(extension_id))
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+pub(crate) fn vscode_extension_task_dirs_from(
+    config_dir: Option<PathBuf>,
+    extension_id: &str,
+) -> Vec<PathBuf> {
+    vscode_extension_storage_dirs_from(config_dir, extension_id)
+        .into_iter()
+        .map(|dir| dir.join("tasks"))
         .filter(|path| path.is_dir())
         .collect()
 }
@@ -120,5 +124,23 @@ mod tests {
             "saoudrizwan.claude-dev",
         );
         assert_eq!(dirs, vec![oss]);
+    }
+
+    #[test]
+    fn storage_dirs_include_cursor_and_skip_missing_hosts() {
+        let root = tempfile::tempdir().unwrap();
+        let cursor =
+            root.path().join("Cursor").join("User").join("globalStorage").join("sourcegraph.amp");
+        let code =
+            root.path().join("Code").join("User").join("globalStorage").join("sourcegraph.amp");
+        fs::create_dir_all(&cursor).unwrap();
+        fs::create_dir_all(&code).unwrap();
+        fs::create_dir_all(
+            root.path().join("VSCodium").join("User").join("globalStorage").join("other"),
+        )
+        .unwrap();
+        let dirs =
+            vscode_extension_storage_dirs_from(Some(root.path().to_path_buf()), "sourcegraph.amp");
+        assert_eq!(dirs, vec![code, cursor]);
     }
 }

--- a/tests/fixtures/amp/thread.json
+++ b/tests/fixtures/amp/thread.json
@@ -4,9 +4,12 @@
   "created": 1700000000000,
   "title": "Amp thread title",
   "env": {
-    "trees": [
-      { "cwd": "/tmp/amp-project" }
-    ]
+    "initial": {
+      "workingDirectory": "file:///tmp/amp-project",
+      "trees": [
+        { "uri": "file:///tmp/amp-project" }
+      ]
+    }
   },
   "messages": [
     {

--- a/tests/fixtures/amp/thread.json
+++ b/tests/fixtures/amp/thread.json
@@ -1,0 +1,26 @@
+{
+  "v": 3,
+  "id": "T-0199aaaa-bbbb-7ccc-8ddd-eeeeffff0001",
+  "created": 1700000000000,
+  "title": "Amp thread title",
+  "env": {
+    "trees": [
+      { "cwd": "/tmp/amp-project" }
+    ]
+  },
+  "messages": [
+    {
+      "role": "human",
+      "content": [{ "type": "text", "text": "hello from amp" }],
+      "created": 1700000001000
+    },
+    {
+      "role": "agent",
+      "content": [
+        { "type": "text", "text": "hi back" },
+        { "type": "tool_use", "name": "bash", "input": { "cmd": "ls" } }
+      ],
+      "created": 1700000002000
+    }
+  ]
+}

--- a/tests/fixtures/amp/wrapped-thread.json
+++ b/tests/fixtures/amp/wrapped-thread.json
@@ -1,0 +1,19 @@
+{
+  "thread": {
+    "id": "T-0199cccc-dddd-7eee-8fff-000011112222",
+    "created": 1700000100000,
+    "title": "Wrapped thread",
+    "messages": [
+      {
+        "role": "user",
+        "content": "wrapped user",
+        "created": 1700000101000
+      },
+      {
+        "role": "assistant",
+        "content": "wrapped assistant",
+        "created": 1700000102000
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an in-tree Amp `SourceAdapter` and register it in `all_adapters()`.

- Discovers `$AMP_THREADS_DIR`, `$XDG_DATA_HOME/amp/threads` or `~/.local/share/amp/threads`, and VS Code-family `globalStorage/sourcegraph.amp/{threads,threads3}`.
- Prefers JSON `id` over filename (`thread.json` collisions).
- Incremental scan always re-reads within an 8 MiB cap (Amp does not bump mtime).
- Resume: `amp threads continue <id>`. Missing roots are an empty success. Does not read `secrets.json`.
- `updated_at` uses last message time, not `created` (P1: `last_timestamp` returns meta when Some).

Draft. No Aider. Supersedes the Amp slice of #228.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e817d764-6309-4a38-b9ec-7e243b02d4f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e817d764-6309-4a38-b9ec-7e243b02d4f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

