### PR TITLE
feat(session): handoff via pointer and installed adapters

### DIFF
--- a/src/adapters/AGENTS.md
+++ b/src/adapters/AGENTS.md
@@ -9,7 +9,11 @@ apply when working here.
 - The `SourceAdapter` trait in `mod.rs` is the authoritative contract, not the
   DEVELOPMENT.md example. `id()`, `label()`, `scan()`, and `resume_command()`
   are required; `scan_for_sync()`, `scan_for_sync_output()`, `app_command()`,
-  and `usage_parser_version()` are optional overrides.
+  `usage_parser_version()`, and `start_command()` are optional overrides.
+  `start_command()` is how an adapter becomes a handoff target: implement it
+  when the CLI can start a new session from an initial prompt. Registration
+  plus a present binary on PATH is what the TUI/CLI list; do not keep a
+  parallel target table.
 - Adapters never delete from `Store`. An adapter with a complete source
   inventory may return a bounded `ReconcilePlan`; sync owns applying it after
   the source run succeeds and only in global scope.

--- a/src/adapters/antigravity.rs
+++ b/src/adapters/antigravity.rs
@@ -35,6 +35,10 @@ impl SourceAdapter for AntigravityAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(ResumeCommand { program: "agy".to_string(), args: vec!["-i".to_string(), prompt] })
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(cli_dir) = resolve_antigravity_dir()? else {
             return Ok(vec![]);

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -42,6 +42,10 @@ impl SourceAdapter for ClaudeCodeAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("claude", prompt))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/codex.rs
+++ b/src/adapters/codex.rs
@@ -42,6 +42,10 @@ impl SourceAdapter for CodexAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("codex", prompt))
+    }
+
     fn app_command(&self, source_id: &str) -> Option<ResumeCommand> {
         Some(open_url_command(codex_thread_url(source_id)))
     }

--- a/src/adapters/copilot.rs
+++ b/src/adapters/copilot.rs
@@ -40,6 +40,10 @@ impl SourceAdapter for CopilotAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("copilot", prompt))
+    }
+
     fn app_command(&self, source_id: &str) -> Option<ResumeCommand> {
         Some(open_url_command(copilot_session_url(source_id)))
     }

--- a/src/adapters/cursor.rs
+++ b/src/adapters/cursor.rs
@@ -66,6 +66,10 @@ impl SourceAdapter for CursorAdapter {
         cli_store::resume_command(source_id)
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("agent", prompt))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/droid.rs
+++ b/src/adapters/droid.rs
@@ -39,6 +39,10 @@ impl SourceAdapter for DroidAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("droid", prompt))
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(sessions_dir) = resolve_sessions_dir() else {
             return Ok(vec![]);

--- a/src/adapters/gemini.rs
+++ b/src/adapters/gemini.rs
@@ -31,6 +31,10 @@ impl SourceAdapter for GeminiAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("gemini", prompt))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/grok.rs
+++ b/src/adapters/grok.rs
@@ -40,6 +40,10 @@ impl SourceAdapter for GrokAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("grok", prompt))
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(sessions_dir) = resolve_grok_sessions_dir()? else {
             return Ok(vec![]);

--- a/src/adapters/kilo.rs
+++ b/src/adapters/kilo.rs
@@ -28,6 +28,13 @@ impl SourceAdapter for KiloCodeAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "kilo".to_string(),
+            args: vec!["--prompt".to_string(), prompt],
+        })
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(conn) = open_kilo_db()? else {
             return Ok(vec![]);

--- a/src/adapters/mimo_code.rs
+++ b/src/adapters/mimo_code.rs
@@ -30,6 +30,13 @@ impl SourceAdapter for MimoCodeAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "mimo".to_string(),
+            args: vec!["--prompt".to_string(), prompt],
+        })
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(conn) = open_mimo_db()? else {
             return Ok(vec![]);

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -74,6 +74,9 @@ pub(crate) trait SourceAdapter {
     fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
         None
     }
+    fn start_command(&self, _prompt: String) -> Option<ResumeCommand> {
+        None
+    }
 }
 
 pub(crate) struct AdapterSyncContext {
@@ -362,6 +365,10 @@ impl ResumeCommand {
         }
         out
     }
