### PR TITLE
fix(adapters): recover sessions across storage formats

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -15,10 +15,9 @@ use crate::adapters::invocation_probe::{
     probe_recent_files,
 };
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
-use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::paths::{self, resolve_home_dir};
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-    first_timestamp,
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, first_timestamp,
 };
 use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, Role, ThreadRole};
 
@@ -26,7 +25,7 @@ pub(crate) struct ClaudeCodeAdapter;
 
 const USAGE_PARSER_VERSION: u32 = 5;
 const EVENT_PARSER_VERSION: u32 = 4;
-const METADATA_PARSER_VERSION: u32 = 1;
+const METADATA_PARSER_VERSION: u32 = 2;
 
 impl SourceAdapter for ClaudeCodeAdapter {
     fn id(&self) -> &str {
@@ -48,25 +47,7 @@ impl SourceAdapter for ClaudeCodeAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let Some(claude_dir) = resolve_claude_dir()? else {
-            return Ok(vec![]);
-        };
-        let mut indexes = load_session_indexes(&claude_dir);
-
-        let mut sessions = Vec::new();
-        let mut entries = collect_project_entries(&claude_dir, &mut indexes);
-        entries.extend(collect_transcript_entries(&claude_dir));
-
-        for entry in entries {
-            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
-                continue;
-            };
-            if let Some(raw) = parse_claude_session_file(entry, mtime_ms, &indexes, true)? {
-                sessions.push(raw);
-            }
-        }
-
-        Ok(sessions)
+        scan_claude_dirs(&resolve_claude_dirs()?)
     }
 
     fn scan_for_sync(
@@ -75,16 +56,57 @@ impl SourceAdapter for ClaudeCodeAdapter {
         since_ts: Option<i64>,
         include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        let Some(claude_dir) = resolve_claude_dir()? else {
-            return Ok(Some(SyncScanResult {
-                sessions: vec![],
-                stats: SyncScanStats::default(),
-                observations: Vec::new(),
-            }));
-        };
-        let result = scan_for_sync_impl(&claude_dir, context, since_ts, include_events)?;
-        Ok(Some(result))
+        Ok(Some(scan_claude_dirs_for_sync(
+            &resolve_claude_dirs()?,
+            context,
+            since_ts,
+            include_events,
+        )?))
     }
+}
+
+fn scan_claude_dirs(claude_dirs: &[PathBuf]) -> anyhow::Result<Vec<RawSession>> {
+    let mut sessions = Vec::new();
+    let mut claimed = HashSet::new();
+    for claude_dir in claude_dirs {
+        let mut indexes = load_session_indexes(claude_dir);
+        let mut entries = collect_project_entries(claude_dir, &mut indexes);
+        entries.extend(collect_transcript_entries(claude_dir));
+        claim_session_entries(&mut entries, &mut claimed);
+        for entry in entries {
+            let Some(mtime_ms) = file_scan::stat_mtime_ms(&entry.stat_target) else {
+                continue;
+            };
+            if let Some(raw) = parse_claude_session_file(entry, mtime_ms, &indexes, true)? {
+                sessions.push(raw);
+            }
+        }
+    }
+    Ok(sessions)
+}
+
+fn scan_claude_dirs_for_sync(
+    claude_dirs: &[PathBuf],
+    context: &AdapterSyncContext,
+    since_ts: Option<i64>,
+    include_events: bool,
+) -> anyhow::Result<SyncScanResult> {
+    let mut combined = SyncScanResult::default();
+    let mut claimed = HashSet::new();
+    for claude_dir in claude_dirs {
+        combined.absorb(scan_for_sync_claimed(
+            claude_dir,
+            context,
+            since_ts,
+            include_events,
+            &mut claimed,
+        )?);
+    }
+    Ok(combined)
+}
+
+fn claim_session_entries(entries: &mut Vec<FileScanEntry>, claimed: &mut HashSet<String>) {
+    entries.retain(|entry| claimed.insert(entry.session_id.clone()));
 }
 
 struct SessionMeta {
@@ -103,36 +125,44 @@ fn load_session_indexes(claude_dir: &Path) -> SessionIndexes {
     SessionIndexes { live: load_session_index(claude_dir), project_summaries: HashMap::new() }
 }
 
-fn resolve_claude_dir() -> anyhow::Result<Option<PathBuf>> {
-    resolve_home_dir(".claude", "~/.claude not found, skipping Claude Code")
+fn resolve_claude_dirs() -> anyhow::Result<Vec<PathBuf>> {
+    if let Some(dir) = paths::env_path_dir("CLAUDE_CONFIG_DIR") {
+        let Some(dir) = paths::existing_dir(dir) else {
+            debug!("CLAUDE_CONFIG_DIR not found, skipping Claude Code");
+            return Ok(Vec::new());
+        };
+        return Ok(vec![dir]);
+    }
+    let mut dirs = Vec::new();
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty())
+        && let Some(dir) = paths::existing_dir(PathBuf::from(xdg).join("claude-code"))
+    {
+        dirs.push(dir);
+    }
+    if let Some(dir) = resolve_home_dir(".claude", "~/.claude not found, skipping Claude Code")?
+        && !dirs.iter().any(|existing| existing == &dir)
+    {
+        dirs.push(dir);
+    }
+    Ok(dirs)
 }
 
 pub(crate) fn probe_invocation_nonce(
     nonce: &str,
     budget: InvocationProbeBudget,
 ) -> anyhow::Result<ProviderInvocationProbe> {
-    let Some(claude_dir) = resolve_claude_dir()? else {
-        return Ok(ProviderInvocationProbe {
-            source_ids: Vec::new(),
-            files_read: 0,
-            bytes_read: 0,
-            complete: true,
-        });
-    };
-    Ok(probe_invocation_nonce_in(&claude_dir, nonce, budget))
+    let claude_dirs = resolve_claude_dirs()?;
+    Ok(probe_invocation_nonce_in(&claude_dirs, nonce, budget))
 }
 
 fn probe_invocation_nonce_in(
-    claude_dir: &Path,
+    claude_dirs: &[PathBuf],
     nonce: &str,
     budget: InvocationProbeBudget,
 ) -> ProviderInvocationProbe {
-    probe_recent_files(
-        nonce,
-        collect_invocation_entries(claude_dir),
-        budget,
-        claude_invocation_input,
-    )
+    let entries =
+        claude_dirs.iter().flat_map(|claude_dir| collect_invocation_entries(claude_dir)).collect();
+    probe_recent_files(nonce, entries, budget, claude_invocation_input)
 }
 
 fn collect_invocation_entries(claude_dir: &Path) -> Vec<FileScanEntry> {
@@ -184,15 +214,27 @@ fn transcript_source_id(path: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
+#[cfg(test)]
 fn scan_for_sync_impl(
     claude_dir: &Path,
     context: &AdapterSyncContext,
     since_ts: Option<i64>,
     include_events: bool,
 ) -> anyhow::Result<SyncScanResult> {
+    scan_for_sync_claimed(claude_dir, context, since_ts, include_events, &mut HashSet::new())
+}
+
+fn scan_for_sync_claimed(
+    claude_dir: &Path,
+    context: &AdapterSyncContext,
+    since_ts: Option<i64>,
+    include_events: bool,
+    claimed: &mut HashSet<String>,
+) -> anyhow::Result<SyncScanResult> {
     let mut indexes = load_session_indexes(claude_dir);
     let mut entries = collect_project_entries(claude_dir, &mut indexes);
     entries.extend(collect_transcript_entries(claude_dir));
+    claim_session_entries(&mut entries, claimed);
 
     file_scan::run_file_scan_with_options(
         context,
@@ -420,6 +462,7 @@ fn parse_claude_session_file(
         thread_role,
         parent_links,
         metadata_parser_version: Some(METADATA_PARSER_VERSION),
+        refresh_session_on_metadata_backfill: false,
     }))
 }
 
@@ -486,12 +529,15 @@ pub(crate) fn parse_conversation_jsonl(
 
         let msg_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
-        if msg_type == "custom-title"
-            && let Some(title) = v.get("customTitle").and_then(|t| t.as_str())
-        {
-            let trimmed = title.trim();
-            if !trimmed.is_empty() {
-                custom_title = Some(trimmed.to_string());
+        if matches!(msg_type, "custom-title" | "ai-title" | "title") {
+            let title = v
+                .get("customTitle")
+                .or_else(|| v.get("title"))
+                .and_then(|t| t.as_str())
+                .map(str::trim)
+                .filter(|title| !title.is_empty());
+            if let Some(title) = title {
+                custom_title = Some(title.to_string());
             }
             continue;
         }
@@ -1390,6 +1436,38 @@ mod tests {
     }
 
     #[test]
+    fn parse_claude_session_prefers_ai_title_when_present() {
+        let root = temp_claude_root("ai-title");
+        let project = root.join("projects").join("-tmp-ai");
+        fs::create_dir_all(&project).unwrap();
+        let path = project.join("ai-session.jsonl");
+        let lines = [
+            serde_json::json!({"type":"user","message":{"content":"start"},"timestamp":"2026-04-13T10:00:00Z"}),
+            serde_json::json!({"type":"ai-title","title":"Named by Claude"}),
+            serde_json::json!({"type":"assistant","message":{"content":"done"},"timestamp":"2026-04-13T10:00:01Z"}),
+        ];
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+        let raw = parse_claude_session_file(
+            FileScanEntry {
+                session_id: "ai-session".to_string(),
+                stat_target: path,
+                directory: None,
+            },
+            mtime,
+            &SessionIndexes::default(),
+            false,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(raw.custom_title.as_deref(), Some("Named by Claude"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn scan_for_sync_uses_project_sessions_index_summary() {
         let root = temp_claude_root("project-summary");
         let project = root.join("projects").join("-tmp-index");
@@ -1586,6 +1664,62 @@ mod tests {
     }
 
     #[test]
+    fn scan_for_sync_reparses_unchanged_session_for_ai_title_backfill() {
+        let root = temp_claude_root("ai-title-backfill");
+        let project = root.join("projects").join("-tmp-proj");
+        let path = write_user_jsonl(&project, "sess-ai-title", "hello");
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(file, "{}", serde_json::json!({"type":"ai-title","title":"Named by Claude"}))
+            .unwrap();
+        drop(file);
+        let mtime = file_scan::stat_mtime_ms(&path).unwrap();
+
+        let store = setup_store();
+        store.insert_session(&make_existing_session("sess-ai-title", mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "claude-code",
+                "sess-ai-title",
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_session_events_for_existing_session(
+                "claude-code",
+                "sess-ai-title",
+                &[],
+                EVENT_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+        store
+            .persist_topology_for_existing_session(
+                "claude-code",
+                "sess-ai-title",
+                &crate::db::store::SessionTopologyWrite {
+                    thread_role: None,
+                    parents: &[],
+                    parser_version: Some(1),
+                },
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].custom_title.as_deref(), Some("Named by Claude"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn scan_for_sync_reparses_unchanged_session_with_stale_event_parser() {
         let root = temp_claude_root("event-parser-backfill");
         let project = root.join("projects").join("-tmp-proj");
@@ -1710,13 +1844,16 @@ mod tests {
         writeln!(file, "{call}").unwrap();
         writeln!(file, "{call}").unwrap();
 
-        let result =
-            probe_invocation_nonce_in(&root, "nonce-claude", InvocationProbeBudget::default());
+        let result = probe_invocation_nonce_in(
+            std::slice::from_ref(&root),
+            "nonce-claude",
+            InvocationProbeBudget::default(),
+        );
         assert!(result.complete);
         assert_eq!(result.source_ids, vec!["claude-session".to_string()]);
 
         let normal = probe_invocation_nonce_in(
-            &root,
+            std::slice::from_ref(&root),
             "normal nonce-claude reference",
             InvocationProbeBudget::default(),
         );
@@ -1746,12 +1883,73 @@ mod tests {
             writeln!(file, "{call}").unwrap();
         }
 
-        let result =
-            probe_invocation_nonce_in(&root, "nonce-shared", InvocationProbeBudget::default());
+        let result = probe_invocation_nonce_in(
+            std::slice::from_ref(&root),
+            "nonce-shared",
+            InvocationProbeBudget::default(),
+        );
         assert!(result.complete);
         assert_eq!(result.source_ids.len(), 2);
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_probe_shares_budget_across_roots() {
+        let first = temp_claude_root("invocation-probe-budget-first");
+        let second = temp_claude_root("invocation-probe-budget-second");
+        for (root, prefix) in [(&first, "first"), (&second, "second")] {
+            let project = root.join("projects").join("-tmp-probe");
+            for index in 0..40 {
+                write_user_jsonl(&project, &format!("{prefix}-{index}"), "ordinary");
+            }
+        }
+
+        let result = probe_invocation_nonce_in(
+            &[first.clone(), second.clone()],
+            "absent-nonce",
+            InvocationProbeBudget::default(),
+        );
+        assert!(result.files_read <= 64);
+        assert!(!result.complete);
+
+        let _ = fs::remove_dir_all(first);
+        let _ = fs::remove_dir_all(second);
+    }
+
+    #[test]
+    fn duplicate_session_ids_prefer_the_first_claude_root() {
+        let preferred = temp_claude_root("duplicate-preferred");
+        let fallback = temp_claude_root("duplicate-fallback");
+        write_user_jsonl(
+            &preferred.join("projects").join("-tmp-probe"),
+            "shared-session",
+            "preferred",
+        );
+        write_user_jsonl(
+            &fallback.join("projects").join("-tmp-probe"),
+            "shared-session",
+            "fallback",
+        );
+        let roots = [preferred.clone(), fallback.clone()];
+
+        let sessions = scan_claude_dirs(&roots).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].messages[0].content, "preferred");
+
+        let store = setup_store();
+        let result = scan_claude_dirs_for_sync(
+            &roots,
+            &AdapterSyncContext::from_store_for_test(&store, "claude-code").unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "preferred");
+
+        let _ = fs::remove_dir_all(preferred);
+        let _ = fs::remove_dir_all(fallback);
     }
 
     #[test]

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -14,7 +14,7 @@ use crate::adapters::invocation_probe::{
     probe_recent_files,
 };
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
-use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::paths::{self, resolve_home_dir};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
     first_timestamp, last_timestamp,
@@ -23,7 +23,7 @@ use crate::types::{ParentLink, ParentRelation, RawSessionEvent, RawUsageEvent, R
 
 pub(crate) struct CodexAdapter;
 
-const USAGE_PARSER_VERSION: u32 = 5;
+const USAGE_PARSER_VERSION: u32 = 6;
 const EVENT_PARSER_VERSION: u32 = 4;
 const METADATA_PARSER_VERSION: u32 = 1;
 
@@ -110,6 +110,13 @@ fn open_url_command(url: String) -> ResumeCommand {
 }
 
 fn resolve_codex_dir() -> anyhow::Result<Option<PathBuf>> {
+    if let Some(dir) = paths::env_path_dir("CODEX_HOME") {
+        if dir.is_dir() {
+            return Ok(Some(dir));
+        }
+        debug!("CODEX_HOME not found, skipping Codex");
+        return Ok(None);
+    }
     resolve_home_dir(".codex", "~/.codex not found, skipping Codex")
 }
 
@@ -446,6 +453,7 @@ pub(crate) fn parse_codex_session_with_options(
     let mut forked_child_inherited_baseline: Option<CodexUsageTotals> = None;
     let mut forked_child_inherited_reported_total: Option<i64> = None;
     let mut last_visible_message_seq: Option<u32> = None;
+    let mut user_dedup = CodexUserDedup::default();
     let source_path = path.to_string_lossy().to_string();
 
     for item in jsonl_indexed(reader.lines()) {
@@ -575,9 +583,10 @@ pub(crate) fn parse_codex_session_with_options(
                                 && !text.is_empty()
                             {
                                 let ts = parse_timestamp(&v);
-                                last_visible_message_seq = push_codex_message(
+                                last_visible_message_seq = push_codex_user(
                                     &mut messages,
-                                    Role::User,
+                                    &mut user_dedup,
+                                    CodexUserStream::EventMsg,
                                     text.to_string(),
                                     ts,
                                 );
@@ -605,7 +614,18 @@ pub(crate) fn parse_codex_session_with_options(
                     let timestamp = parse_timestamp(&v);
                     let payload_type = payload.get("type").and_then(|t| t.as_str());
                     let role = payload.get("role").and_then(|r| r.as_str());
-                    if payload_type == Some("message") && role == Some("assistant") {
+                    if payload_type == Some("message") && role == Some("user") {
+                        let text = extract_content_array(payload.get("content"));
+                        if !text.is_empty() && !is_codex_injected_context(&text) {
+                            last_visible_message_seq = push_codex_user(
+                                &mut messages,
+                                &mut user_dedup,
+                                CodexUserStream::ResponseItem,
+                                text,
+                                timestamp,
+                            );
+                        }
+                    } else if payload_type == Some("message") && role == Some("assistant") {
                         let text = extract_content_array(payload.get("content"));
                         let message_seq = if text.is_empty() {
                             None
@@ -695,6 +715,7 @@ pub(crate) fn parse_codex_session_with_options(
         thread_role,
         parent_links,
         metadata_parser_version: Some(METADATA_PARSER_VERSION),
+        refresh_session_on_metadata_backfill: false,
     }))
 }
 
@@ -891,8 +912,10 @@ fn codex_content_has_visible_text(content: Option<&Value>) -> bool {
         return false;
     };
     items.iter().any(|item| {
-        matches!(item.get("type").and_then(Value::as_str), Some("text" | "output_text"))
-            && item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty())
+        matches!(
+            item.get("type").and_then(Value::as_str),
+            Some("text" | "output_text" | "input_text")
+        ) && item.get("text").and_then(Value::as_str).is_some_and(|text| !text.is_empty())
     })
 }
 
@@ -954,7 +977,7 @@ fn extract_content_array(content: Option<&Value>) -> String {
             let mut parts = Vec::new();
             for item in arr {
                 match item.get("type").and_then(|t| t.as_str()) {
-                    Some("text" | "output_text") => {
+                    Some("text" | "output_text" | "input_text") => {
                         if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
                             parts.push(text.to_string());
                         }
@@ -1201,6 +1224,55 @@ fn apply_pending_codex_model(
 
 fn parse_timestamp(v: &Value) -> Option<i64> {
     rfc3339_ms(v.get("timestamp"))
+}
+
+const CODEX_INJECTED_CONTEXT_PREFIXES: &[&str] =
+    &["# AGENTS.md instructions", "<environment_context>", "<user_instructions>", "<INSTRUCTIONS>"];
+
+fn is_codex_injected_context(text: &str) -> bool {
+    text.lines().any(|line| {
+        let trimmed = line.trim_start();
+        CODEX_INJECTED_CONTEXT_PREFIXES.iter().any(|prefix| trimmed.starts_with(prefix))
+    })
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CodexUserStream {
+    EventMsg,
+    ResponseItem,
+}
+
+#[derive(Default)]
+struct CodexUserDedup {
+    last_seq: Option<u32>,
+    streams_seen: u8,
+}
+
+fn push_codex_user(
+    messages: &mut Vec<RawMessage>,
+    dedup: &mut CodexUserDedup,
+    stream: CodexUserStream,
+    content: String,
+    timestamp: Option<i64>,
+) -> Option<u32> {
+    let stream_bit = match stream {
+        CodexUserStream::EventMsg => 1,
+        CodexUserStream::ResponseItem => 2,
+    };
+    if let Some(seq) = dedup.last_seq
+        && seq as usize + 1 == messages.len()
+        && messages
+            .get(seq as usize)
+            .is_some_and(|message| message.role == Role::User && message.content == content)
+        && dedup.streams_seen & stream_bit == 0
+    {
+        dedup.streams_seen |= stream_bit;
+        return Some(seq);
+    }
+    let seq = push_codex_message(messages, Role::User, content.clone(), timestamp);
+    dedup.last_seq = seq;
+    dedup.streams_seen = stream_bit;
+    seq
 }
 
 fn push_codex_message(
@@ -1484,6 +1556,225 @@ mod tests {
         assert_eq!(raw.events[0].message_seq, None);
         assert_eq!(raw.events[0].source_event_id.as_deref(), Some("1:0"));
         assert_eq!(raw.events[0].tool_call_id.as_deref(), Some("call_empty"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_indexes_response_item_users_and_dedups_event_msg() {
+        let root = temp_codex_root("response-user");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2399";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let lines = [
+            serde_json::json!({
+                "type": "session_meta",
+                "timestamp": "2026-04-13T10:00:00Z",
+                "payload": {"id": uuid, "cwd": "/tmp/foo"}
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "fix the parser"}]
+                }
+            }),
+            serde_json::json!({
+                "type": "event_msg",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "payload": {"type": "user_message", "message": "fix the parser"}
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:02Z",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "ok"}]
+                }
+            }),
+        ];
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+        assert_eq!(raw.messages.len(), 2);
+        assert_eq!(raw.messages[0].role, Role::User);
+        assert_eq!(raw.messages[0].content, "fix the parser");
+        assert_eq!(raw.messages[1].content, "ok");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_drops_injected_context_response_items() {
+        let root = temp_codex_root("injected-context");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2401";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let injected = [
+            "# AGENTS.md instructions for /tmp/foo\n\nalways run make check",
+            "<environment_context>\n  <cwd>/tmp/foo</cwd>\n</environment_context>",
+            "<user_instructions>\nbe terse\n</user_instructions>",
+            "wrapper\n<environment_context>\n  <cwd>/tmp/foo</cwd>\n</environment_context>",
+        ];
+        let mut lines = vec![serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {"id": uuid, "cwd": "/tmp/foo"}
+        })];
+        for text in injected {
+            lines.push(serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}]
+                }
+            }));
+        }
+        lines.push(serde_json::json!({
+            "type": "response_item",
+            "timestamp": "2026-04-13T10:00:02Z",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "fix the parser"}]
+            }
+        }));
+        let body = lines.iter().map(|line| line.to_string()).collect::<Vec<_>>().join("\n") + "\n";
+        fs::write(&path, body).unwrap();
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+        let users: Vec<&str> = raw
+            .messages
+            .iter()
+            .filter(|message| message.role == Role::User)
+            .map(|message| message.content.as_str())
+            .collect();
+        assert_eq!(users, vec!["fix the parser"]);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_repeated_user_turns() {
+        let root = temp_codex_root("repeat-user");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2400";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let mut lines = vec![serde_json::json!({
+            "type": "session_meta",
+            "timestamp": "2026-04-13T10:00:00Z",
+            "payload": {"id": uuid, "cwd": "/tmp/foo"}
+        })];
+        for turn in 0..3 {
+            lines.push(serde_json::json!({
+                "type": "response_item",
+                "timestamp": format!("2026-04-13T10:0{turn}:01Z"),
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue"}]
+                }
+            }));
+            lines.push(serde_json::json!({
+                "type": "event_msg",
+                "timestamp": format!("2026-04-13T10:0{turn}:01Z"),
+                "payload": {"type": "user_message", "message": "continue"}
+            }));
+            lines.push(serde_json::json!({
+                "type": "response_item",
+                "timestamp": format!("2026-04-13T10:0{turn}:02Z"),
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": format!("step {turn}")}]
+                }
+            }));
+        }
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+        let users: Vec<&str> = raw
+            .messages
+            .iter()
+            .filter(|message| message.role == Role::User)
+            .map(|message| message.content.as_str())
+            .collect();
+        assert_eq!(users, vec!["continue", "continue", "continue"]);
+        assert_eq!(raw.messages.len(), 6);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parse_codex_session_keeps_same_text_from_separate_stream_turns() {
+        let root = temp_codex_root("separate-stream-turns");
+        let sessions_dir = root.join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let uuid = "019a4c01-e8f4-7270-bdab-7f19273b2402";
+        let path = sessions_dir.join(format!("rollout-2026-04-13T10-00-00-{uuid}.jsonl"));
+        let lines = [
+            serde_json::json!({
+                "type": "session_meta",
+                "timestamp": "2026-04-13T10:00:00Z",
+                "payload": {"id": uuid, "cwd": "/tmp/foo"}
+            }),
+            serde_json::json!({
+                "type": "event_msg",
+                "timestamp": "2026-04-13T10:00:01Z",
+                "payload": {"type": "user_message", "message": "continue"}
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:00:02Z",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "first"}]
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:01:01Z",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue"}]
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "timestamp": "2026-04-13T10:01:02Z",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "second"}]
+                }
+            }),
+        ];
+        let mut file = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+
+        let raw = parse_codex_session(&path).unwrap().unwrap();
+        let users: Vec<&str> = raw
+            .messages
+            .iter()
+            .filter(|message| message.role == Role::User)
+            .map(|message| message.content.as_str())
+            .collect();
+        assert_eq!(users, vec!["continue", "continue"]);
+        assert_eq!(raw.messages.len(), 4);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/copilot_chat.rs
+++ b/src/adapters/copilot_chat.rs
@@ -1,22 +1,26 @@
-use std::collections::HashMap;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::json_i64;
+use crate::adapters::sync_state::metadata_state_is_current_for_mtime;
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, first_timestamp,
+    RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter, SyncScanOutput,
+    SyncScanResult, first_timestamp,
 };
 use crate::types::Role;
 
 pub(crate) struct CopilotChatAdapter;
 
-const HOSTS: &[&str] = &["Code", "Code - Insiders"];
+const HOSTS: &[&str] = &["Code", "Code - Insiders", "VSCodium"];
+const METADATA_PARSER_VERSION: u32 = 1;
 
 impl SourceAdapter for CopilotChatAdapter {
     fn id(&self) -> &str {
@@ -44,17 +48,149 @@ impl SourceAdapter for CopilotChatAdapter {
         Ok(sessions)
     }
 
-    fn scan_for_sync(
+    fn scan_for_sync_output(
         &self,
         context: &AdapterSyncContext,
         since_ts: Option<i64>,
         _include_events: bool,
-    ) -> anyhow::Result<Option<SyncScanResult>> {
-        let entries = collect_chat_entries(&vscode_user_roots());
-        let result =
-            file_scan::run_file_scan(context, since_ts, entries, parse_chat_session_for_entry)?;
-        Ok(Some(result))
+        force: bool,
+    ) -> anyhow::Result<Option<SyncScanOutput>> {
+        Ok(Some(scan_chat_entries_for_sync(
+            collect_chat_entries(&vscode_user_roots()),
+            context,
+            since_ts,
+            force,
+        )?))
     }
+}
+
+fn scan_chat_entries_for_sync(
+    entries: Vec<FileScanEntry>,
+    context: &AdapterSyncContext,
+    since_ts: Option<i64>,
+    force: bool,
+) -> anyhow::Result<SyncScanOutput> {
+    let tombstones = RefCell::new(HashSet::new());
+    let scan = if force {
+        let mut result = SyncScanResult::default();
+        for entry in entries {
+            result.stats.candidates += 1;
+            let Some(snapshot) = file_scan::file_metadata_snapshot(&entry.stat_target) else {
+                result.stats.rejected_before_parse += 1;
+                continue;
+            };
+            let Some(mtime_ms) = snapshot.mtime_ms() else {
+                result.stats.rejected_before_parse += 1;
+                continue;
+            };
+            result.stats.parsed += 1;
+            let Some(parsed) =
+                parse_stable_chat_entry_with(entry, mtime_ms, snapshot, parse_chat_entry)?
+            else {
+                result.stats.unstable_sessions += 1;
+                continue;
+            };
+            if let Some(source_id) = parsed.other_provider {
+                tombstones.borrow_mut().insert(source_id);
+            }
+            if let Some(session) = parsed.session {
+                result.sessions.push(session);
+            }
+        }
+        result
+    } else {
+        let mut migration = SyncScanResult::default();
+        let mut current_entries = Vec::new();
+        let unstable = Cell::new(0);
+        for entry in entries {
+            let Some(snapshot) = file_scan::file_metadata_snapshot(&entry.stat_target) else {
+                current_entries.push(entry);
+                continue;
+            };
+            let Some(mtime_ms) = snapshot.mtime_ms() else {
+                current_entries.push(entry);
+                continue;
+            };
+            let needs_migration = context.session_meta().contains_key(&entry.session_id)
+                && !metadata_state_is_current_for_mtime(
+                    Some(METADATA_PARSER_VERSION),
+                    context.metadata_state().get(&entry.session_id).copied(),
+                    mtime_ms,
+                );
+            if !needs_migration {
+                current_entries.push(entry);
+                continue;
+            }
+            migration.stats.candidates += 1;
+            migration.stats.parsed += 1;
+            let Some(parsed) =
+                parse_stable_chat_entry_with(entry, mtime_ms, snapshot, parse_chat_entry)?
+            else {
+                migration.stats.unstable_sessions += 1;
+                continue;
+            };
+            if let Some(source_id) = parsed.other_provider {
+                tombstones.borrow_mut().insert(source_id);
+            }
+            if let Some(session) = parsed.session {
+                migration.sessions.push(session);
+            }
+        }
+        let mut result = file_scan::run_file_scan_with_options(
+            context,
+            since_ts,
+            file_scan::FileScanOptions {
+                metadata_parser_version: Some(METADATA_PARSER_VERSION),
+                ..Default::default()
+            },
+            current_entries,
+            |entry, mtime_ms| {
+                let Some(snapshot) = file_scan::file_metadata_snapshot(&entry.stat_target) else {
+                    unstable.set(unstable.get() + 1);
+                    return Ok(None);
+                };
+                let Some(parsed) =
+                    parse_stable_chat_entry_with(entry, mtime_ms, snapshot, parse_chat_entry)?
+                else {
+                    unstable.set(unstable.get() + 1);
+                    return Ok(None);
+                };
+                if let Some(source_id) = parsed.other_provider {
+                    tombstones.borrow_mut().insert(source_id);
+                }
+                Ok(parsed.session)
+            },
+        )?;
+        result.stats.unstable_sessions += unstable.get();
+        result.absorb(migration);
+        result
+    };
+    Ok(SyncScanOutput {
+        scan,
+        reconcile: Some(ReconcilePlan::ExactTombstones(tombstones.into_inner())),
+    })
+}
+
+fn parse_stable_chat_entry_with<F>(
+    entry: FileScanEntry,
+    mtime_ms: i64,
+    before: file_scan::FileMetadataSnapshot,
+    parse_fn: F,
+) -> anyhow::Result<Option<ParsedChatEntry>>
+where
+    F: FnOnce(FileScanEntry, i64) -> anyhow::Result<ParsedChatEntry>,
+{
+    let path = entry.stat_target.clone();
+    let source_id = entry.session_id.clone();
+    let parsed = parse_fn(entry, mtime_ms)?;
+    if file_scan::file_metadata_snapshot(&path).as_ref() != Some(&before) {
+        warn!(
+            "skipping unstable Copilot Chat session {source_id}: source file changed while parsing ({})",
+            path.display()
+        );
+        return Ok(None);
+    }
+    Ok(Some(parsed))
 }
 
 fn vscode_user_roots() -> Vec<PathBuf> {
@@ -68,6 +204,7 @@ fn collect_chat_entries(user_roots: &[PathBuf]) -> Vec<FileScanEntry> {
     let mut by_id: HashMap<String, FileScanEntry> = HashMap::new();
     for user_root in user_roots {
         collect_empty_window_entries(user_root, &mut by_id);
+        collect_transferred_entries(user_root, &mut by_id);
         collect_workspace_entries(user_root, &mut by_id);
     }
     by_id.into_values().collect()
@@ -75,6 +212,11 @@ fn collect_chat_entries(user_roots: &[PathBuf]) -> Vec<FileScanEntry> {
 
 fn collect_empty_window_entries(user_root: &Path, by_id: &mut HashMap<String, FileScanEntry>) {
     let dir = user_root.join("globalStorage").join("emptyWindowChatSessions");
+    collect_session_files(&dir, None, by_id);
+}
+
+fn collect_transferred_entries(user_root: &Path, by_id: &mut HashMap<String, FileScanEntry>) {
+    let dir = user_root.join("globalStorage").join("transferredChatSessions");
     collect_session_files(&dir, None, by_id);
 }
 
@@ -189,13 +331,33 @@ fn parse_chat_session_for_entry(
     entry: FileScanEntry,
     mtime_ms: i64,
 ) -> anyhow::Result<Option<RawSession>> {
+    Ok(parse_chat_entry(entry, mtime_ms)?.session)
+}
+
+#[derive(Default)]
+struct ParsedChatEntry {
+    session: Option<RawSession>,
+    other_provider: Option<String>,
+}
+
+fn parse_chat_entry(entry: FileScanEntry, mtime_ms: i64) -> anyhow::Result<ParsedChatEntry> {
     let source_file_path = entry.stat_target.to_str().map(str::to_string);
     let Some(doc) = load_chat_document(&entry.stat_target) else {
-        return Ok(None);
+        return Ok(ParsedChatEntry::default());
     };
+    match classify_chat_provider(&doc) {
+        ChatProvider::Copilot => {}
+        ChatProvider::Other => {
+            return Ok(ParsedChatEntry {
+                other_provider: Some(entry.session_id),
+                ..Default::default()
+            });
+        }
+        ChatProvider::Unknown => return Ok(ParsedChatEntry::default()),
+    }
     let parsed = messages_from_doc(&doc);
     if parsed.messages.is_empty() {
-        return Ok(None);
+        return Ok(ParsedChatEntry::default());
     }
     let started_at = first_timestamp(parsed.started_at, &parsed.messages, &[], &[]).unwrap_or(0);
     let updated_at = Some(mtime_ms);
@@ -209,7 +371,8 @@ fn parse_chat_session_for_entry(
     );
     session.source_file_path = source_file_path;
     session.custom_title = parsed.custom_title;
-    Ok(Some(session))
+    session.metadata_parser_version = Some(METADATA_PARSER_VERSION);
+    Ok(ParsedChatEntry { session: Some(session), other_provider: None })
 }
 
 fn load_chat_document(path: &Path) -> Option<Value> {
@@ -240,19 +403,26 @@ fn replay_chat_jsonl(path: &Path) -> Option<Value> {
             return None;
         }
     };
+    let mut lines = BufReader::new(file).lines().map_while(Result::ok).enumerate().peekable();
     let mut doc = None;
-    for line in BufReader::new(file).lines() {
-        let line = match line {
-            Ok(line) => line,
-            Err(_) => break,
-        };
-        let line = line.trim();
+    while let Some((index, line)) = lines.next() {
+        let is_last = lines.peek().is_none();
+        let line = line.trim().trim_start_matches('\u{feff}');
         if line.is_empty() {
             continue;
         }
         let event: Value = match serde_json::from_str(line) {
             Ok(event) => event,
-            Err(_) => break,
+            Err(_) => {
+                if !is_last {
+                    debug!(
+                        "skipping malformed copilot chat jsonl line {} in {}",
+                        index + 1,
+                        path.display()
+                    );
+                }
+                continue;
+            }
         };
         match json_i64(event.get("kind")).unwrap_or(-1) {
             0 => doc = event.get("v").cloned(),
@@ -262,6 +432,14 @@ fn replay_chat_jsonl(path: &Path) -> Option<Value> {
                 }
             }
             2 => {
+                if let Some(root) = doc.as_mut() {
+                    let values = event.get("v").and_then(Value::as_array);
+                    let truncate_to =
+                        json_i64(event.get("i")).and_then(|index| usize::try_from(index).ok());
+                    apply_push(root, event.get("k"), values, truncate_to);
+                }
+            }
+            3 => {
                 if let Some(root) = doc.as_mut() {
                     apply_delete(root, event.get("k"));
                 }
@@ -308,6 +486,67 @@ fn apply_set(root: &mut Value, path: Option<&Value>, value: Value) {
     }
     if let Some(last) = segs.last() {
         assign_last(current, last, value);
+    }
+}
+
+fn apply_push(
+    root: &mut Value,
+    path: Option<&Value>,
+    values: Option<&Vec<Value>>,
+    truncate_to: Option<usize>,
+) {
+    let Some(segs) = path_segs(path) else {
+        return;
+    };
+    if segs.is_empty() {
+        return;
+    }
+    let mut current = root;
+    for index in 0..segs.len() - 1 {
+        current = match get_or_create(current, &segs[index], Some(&segs[index + 1])) {
+            Some(next) => next,
+            None => return,
+        };
+    }
+    let Some(last) = segs.last() else {
+        return;
+    };
+    let slot = match last {
+        PathSeg::Key(key) => {
+            if !current.is_object() {
+                *current = Value::Object(Map::new());
+            }
+            let object = match current.as_object_mut() {
+                Some(object) => object,
+                None => return,
+            };
+            object.entry(key.clone()).or_insert_with(|| Value::Array(Vec::new()))
+        }
+        PathSeg::Index(index) => {
+            if !current.is_array() {
+                *current = Value::Array(Vec::new());
+            }
+            let array = match current.as_array_mut() {
+                Some(array) => array,
+                None => return,
+            };
+            while array.len() <= *index {
+                array.push(Value::Null);
+            }
+            &mut array[*index]
+        }
+    };
+    if slot.is_null() {
+        *slot = Value::Array(Vec::new());
+    }
+    let Some(array) = slot.as_array_mut() else {
+        return;
+    };
+    if let Some(len) = truncate_to {
+        array.truncate(len);
+    }
+    if let Some(values) = values {
+        array.extend(values.iter().cloned());
     }
 }
 
@@ -428,19 +667,16 @@ fn messages_from_doc(doc: &Value) -> ParsedChat {
         return ParsedChat { messages, custom_title, started_at };
     };
     for request in requests {
-        if request.get("hiddenFromTranscript").and_then(|value| value.as_bool()) == Some(true) {
+        if request.get("hiddenFromTranscript").and_then(|value| value.as_bool()) == Some(true)
+            || request.get("isHidden").and_then(|value| value.as_bool()) == Some(true)
+        {
             continue;
         }
         let timestamp = json_i64(request.get("timestamp"))
             .or_else(|| json_i64(request.get("responseTimestamp")));
-        if let Some(text) = request
-            .get("message")
-            .and_then(|message| message.get("text"))
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|text| !text.is_empty())
-        {
-            messages.push(RawMessage { role: Role::User, content: text.to_string(), timestamp });
+        let text = request_text(request.get("message"));
+        if !text.is_empty() {
+            messages.push(RawMessage { role: Role::User, content: text, timestamp });
         }
         let assistant = response_text(request.get("response"));
         if !assistant.is_empty() {
@@ -448,6 +684,69 @@ fn messages_from_doc(doc: &Value) -> ParsedChat {
         }
     }
     ParsedChat { messages, custom_title, started_at }
+}
+
+fn request_text(message: Option<&Value>) -> String {
+    let Some(message) = message else {
+        return String::new();
+    };
+    if let Some(text) = message.as_str().map(str::trim).filter(|text| !text.is_empty()) {
+        return text.to_string();
+    }
+    if let Some(text) =
+        message.get("text").and_then(Value::as_str).map(str::trim).filter(|text| !text.is_empty())
+    {
+        return text.to_string();
+    }
+    let Some(parts) = message.get("parts").and_then(Value::as_array) else {
+        return String::new();
+    };
+    parts
+        .iter()
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatProvider {
+    Copilot,
+    Other,
+    Unknown,
+}
+
+fn classify_chat_provider(session: &Value) -> ChatProvider {
+    let responder = session
+        .get("responderUsername")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+    if responder.is_some_and(|name| name.eq_ignore_ascii_case("github copilot")) {
+        return ChatProvider::Copilot;
+    }
+    let mut saw_other = responder.is_some();
+    for id in session
+        .get("requests")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|request| {
+            request
+                .pointer("/agent/extensionId/value")
+                .or_else(|| request.pointer("/agent/extensionId"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        if id.to_ascii_lowercase().starts_with("github.copilot") {
+            return ChatProvider::Copilot;
+        }
+        saw_other = true;
+    }
+    if saw_other { ChatProvider::Other } else { ChatProvider::Unknown }
 }
 
 fn response_text(response: Option<&Value>) -> String {
@@ -459,16 +758,18 @@ fn response_text(response: Option<&Value>) -> String {
         let Some(object) = item.as_object() else {
             continue;
         };
-        if object.get("kind").and_then(|value| value.as_str()).is_some() {
-            continue;
-        }
-        if let Some(text) = object
-            .get("value")
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|text| !text.is_empty())
-        {
-            parts.push(text.to_string());
+        match object.get("kind").and_then(|value| value.as_str()) {
+            None | Some("markdownContent") => {
+                if let Some(text) = object
+                    .get("value")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                {
+                    parts.push(text.to_string());
+                }
+            }
+            _ => {}
         }
     }
     parts.join("\n")
@@ -548,7 +849,7 @@ mod tests {
         let path = root.join("sess-2.json");
         fs::write(
             &path,
-            r#"{"version":3,"sessionId":"sess-2","creationDate":1700000000000,"customTitle":"Old chat","requests":[{"timestamp":1700000001000,"message":{"text":"translate this"},"response":[{"kind":"toolInvocationSerialized","value":"read"},{"value":"done"}]}]}"#,
+            r#"{"version":3,"sessionId":"sess-2","creationDate":1700000000000,"customTitle":"Old chat","responderUsername":"GitHub Copilot","requests":[{"timestamp":1700000001000,"message":{"text":"translate this"},"response":[{"kind":"toolInvocationSerialized","value":"read"},{"value":"done"}]}]}"#,
         )
         .unwrap();
 
@@ -588,7 +889,7 @@ mod tests {
         write_jsonl(
             &path,
             &[
-                r#"{"kind":0,"v":{"version":3,"creationDate":1,"requests":[{"timestamp":2,"message":{"text":"keep"},"response":[{"value":"ok"}]}]}}"#,
+                r#"{"kind":0,"v":{"version":3,"creationDate":1,"responderUsername":"GitHub Copilot","requests":[{"timestamp":2,"message":{"text":"keep"},"response":[{"value":"ok"}]}]}}"#,
                 r#"{"kind":1,"k":["requests",0,"response""#,
             ],
         );
@@ -638,9 +939,200 @@ mod tests {
     }
 
     #[test]
+    fn jsonl_kind_two_pushes_and_kind_three_deletes() {
+        let root = temp_root("push");
+        let path = root.join("sess-push.jsonl");
+        write_jsonl(
+            &path,
+            &[
+                r#"{"kind":0,"v":{"version":3,"responderUsername":"GitHub Copilot","requests":[{"timestamp":1,"message":{"text":"hello"},"response":[]}]}}"#,
+                r#"{"kind":2,"k":["requests",0,"response"],"v":[{"value":"Hi."}]}"#,
+                r#"{"kind":3,"k":["requests",0,"response",0]}"#,
+                r#"{"kind":2,"k":["requests",0,"response"],"v":[{"value":"Hello."}]}"#,
+            ],
+        );
+        let session = parse_chat_session_for_entry(
+            FileScanEntry {
+                session_id: "sess-push".to_string(),
+                stat_target: path,
+                directory: None,
+            },
+            1,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[1].content, "Hello.");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn markdown_content_parts_are_indexed() {
+        let doc = serde_json::json!({
+            "responderUsername": "GitHub Copilot",
+            "requests": [{
+                "message": {"text": "q"},
+                "response": [{"kind":"markdownContent","value":"answer"}]
+            }]
+        });
+        let parsed = messages_from_doc(&doc);
+        assert_eq!(parsed.messages[1].content, "answer");
+    }
+
+    #[test]
+    fn other_chat_providers_are_skipped() {
+        let root = temp_root("other");
+        let path = root.join("other.json");
+        fs::write(
+            &path,
+            r#"{"responderUsername":"Other Agent","requests":[{"message":{"text":"nope"},"response":[{"value":"nope"}]}]}"#,
+        )
+        .unwrap();
+        let session = parse_chat_session_for_entry(
+            FileScanEntry { session_id: "other".to_string(), stat_target: path, directory: None },
+            1,
+        )
+        .unwrap();
+        assert!(session.is_none());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn explicit_other_provider_is_distinct_from_unknown() {
+        let other = serde_json::json!({"responderUsername": "Other Agent"});
+        let unknown = serde_json::json!({"requests": [{"message": {"text": "hello"}}]});
+
+        assert_ne!(classify_chat_provider(&other), classify_chat_provider(&unknown));
+    }
+
+    #[test]
+    fn unstable_provider_file_produces_no_classification() {
+        let root = temp_root("unstable-provider");
+        let path = root.join("changing.json");
+        fs::write(&path, r#"{"responderUsername":"Other Agent","requests":[]}"#).unwrap();
+        let snapshot = file_scan::file_metadata_snapshot(&path).unwrap();
+        let mtime_ms = snapshot.mtime_ms().unwrap();
+        let parsed = parse_stable_chat_entry_with(
+            FileScanEntry {
+                session_id: "changing".to_string(),
+                stat_target: path.clone(),
+                directory: None,
+            },
+            mtime_ms,
+            snapshot,
+            |entry, mtime_ms| {
+                let parsed = parse_chat_entry(entry, mtime_ms)?;
+                fs::write(
+                    &path,
+                    r#"{"responderUsername":"GitHub Copilot","requests":[{"message":{"text":"changed"}}]}"#,
+                )?;
+                Ok(parsed)
+            },
+        )
+        .unwrap();
+        assert!(parsed.is_none());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn sync_tombstones_only_explicit_other_provider_and_can_rebuild() {
+        let root = temp_root("reconcile");
+        let user = root.join("User");
+        let dir = user.join("globalStorage").join("emptyWindowChatSessions");
+        fs::create_dir_all(&dir).unwrap();
+        let other_path = dir.join("other.json");
+        fs::write(
+            &other_path,
+            r#"{"responderUsername":"Other Agent","requests":[{"message":{"text":"other"},"response":[{"value":"answer"}]}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("unknown.json"),
+            r#"{"requests":[{"message":{"text":"unknown"},"response":[{"value":"answer"}]}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("copilot.json"),
+            r#"{"responderUsername":"GitHub Copilot","requests":[{"message":{"text":"copilot"},"response":[{"value":"answer"}]}]}"#,
+        )
+        .unwrap();
+
+        let store = setup_store();
+        for source_id in ["other", "unknown"] {
+            store
+                .insert_session(&Session {
+                    id: format!("internal-{source_id}"),
+                    source: "copilot-chat".to_string(),
+                    source_id: source_id.to_string(),
+                    title: "existing".to_string(),
+                    directory: None,
+                    repo_remote: None,
+                    repo_slug: None,
+                    repo_name: None,
+                    started_at: 0,
+                    updated_at: file_scan::stat_mtime_ms(&dir.join(format!("{source_id}.json"))),
+                    message_count: 2,
+                    entrypoint: None,
+                    custom_title: None,
+                    summary: None,
+                    duration_minutes: None,
+                    source_file_path: None,
+                    is_import: false,
+                })
+                .unwrap();
+        }
+        let context = AdapterSyncContext::from_store_for_test(&store, "copilot-chat").unwrap();
+        let output = scan_chat_entries_for_sync(
+            collect_chat_entries(std::slice::from_ref(&user)),
+            &context,
+            Some(i64::MAX),
+            false,
+        )
+        .unwrap();
+        assert!(matches!(
+            output.reconcile,
+            Some(ReconcilePlan::ExactTombstones(ids)) if ids == HashSet::from(["other".to_string()])
+        ));
+        assert!(output.scan.sessions.is_empty());
+
+        fs::write(
+            &other_path,
+            r#"{"responderUsername":"GitHub Copilot","requests":[{"message":{"text":"restored"},"response":[{"value":"answer"}]}]}"#,
+        )
+        .unwrap();
+        let rebuilt = scan_chat_entries_for_sync(
+            collect_chat_entries(&[user]),
+            &AdapterSyncContext::empty_for_test("copilot-chat"),
+            None,
+            true,
+        )
+        .unwrap();
+        assert!(matches!(
+            rebuilt.reconcile,
+            Some(ReconcilePlan::ExactTombstones(ids)) if ids.is_empty()
+        ));
+        assert!(rebuilt.scan.sessions.iter().any(|session| session.source_id == "other"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_includes_transferred_chat_sessions() {
+        let root = temp_root("xfer");
+        let user = root.join("User");
+        write_jsonl(
+            &user.join("globalStorage").join("transferredChatSessions").join("moved.jsonl"),
+            &sample_jsonl_lines(),
+        );
+        let entries = collect_chat_entries(&[user]);
+        assert!(entries.iter().any(|entry| entry.session_id == "moved"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn hidden_requests_are_skipped() {
         let doc = serde_json::json!({
             "creationDate": 1,
+            "responderUsername": "GitHub Copilot",
             "requests": [{
                 "hiddenFromTranscript": true,
                 "timestamp": 2,

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -1,18 +1,20 @@
 use std::fs;
-use std::io::BufReader;
-use std::path::Path;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tracing::debug;
 use walkdir::WalkDir;
 
+use crate::adapters::json_util::rfc3339_ms;
+use crate::adapters::paths;
 use crate::adapters::usage::usage_count;
 use crate::adapters::{RawMessage, RawSession, ResumeCommand, SourceAdapter};
 use crate::types::{RawUsageEvent, Role};
 
 pub(crate) struct GeminiAdapter;
 
-const USAGE_PARSER_VERSION: u32 = 2;
+const USAGE_PARSER_VERSION: u32 = 3;
 
 impl SourceAdapter for GeminiAdapter {
     fn id(&self) -> &str {
@@ -34,29 +36,13 @@ impl SourceAdapter for GeminiAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-
-        let gemini_tmp = home.join(".gemini/tmp");
-        if !gemini_tmp.exists() {
-            debug!("~/.gemini/tmp not found, skipping Gemini CLI");
+        let Some(root) = resolve_gemini_root()? else {
             return Ok(vec![]);
-        }
+        };
 
         let mut sessions = Vec::new();
-
-        for entry in WalkDir::new(&gemini_tmp).into_iter().filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            if !path.is_file() {
-                continue;
-            }
-            if path.parent().is_none_or(|p| p.file_name().is_none_or(|n| n != "chats")) {
-                continue;
-            }
-
-            match parse_gemini_session_file(path) {
+        for path in collect_gemini_session_files(&root) {
+            match parse_gemini_session_file(&path) {
                 Ok(Some(session)) => sessions.push(session),
                 Ok(None) => {}
                 Err(e) => {
@@ -69,12 +55,106 @@ impl SourceAdapter for GeminiAdapter {
     }
 }
 
+fn resolve_gemini_root() -> anyhow::Result<Option<PathBuf>> {
+    if let Some(dir) = paths::env_path_dir("GEMINI_HOME") {
+        if dir.is_dir() {
+            return Ok(Some(dir));
+        }
+        debug!("GEMINI_HOME not found, skipping Gemini CLI");
+        return Ok(None);
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let gemini_tmp = home.join(".gemini/tmp");
+    if !gemini_tmp.exists() {
+        debug!("~/.gemini/tmp not found, skipping Gemini CLI");
+        return Ok(None);
+    }
+    Ok(Some(gemini_tmp))
+}
+
+fn collect_gemini_session_files(root: &Path) -> Vec<PathBuf> {
+    let mut by_stem: std::collections::HashMap<(PathBuf, String), PathBuf> =
+        std::collections::HashMap::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.parent().is_none_or(|parent| parent.file_name().is_none_or(|name| name != "chats"))
+        {
+            continue;
+        }
+        let ext = path.extension().and_then(|ext| ext.to_str()).map(str::to_ascii_lowercase);
+        if ext.as_deref() != Some("json") && ext.as_deref() != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let key = (path.parent().unwrap_or(root).to_path_buf(), stem.to_string());
+        match by_stem.get(&key) {
+            Some(existing)
+                if existing.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                    && ext.as_deref() == Some("json") =>
+            {
+                continue;
+            }
+            _ => {}
+        }
+        by_stem.insert(key, path.to_path_buf());
+    }
+    by_stem.into_values().collect()
+}
+
 fn parse_gemini_session_file(path: &Path) -> anyhow::Result<Option<RawSession>> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
-    let doc: Value = serde_json::from_reader(reader)?;
+    let is_jsonl = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"));
+    let doc = if is_jsonl { replay_gemini_jsonl(reader) } else { serde_json::from_reader(reader)? };
     let fallback_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown");
     parse_gemini_session_value(doc, fallback_id, Some(path.display().to_string()))
+}
+
+fn replay_gemini_jsonl(reader: impl BufRead) -> Value {
+    let mut session = Map::new();
+    let mut messages = Vec::new();
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        let trimmed = line.trim().trim_start_matches('\u{feff}');
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(Value::Object(mut object)) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        let fields = match object.remove("$set") {
+            Some(Value::Object(fields)) => fields,
+            Some(_) => continue,
+            None if object.get("kind").and_then(Value::as_str) == Some("main") => object,
+            None => {
+                if object.get("type").and_then(Value::as_str).is_some() {
+                    messages.push(Value::Object(object));
+                }
+                continue;
+            }
+        };
+        for (key, value) in fields {
+            if key == "messages" {
+                if let Value::Array(snapshot) = value {
+                    messages = snapshot;
+                }
+            } else {
+                session.insert(key, value);
+            }
+        }
+    }
+    session.insert("messages".to_string(), Value::Array(messages));
+    Value::Object(session)
 }
 
 #[cfg(test)]
@@ -94,18 +174,8 @@ fn parse_gemini_session_value(
     let session_id =
         doc.get("sessionId").and_then(|s| s.as_str()).unwrap_or(fallback_id).to_string();
 
-    let started_at = doc
-        .get("startTime")
-        .and_then(|t| t.as_str())
-        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-        .map(|dt| dt.timestamp_millis())
-        .unwrap_or(0);
-
-    let updated_at = doc
-        .get("lastUpdated")
-        .and_then(|t| t.as_str())
-        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-        .map(|dt| dt.timestamp_millis());
+    let started_at = rfc3339_ms(doc.get("startTime")).unwrap_or(0);
+    let updated_at = rfc3339_ms(doc.get("lastUpdated"));
 
     let messages_arr = match doc.get("messages").and_then(|m| m.as_array()) {
         Some(arr) => arr,
@@ -119,17 +189,13 @@ fn parse_gemini_session_value(
         let msg_type = msg.get("type").and_then(|t| t.as_str()).unwrap_or("");
         let role = match msg_type {
             "user" => Role::User,
-            "gemini" => Role::Assistant,
+            "gemini" | "model" => Role::Assistant,
             _ => continue,
         };
 
-        let timestamp = msg
-            .get("timestamp")
-            .and_then(|t| t.as_str())
-            .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-            .map(|dt| dt.timestamp_millis());
+        let timestamp = rfc3339_ms(msg.get("timestamp"));
 
-        let prose = msg.get("content").and_then(|c| c.as_str()).unwrap_or("").trim().to_string();
+        let prose = gemini_text(msg.get("content"));
 
         let tool_text = if matches!(role, Role::Assistant) {
             extract_tool_calls(msg.get("toolCalls"))
@@ -147,7 +213,7 @@ fn parse_gemini_session_value(
         let message_seq = messages.len() as u32;
         messages.push(RawMessage { role, content, timestamp });
 
-        if msg_type == "gemini"
+        if matches!(msg_type, "gemini" | "model")
             && let Some(event) = extract_gemini_usage_event(
                 msg,
                 index as u32,
@@ -171,6 +237,24 @@ fn parse_gemini_session_value(
         session = session.with_usage(usage_events, USAGE_PARSER_VERSION);
     }
     Ok(Some(session))
+}
+
+fn gemini_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|item| match item {
+                Value::String(text) => Some(text.as_str()),
+                Value::Object(object) => object.get("text").and_then(Value::as_str),
+                _ => None,
+            })
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
 }
 
 fn extract_gemini_usage_event(
@@ -299,5 +383,75 @@ mod tests {
         let session = parse_gemini_session_file(&path).unwrap().unwrap();
 
         assert_eq!(session.source_file_path.as_deref(), path.to_str());
+    }
+
+    #[test]
+    fn parse_gemini_session_accepts_model_type_and_array_content() {
+        let json = r#"{
+            "sessionId": "model-1",
+            "messages": [
+                {"type":"user","content":[{"text":"hello"}]},
+                {"type":"model","content":[{"text":"hi"}],"tokens":{"input":10,"output":2}}
+            ]
+        }"#;
+        let session = parse_gemini_session(json, "fallback").unwrap().unwrap();
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "hello");
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content, "hi");
+        assert_eq!(session.usage_events.len(), 1);
+        assert_eq!(session.usage_parser_version, Some(USAGE_PARSER_VERSION));
+    }
+
+    #[test]
+    fn parse_gemini_jsonl_replays_set_patches_and_bare_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-abc.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"kind":"main","sessionId":"abc"}"#,
+                "\n",
+                r#"{"$set":{"startTime":"2025-11-13T13:48:00.000Z"}}"#,
+                "\n",
+                r#"{"type":"user","content":"hello"}"#,
+                "\n",
+                r#"{"type":"gemini","content":"there"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let session = parse_gemini_session_file(&path).unwrap().unwrap();
+        assert_eq!(session.source_id, "abc");
+        assert_eq!(session.messages[0].content, "hello");
+        assert_eq!(session.messages[1].content, "there");
+        assert_eq!(
+            session.started_at,
+            rfc3339_ms(Some(&Value::String("2025-11-13T13:48:00.000Z".into()))).unwrap()
+        );
+    }
+
+    #[test]
+    fn collect_gemini_session_files_keeps_same_stem_in_different_projects() {
+        let dir = tempfile::tempdir().unwrap();
+        for project in ["proj-a", "proj-b"] {
+            let chats = dir.path().join(project).join("chats");
+            std::fs::create_dir_all(&chats).unwrap();
+            std::fs::write(chats.join("wip.json"), "{}").unwrap();
+        }
+        let files = collect_gemini_session_files(dir.path());
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn collect_gemini_session_files_prefers_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let chats = dir.path().join("proj").join("chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        std::fs::write(chats.join("session-1.json"), "{}").unwrap();
+        std::fs::write(chats.join("session-1.jsonl"), "{}\n").unwrap();
+        let files = collect_gemini_session_files(dir.path());
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].extension().and_then(|ext| ext.to_str()), Some("jsonl"));
     }
 }

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -9,14 +9,14 @@ use tracing::debug;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
-use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::paths::{self, resolve_home_dir};
 use crate::adapters::{
     InventoryIssue, RawMessage, RawSession, ReconcilePlan, ResumeCommand, SourceAdapter,
     SyncScanOutput, SyncScanResult, SyncScanStats,
 };
 use crate::types::{RawUsageEvent, Role};
 
-const USAGE_PARSER_VERSION: u32 = 1;
+const USAGE_PARSER_VERSION: u32 = 2;
 
 pub(crate) struct GrokAdapter;
 
@@ -110,6 +110,14 @@ struct PendingAgentMessage {
 }
 
 fn resolve_grok_sessions_dir() -> anyhow::Result<Option<PathBuf>> {
+    if let Some(home) = paths::env_path_dir("GROK_HOME") {
+        let sessions = home.join("sessions");
+        if sessions.is_dir() {
+            return Ok(Some(sessions));
+        }
+        debug!("GROK_HOME/sessions not found, skipping Grok");
+        return Ok(None);
+    }
     resolve_home_dir(".grok/sessions", "~/.grok/sessions not found, skipping Grok")
 }
 
@@ -136,7 +144,7 @@ fn scan_for_sync_impl(
         }
         SyncScanResult { sessions, stats, observations: Vec::new() }
     } else {
-        file_scan::run_file_scan_with_options(
+        file_scan::run_file_scan_with_options_and_snapshot(
             context,
             since_ts,
             FileScanOptions {
@@ -145,10 +153,35 @@ fn scan_for_sync_impl(
                 metadata_parser_version: None,
             },
             entries,
+            grok_session_snapshot,
             |entry, mtime_ms| parse_grok_session_for_entry(&entry, mtime_ms),
         )?
     };
     Ok(SyncScanOutput { scan: result, reconcile: Some(reconcile) })
+}
+
+#[derive(PartialEq)]
+struct GrokSessionSnapshot {
+    updates: Option<file_scan::FileMetadataSnapshot>,
+    chat_history: Option<file_scan::FileMetadataSnapshot>,
+    summary: Option<file_scan::FileMetadataSnapshot>,
+}
+
+fn grok_session_snapshot(
+    entry: &FileScanEntry,
+) -> Option<file_scan::FileScanSnapshot<GrokSessionSnapshot>> {
+    let session_dir = entry.stat_target.parent()?;
+    let snapshot = GrokSessionSnapshot {
+        updates: file_scan::file_metadata_snapshot(&session_dir.join("updates.jsonl")),
+        chat_history: file_scan::file_metadata_snapshot(&session_dir.join("chat_history.jsonl")),
+        summary: file_scan::file_metadata_snapshot(&session_dir.join("summary.json")),
+    };
+    let effective_mtime_ms = [&snapshot.updates, &snapshot.chat_history, &snapshot.summary]
+        .into_iter()
+        .flatten()
+        .filter_map(file_scan::FileMetadataSnapshot::mtime_ms)
+        .max()?;
+    Some(file_scan::FileScanSnapshot::new(effective_mtime_ms, snapshot))
 }
 
 fn collect_grok_entries(sessions_dir: &Path) -> (Vec<FileScanEntry>, ReconcilePlan) {
@@ -260,15 +293,21 @@ fn collect_grok_workspace(
         };
 
         let updates_path = session_path.join("updates.jsonl");
-        match fs::metadata(&updates_path) {
-            Ok(metadata) if metadata.is_file() => {}
-            Ok(_) => continue,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+        let chat_history_path = session_path.join("chat_history.jsonl");
+        let has_updates = match fs::metadata(&updates_path) {
+            Ok(metadata) if metadata.is_file() => true,
+            Ok(_) => false,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
             Err(err) => {
-                issues.push(InventoryIssue { path: updates_path, category: err.kind() });
+                issues.push(InventoryIssue { path: updates_path.clone(), category: err.kind() });
                 continue;
             }
+        };
+        let has_history = chat_history_path.is_file();
+        if !has_updates && !has_history {
+            continue;
         }
+        let stat_target = if has_updates { updates_path } else { chat_history_path };
 
         let (summary_directory, session_kind) = load_summary_probe(&session_path);
         if matches!(session_kind.as_deref(), Some("subagent" | "subagent_resume")) {
@@ -277,7 +316,7 @@ fn collect_grok_workspace(
         }
 
         let directory = summary_directory.or(fallback_directory.clone());
-        entries.push(FileScanEntry { session_id, stat_target: updates_path, directory });
+        entries.push(FileScanEntry { session_id, stat_target, directory });
     }
 }
 
@@ -335,37 +374,52 @@ fn parse_grok_session_for_entry(
         .parent()
         .ok_or_else(|| anyhow::anyhow!("grok updates path has no parent"))?;
 
-    let summary = match load_grok_summary(session_dir, &entry.session_id) {
-        Ok(summary) => summary,
-        Err(err) => {
-            debug!("failed to read Grok summary for {}: {err}", entry.session_id);
-            return Ok(None);
+    let summary = load_grok_summary(session_dir, &entry.session_id).unwrap_or(GrokSummary {
+        session_id: entry.session_id.clone(),
+        directory: entry.directory.clone(),
+        started_at: 0,
+        updated_at: None,
+        current_model_id: None,
+    });
+
+    let updates_path = session_dir.join("updates.jsonl");
+    let (mut messages, mut usage_events) = if updates_path.is_file() {
+        match parse_grok_updates(&updates_path) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                debug!("failed to parse Grok updates {}: {err}", updates_path.display());
+                (Vec::new(), Vec::new())
+            }
         }
+    } else {
+        (Vec::new(), Vec::new())
     };
 
-    let (messages, mut usage_events) = match parse_grok_updates(&entry.stat_target) {
-        Ok(parsed) => parsed,
-        Err(err) => {
-            debug!("failed to parse Grok updates {}: {err}", entry.stat_target.display());
-            return Ok(None);
+    let usage_source_path = updates_path.to_str().map(str::to_string);
+    let mut source_path = usage_source_path.clone();
+    if messages.is_empty() {
+        let chat_history_path = session_dir.join("chat_history.jsonl");
+        if chat_history_path.is_file() {
+            messages = parse_chat_history_fallback(&chat_history_path);
+            source_path = chat_history_path.to_str().map(str::to_string);
         }
-    };
+    }
 
     if messages.is_empty() {
         return Ok(None);
     }
 
     let fallback_model = summary.current_model_id.clone().unwrap_or_else(|| "grok".to_string());
-    let source_path = entry.stat_target.to_str().map(str::to_string);
     for event in &mut usage_events {
         if event.model.is_empty() {
             event.model = fallback_model.clone();
         }
-        event.source_path = source_path.clone();
+        event.source_path = usage_source_path.clone();
     }
 
     let started_at =
         summary.started_at.max(messages.first().and_then(|message| message.timestamp).unwrap_or(0));
+    let started_at = if started_at == 0 { mtime_ms } else { started_at };
 
     let mut session = RawSession::search_only(
         summary.session_id,
@@ -413,6 +467,82 @@ fn load_grok_summary(session_dir: &Path, fallback_id: &str) -> anyhow::Result<Gr
     let started_at = rfc3339_ms(doc.get("created_at")).unwrap_or(0);
     let updated_at = rfc3339_ms(doc.get("updated_at"));
     Ok(GrokSummary { session_id, directory, started_at, updated_at, current_model_id })
+}
+
+fn parse_chat_history_fallback(path: &Path) -> Vec<RawMessage> {
+    let Ok(file) = fs::File::open(path) else {
+        return Vec::new();
+    };
+    let mut messages = Vec::new();
+    for item in jsonl_indexed(BufReader::new(file).lines()) {
+        let Ok((_, val)) = item else {
+            continue;
+        };
+        let msg_type = val.get("type").and_then(Value::as_str).unwrap_or("");
+        match msg_type {
+            "user" => {
+                if val.get("synthetic_reason").is_some() || val.get("prompt_index").is_none() {
+                    continue;
+                }
+                let text = grok_history_text(val.get("content"));
+                let queries = extract_user_queries(&text);
+                let body = if queries.is_empty() { text } else { queries.join("\n\n") };
+                if body.is_empty() {
+                    continue;
+                }
+                messages.push(RawMessage { role: Role::User, content: body, timestamp: None });
+            }
+            "assistant" => {
+                let text = grok_history_text(val.get("content"));
+                if text.is_empty() {
+                    continue;
+                }
+                messages.push(RawMessage { role: Role::Assistant, content: text, timestamp: None });
+            }
+            _ => {}
+        }
+    }
+    messages
+}
+
+fn grok_history_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|item| {
+                item.as_str()
+                    .or_else(|| item.get("text").and_then(Value::as_str))
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Some(Value::Object(object)) => {
+            object.get("text").and_then(Value::as_str).unwrap_or("").trim().to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+fn extract_user_queries(text: &str) -> Vec<String> {
+    const OPEN: &str = "<user_query>";
+    const CLOSE: &str = "</user_query>";
+    let mut blocks = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find(OPEN) {
+        rest = &rest[start + OPEN.len()..];
+        let Some(end) = rest.find(CLOSE) else {
+            break;
+        };
+        let body = rest[..end].trim();
+        if !body.is_empty() {
+            blocks.push(body.to_string());
+        }
+        rest = &rest[end + CLOSE.len()..];
+    }
+    blocks
 }
 
 fn parse_grok_updates(
@@ -816,6 +946,47 @@ mod tests {
     }
 
     #[test]
+    fn parse_grok_session_falls_back_to_chat_history_without_losing_usage_provenance() {
+        let root = temp_grok_root("history");
+        let session_id = "019e9003-1ed9-70e3-803b-1e7f96a072eb";
+        let session_dir = root.join("%2Ftmp").join(session_id);
+        fs::create_dir_all(&session_dir).unwrap();
+        let updates_path = session_dir.join("updates.jsonl");
+        fs::write(
+            &updates_path,
+            r#"{"timestamp":10,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}},"_meta":{"totalTokens":100,"promptId":"prompt-a"}}}
+"#,
+        )
+        .unwrap();
+        let chat_history_path = session_dir.join("chat_history.jsonl");
+        fs::write(
+            &chat_history_path,
+            r#"{"type":"user","prompt_index":0,"content":"<user_query>hello from history</user_query>"}
+{"type":"user","synthetic_reason":"env","content":"ignore"}
+{"type":"assistant","content":"hi"}
+"#,
+        )
+        .unwrap();
+        let session = parse_grok_session_for_entry(
+            &FileScanEntry {
+                session_id: session_id.to_string(),
+                stat_target: updates_path.clone(),
+                directory: None,
+            },
+            1,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].content, "hello from history");
+        assert_eq!(session.messages[1].content, "hi");
+        assert_eq!(session.source_file_path.as_deref(), chat_history_path.to_str());
+        assert_eq!(session.usage_events.len(), 1);
+        assert_eq!(session.usage_events[0].source_path.as_deref(), updates_path.to_str());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn collect_grok_entries_reads_summary_cwd() {
         let root = temp_grok_root("collect");
         let session_id = "019e9003-1ed9-70e3-803b-1e7f96a072eb";
@@ -1045,6 +1216,84 @@ mod tests {
             forced.reconcile,
             Some(ReconcilePlan::ExactTombstones(ids)) if ids.is_empty()
         ));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_for_sync_notices_chat_history_growth() {
+        let root = temp_grok_root("history-growth");
+        let session_id = "019e9003-1ed9-70e3-803b-1e7f96a072eb";
+        let updates_path = write_grok_session(
+            &root,
+            "%2Ftmp%2Fproject",
+            session_id,
+            r#"{"info":{"id":"019e9003-1ed9-70e3-803b-1e7f96a072eb","cwd":"/tmp/project"},"created_at":"2026-06-04T00:00:00Z"}"#,
+            "",
+        );
+        let session_dir = updates_path.parent().unwrap().to_path_buf();
+        let chat_history_path = session_dir.join("chat_history.jsonl");
+        fs::write(
+            &chat_history_path,
+            "{\"type\":\"user\",\"prompt_index\":0,\"content\":\"hey\"}\n",
+        )
+        .unwrap();
+
+        let mtime = grok_session_snapshot(&FileScanEntry {
+            session_id: session_id.to_string(),
+            stat_target: updates_path.clone(),
+            directory: None,
+        })
+        .unwrap()
+        .effective_mtime_ms();
+        let store = setup_store();
+        store.insert_session(&make_existing_session(session_id, mtime, 1)).unwrap();
+        store
+            .persist_usage_events_for_existing_session(
+                "grok",
+                session_id,
+                &[],
+                USAGE_PARSER_VERSION,
+                Some(mtime),
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(result.scan.sessions.len(), 0);
+        assert_eq!(result.scan.stats.skipped_sessions, 1);
+
+        fs::write(
+            &chat_history_path,
+            "{\"type\":\"user\",\"prompt_index\":0,\"content\":\"hey\"}\n{\"type\":\"user\",\"prompt_index\":1,\"content\":\"again\"}\n",
+        )
+        .unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&chat_history_path)
+            .unwrap()
+            .set_modified(
+                std::time::UNIX_EPOCH + std::time::Duration::from_millis((mtime + 60_000) as u64),
+            )
+            .unwrap();
+
+        let result = scan_for_sync_impl(
+            &root,
+            &AdapterSyncContext::from_store_for_test(&store, "grok").unwrap(),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            result.scan.sessions.len(),
+            1,
+            "appending to chat_history.jsonl must re-parse the session"
+        );
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/adapters/json_util.rs
+++ b/src/adapters/json_util.rs
@@ -20,7 +20,7 @@ pub(crate) fn jsonl_indexed(
 ) -> impl Iterator<Item = io::Result<(usize, Value)>> {
     lines.into_iter().enumerate().filter_map(|(index, line)| match line {
         Ok(line) => {
-            let trimmed = line.trim();
+            let trimmed = line.trim().trim_start_matches('\u{feff}');
             if trimmed.is_empty() {
                 None
             } else {
@@ -29,4 +29,17 @@ pub(crate) fn jsonl_indexed(
         }
         Err(error) => Some(Err(error)),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonl_indexed_strips_utf8_bom() {
+        let lines = [Ok("\u{feff}{\"type\":\"user\"}".to_string())];
+        let items: Vec<_> = jsonl_indexed(lines).collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].1.get("type").and_then(Value::as_str), Some("user"));
+    }
 }

--- a/src/adapters/kimi_code.rs
+++ b/src/adapters/kimi_code.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -10,11 +11,10 @@ use walkdir::WalkDir;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed};
-use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::paths;
 use crate::adapters::usage::usage_count;
 use crate::adapters::{
-    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
-    first_timestamp,
+    RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, first_timestamp,
 };
 use crate::types::{RawUsageEvent, Role};
 
@@ -49,10 +49,7 @@ impl SourceAdapter for KimiCodeAdapter {
     }
 
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
-        let Some(sessions_dir) = resolve_kimi_dir()? else {
-            return Ok(vec![]);
-        };
-        scan_kimi_sessions(&sessions_dir)
+        scan_kimi_dirs(&resolve_kimi_dirs()?)
     }
 
     fn scan_for_sync(
@@ -61,42 +58,75 @@ impl SourceAdapter for KimiCodeAdapter {
         since_ts: Option<i64>,
         _include_events: bool,
     ) -> anyhow::Result<Option<SyncScanResult>> {
-        let Some(sessions_dir) = resolve_kimi_dir()? else {
-            return Ok(Some(SyncScanResult {
-                sessions: vec![],
-                stats: SyncScanStats::default(),
-                observations: Vec::new(),
-            }));
-        };
-        let result = file_scan::run_file_scan_with_options_and_snapshot(
-            context,
-            since_ts,
-            kimi_scan_options(),
-            collect_session_entries(&sessions_dir),
-            kimi_session_snapshot,
-            parse_kimi_session_file,
-        )?;
-        Ok(Some(result))
+        Ok(Some(scan_kimi_dirs_for_sync(&resolve_kimi_dirs()?, context, since_ts)?))
     }
 }
 
-fn resolve_kimi_dir() -> anyhow::Result<Option<PathBuf>> {
-    resolve_home_dir(".kimi-code/sessions", "~/.kimi-code/sessions not found, skipping Kimi Code")
+fn scan_kimi_dirs(sessions_dirs: &[PathBuf]) -> anyhow::Result<Vec<RawSession>> {
+    let mut sessions = Vec::new();
+    let mut claimed = HashSet::new();
+    for sessions_dir in sessions_dirs {
+        sessions.extend(scan_kimi_session_entries_with_parser(
+            claim_session_entries(collect_session_entries(sessions_dir), &mut claimed),
+            parse_kimi_session_file,
+        )?);
+    }
+    Ok(sessions)
 }
 
-fn scan_kimi_sessions(sessions_dir: &Path) -> anyhow::Result<Vec<RawSession>> {
-    scan_kimi_sessions_with_parser(sessions_dir, parse_kimi_session_file)
+fn scan_kimi_dirs_for_sync(
+    sessions_dirs: &[PathBuf],
+    context: &AdapterSyncContext,
+    since_ts: Option<i64>,
+) -> anyhow::Result<SyncScanResult> {
+    let mut combined = SyncScanResult::default();
+    let mut claimed = HashSet::new();
+    for sessions_dir in sessions_dirs {
+        combined.absorb(file_scan::run_file_scan_with_options_and_snapshot(
+            context,
+            since_ts,
+            kimi_scan_options(),
+            claim_session_entries(collect_session_entries(sessions_dir), &mut claimed),
+            kimi_session_snapshot,
+            parse_kimi_session_file,
+        )?);
+    }
+    Ok(combined)
 }
 
-fn scan_kimi_sessions_with_parser<F>(
-    sessions_dir: &Path,
+fn claim_session_entries(
+    entries: Vec<FileScanEntry>,
+    claimed: &mut HashSet<String>,
+) -> Vec<FileScanEntry> {
+    entries.into_iter().filter(|entry| claimed.insert(entry.session_id.clone())).collect()
+}
+
+fn resolve_kimi_dirs() -> anyhow::Result<Vec<PathBuf>> {
+    if let Some(home) = paths::env_path_dir("KIMI_CODE_HOME") {
+        return Ok(paths::existing_dir(home.join("sessions")).into_iter().collect());
+    }
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    let mut dirs = Vec::new();
+    for relative in [".kimi-code/sessions", ".kimi/sessions"] {
+        if let Some(dir) = paths::existing_dir(home.join(relative)) {
+            dirs.push(dir);
+        }
+    }
+    if dirs.is_empty() {
+        warn!("~/.kimi-code/sessions not found, skipping Kimi Code");
+    }
+    Ok(dirs)
+}
+
+fn scan_kimi_session_entries_with_parser<F>(
+    entries: Vec<FileScanEntry>,
     parse_fn: F,
 ) -> anyhow::Result<Vec<RawSession>>
 where
     F: Fn(FileScanEntry, i64) -> anyhow::Result<Option<RawSession>>,
 {
     let mut sessions = Vec::new();
-    for entry in collect_session_entries(sessions_dir) {
+    for entry in entries {
         let Some(snapshot) = kimi_session_snapshot(&entry) else {
             continue;
         };
@@ -693,15 +723,51 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         write_kimi_fixture(root.path());
 
-        let sessions = scan_kimi_sessions_with_parser(root.path(), |entry, mtime_ms| {
-            let raw = parse_kimi_session_file(entry.clone(), mtime_ms)?;
-            append_wire_change(&entry.stat_target)?;
-            Ok(raw)
-        })
+        let sessions = scan_kimi_session_entries_with_parser(
+            collect_session_entries(root.path()),
+            |entry, mtime_ms| {
+                let raw = parse_kimi_session_file(entry.clone(), mtime_ms)?;
+                append_wire_change(&entry.stat_target)?;
+                Ok(raw)
+            },
+        )
         .unwrap();
 
         assert!(sessions.is_empty());
-        assert_eq!(scan_kimi_sessions(root.path()).unwrap().len(), 1);
+        assert_eq!(
+            scan_kimi_session_entries_with_parser(
+                collect_session_entries(root.path()),
+                parse_kimi_session_file,
+            )
+            .unwrap()
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn duplicate_session_ids_prefer_the_first_kimi_root() {
+        let preferred = tempfile::tempdir().unwrap();
+        let fallback = tempfile::tempdir().unwrap();
+        write_kimi_fixture(preferred.path());
+        let (_, fallback_wire) = write_kimi_fixture(fallback.path());
+        fs::write(&fallback_wire, fixture_wire().replace("fix the bug", "fallback")).unwrap();
+        let roots = [preferred.path().to_path_buf(), fallback.path().to_path_buf()];
+
+        let sessions = scan_kimi_dirs(&roots).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].messages[0].content, "fix the bug");
+
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let result = scan_kimi_dirs_for_sync(
+            &roots,
+            &AdapterSyncContext::from_store_for_test(&store, "kimi-code").unwrap(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].messages[0].content, "fix the bug");
     }
 
     #[test]
@@ -776,7 +842,11 @@ mod tests {
         assert_eq!(result.sessions[0].updated_at, Some(state_mtime));
         assert_eq!(result.sessions[0].custom_title.as_deref(), Some("renamed"));
 
-        let sessions = scan_kimi_sessions(root.path()).unwrap();
+        let sessions = scan_kimi_session_entries_with_parser(
+            collect_session_entries(root.path()),
+            parse_kimi_session_file,
+        )
+        .unwrap();
         assert_eq!(sessions[0].updated_at, Some(state_mtime));
     }
 }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -204,6 +204,7 @@ pub(crate) struct RawSession {
     pub(crate) thread_role: Option<ThreadRole>,
     pub(crate) parent_links: Vec<ParentLink>,
     pub(crate) metadata_parser_version: Option<u32>,
+    pub(crate) refresh_session_on_metadata_backfill: bool,
 }
 
 impl RawSession {
@@ -233,6 +234,7 @@ impl RawSession {
             thread_role: None,
             parent_links: Vec::new(),
             metadata_parser_version: None,
+            refresh_session_on_metadata_backfill: false,
         }
     }
 
@@ -297,10 +299,24 @@ pub(crate) struct SyncScanStats {
     pub(crate) parsed: u32,
 }
 
+#[derive(Default)]
 pub(crate) struct SyncScanResult {
     pub(crate) sessions: Vec<RawSession>,
     pub(crate) stats: SyncScanStats,
     pub(crate) observations: Vec<SourceObservation>,
+}
+
+impl SyncScanResult {
+    pub(crate) fn absorb(&mut self, other: SyncScanResult) {
+        self.sessions.extend(other.sessions);
+        self.observations.extend(other.observations);
+        self.stats.skipped_sessions += other.stats.skipped_sessions;
+        self.stats.filtered_sessions += other.stats.filtered_sessions;
+        self.stats.unstable_sessions += other.stats.unstable_sessions;
+        self.stats.candidates += other.stats.candidates;
+        self.stats.rejected_before_parse += other.stats.rejected_before_parse;
+        self.stats.parsed += other.stats.parsed;
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/adapters/omp.rs
+++ b/src/adapters/omp.rs
@@ -10,6 +10,7 @@ use walkdir::WalkDir;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry};
 use crate::adapters::json_util::{json_i64, jsonl_indexed, rfc3339_ms};
+use crate::adapters::paths;
 use crate::adapters::usage::{disjoint_output_and_reasoning, usage_count};
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -93,16 +94,28 @@ struct ParsedOmpSession {
 
 fn resolve_omp_session_dirs() -> anyhow::Result<Vec<PathBuf>> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    let session_dirs = resolve_omp_session_dirs_from(&home);
+    let session_dirs = resolve_omp_session_dirs_from(
+        &home,
+        paths::env_path_dir("XDG_DATA_HOME"),
+        paths::env_path_dir("PI_CODING_AGENT_SESSION_DIR"),
+    );
     if session_dirs.is_empty() {
         debug!("OMP session directory not found, skipping OMP");
     }
     Ok(session_dirs)
 }
 
-fn resolve_omp_session_dirs_from(home: &Path) -> Vec<PathBuf> {
+fn resolve_omp_session_dirs_from(
+    home: &Path,
+    xdg_data_home: Option<PathBuf>,
+    session_dir_override: Option<PathBuf>,
+) -> Vec<PathBuf> {
     let mut session_dirs = Vec::new();
     let mut seen = HashSet::new();
+
+    if let Some(session_dir) = session_dir_override {
+        push_existing_unique_dir(&mut session_dirs, &mut seen, session_dir);
+    }
 
     push_existing_unique_dir(
         &mut session_dirs,
@@ -120,6 +133,18 @@ fn resolve_omp_session_dirs_from(home: &Path) -> Vec<PathBuf> {
                     &mut seen,
                     path.join("agent").join("sessions"),
                 );
+            }
+        }
+    }
+
+    let xdg_root = xdg_data_home.unwrap_or_else(|| home.join(".local").join("share"));
+    push_existing_unique_dir(&mut session_dirs, &mut seen, xdg_root.join("omp").join("sessions"));
+    let xdg_profiles = xdg_root.join("omp").join("profiles");
+    if let Ok(entries) = fs::read_dir(xdg_profiles) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                push_existing_unique_dir(&mut session_dirs, &mut seen, path.join("sessions"));
             }
         }
     }
@@ -275,6 +300,7 @@ fn parse_omp_session_file(
         thread_role: Some(ThreadRole::Primary),
         parent_links,
         metadata_parser_version: Some(METADATA_PARSER_VERSION),
+        refresh_session_on_metadata_backfill: false,
     }))
 }
 
@@ -757,7 +783,7 @@ mod tests {
         fs::create_dir_all(&default_sessions).unwrap();
         fs::create_dir_all(&profile_sessions).unwrap();
 
-        let dirs = resolve_omp_session_dirs_from(&root);
+        let dirs = resolve_omp_session_dirs_from(&root, None, None);
         assert!(dirs.iter().any(|dir| dir == &default_sessions));
         assert!(dirs.iter().any(|dir| dir == &profile_sessions));
 
@@ -774,7 +800,7 @@ mod tests {
         fs::create_dir_all(&pi_sessions).unwrap();
         fs::create_dir_all(&custom_sessions).unwrap();
 
-        assert_eq!(resolve_omp_session_dirs_from(&root), vec![omp_sessions]);
+        assert_eq!(resolve_omp_session_dirs_from(&root, None, None), vec![omp_sessions]);
 
         let _ = fs::remove_dir_all(&root);
     }
@@ -782,7 +808,21 @@ mod tests {
     #[test]
     fn resolve_session_dirs_skips_missing_roots() {
         let root = temp_omp_root("missing");
-        assert!(resolve_omp_session_dirs_from(&root).is_empty());
+        assert!(resolve_omp_session_dirs_from(&root, None, None).is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolve_session_dirs_includes_xdg_omp_sessions() {
+        let root = temp_omp_root("xdg");
+        let xdg = root.join("xdg-data");
+        let xdg_sessions = xdg.join("omp").join("sessions");
+        let profile_sessions = xdg.join("omp").join("profiles").join("work").join("sessions");
+        fs::create_dir_all(&xdg_sessions).unwrap();
+        fs::create_dir_all(&profile_sessions).unwrap();
+        let dirs = resolve_omp_session_dirs_from(&root, Some(xdg), None);
+        assert!(dirs.iter().any(|dir| dir == &xdg_sessions));
+        assert!(dirs.iter().any(|dir| dir == &profile_sessions));
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use rusqlite::{Connection, OpenFlags, params_from_iter};
+use rusqlite::{Connection, OpenFlags, params_from_iter, types::ValueRef};
 use serde_json::Value;
 use tracing::debug;
+
+use crate::adapters::json_util::rfc3339_ms;
+use crate::adapters::paths;
 
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::events;
@@ -13,9 +16,9 @@ use crate::adapters::{
 use crate::types::{RawSessionEvent, RawUsageEvent, Role};
 
 const MAX_SQL_VARS_PER_BATCH: usize = 900;
-pub(crate) const USAGE_PARSER_VERSION: u32 = 1;
-pub(crate) const EVENT_PARSER_VERSION: u32 = 4;
-pub(crate) const METADATA_PARSER_VERSION: u32 = 1;
+pub(crate) const USAGE_PARSER_VERSION: u32 = 2;
+pub(crate) const EVENT_PARSER_VERSION: u32 = 5;
+pub(crate) const METADATA_PARSER_VERSION: u32 = 2;
 const PARSED_PART_FILTER_SQL: &str = "
     json_valid(m.data)
     AND json_valid(p.data)
@@ -103,10 +106,32 @@ impl SourceAdapter for OpenCodeAdapter {
 }
 
 fn open_opencode_db() -> anyhow::Result<Option<Connection>> {
-    let db_path = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("no home dir"))?
-        .join(".local/share/opencode/opencode.db");
-    open_readonly(&db_path)
+    for db_path in opencode_db_candidates() {
+        if let Some(conn) = open_readonly(&db_path)? {
+            return Ok(Some(conn));
+        }
+    }
+    Ok(None)
+}
+
+fn opencode_db_candidates() -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Some(explicit) = paths::env_path_dir("OPENCODE_SQLITE_DB") {
+        out.push(explicit);
+    }
+    if let Some(home) = dirs::home_dir() {
+        out.push(home.join(".local/share/opencode/opencode.db"));
+        out.push(home.join(".config/opencode/opencode.db"));
+    }
+    if let Some(data) = dirs::data_local_dir() {
+        out.push(data.join("opencode/opencode.db"));
+    }
+    if let Some(config) = dirs::config_dir() {
+        out.push(config.join("opencode/opencode.db"));
+    }
+    let mut seen = std::collections::HashSet::new();
+    out.retain(|path| seen.insert(path.clone()));
+    out
 }
 
 pub(crate) fn open_readonly(db_path: &Path) -> anyhow::Result<Option<Connection>> {
@@ -129,42 +154,17 @@ pub(crate) fn scan_with_options(
     include_events: bool,
     options: ScanOptions,
 ) -> anyhow::Result<Vec<RawSession>> {
-    let sessions = load_session_rows(conn, None)?;
+    let (sessions, _) = load_session_rows(conn, None)?;
     scan_session_messages(conn, sessions, include_events, options)
 }
 
-fn count_filtered_sessions(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<u32> {
-    let Some(cutoff) = since_ts else {
-        return Ok(0);
-    };
-
-    conn.query_row(
-        "SELECT COUNT(*)
-         FROM session
-         WHERE COALESCE(time_updated, time_created) < ?1",
-        rusqlite::params![cutoff],
-        |row| row.get::<_, i64>(0),
-    )
-    .map(|count| count as u32)
-    .map_err(Into::into)
-}
-
-fn load_session_rows(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result<Vec<SessionRow>> {
-    let sql = if since_ts.is_some() {
-        "SELECT id, directory, time_created, time_updated, title
-         FROM session
-         WHERE COALESCE(time_updated, time_created) >= ?1"
-    } else {
-        "SELECT id, directory, time_created, time_updated, title FROM session"
-    };
-
-    let mut stmt = conn.prepare(sql)?;
-    let rows = if let Some(cutoff) = since_ts {
-        stmt.query_map(rusqlite::params![cutoff], map_session_row)?
-    } else {
-        stmt.query_map([], map_session_row)?
-    };
-
+fn load_session_rows(
+    conn: &Connection,
+    since_ts: Option<i64>,
+) -> anyhow::Result<(Vec<SessionRow>, u32)> {
+    let mut stmt =
+        conn.prepare("SELECT id, directory, time_created, time_updated, title FROM session")?;
+    let rows = stmt.query_map([], map_session_row)?;
     let mut sessions = Vec::new();
     for row in rows {
         match row {
@@ -172,17 +172,57 @@ fn load_session_rows(conn: &Connection, since_ts: Option<i64>) -> anyhow::Result
             Err(err) => debug!("skipping malformed OpenCode session row: {err}"),
         }
     }
-    Ok(sessions)
+    let Some(cutoff) = since_ts else {
+        return Ok((sessions, 0));
+    };
+    let before = sessions.len();
+    sessions.retain(|row| row.time_updated.unwrap_or(row.time_created) >= cutoff);
+    let filtered = (before - sessions.len()) as u32;
+    Ok((sessions, filtered))
 }
 
 fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
     Ok(SessionRow {
         id: row.get(0)?,
         directory: row.get(1)?,
-        time_created: row.get(2)?,
-        time_updated: row.get(3)?,
+        time_created: sqlite_millis(row, 2)?.unwrap_or(0),
+        time_updated: sqlite_millis(row, 3)?,
         title: row.get(4)?,
     })
+}
+
+fn sqlite_millis(row: &rusqlite::Row<'_>, idx: usize) -> rusqlite::Result<Option<i64>> {
+    match row.get_ref(idx)? {
+        ValueRef::Null => Ok(None),
+        ValueRef::Integer(value) => Ok(Some(normalize_opencode_ts(value))),
+        ValueRef::Real(value) => Ok(Some(normalize_opencode_ts(value as i64))),
+        ValueRef::Text(bytes) => {
+            let text = std::str::from_utf8(bytes).unwrap_or("").trim();
+            Ok(parse_opencode_text_millis(text))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_opencode_text_millis(text: &str) -> Option<i64> {
+    if let Ok(value) = text.parse::<i64>() {
+        return Some(normalize_opencode_ts(value));
+    }
+    if let Some(timestamp) = rfc3339_ms(Some(&Value::String(text.to_string()))) {
+        return Some(timestamp);
+    }
+    ["%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S%.f"]
+        .into_iter()
+        .find_map(|format| chrono::NaiveDateTime::parse_from_str(text, format).ok())
+        .map(|timestamp| timestamp.and_utc().timestamp_millis())
+}
+
+fn normalize_opencode_ts(value: i64) -> i64 {
+    if (1_000_000_000..1_000_000_000_000).contains(&value.abs()) {
+        value.saturating_mul(1000)
+    } else {
+        value
+    }
 }
 
 fn scan_session_messages(
@@ -229,6 +269,7 @@ fn scan_session_messages(
         raw.custom_title =
             session.title.map(|title| title.trim().to_string()).filter(|title| !title.is_empty());
         raw.metadata_parser_version = Some(METADATA_PARSER_VERSION);
+        raw.refresh_session_on_metadata_backfill = true;
         raw_sessions.push(if include_events {
             raw.with_events(events, EVENT_PARSER_VERSION)
         } else {
@@ -263,12 +304,14 @@ fn load_event_chunk(
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
             row.get::<_, String>(2)?,
-            row.get::<_, Option<i64>>(3)?,
+            sqlite_millis(row, 3)?,
         ))
     })?;
+    let mut rows = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.sort_by_key(|row| row.3);
 
     for row in rows {
-        let (session_id, part_id, part_data, timestamp) = row?;
+        let (session_id, part_id, part_data, timestamp) = row;
         let events = session_events.entry(session_id).or_default();
         let part_events = parse_part_events(&part_id, &part_data, timestamp, events.len() as u32);
         events.extend(part_events);
@@ -435,12 +478,14 @@ fn load_message_chunk(
         let session_id: String = row.get(0)?;
         let role: Option<String> = row.get(1)?;
         let part_data: String = row.get(2)?;
-        let timestamp: Option<i64> = row.get(3)?;
+        let timestamp = sqlite_millis(row, 3)?;
         Ok((session_id, role, part_data, timestamp))
     })?;
+    let mut msg_rows = msg_rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    msg_rows.sort_by_key(|row| row.3);
 
     for row in msg_rows {
-        let (session_id, role_str, part_data, timestamp) = row?;
+        let (session_id, role_str, part_data, timestamp) = row;
         let Some(role) = parse_role(role_str.as_deref()) else {
             continue;
         };
@@ -483,12 +528,14 @@ fn load_usage_chunk(
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
             row.get::<_, String>(2)?,
-            row.get::<_, i64>(3)?,
+            sqlite_millis(row, 3)?.unwrap_or(0),
         ))
     })?;
+    let mut rows = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.sort_by_key(|row| row.3);
 
     for row in rows {
-        let (message_id, session_id, data, timestamp) = row?;
+        let (message_id, session_id, data, timestamp) = row;
         let events = session_usage_events.entry(session_id).or_default();
         if let Some(event) = parse_usage_event(&message_id, &data, timestamp, events.len() as u32) {
             events.push(event);
@@ -660,8 +707,7 @@ pub(crate) fn scan_for_sync_conn_with_options(
     include_events: bool,
     options: ScanOptions,
 ) -> anyhow::Result<SyncScanResult> {
-    let filtered_sessions = count_filtered_sessions(conn, since_ts)?;
-    let sessions = load_session_rows(conn, since_ts)?;
+    let (sessions, filtered_sessions) = load_session_rows(conn, since_ts)?;
     let existing = context.session_meta();
     let usage_state = context.usage_state();
     let event_state = context.event_state();
@@ -840,6 +886,285 @@ mod tests {
                 },
             )
             .unwrap();
+    }
+
+    #[test]
+    fn map_session_row_parses_iso_text_timestamps() {
+        let path =
+            std::env::temp_dir().join(format!("recall-opencode-iso-{}.db", uuid::Uuid::new_v4()));
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created TEXT,
+                time_updated TEXT
+            );
+            CREATE TABLE message (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                time_created INTEGER
+            );
+            CREATE TABLE part (
+                id INTEGER PRIMARY KEY,
+                message_id INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            ",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('iso-1', 'Test', '/tmp/project', '2026-04-13T10:00:00Z', '2026-04-13T10:01:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('iso-1', '{\"role\":\"user\"}', 1)",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (message_id, data) VALUES (?1, '{\"type\":\"text\",\"text\":\"hello\"}')",
+            rusqlite::params![message_id],
+        )
+        .unwrap();
+        let sessions = scan(&conn, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].started_at,
+            rfc3339_ms(Some(&Value::String("2026-04-13T10:00:00Z".into()))).unwrap()
+        );
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scan_parses_sqlite_current_timestamp_defaults() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created TEXT DEFAULT CURRENT_TIMESTAMP,
+                time_updated TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE message (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                time_created TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE part (
+                id INTEGER PRIMARY KEY,
+                message_id INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            INSERT INTO session (id, title, directory)
+            VALUES ('sqlite-ts', 'Test', '/tmp/project');
+            INSERT INTO message (session_id, data)
+            VALUES ('sqlite-ts', '{"role":"user"}');
+            INSERT INTO part (message_id, data)
+            VALUES (last_insert_rowid(), '{"type":"text","text":"hello"}');
+            "#,
+        )
+        .unwrap();
+
+        let sessions = scan(&conn, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(sessions[0].started_at > 0);
+        assert!(sessions[0].messages[0].timestamp.is_some_and(|timestamp| timestamp > 0));
+    }
+
+    #[test]
+    fn text_message_timestamps_do_not_abort_the_scan() {
+        let path =
+            std::env::temp_dir().join(format!("recall-opencode-txt-{}.db", uuid::Uuid::new_v4()));
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created TEXT,
+                time_updated TEXT
+            );
+            CREATE TABLE message (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                time_created TEXT
+            );
+            CREATE TABLE part (
+                id INTEGER PRIMARY KEY,
+                message_id INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );
+            ",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('txt-1', 'Test', '/tmp/project', '2026-04-13T10:00:00Z', '2026-04-13T10:01:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (session_id, data, time_created)
+             VALUES ('txt-1', '{\"role\":\"user\"}', '2026-04-13T10:00:30Z')",
+            [],
+        )
+        .unwrap();
+        let message_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO part (message_id, data) VALUES (?1, '{\"type\":\"text\",\"text\":\"hello\"}')",
+            rusqlite::params![message_id],
+        )
+        .unwrap();
+
+        let sessions = scan(&conn, false).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].messages.len(), 1);
+        assert_eq!(
+            sessions[0].messages[0].timestamp,
+            rfc3339_ms(Some(&Value::String("2026-04-13T10:00:30Z".into())))
+        );
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn since_cutoff_compares_normalized_second_granularity_timestamps() {
+        let (path, conn) = setup_opencode_db();
+        insert_session_with_message(&conn, "recent", 1_800_000_000, 1_800_000_000, "hello");
+        insert_session_with_message(&conn, "old", 1_600_000_000, 1_600_000_000, "hello");
+
+        let cutoff = 1_700_000_000_000;
+        let (kept, filtered) = load_session_rows(&conn, Some(cutoff)).unwrap();
+        assert_eq!(kept.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(), vec!["recent"]);
+        assert_eq!(filtered, 1);
+
+        drop(conn);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn mixed_timestamp_representations_are_sequenced_after_normalization() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                directory TEXT,
+                time_created INTEGER,
+                time_updated INTEGER
+            );
+            CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                time_created INTEGER
+            );
+            CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL,
+                data TEXT NOT NULL
+            );
+            INSERT INTO session VALUES ('mixed', 'Mixed', '/tmp/project', 1700000000000, 1800000000000);
+            INSERT INTO message VALUES ('later', 'mixed', '{"role":"assistant","providerID":"p","modelID":"m","tokens":{"input":3}}', 1800000000);
+            INSERT INTO message VALUES ('middle', 'mixed', '{"role":"assistant","providerID":"p","modelID":"m","tokens":{"input":2}}', 1750000000000);
+            INSERT INTO message VALUES ('earlier', 'mixed', '{"role":"assistant","providerID":"p","modelID":"m","tokens":{"input":1}}', '2023-11-14 22:13:20');
+            INSERT INTO part VALUES ('later-text', 'later', '{"type":"text","text":"later"}');
+            INSERT INTO part VALUES ('middle-text', 'middle', '{"type":"text","text":"middle"}');
+            INSERT INTO part VALUES ('earlier-text', 'earlier', '{"type":"text","text":"earlier"}');
+            INSERT INTO part VALUES ('later-tool', 'later', '{"type":"tool-invocation","toolName":"read","input":{}}');
+            INSERT INTO part VALUES ('middle-tool', 'middle', '{"type":"tool-invocation","toolName":"read","input":{}}');
+            INSERT INTO part VALUES ('earlier-tool', 'earlier', '{"type":"tool-invocation","toolName":"read","input":{}}');
+            "#,
+        )
+        .unwrap();
+
+        let sessions = scan(&conn, true).unwrap();
+        let session = &sessions[0];
+        assert_eq!(
+            session.messages.iter().map(|message| message.content.as_str()).collect::<Vec<_>>(),
+            vec!["earlier", "middle", "later"]
+        );
+        assert_eq!(
+            session.usage_events.iter().map(|event| event.event_key.as_str()).collect::<Vec<_>>(),
+            vec!["message:earlier", "message:middle", "message:later"]
+        );
+        assert_eq!(
+            session
+                .events
+                .iter()
+                .filter_map(|event| event.source_event_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["earlier-tool", "middle-tool", "later-tool"]
+        );
+    }
+
+    #[test]
+    fn timestamp_parser_migration_refreshes_existing_messages() {
+        let (path, conn) = setup_opencode_db();
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_created, time_updated)
+             VALUES ('migrate', 'Test', '/tmp/project', 1800000000000, 1800000000000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data, time_created)
+             VALUES (1, 'migrate', '{\"role\":\"user\"}', 1800000000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, data)
+             VALUES (1, 1, '{\"type\":\"text\",\"text\":\"hello\"}')",
+            [],
+        )
+        .unwrap();
+
+        let mut old = RawSession::search_only(
+            "migrate",
+            Some("/tmp/project".to_string()),
+            1_800_000_000_000,
+            Some(1_800_000_000_000),
+            None,
+            vec![RawMessage {
+                role: Role::User,
+                content: "hello".to_string(),
+                timestamp: Some(1_800_000_000),
+            }],
+        )
+        .with_usage(Vec::new(), USAGE_PARSER_VERSION)
+        .with_events(Vec::new(), EVENT_PARSER_VERSION);
+        old.metadata_parser_version = Some(METADATA_PARSER_VERSION - 1);
+        let store =
+            crate::sync::persist_raw_session_for_conformance(setup_store(), "opencode", old)
+                .unwrap();
+        let session = store.get_session_by_source_id("opencode", "migrate").unwrap().unwrap();
+        assert_eq!(store.get_messages(&session.id).unwrap()[0].timestamp, Some(1_800_000_000));
+
+        let fresh = scan(&conn, true).unwrap().pop().unwrap();
+        assert!(fresh.refresh_session_on_metadata_backfill);
+        let store =
+            crate::sync::persist_raw_session_for_conformance(store, "opencode", fresh).unwrap();
+        let session = store.get_session_by_source_id("opencode", "migrate").unwrap().unwrap();
+        assert_eq!(store.get_messages(&session.id).unwrap()[0].timestamp, Some(1_800_000_000_000));
+
+        drop(conn);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
@@ -1041,7 +1366,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = load_session_rows(&conn, None).unwrap();
+        let (sessions, _) = load_session_rows(&conn, None).unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "good");
         drop(conn);
@@ -1088,7 +1413,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = load_session_rows(&conn, None).unwrap();
+        let (sessions, _) = load_session_rows(&conn, None).unwrap();
         let raw = scan_session_messages(&conn, sessions, false, ScanOptions::default()).unwrap();
         let titled = raw.iter().find(|session| session.source_id == "s1").unwrap();
         let blank = raw.iter().find(|session| session.source_id == "s2").unwrap();
@@ -1134,7 +1459,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = load_session_rows(&conn, None).unwrap();
+        let (sessions, _) = load_session_rows(&conn, None).unwrap();
         let raw = scan_session_messages(&conn, sessions, true, ScanOptions::default()).unwrap();
 
         assert_eq!(raw.len(), 1);
@@ -1184,7 +1509,7 @@ mod tests {
         )
         .unwrap();
 
-        let sessions = load_session_rows(&conn, None).unwrap();
+        let (sessions, _) = load_session_rows(&conn, None).unwrap();
         let raw = scan_session_messages(&conn, sessions, true, ScanOptions::default()).unwrap();
 
         assert_eq!(raw.len(), 1);

--- a/src/adapters/paths.rs
+++ b/src/adapters/paths.rs
@@ -23,6 +23,29 @@ pub(crate) fn resolve_home_dir(
     Ok(Some(dir))
 }
 
+pub(crate) fn env_path_dir(name: &str) -> Option<PathBuf> {
+    let raw = std::env::var(name).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    expand_user_path(trimmed)
+}
+
+fn expand_user_path(raw: &str) -> Option<PathBuf> {
+    if raw == "~" {
+        return dirs::home_dir();
+    }
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+        return dirs::home_dir().map(|home| home.join(rest));
+    }
+    Some(PathBuf::from(raw))
+}
+
+pub(crate) fn existing_dir(path: PathBuf) -> Option<PathBuf> {
+    path.is_dir().then_some(path)
+}
+
 pub(crate) fn vscode_extension_task_dirs(extension_id: &str) -> Vec<PathBuf> {
     vscode_extension_task_dirs_from(dirs::config_dir(), extension_id)
 }
@@ -120,5 +143,12 @@ mod tests {
             "saoudrizwan.claude-dev",
         );
         assert_eq!(dirs, vec![oss]);
+    }
+
+    #[test]
+    fn expand_user_path_handles_home_and_absolute() {
+        assert!(expand_user_path("~/.qwen").unwrap().ends_with(".qwen"));
+        assert_eq!(expand_user_path("/tmp/qwen").unwrap(), PathBuf::from("/tmp/qwen"));
+        assert_eq!(expand_user_path("~").unwrap(), dirs::home_dir().unwrap());
     }
 }

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -315,6 +315,7 @@ fn parse_pi_session_file(
         thread_role: Some(ThreadRole::Primary),
         parent_links,
         metadata_parser_version: Some(METADATA_PARSER_VERSION),
+        refresh_session_on_metadata_backfill: false,
     }))
 }
 

--- a/src/adapters/qwen.rs
+++ b/src/adapters/qwen.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 use crate::adapters::AdapterSyncContext;
 use crate::adapters::file_scan::{self, FileScanEntry, FileScanOptions};
 use crate::adapters::json_util::{jsonl_indexed, rfc3339_ms};
-use crate::adapters::paths::resolve_home_dir;
+use crate::adapters::paths::{self, resolve_home_dir};
 use crate::adapters::usage::usage_count;
 use crate::adapters::{
     RawMessage, RawSession, ResumeCommand, SourceAdapter, SyncScanResult, SyncScanStats,
@@ -75,28 +75,13 @@ impl SourceAdapter for QwenAdapter {
 }
 
 fn resolve_qwen_runtime_dir() -> anyhow::Result<Option<PathBuf>> {
-    if let Some(dir) = env_path("QWEN_RUNTIME_DIR") {
+    if let Some(dir) = paths::env_path_dir("QWEN_RUNTIME_DIR") {
         return existing_dir(dir, "QWEN_RUNTIME_DIR not found, skipping Qwen Code");
     }
-    if let Some(dir) = env_path("QWEN_HOME") {
+    if let Some(dir) = paths::env_path_dir("QWEN_HOME") {
         return existing_dir(dir, "QWEN_HOME not found, skipping Qwen Code");
     }
     resolve_home_dir(".qwen", "~/.qwen not found, skipping Qwen Code")
-}
-
-fn env_path(name: &str) -> Option<PathBuf> {
-    let raw = std::env::var(name).ok().filter(|value| !value.is_empty())?;
-    expand_user_path(&raw)
-}
-
-fn expand_user_path(raw: &str) -> Option<PathBuf> {
-    if raw == "~" {
-        return dirs::home_dir();
-    }
-    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
-        return dirs::home_dir().map(|home| home.join(rest));
-    }
-    Some(PathBuf::from(raw))
 }
 
 fn existing_dir(dir: PathBuf, missing_message: &str) -> anyhow::Result<Option<PathBuf>> {
@@ -525,13 +510,6 @@ mod tests {
         .unwrap();
         assert_eq!(second.stats.parsed, 0);
         assert!(second.sessions.is_empty());
-    }
-
-    #[test]
-    fn expand_user_path_handles_home_and_absolute() {
-        let expanded = expand_user_path("~/.qwen").unwrap();
-        assert!(expanded.ends_with(".qwen"));
-        assert_eq!(expand_user_path("/tmp/qwen").unwrap(), PathBuf::from("/tmp/qwen"));
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -753,7 +753,8 @@ impl SyncJob {
                 });
                 let content_changed = old.message_count != msg_count
                     || metadata_changed
-                    || (raw.updated_at.is_some() && raw.updated_at != old.updated_at);
+                    || (raw.updated_at.is_some() && raw.updated_at != old.updated_at)
+                    || (raw.refresh_session_on_metadata_backfill && metadata_backfill_needed);
                 match decide_existing_session_action(
                     self.options.usage_only,
                     self.options.backfill_events,


### PR DESCRIPTION
### What's changed?

- Discover sessions through supported environment overrides and additional tool storage locations.
- Parse newer JSON, JSONL, message, title, timestamp, and usage shapes across the affected adapters.
- Reconcile only stable, explicitly non-Copilot VS Code chat records while keeping source transcripts available for rebuilds.

### Why

- Existing adapters missed or misread sessions after upstream tools changed their storage paths and on-disk formats.
- Keep the Recall index accurate without deleting source transcripts or adding adapter-specific persistence paths.

### Verification

- cargo test adapters::
- cargo test sync::tests
- make check