### PR TITLE
feat(tui): add manual session sync

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -149,7 +149,7 @@ pub(crate) fn run(format: InfoFormat) -> Result<()> {
     }
 
     println!();
-    println!("Tip: open the TUI and press Ctrl+S to edit settings.");
+    println!("Tip: open the TUI and press Ctrl+S to sync, Ctrl+P to edit settings.");
 
     Ok(())
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -37,19 +37,24 @@ pub(crate) fn run_cli(
     source_filter: Option<&str>,
     project_filter: Option<&str>,
 ) -> Result<()> {
-    let labels = adapters::source_labels();
-    let sources = resolve_source_filter(source_filter, &labels)?;
-    let scope = Store::open()?.resolve_scope(project_filter, None)?.announce();
-    run_sync_job_inner(SyncRunOptions {
-        force,
-        verbose,
-        emit: true,
-        usage_only: false,
-        backfill_events: false,
-        sources,
-        scope,
+    run_with_sync_lock(|| {
+        let labels = adapters::source_labels();
+        let sources = resolve_source_filter(source_filter, &labels)?;
+        let scope = Store::open()?.resolve_scope(project_filter, None)?.announce();
+        run_sync_job_with(
+            SyncRunOptions {
+                force,
+                verbose,
+                emit: true,
+                usage_only: false,
+                backfill_events: false,
+                sources,
+                scope,
+            },
+            None,
+        )?;
+        compact_database_if_bloated()
     })?;
-    compact_database_if_bloated()?;
     semantic::ensure_background_worker(false)?;
     Ok(())
 }
@@ -101,7 +106,7 @@ pub(crate) fn run_usage_sync_job() -> Result<()> {
 }
 
 pub(crate) fn run_usage_sync_job_with_progress(on_source: &mut dyn FnMut(&str)) -> Result<()> {
-    run_sync_job_with(usage_sync_options(), Some(on_source))
+    run_with_sync_lock(|| run_sync_job_with(usage_sync_options(), Some(on_source)))
 }
 
 pub(crate) fn run_dashboard_sync_job() -> Result<()> {
@@ -243,7 +248,12 @@ impl ExistingState {
 }
 
 pub(crate) fn run_sync_job_inner(options: SyncRunOptions) -> Result<()> {
-    run_sync_job_with(options, None)
+    run_with_sync_lock(|| run_sync_job_with(options, None))
+}
+
+fn run_with_sync_lock<T>(run: impl FnOnce() -> Result<T>) -> Result<T> {
+    let _lock = utils::acquire_sync_lock()?;
+    run()
 }
 
 fn run_sync_job_with(

--- a/src/tui/AGENTS.md
+++ b/src/tui/AGENTS.md
@@ -9,6 +9,7 @@ ratatui application. Module roles:
 - `search_state.rs`, `share_state.rs`, `usage_state.rs`, `viewing_state.rs` —
   per-concern state, kept out of `app.rs` when self-contained.
 - `search_worker.rs` — background search thread connected by mpsc channels.
+- `sync_worker.rs` — background incremental sync thread connected by mpsc channels.
 - `layout.rs`, `text_layout.rs` — geometry and text wrapping.
 - `ui/` — rendering only. Draw functions read state; they must not mutate it.
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -24,6 +24,7 @@ use crate::tui::search_worker::{SearchPhase, SearchRequest, SearchResponse, Sear
 use crate::tui::share_state::{
     AppMode, PendingCommandAction, PendingResume, ResumeOrigin, SharePopup,
 };
+use crate::tui::sync_worker::SyncRequest;
 use crate::tui::text_layout::wrap_visual_rows;
 use crate::tui::usage_state::UsageTab;
 use crate::tui::usage_worker::{UsageRequest, UsageResponse};
@@ -166,6 +167,8 @@ pub(crate) struct App {
     pub(crate) active_search_id: u64,
     pub(crate) search_in_flight: bool,
     pub(crate) search_feedback: Option<String>,
+    pub(crate) sync_requested: bool,
+    pub(crate) sync_in_flight: bool,
     pub(crate) embedding_unavailable: bool,
     pub(crate) status_message: Option<String>,
     pub(crate) sort_order: SortOrder,
@@ -264,6 +267,8 @@ impl App {
             active_search_id: 0,
             search_in_flight: false,
             search_feedback: None,
+            sync_requested: false,
+            sync_in_flight: false,
             embedding_unavailable: false,
             status_message: None,
             sort_order: SortOrder::Relevance,
@@ -1108,6 +1113,11 @@ impl App {
         }
 
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+            self.sync_requested = true;
+            return;
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('p') {
             self.mode = AppMode::Settings;
             self.settings_selected = 0;
             return;
@@ -1210,7 +1220,9 @@ impl App {
                 self.cycle_usage_time(false);
                 self.request_usage_refresh();
             }
-            KeyCode::Char('s') | KeyCode::Char('S') => {
+            KeyCode::Char('s') | KeyCode::Char('S')
+                if !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
                 self.cycle_usage_source(false);
                 self.request_usage_refresh();
             }
@@ -1239,6 +1251,10 @@ impl App {
         }
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('o') {
             self.start_app_open_confirmation(ResumeOrigin::Viewing);
+            return;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+            self.sync_requested = true;
             return;
         }
         match key.code {
@@ -2002,6 +2018,64 @@ impl App {
             time_range: self.usage_time_filter,
             sync,
         })
+    }
+
+    pub(crate) fn take_sync_request(&mut self) -> Option<SyncRequest> {
+        if !self.sync_requested || self.sync_in_flight {
+            return None;
+        }
+
+        self.sync_requested = false;
+        self.sync_in_flight = true;
+        Some(SyncRequest { sources: self.source_filter_ids(), scope: self.scope.clone() })
+    }
+
+    pub(crate) fn fail_sync(&mut self, error: impl std::fmt::Display) {
+        self.sync_requested = false;
+        self.sync_in_flight = false;
+        self.status_message = Some(format!("Sync failed: {error}"));
+    }
+
+    pub(crate) fn apply_sync_response(&mut self, store: &Store, result: Result<(), String>) {
+        if !self.sync_in_flight {
+            return;
+        }
+
+        self.sync_in_flight = false;
+        match result {
+            Ok(()) => {
+                self.reload_after_sync(store);
+                if !self.sync_requested {
+                    self.status_message = Some("Synced".to_string());
+                }
+            }
+            Err(error) => {
+                if !self.sync_requested {
+                    self.status_message = Some(format!("Sync failed: {error}"));
+                }
+            }
+        }
+    }
+
+    fn reload_after_sync(&mut self, store: &Store) {
+        self.project_directories = store.list_project_directories().unwrap_or_default();
+        self.update_scope_metrics(store);
+        if matches!(self.mode, AppMode::Viewing) && self.viewing_search_input.is_none() {
+            let selected = self.viewing_selected_msg;
+            if let Some(session) = self.viewing_session.clone() {
+                let session =
+                    store.get_session_by_id(&session.id).ok().flatten().unwrap_or(session);
+                if self.load_into_viewing(session, store) && !self.viewing_messages.is_empty() {
+                    self.viewing_selected_msg = selected.min(self.viewing_messages.len() - 1);
+                    self.anchor_viewing_scroll();
+                }
+            }
+        }
+        if self.query.trim().is_empty() {
+            self.load_recent(store);
+        } else {
+            self.queue_search_now();
+        }
     }
 
     pub(crate) fn request_usage_refresh(&mut self) {
@@ -2847,6 +2921,8 @@ mod tests {
             active_search_id: 0,
             search_in_flight: false,
             search_feedback: None,
+            sync_requested: false,
+            sync_in_flight: false,
             embedding_unavailable: false,
             status_message: None,
             sort_order: SortOrder::Relevance,
@@ -3510,6 +3586,121 @@ mod tests {
                 .iter()
                 .any(|arg| arg == "codex://threads/019e6d8d-588b-7fd2-a326-c525469ed120")
         );
+    }
+
+    #[test]
+    fn ctrl_p_from_search_opens_settings() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+
+        app.handle_search_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL), &store);
+
+        assert!(matches!(app.mode, AppMode::Settings));
+    }
+
+    #[test]
+    fn ctrl_s_from_search_requests_sync_instead_of_settings() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+
+        app.handle_search_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL), &store);
+
+        assert!(matches!(app.mode, AppMode::Search));
+        let request = app.take_sync_request().expect("sync request");
+        assert_eq!(request.scope, ProjectScope::Global);
+        assert!(request.sources.is_none());
+        assert!(app.sync_in_flight);
+        assert!(app.take_sync_request().is_none());
+    }
+
+    #[test]
+    fn ctrl_s_from_viewing_syncs_instead_of_sharing() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.mode = AppMode::Viewing;
+        app.viewing_session = Some(codex_search_result().session);
+
+        app.handle_viewing_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL), &store);
+
+        assert!(matches!(app.mode, AppMode::Viewing));
+        assert!(app.share_popup.is_none());
+        assert!(app.sync_requested);
+    }
+
+    #[test]
+    fn in_flight_sync_coalesces_another_ctrl_s() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+
+        app.handle_search_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL), &store);
+        assert!(app.take_sync_request().is_some());
+        app.handle_search_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL), &store);
+        assert!(app.take_sync_request().is_none());
+
+        app.apply_sync_response(&store, Ok(()));
+        assert!(app.take_sync_request().is_some());
+    }
+
+    #[test]
+    fn sync_response_reloads_recent_results() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        store.insert_session(&codex_search_result().session).unwrap();
+        app.sync_in_flight = true;
+
+        app.apply_sync_response(&store, Ok(()));
+
+        assert_eq!(app.results.len(), 1);
+        assert_eq!(app.results[0].session.id, "session1");
+        assert!(!app.sync_in_flight);
+    }
+
+    #[test]
+    fn sync_response_keeps_selected_viewing_message_visible() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        let mut result = codex_search_result();
+        result.session.message_count = 5;
+        let messages = (0..5).map(|n| message(Role::User, None, n)).collect::<Vec<_>>();
+        store.insert_session(&result.session).unwrap();
+        store.insert_messages(&messages).unwrap();
+        app.set_terminal_size(80, 10);
+        app.mode = AppMode::Viewing;
+        app.viewing_session = Some(result.session);
+        app.viewing_messages = messages;
+        app.viewing_sanitized_lines = build_viewing_caches(&app.viewing_messages);
+        app.viewing_selected_msg = 4;
+        app.viewing_scroll_offset = 9;
+        app.sync_in_flight = true;
+
+        app.apply_sync_response(&store, Ok(()));
+
+        assert_eq!(app.viewing_selected_msg, 4);
+        let layout = viewing_layout(app.terminal_area);
+        let pane = app.viewing_pane(layout.messages.width as usize);
+        let selected_start = pane.start_of(app.viewing_selected_msg);
+        assert!(selected_start >= app.viewing_scroll_offset);
+        assert!(selected_start < app.viewing_scroll_offset + layout.messages.height as usize);
+    }
+
+    #[test]
+    fn sync_with_query_queues_search() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        let mut app = app_with_sources();
+        app.query = "handoff".to_string();
+        app.sync_in_flight = true;
+
+        app.apply_sync_response(&store, Ok(()));
+
+        assert!(app.search_pending);
+        assert!(app.results.is_empty());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod runner;
 pub(crate) mod search_state;
 pub(crate) mod search_worker;
 pub(crate) mod share_state;