+}
+
+pub(crate) fn prompt_start(program: &str, prompt: String) -> ResumeCommand {
+    ResumeCommand { program: program.to_string(), args: vec![prompt] }
 }
 
 pub(crate) fn all_adapters() -> Vec<Box<dyn SourceAdapter>> {

--- a/src/adapters/omp.rs
+++ b/src/adapters/omp.rs
@@ -40,6 +40,10 @@ impl SourceAdapter for OmpAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("omp", prompt))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/opencode.rs
+++ b/src/adapters/opencode.rs
@@ -76,6 +76,13 @@ impl SourceAdapter for OpenCodeAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(ResumeCommand {
+            program: "opencode".to_string(),
+            args: vec!["run".to_string(), "-i".to_string(), prompt],
+        })
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/openhands.rs
+++ b/src/adapters/openhands.rs
@@ -54,6 +54,10 @@ impl SourceAdapter for OpenHandsAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("openhands", prompt))
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         scan_conversations(conversations_dir())
     }

--- a/src/adapters/pi.rs
+++ b/src/adapters/pi.rs
@@ -39,6 +39,10 @@ impl SourceAdapter for PiAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("pi", prompt))
+    }
+
     fn usage_parser_version(&self) -> Option<u32> {
         Some(USAGE_PARSER_VERSION)
     }

--- a/src/adapters/qwen.rs
+++ b/src/adapters/qwen.rs
@@ -40,6 +40,10 @@ impl SourceAdapter for QwenAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("qwen", prompt))
+    }
+
     fn scan(&self) -> anyhow::Result<Vec<RawSession>> {
         let Some(runtime_dir) = resolve_qwen_runtime_dir()? else {
             return Ok(vec![]);

--- a/src/adapters/zcode.rs
+++ b/src/adapters/zcode.rs
@@ -28,6 +28,10 @@ impl SourceAdapter for ZcodeAdapter {
         })
     }
 
+    fn start_command(&self, prompt: String) -> Option<ResumeCommand> {
+        Some(crate::adapters::prompt_start("zcode", prompt))
+    }
+
     fn app_command(&self, _source_id: &str) -> Option<ResumeCommand> {
         open_zcode_app()
     }

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,48 +1,130 @@
 use anyhow::Result;
 
-use crate::adapters::ResumeCommand;
-use crate::transcript;
-use crate::types::{Message, Session};
+use crate::adapters::{self, ResumeCommand};
+use crate::types::{Message, Role, Session};
+use crate::utils::binary_on_path;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+const LAST_USER_CHARS: usize = 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HandoffTarget {
-    pub(crate) id: &'static str,
-    pub(crate) label: &'static str,
+    pub(crate) id: String,
+    pub(crate) label: String,
 }
 
-pub(crate) const TARGETS: [HandoffTarget; 4] = [
-    HandoffTarget { id: "codex", label: "Codex" },
-    HandoffTarget { id: "grok", label: "Grok" },
-    HandoffTarget { id: "claude-code", label: "Claude Code" },
-    HandoffTarget { id: "opencode", label: "OpenCode" },
-];
+pub(crate) fn available_targets() -> Vec<HandoffTarget> {
+    available_targets_with(binary_on_path)
+}
+
+pub(crate) fn available_targets_with(present: impl Fn(&str) -> bool) -> Vec<HandoffTarget> {
+    let mut targets = Vec::new();
+    for adapter in adapters::all_adapters() {
+        let Some(command) = adapter.start_command(String::new()) else {
+            continue;
+        };
+        if present(&command.program) {
+            targets.push(target_from_adapter(adapter.as_ref()));
+        }
+    }
+    targets
+}
 
 pub(crate) fn build_prompt(session: &Session, messages: &[Message]) -> String {
-    format!(
-        "Use this Recall indexed session transcript as context for a new session. This is a handoff, not a native resume.\n\n{}",
-        transcript::render_plain(session, messages)
-    )
-}
+    let last_user = messages
+        .iter()
+        .rev()
+        .find(|message| message.role == Role::User)
+        .map(|message| truncate_chars(&message.content, LAST_USER_CHARS))
+        .filter(|content| !content.is_empty())
+        .unwrap_or_else(|| "(none)".to_string());
 
-pub(crate) fn command_for_target(target: &HandoffTarget, prompt: String) -> ResumeCommand {
-    match target.id {
-        "codex" => ResumeCommand { program: "codex".to_string(), args: vec![prompt] },
-        "grok" => ResumeCommand { program: "grok".to_string(), args: vec![prompt] },
-        "claude-code" => ResumeCommand { program: "claude".to_string(), args: vec![prompt] },
-        "opencode" => ResumeCommand {
-            program: "opencode".to_string(),
-            args: vec!["run".to_string(), "-i".to_string(), prompt],
-        },
-        _ => unreachable!(),
+    let mut prompt = String::new();
+    prompt.push_str("Use Recall session ");
+    prompt.push_str(&session.id);
+    prompt.push_str(" as prior context. This is a handoff, not a native resume.\n");
+    prompt.push_str("Title: ");
+    prompt.push_str(&session.title);
+    prompt.push('\n');
+    prompt.push_str("Source: ");
+    prompt.push_str(&session.source);
+    prompt.push_str(" (");
+    prompt.push_str(&session.source_id);
+    prompt.push_str(")\n");
+    if let Some(directory) = session.directory.as_deref() {
+        prompt.push_str("Directory: ");
+        prompt.push_str(directory);
+        prompt.push('\n');
     }
+    prompt.push_str("Messages: ");
+    prompt.push_str(&messages.len().to_string());
+    prompt.push('\n');
+    prompt.push_str("Last user request:\n");
+    prompt.push_str(&last_user);
+    prompt.push_str("\n\nLoad evidence with Recall MCP get_session or `recall session show --id ");
+    prompt.push_str(&session.id);
+    prompt.push_str("`.\n");
+    prompt
 }
 
-pub(crate) fn target_for(target_id: &str) -> Result<&'static HandoffTarget> {
+pub(crate) fn command_for_target(target: &HandoffTarget, prompt: String) -> Result<ResumeCommand> {
+    adapters::all_adapters()
+        .into_iter()
+        .find(|adapter| adapter.id() == target.id)
+        .and_then(|adapter| adapter.start_command(prompt))
+        .ok_or_else(|| anyhow::anyhow!("unsupported handoff target: {}", target.id))
+}
+
+pub(crate) fn target_for(target_id: &str) -> Result<HandoffTarget> {
     let id = target_id.to_ascii_lowercase();
-    TARGETS.iter().find(|target| target.id == id).ok_or_else(|| {
-        let supported = TARGETS.iter().map(|target| target.id).collect::<Vec<_>>().join(", ");
-        anyhow::anyhow!("unsupported handoff target: {target_id} (supported: {supported})")
+    let supported = supported_targets();
+    supported.into_iter().find(|target| target.id == id).ok_or_else(|| {
+        let names = supported_target_ids().join(", ");
+        anyhow::anyhow!("unsupported handoff target: {target_id} (supported: {names})")
     })
+}
+
+pub(crate) fn require_installed(command: &ResumeCommand) -> Result<()> {
+    if binary_on_path(&command.program) {
+        return Ok(());
+    }
+    anyhow::bail!("{} not found on PATH", command.program)
+}
+
+fn supported_targets() -> Vec<HandoffTarget> {
+    adapters::all_adapters()
+        .into_iter()
+        .filter(|adapter| adapter.start_command(String::new()).is_some())
+        .map(|adapter| target_from_adapter(adapter.as_ref()))
+        .collect()
+}
+
+fn supported_target_ids() -> Vec<String> {
+    supported_targets().into_iter().map(|target| target.id).collect()
+}
+
+fn target_from_adapter(adapter: &dyn adapters::SourceAdapter) -> HandoffTarget {
+    HandoffTarget { id: adapter.id().to_string(), label: display_label(adapter.id()) }
+}
+
+fn display_label(id: &str) -> String {
+    id.split('-')
+        .map(|part| {
+            if part.eq_ignore_ascii_case("cli") {
+                "CLI".to_string()
+            } else {
+                let mut chars = part.chars();
+                match chars.next() {
+                    Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    text.chars().take(max_chars).collect()
 }
 
 #[cfg(test)]
@@ -72,40 +154,78 @@ mod tests {
         }
     }
 
-    fn message() -> Message {
+    fn message(role: Role, content: &str, seq: u32) -> Message {
         Message {
             session_id: "s1".to_string(),
-            role: Role::User,
-            content: "continue this work".to_string(),
+            role,
+            content: content.to_string(),
             timestamp: None,
-            seq: 0,
+            seq,
         }
     }
 
-    #[test]
-    fn handoff_prompt_wraps_plain_transcript() {
-        let prompt = build_prompt(&session(), &[message()]);
-
-        assert!(prompt.contains("This is a handoff, not a native resume."));
-        assert!(prompt.contains("Session: Fix login bug"));
-        assert!(prompt.contains("## User [0]"));
-        assert!(prompt.contains("continue this work"));
+    fn target(id: &str) -> HandoffTarget {
+        target_for(id).unwrap()
     }
 
     #[test]
-    fn handoff_commands_cover_first_target_set() {
+    fn handoff_prompt_is_a_recall_pointer() {
+        let prompt = build_prompt(
+            &session(),
+            &[
+                message(Role::User, "old request that must not leak", 0),
+                message(Role::Assistant, "old answer", 1),
+                message(Role::User, "continue this work", 2),
+            ],
+        );
+
+        assert!(prompt.contains("This is a handoff, not a native resume."));
+        assert!(prompt.contains("Use Recall session s1"));
+        assert!(prompt.contains("Title: Fix login bug"));
+        assert!(prompt.contains("Source: grok (raw1)"));
+        assert!(prompt.contains("Directory: /tmp/project"));
+        assert!(prompt.contains("continue this work"));
+        assert!(prompt.contains("recall session show --id s1"));
+        assert!(!prompt.contains("old request that must not leak"));
+        assert!(!prompt.contains("old answer"));
+        assert!(!prompt.contains("## User"));
+    }
+
+    #[test]
+    fn handoff_commands_use_adapter_start() {
         let cases = [
             ("codex", "codex", vec!["prompt"]),
             ("grok", "grok", vec!["prompt"]),
             ("claude-code", "claude", vec!["prompt"]),
             ("opencode", "opencode", vec!["run", "-i", "prompt"]),
+            ("antigravity-cli", "agy", vec!["-i", "prompt"]),
+            ("cursor", "agent", vec!["prompt"]),
+            ("kilo-code", "kilo", vec!["--prompt", "prompt"]),
+            ("mimo-code", "mimo", vec!["--prompt", "prompt"]),
         ];
 
         for (target_id, program, args) in cases {
-            let target = target_for(target_id).unwrap();
-            let command = command_for_target(target, "prompt".to_string());
+            let command = command_for_target(&target(target_id), "prompt".to_string()).unwrap();
             assert_eq!(command.program, program);
             assert_eq!(command.args, args);
         }
+    }
+
+    #[test]
+    fn available_targets_keep_installed_startable_adapters() {
+        let targets = available_targets_with(|program| matches!(program, "codex" | "agy"));
+        let ids: Vec<_> = targets.iter().map(|target| target.id.as_str()).collect();
+        assert_eq!(ids, vec!["codex", "antigravity-cli"]);
+        assert_eq!(targets[0].label, "Codex");
+        assert_eq!(targets[1].label, "Antigravity CLI");
+    }
+
+    #[test]
+    fn target_for_rejects_unknown_and_unstartable_ids() {
+        let error = target_for("not-a-tool").unwrap_err().to_string();
+        assert!(error.contains("unsupported handoff target: not-a-tool"));
+        assert!(error.contains("codex"));
+        assert!(!error.contains("kimi-code"));
+        assert!(target_for("CODEX").is_ok());
     }
 }

--- a/src/mcp_host.rs
+++ b/src/mcp_host.rs
@@ -6,6 +6,8 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value};
 
+use crate::utils::binary_on_path;
+
 const SERVER_NAME: &str = "recall";
 const DEFAULT_BIN: &str = "recall";
 const SERVER_ARG: &str = "mcp";
@@ -393,35 +395,6 @@ fn quote_arg(arg: &str) -> String {
     } else {
         arg.to_string()
     }
-}
-
-fn binary_on_path(name: &str) -> bool {
-    let Some(paths) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&paths).any(|dir| host_binary_in(&dir, name))
-}
-
-#[cfg(unix)]
-fn host_binary_in(dir: &Path, name: &str) -> bool {
-    is_unix_executable(&dir.join(name))
-}
-
-#[cfg(windows)]
-fn host_binary_in(dir: &Path, name: &str) -> bool {
-    dir.join(name).is_file() || dir.join(format!("{name}.exe")).is_file()
-}
-
-#[cfg(not(any(unix, windows)))]
-fn host_binary_in(dir: &Path, name: &str) -> bool {
-    dir.join(name).is_file()
-}
-
-#[cfg(unix)]
-fn is_unix_executable(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    path.is_file()
-        && path.metadata().ok().is_some_and(|meta| meta.permissions().mode() & 0o111 != 0)
 }
 
 #[cfg(test)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -684,7 +684,8 @@ fn cmd_session_handoff(
         return Ok(());
     }
 
-    let command = handoff::command_for_target(target, prompt);
+    let command = handoff::command_for_target(&target, prompt)?;
+    handoff::require_installed(&command)?;
     session_action::run(&command, handoff_working_directory(session.directory.as_deref()))
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -178,6 +178,7 @@ pub(crate) struct App {
     pub(crate) semantic_last_refresh: Instant,
     pub(crate) settings_selected: usize,
     pub(crate) pending_resume: Option<PendingResume>,
+    pub(crate) handoff_targets: Vec<handoff::HandoffTarget>,
     pub(crate) handoff_target_selected: usize,
     pub(crate) share_popup: Option<SharePopup>,
     pub(crate) share_publish_rx: Option<mpsc::Receiver<Result<String, String>>>,
@@ -275,6 +276,7 @@ impl App {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            handoff_targets: Vec::new(),
             handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
@@ -1490,6 +1492,15 @@ impl App {
     }
 
     fn open_handoff_target_picker(&mut self) {
+        self.present_handoff_targets(handoff::available_targets());
+    }
+
+    fn present_handoff_targets(&mut self, targets: Vec<handoff::HandoffTarget>) {
+        if targets.is_empty() {
+            self.status_message = Some("No handoff targets found on PATH".to_string());
+            return;
+        }
+        self.handoff_targets = targets;
         self.handoff_target_selected = 0;
         self.mode = AppMode::HandoffTarget;
     }
@@ -1503,13 +1514,16 @@ impl App {
                 self.handoff_target_selected -= 1;
             }
             KeyCode::Down | KeyCode::Char('j')
-                if self.handoff_target_selected + 1 < handoff::TARGETS.len() =>
+                if self.handoff_target_selected + 1 < self.handoff_targets.len() =>
             {
                 self.handoff_target_selected += 1;
             }
             KeyCode::Enter | KeyCode::Char(' ') => {
-                let target = &handoff::TARGETS[self.handoff_target_selected];
-                self.start_handoff_confirmation(target);
+                let Some(target) = self.handoff_targets.get(self.handoff_target_selected).cloned()
+                else {
+                    return;
+                };
+                self.start_handoff_confirmation(&target);
             }
             _ => {}
         }
@@ -1520,11 +1534,18 @@ impl App {
             return;
         };
         let prompt = handoff::build_prompt(session, &self.viewing_messages);
-        let command = handoff::command_for_target(target, prompt);
+        let command = match handoff::command_for_target(target, prompt) {
+            Ok(command) => command,
+            Err(error) => {
+                self.status_message = Some(error.to_string());
+                self.mode = AppMode::Viewing;
+                return;
+            }
+        };
         self.pending_resume = Some(PendingResume {
             command,
             action: PendingCommandAction::Handoff,
-            source_label: target.label.to_string(),
+            source_label: target.label.clone(),
             session_title: session.title.clone(),
             cwd: session.directory.clone(),
             origin: ResumeOrigin::Viewing,
@@ -2838,6 +2859,7 @@ mod tests {
             semantic_last_refresh: Instant::now(),
             settings_selected: 0,
             pending_resume: None,
+            handoff_targets: Vec::new(),
             handoff_target_selected: 0,
             share_popup: None,
             share_publish_rx: None,
@@ -3520,8 +3542,6 @@ mod tests {
 
     #[test]
     fn imported_session_can_handoff_from_detail_view() {
-        crate::db::schema::register_sqlite_vec();
-        let store = Store::open_in_memory().unwrap();
         let mut app = app_with_sources();
         let mut result = codex_search_result();
         result.session.is_import = true;
@@ -3530,7 +3550,10 @@ mod tests {
         app.viewing_messages = vec![message(Role::User, None, 0)];
         app.mode = AppMode::Viewing;
 
-        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE), &store);
+        app.present_handoff_targets(vec![handoff::HandoffTarget {
+            id: "codex".to_string(),
+            label: "Codex".to_string(),
+        }]);
         assert!(matches!(app.mode, AppMode::HandoffTarget));
 
         app.handle_handoff_target_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -3540,6 +3563,20 @@ mod tests {
         assert_eq!(pending.action, PendingCommandAction::Handoff);
         assert_eq!(pending.command.program, "codex");
         assert!(pending.command.args[0].contains("This is a handoff, not a native resume."));
+        assert!(pending.command.args[0].contains("Use Recall session"));
+    }
+
+    #[test]
+    fn missing_handoff_targets_stay_in_viewing() {
+        let mut app = app_with_sources();
+        app.mode = AppMode::Viewing;
+
+        app.present_handoff_targets(Vec::new());
+
+        assert!(matches!(app.mode, AppMode::Viewing));
+        assert!(
+            app.status_message.as_deref().unwrap_or_default().contains("No handoff targets found")
+        );
     }
 
     #[test]

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -575,6 +575,12 @@ mod tests {
         let mut app =
             App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
         app.mode = AppMode::HandoffTarget;
+        app.handoff_targets = vec![
+            crate::handoff::HandoffTarget { id: "codex".into(), label: "Codex".into() },
+            crate::handoff::HandoffTarget { id: "grok".into(), label: "Grok".into() },
+            crate::handoff::HandoffTarget { id: "claude-code".into(), label: "Claude Code".into() },
+            crate::handoff::HandoffTarget { id: "opencode".into(), label: "OpenCode".into() },
+        ];
         app.handoff_target_selected = 3;
         app.results = vec![SearchResult {
             session: Session {
@@ -623,13 +629,41 @@ mod tests {
         assert!(rendered.contains("[Enter]"));
         assert!(rendered.contains("select"));
 
-        let width = 90u16.clamp(36, 56);
-        let height = (crate::handoff::TARGETS.len() as u16 + 5).max(8);
+        let width = 90u16.clamp(36, 56).min(90);
+        let desired = app.handoff_targets.len() as u16 + 5;
+        let height = desired.clamp(8, 18);
         let rect = Rect::new((90 - width) / 2, (18 - height) / 2, width, height);
         let selected = &terminal.backend().buffer()
             [(rect.x + 1, rect.y + 2 + app.handoff_target_selected as u16)];
         assert_eq!(selected.fg, THEME.selected_fg);
         assert_eq!(selected.bg, THEME.selected_bg);
+    }
+
+    #[test]
+    fn render_handoff_target_picker_fits_short_terminal() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app =
+            App::new(&store, vec![("codex".to_string(), "CDX".to_string())], AppConfig::default());
+        app.mode = AppMode::HandoffTarget;
+        app.handoff_targets = (0..17)
+            .map(|index| crate::handoff::HandoffTarget {
+                id: format!("t{index}"),
+                label: format!("Target{index}"),
+            })
+            .collect();
+        app.handoff_target_selected = 16;
+
+        let backend = TestBackend::new(90, 18);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app)).unwrap();
+        let rendered = (0..18)
+            .map(|y| buffer_row(terminal.backend().buffer(), y, 90))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Target16 (t16)"));
+        assert!(!rendered.contains("Target0 (t0)"));
     }
 
     fn buffer_row(buffer: &ratatui::buffer::Buffer, y: u16, width: u16) -> String {

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -5,7 +5,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::handoff;
 use crate::tui::app::App;
 use crate::tui::search_state::{PanelFocus, ProjectPickerRow, SourcePickerRow};
 use crate::tui::share_state::PendingCommandAction;
@@ -114,8 +113,11 @@ pub(super) fn render_subagents_picker(f: &mut Frame, app: &App) {
 
 pub(super) fn render_handoff_target_picker(f: &mut Frame, app: &App) {
     let area = f.area();
-    let width = area.width.clamp(36, 56);
-    let height = (handoff::TARGETS.len() as u16 + 5).max(8);
+    let width = area.width.clamp(36, 56).min(area.width);
+    let count = app.handoff_targets.len();
+    let desired_height = count as u16 + 5;
+    let max_height = area.height.max(1);
+    let height = if max_height < 8 { max_height } else { desired_height.clamp(8, max_height) };
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;
     let rect = Rect::new(x, y, width, height);
@@ -126,9 +128,14 @@ pub(super) fn render_handoff_target_picker(f: &mut Frame, app: &App) {
         .border_style(Style::default().fg(THEME.accent))
         .style(Style::default().bg(THEME.popup_bg));
 
-    let mut lines = Vec::new();
-    lines.push(Line::from(""));
-    for (index, target) in handoff::TARGETS.iter().enumerate() {
+    let visible_rows = (height as usize).saturating_sub(5).max(1);
+    let selected = app.handoff_target_selected.min(count.saturating_sub(1));
+    let start = if count == 0 || selected < visible_rows { 0 } else { selected + 1 - visible_rows };
+    let end = (start + visible_rows).min(count);
+
+    let mut lines = vec![Line::from("")];
+    for (offset, target) in app.handoff_targets[start..end].iter().enumerate() {
+        let index = start + offset;
         let selected = index == app.handoff_target_selected;
         let marker = if selected { ">" } else { " " };
         let style = if selected {
@@ -141,7 +148,7 @@ pub(super) fn render_handoff_target_picker(f: &mut Frame, app: &App) {
         };
         lines.push(Line::from(vec![
             Span::styled(format!(" {marker} "), style),
-            Span::styled(target.label, style),
+            Span::styled(target.label.as_str(), style),
             Span::styled(format!(" ({})", target.id), style),
         ]));
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,38 @@
 use std::fs::{File, OpenOptions};
 use std::io::Write as _;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use fs2::FileExt;
+
+pub(crate) fn binary_on_path(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| binary_in(&dir, name))
+}
+
+#[cfg(unix)]
+fn binary_in(dir: &Path, name: &str) -> bool {
+    is_unix_executable(&dir.join(name))
+}
+
+#[cfg(windows)]
+fn binary_in(dir: &Path, name: &str) -> bool {
+    dir.join(name).is_file() || dir.join(format!("{name}.exe")).is_file()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn binary_in(dir: &Path, name: &str) -> bool {
+    dir.join(name).is_file()
+}
+
+#[cfg(unix)]
+fn is_unix_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.is_file()
+        && path.metadata().ok().is_some_and(|meta| meta.permissions().mode() & 0o111 != 0)
+}
 
 pub(crate) fn text_needs_trigram(text: &str) -> bool {
     if text.is_ascii() {


### PR DESCRIPTION
### What's changed?

- Replace full-transcript argv handoff with a Recall session pointer and last-user brief
- Discover handoff targets from adapters that implement start_command whose CLI is on PATH
- Use `--prompt` for kilo and mimo; omit crush (no interactive prompt start)
- Clamp and scroll the TUI target picker so a long list cannot overflow the terminal

### Why

- Destination agents already have Recall, so copying the indexed transcript is the wrong transport and can exceed ARG_MAX
- A hardcoded four-tool table cannot follow adapters the user actually has installed