+pub(crate) mod sync_worker;
 pub(crate) mod text_layout;
 pub(crate) mod theme;
 pub(crate) mod ui;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -6,6 +6,7 @@ use crate::db::search::TimeRange;
 use crate::db::store::Store;
 use crate::semantic;
 use crate::tui::search_worker::SearchWorker;
+use crate::tui::sync_worker::SyncWorker;
 use crate::tui::usage_worker::UsageWorker;
 
 pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>) -> Result<()> {
@@ -76,6 +77,7 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
             Some("Debug builds do not start semantic indexing; run cargo run -- sync first".into());
     }
     let search_worker = SearchWorker::spawn();
+    let sync_worker = SyncWorker::spawn();
     let usage_worker = UsageWorker::spawn();
     if let Some((source_filter, time_filter)) = usage_start {
         app.source_filter_selection = source_filter.unwrap_or_default();
@@ -92,6 +94,9 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
         app.poll_share_publish();
         while let Some(response) = search_worker.try_recv() {
             app.apply_search_response(&store, response);
+        }
+        while let Some(response) = sync_worker.try_recv() {
+            app.apply_sync_response(&store, response);
         }
         while let Some(response) = usage_worker.try_recv() {
             app.apply_usage_response(response);
@@ -116,6 +121,11 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
             break;
         }
 
+        if let Some(request) = app.take_sync_request()
+            && !sync_worker.refresh(request)
+        {
+            app.fail_sync("Sync worker unavailable");
+        }
         if let Some(request) = app.take_usage_request(usage_sync_pending) {
             usage_sync_pending = false;
             if !usage_worker.refresh(request) {
@@ -125,6 +135,9 @@ pub(crate) fn run(usage_start: Option<(Option<Vec<String>>, Option<TimeRange>)>)
         app.try_search(&store, &search_worker);
         while let Some(response) = search_worker.try_recv() {
             app.apply_search_response(&store, response);
+        }
+        while let Some(response) = sync_worker.try_recv() {
+            app.apply_sync_response(&store, response);
         }
         while let Some(response) = usage_worker.try_recv() {
             app.apply_usage_response(response);

--- a/src/tui/sync_worker.rs
+++ b/src/tui/sync_worker.rs
@@ -1,0 +1,52 @@
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+
+use crate::project_scope::ProjectScope;
+use crate::semantic;
+use crate::sync::{SyncRunOptions, run_sync_job_inner};
+
+pub(crate) struct SyncRequest {
+    pub(crate) sources: Option<Vec<String>>,
+    pub(crate) scope: ProjectScope,
+}
+
+pub(crate) struct SyncWorker {
+    request_tx: Sender<SyncRequest>,
+    response_rx: Receiver<Result<(), String>>,
+}
+
+impl SyncWorker {
+    pub(crate) fn spawn() -> Self {
+        let (request_tx, request_rx) = mpsc::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        thread::spawn(move || run_worker(request_rx, response_tx));
+        Self { request_tx, response_rx }
+    }
+
+    pub(crate) fn refresh(&self, request: SyncRequest) -> bool {
+        self.request_tx.send(request).is_ok()
+    }
+
+    pub(crate) fn try_recv(&self) -> Option<Result<(), String>> {
+        self.response_rx.try_recv().ok()
+    }
+}
+
+fn run_worker(request_rx: Receiver<SyncRequest>, response_tx: Sender<Result<(), String>>) {
+    while let Ok(request) = request_rx.recv() {
+        let result = run_sync_job_inner(SyncRunOptions {
+            force: false,
+            verbose: false,
+            emit: false,
+            usage_only: false,
+            backfill_events: false,
+            sources: request.sources,
+            scope: request.scope,
+        })
+        .and_then(|_| semantic::ensure_background_worker(false))
+        .map_err(|error| format!("{error:#}"));
+        if response_tx.send(result).is_err() {
+            return;
+        }
+    }
+}

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -612,7 +612,14 @@ pub(super) fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         Style::default().fg(THEME.text_muted),
     );
 
-    let line = if let Some(ref msg) = app.status_message {
+    let line = if app.sync_requested || app.sync_in_flight {
+        let mut spans = vec![Span::styled(" Syncing...", Style::default().fg(THEME.info))];
+        if let Some(span) = semantic_span.clone() {
+            spans.push(span);
+        }
+        spans.push(stats_span);
+        Line::from(spans)
+    } else if let Some(ref msg) = app.status_message {
         let mut spans = vec![Span::styled(format!(" {msg}"), Style::default().fg(THEME.success))];
         if let Some(span) = semantic_span.clone() {
             spans.push(span);
@@ -631,11 +638,13 @@ pub(super) fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled(" detail  ", Style::default().fg(THEME.text_muted)),
                     Span::styled("Ctrl+F", Style::default().fg(THEME.accent)),
                     Span::styled(" filter  ", Style::default().fg(THEME.text_muted)),
+                    Span::styled("Ctrl+S", Style::default().fg(THEME.accent)),
+                    Span::styled(" sync  ", Style::default().fg(THEME.text_muted)),
                     Span::styled("Ctrl+R", Style::default().fg(THEME.accent)),
                     Span::styled(" resume  ", Style::default().fg(THEME.text_muted)),
                     Span::styled("Ctrl+O", Style::default().fg(THEME.accent)),
                     Span::styled(" app  ", Style::default().fg(THEME.text_muted)),
-                    Span::styled("Ctrl+S", Style::default().fg(THEME.accent)),
+                    Span::styled("Ctrl+P", Style::default().fg(THEME.accent)),
                     Span::styled(" settings  ", Style::default().fg(THEME.text_muted)),
                     Span::styled("Esc", Style::default().fg(THEME.accent)),
                     Span::styled(" clear  ", Style::default().fg(THEME.text_muted)),

--- a/src/tui/ui/viewing.rs
+++ b/src/tui/ui/viewing.rs
@@ -161,6 +161,8 @@ pub(super) fn render_viewing(f: &mut Frame, app: &App) {
         help_spans.push(Span::styled(" subs  ", Style::default().fg(THEME.text_muted)));
     }
     help_spans.extend([
+        Span::styled("Ctrl+S", Style::default().fg(THEME.accent)),
+        Span::styled(" sync  ", Style::default().fg(THEME.text_muted)),
         Span::styled("Ctrl+R", Style::default().fg(THEME.accent)),
         Span::styled(" resume  ", Style::default().fg(THEME.text_muted)),
         Span::styled("Ctrl+O", Style::default().fg(THEME.accent)),
@@ -174,6 +176,8 @@ pub(super) fn render_viewing(f: &mut Frame, app: &App) {
             Span::styled(" /", Style::default().fg(THEME.accent).add_modifier(Modifier::BOLD)),
             Span::styled(input.clone(), Style::default().fg(THEME.text)),
         ])
+    } else if app.sync_requested || app.sync_in_flight {
+        Line::from(vec![Span::styled(" Syncing...", Style::default().fg(THEME.info))])
     } else if let Some(ref msg) = app.status_message {
         Line::from(vec![Span::styled(format!(" {msg}"), Style::default().fg(THEME.success))])
     } else if let Some(ref note) = app.viewing_search_status {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,25 +56,47 @@ pub(crate) fn text_needs_trigram(text: &str) -> bool {
 }
 
 pub(crate) fn try_acquire_worker_lock() -> anyhow::Result<Option<File>> {
-    let path = worker_lock_path()?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut file =
-        OpenOptions::new().create(true).truncate(false).read(true).write(true).open(path)?;
+    try_acquire_lock(&recall_lock_path("background-worker.lock")?)
+}
+
+pub(crate) fn acquire_sync_lock() -> anyhow::Result<File> {
+    acquire_lock(&recall_lock_path("sync.lock")?)
+}
+
+fn acquire_lock(path: &Path) -> anyhow::Result<File> {
+    let mut file = open_lock_file(path)?;
+    file.lock_exclusive()?;
+    write_lock_owner(&mut file)?;
+    Ok(file)
+}
+
+fn try_acquire_lock(path: &Path) -> anyhow::Result<Option<File>> {
+    let mut file = open_lock_file(path)?;
     match file.try_lock_exclusive() {
         Ok(()) => {
-            file.set_len(0)?;
-            writeln!(file, "{}", std::process::id())?;
+            write_lock_owner(&mut file)?;
             Ok(Some(file))
         }
         Err(_) => Ok(None),
     }
 }
 
-fn worker_lock_path() -> anyhow::Result<std::path::PathBuf> {
+fn open_lock_file(path: &Path) -> anyhow::Result<File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(OpenOptions::new().create(true).truncate(false).read(true).write(true).open(path)?)
+}
+
+fn write_lock_owner(file: &mut File) -> anyhow::Result<()> {
+    file.set_len(0)?;
+    writeln!(file, "{}", std::process::id())?;
+    Ok(())
+}
+
+fn recall_lock_path(name: &str) -> anyhow::Result<std::path::PathBuf> {
     let dir = dirs::data_dir().ok_or_else(|| anyhow::anyhow!("cannot determine data directory"))?;
-    Ok(dir.join("recall").join("background-worker.lock"))
+    Ok(dir.join("recall").join(name))
 }
 
 pub(crate) fn open_url_in_default_browser(url: &str) -> anyhow::Result<()> {
@@ -260,6 +282,16 @@ fn is_noise_first_message(content: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lock_file_excludes_parallel_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sync.lock");
+        let first = acquire_lock(&path).unwrap();
+
+        assert!(try_acquire_lock(&path).unwrap().is_none());
+        drop(first);
+    }
 
     #[test]
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]


### PR DESCRIPTION
### What's changed?

- add background TUI sync on Ctrl+S and move settings to Ctrl+P
- serialize sync jobs across processes to avoid SQLite writer conflicts
- refresh search and detail state after sync while keeping the selected message visible

### Why

- let users refresh indexed sessions without leaving the TUI
- keep manual sync reliable during startup and background maintenance