### PR TITLE
feat(search): add anchored message retrieval

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -114,12 +114,20 @@ Core support in v0.1:
 - `recall session list` supports `--format json|jsonl`;
 - `recall search --format json` is a thin wrapper over the same JSON shape as
   `recall session list --query ... --format json`;
+- `recall search --messages --format json` returns individual FTS matches in
+  `matches`, with session identity, message sequence, role, and a match-centered
+  excerpt; the default session-search shape is unchanged.
 - `recall session show` supports `--format json|jsonl`;
 - `recall export` emits JSONL, one session record per line, with export record
   schema version 6, and supports `--include metadata,messages,usage,events`
   for field projection. Export projections must include `messages`; `usage`
   and `events` are optional add-ons. `recall session list` and `recall export`
   also accept `--thread-role primary|subagent|unknown` to filter by topology;
+- Paged `session show` reads (`--around-seq`, `--max-chars`, or `--cursor`)
+  add `truncated`, `next_cursor`, and `first_message_byte_offset`. Message
+  content may be a fragment; consume all cursor pages before treating it as
+  a complete transcript. Do not import a partial page as a complete session.
+  Cursors expire when the session is reindexed.
 - `recall session show --format json` defaults to metadata only. Extensions
   that need transcript data must pass `--messages` or
   `--include metadata,messages,usage,events`.

--- a/docs/session.md
+++ b/docs/session.md
@@ -70,6 +70,25 @@ keystrokes, parse terminal UI output, and hope the focused row did not change.
 
 ## Command Design
 
+### `recall search --messages`
+
+Search individual message text with FTS, including assistant responses. The
+existing `recall search` mode continues to return sessions.
+
+```bash
+recall search "sync lock" --messages --project owner/repo --limit 10 --format json
+recall search "sync lock" --messages --session-id <session-id> --format json
+```
+
+`--limit` defaults to 10 and accepts 1–50 message matches. `--session-id`
+limits the search to an exact indexed session; it does not infer a project
+from the working directory. Explicit source, time, project, and repository
+filters still apply. JSON contains `protocol_version` and `matches`; each match
+has `session_id`, `source_session_id`, `source`, `title`, `seq`, `role`,
+`timestamp` (Unix milliseconds or null), and a match-centered `excerpt`.
+Matches are ranked and bounded, not an exhaustive list. This mode uses keyword
+matching only; existing session search retains hybrid retrieval.
+
 ### `recall session list`
 
 List indexed sessions. This command reads the local Recall SQLite index; it does
@@ -198,6 +217,42 @@ JSON output:
   "events": []
 }
 ```
+
+Read around a search hit:
+
+```bash
+recall session show --id <session-id> --messages --around-seq 83 --before 3 --after 3 --format json
+recall session show --id <session-id> --messages --from-seq 80 --to-seq 86 --max-chars 6000 --format json
+recall session show --id <session-id> --messages --cursor '<next_cursor>' --format json
+```
+
+`--around-seq` selects the exact anchor plus actual neighboring messages,
+including across gaps in sequence numbers. `--before` and `--after` default to
+3, allow zero, and require `--around-seq`. Around and explicit range selectors
+are mutually exclusive. Missing or ambiguous anchors are errors. The role
+filter is applied after selecting the neighboring window.
+
+Around reads default to 6,000 Unicode content characters per page. Set
+`--max-chars` to 1–32,000 to change the budget or enable range paging. Pages
+contain at most 1,000 message fragments and may end inside a message. Selected
+messages are returned in conversation order, so a long preceding message can
+fill a page before the anchor; use zero neighbors to read only the anchor.
+Paged JSON/JSONL adds `truncated`, `next_cursor`, and
+`first_message_byte_offset` (UTF-8 offset in the first returned message).
+Text mode prints the continuation argument on stderr. Continue with the same
+session reference and `--cursor`, without selection or role flags. Reindexing
+the session invalidates the cursor even if its content is unchanged. Sequence
+anchors refer to the current index, not permanent source identities.
+
+Without around, cursor, or a character budget, CLI show retains its existing
+full-content output. Bounds and role filtering are applied in SQLite.
+
+MCP exposes the same message search as `search_messages`. Pass `around_seq`,
+`before`, and `after` to `get_session`, or use `from_seq` / `to_seq`. Selected
+MCP reads default to at most 50 messages and 6,000 content characters;
+`max_chars` may lower this budget. `next_cursor` continues the selected window.
+Selectors and cursor cannot be combined with `tail`. Legacy `get_session`
+head/tail calls retain their existing text format and limits.
 
 ### `recall session export`
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -20,21 +20,32 @@ If neither MCP nor the installed CLI is available, stop and offer `brew install 
 
 ## Find Sessions
 
-Use MCP `list_recent_sessions` without a query, `search_sessions` with a query, and `get_session` only when transcript evidence is needed.
+For a specific historical question, use MCP `search_messages` with keywords and the current project. Each match includes `session_id`, `seq`, `role`, and an excerpt around the match. Add `session_id` to search within a known session. This is full-text matching, not semantic search; use `search_sessions` for broader session discovery and `list_recent_sessions` when there is no query.
+
+When a message excerpt needs context, call `get_session` with the returned `session_id` and `around_seq: <seq>`. It reads the anchor and up to three actual messages on each side. Adjust `before` and `after` independently; zero reads only the requested side or anchor. Use `from_seq` / `to_seq` instead when the exact inclusive range is known. Do not combine around and range selectors, or use either with `tail`.
+
+Selected MCP reads return up to 50 messages and 6,000 Unicode content characters. Pages follow conversation order; if preceding content fills the budget before the anchor, use `before: 0, after: 0` to read the anchor itself. For a truncated page, copy `next_cursor` into the next `get_session` call with the same `session_id`, without selectors or `tail`. `first_message_byte_offset` locates a partial first message in its UTF-8 content. A stale cursor requires a fresh search or selection. Sequence numbers locate the current index and are not permanent source-message identities.
 
 Use `session_id` as Recall's index identity and `source_session_id` as the native tool's identity. `get_session` reports the returned message range with `first_message_seq` and `last_message_seq`.
 
 Set `include_events: true` only when structured evidence is needed. Events cover the returned message range plus unanchored events; both count and text are bounded. Check returned counts and truncation flags before treating messages or events as complete. Consult the active tool schema for limits; raw arguments, results, and source paths are not returned.
 
-Pass a fresh high-entropy `invocation_nonce` literal on each MCP search or recent-list call. Only `current_session.resolution: resolved` proves self-exclusion before ranking and limit. If resolution is `unknown`, report that self-exclusion is unverified; never infer identity from time, project, source, or result order.
+Pass a fresh high-entropy `invocation_nonce` literal on each MCP search or recent-list call. For `search_sessions` and `list_recent_sessions`, only `current_session.resolution: resolved` proves self-exclusion before ranking and limit. If resolution is `unknown`, report that self-exclusion is unverified; never infer identity from time, project, source, or result order.
+
+For `search_messages`, `current_session_excluded` states whether self-exclusion was applied; an explicit `session_id` includes that session even when it is current.
 
 Use the equivalent CLI workflow when needed:
 
 ```bash
 recall session list --project /absolute/project/path --source <source> --limit 20 --sort updated --format json
 recall session list --project owner/repo --query "<keywords>" --time 7d --limit 20 --sort updated --format json
-recall session show --id <session-id> --format json --include metadata,messages
+recall search "<keywords>" --messages --project owner/repo --limit 10 --format json
+recall search "<keywords>" --messages --session-id <session-id> --format json
+recall session show --id <session-id> --messages --around-seq <seq> --before 3 --after 3 --format json
+recall session show --id <session-id> --messages --cursor '<next_cursor>' --format json
 ```
+
+CLI around reads default to a 6,000-character page. Use `--max-chars` (1–32,000) to change the budget or enable paging for a range. Without paging, existing CLI range reads return the full selected messages. CLI `--session-id` searches do not infer a project from the working directory; explicit project, source, and time filters still apply.
 
 Add `--sync` only when current data matters and index mutation is permitted. Check the selected session's project before using it. Discover current sources and protocol details with `recall info --format json` or `recall mcp capabilities --format json` instead of maintaining a catalog in this skill.
 
@@ -119,13 +130,13 @@ If a broad review lacks a topic or depth, ask one scoping question. Otherwise se
 
 ```bash
 recall info --format json
-recall search "<query>" --project /absolute/project/path --format json
+recall search "<query>" --messages --project /absolute/project/path --format json
 recall export --project /absolute/project/path --limit 0
 ```
 
 Treat search snippets as leads. Parse exports as JSONL instead of text, and verify historical conclusions against current code. Token usage is not monetary cost without an explicit price source.
 
-Synthesize relevant facts, recurring risks, rejected approaches, user constraints, and next checks. Distinguish history from current-code assumptions. Cite source, title or session id, and approximate time; quote only short supporting excerpts.
+Synthesize relevant facts, recurring risks, rejected approaches, user constraints, and next checks. Distinguish history from current-code assumptions. Cite source, title or session id, message sequence when available, and approximate time; quote only short supporting excerpts.
 
 Route requests about workflow friction, handoffs, repeated corrections, or calibration to the installed `reflect` skill.
 

--- a/src/adapters/invocation_probe.rs
+++ b/src/adapters/invocation_probe.rs
@@ -210,7 +210,10 @@ where
 }
 
 pub(crate) fn is_discovery_tool(name: &str) -> bool {
-    matches!(name.rsplit("__").next(), Some("search_sessions" | "list_recent_sessions"))
+    matches!(
+        name.rsplit("__").next(),
+        Some("search_sessions" | "search_messages" | "list_recent_sessions")
+    )
 }
 
 pub(crate) fn nonce_matches_input(input: &serde_json::Value, nonce: &str) -> bool {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,12 @@ enum Commands {
         repo: Option<String>,
         #[arg(long, value_enum, default_value_t = crate::query::SearchFormat::Text)]
         format: crate::query::SearchFormat,
+        #[arg(long, help = "Return keyword matches with message sequence anchors")]
+        messages: bool,
+        #[arg(long, requires = "messages", help = "Search within one Recall session")]
+        session_id: Option<String>,
+        #[arg(long, requires = "messages", value_parser = clap::value_parser!(u32).range(1..=50), help = "Maximum message matches (default 10, maximum 50)")]
+        limit: Option<u32>,
     },
     #[command(about = "Operate on indexed sessions")]
     Session {
@@ -275,15 +281,38 @@ pub(crate) fn run() -> Result<()> {
             crate::bench::run_eval(dataset.as_deref(), verbose)?
         }
         Some(Commands::BenchDumpSessions) => crate::bench::dump_sessions()?,
-        Some(Commands::Search { query, source, time, project, repo, format }) => {
-            crate::query::run_search(
-                &query,
-                source.as_deref(),
-                time.as_deref(),
-                project.as_deref(),
-                repo.as_deref(),
-                format,
-            )?
+        Some(Commands::Search {
+            query,
+            source,
+            time,
+            project,
+            repo,
+            format,
+            messages,
+            session_id,
+            limit,
+        }) => {
+            if messages {
+                crate::query::run_message_search(
+                    &query,
+                    source.as_deref(),
+                    time.as_deref(),
+                    project.as_deref(),
+                    repo.as_deref(),
+                    session_id.as_deref(),
+                    limit.unwrap_or(10) as usize,
+                    format,
+                )?;
+            } else {
+                crate::query::run_search(
+                    &query,
+                    source.as_deref(),
+                    time.as_deref(),
+                    project.as_deref(),
+                    repo.as_deref(),
+                    format,
+                )?
+            }
         }
         Some(Commands::Usage { json, source, time }) => {
             crate::usage::run_cli(json, source.as_deref(), time.as_deref())?

--- a/src/db/message_store.rs
+++ b/src/db/message_store.rs
@@ -1,0 +1,398 @@
+use anyhow::{Result, bail, ensure};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+use super::store::Store;
+use crate::types::{Message, Role};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MessageWindow {
+    pub(crate) from_seq: Option<u32>,
+    pub(crate) to_seq: Option<u32>,
+    pub(crate) around_seq: Option<u32>,
+    pub(crate) before: Option<u32>,
+    pub(crate) after: Option<u32>,
+}
+
+impl MessageWindow {
+    pub(crate) fn is_selected(&self) -> bool {
+        self.from_seq.is_some()
+            || self.to_seq.is_some()
+            || self.around_seq.is_some()
+            || self.before.is_some()
+            || self.after.is_some()
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(
+            self.around_seq.is_none() || (self.from_seq.is_none() && self.to_seq.is_none()),
+            "around-seq cannot be combined with from-seq or to-seq"
+        );
+        ensure!(
+            self.around_seq.is_some() || (self.before.is_none() && self.after.is_none()),
+            "before and after require around-seq"
+        );
+        ensure!(
+            self.from_seq.unwrap_or(0) <= self.to_seq.unwrap_or(u32::MAX),
+            "from-seq must not exceed to-seq"
+        );
+        Ok(())
+    }
+
+    fn bounds(&self, conn: &Connection, session_id: &str) -> Result<(u32, u32)> {
+        self.validate()?;
+        let Some(seq) = self.around_seq else {
+            return Ok((self.from_seq.unwrap_or(0), self.to_seq.unwrap_or(u32::MAX)));
+        };
+        let count: u64 = conn.query_row(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND seq = ?2",
+            params![session_id, seq],
+            |row| row.get(0),
+        )?;
+        ensure!(count == 1, "message sequence {seq} is missing or ambiguous");
+        let first = conn.query_row(
+            "SELECT COALESCE(MIN(seq), ?2) FROM
+             (SELECT seq FROM messages WHERE session_id = ?1 AND seq < ?2 ORDER BY seq DESC LIMIT ?3)",
+            params![session_id, seq, self.before.unwrap_or(3)], |row| row.get(0))?;
+        let last = conn.query_row(
+            "SELECT COALESCE(MAX(seq), ?2) FROM
+             (SELECT seq FROM messages WHERE session_id = ?1 AND seq > ?2 ORDER BY seq LIMIT ?3)",
+            params![session_id, seq, self.after.unwrap_or(3)],
+            |row| row.get(0),
+        )?;
+        let (count, unique): (u64, u64) = conn.query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT seq) FROM messages WHERE session_id = ?1 AND seq BETWEEN ?2 AND ?3",
+            params![session_id, first, last], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        ensure!(count == unique, "message window contains ambiguous sequences");
+        Ok((first, last))
+    }
+}
+
+pub(crate) struct MessagePage {
+    pub(crate) messages: Vec<Message>,
+    pub(crate) next_cursor: Option<String>,
+    pub(crate) first_message_byte_offset: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+struct MessageCursor {
+    version: u8,
+    session_id: String,
+    snapshot: (i64, u64),
+    from_seq: u32,
+    to_seq: u32,
+    role: Option<String>,
+    next_seq: u32,
+    next_id: i64,
+    byte_offset: usize,
+}
+
+pub(crate) struct MessageRead<'a> {
+    pub(crate) window: &'a MessageWindow,
+    pub(crate) role: Option<&'a str>,
+    pub(crate) max_messages: usize,
+    pub(crate) max_chars: usize,
+    pub(crate) cursor: Option<&'a str>,
+}
+
+impl Store {
+    pub(crate) fn get_messages_in_window(
+        &self,
+        session_id: &str,
+        window: &MessageWindow,
+        role: Option<&str>,
+        limit: usize,
+        tail: bool,
+    ) -> Result<Vec<Message>> {
+        let tx = self.conn.unchecked_transaction()?;
+        let (first, last) = window.bounds(&tx, session_id)?;
+        let order = if tail { "DESC" } else { "ASC" };
+        let mut stmt = tx.prepare(&format!(
+            "SELECT role, content, timestamp, seq FROM messages
+             WHERE session_id = ?1 AND seq BETWEEN ?2 AND ?3 AND (?4 IS NULL OR role = ?4)
+             ORDER BY seq {order}, id {order} LIMIT ?5"
+        ))?;
+        let mut messages = stmt
+            .query_map(
+                params![session_id, first, last, role, i64::try_from(limit).unwrap_or(i64::MAX)],
+                |row| {
+                    Ok(Message {
+                        session_id: session_id.to_string(),
+                        role: row.get::<_, String>(0)?.parse().unwrap_or(Role::User),
+                        content: row.get(1)?,
+                        timestamp: row.get(2)?,
+                        seq: row.get(3)?,
+                    })
+                },
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if tail {
+            messages.reverse();
+        }
+        Ok(messages)
+    }
+
+    pub(crate) fn read_message_page(
+        &self,
+        session_id: &str,
+        read: &MessageRead<'_>,
+    ) -> Result<MessagePage> {
+        ensure!(
+            read.max_messages > 0 && read.max_messages <= 1000,
+            "max-messages must be between 1 and 1000"
+        );
+        ensure!(
+            read.max_chars > 0 && read.max_chars <= 32_000,
+            "max-chars must be between 1 and 32000"
+        );
+        read.window.validate()?;
+        ensure!(
+            read.cursor.is_none() || (!read.window.is_selected() && read.role.is_none()),
+            "cursor cannot be combined with message selection or role"
+        );
+        let tx = self.conn.unchecked_transaction()?;
+        let snapshot = tx.query_row(
+            "SELECT COALESCE(MAX(id), 0), COUNT(*) FROM messages WHERE session_id = ?1",
+            [session_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, u64>(1)?)),
+        )?;
+        let mut cursor = if let Some(value) = read.cursor {
+            ensure!(value.len() <= 4096, "invalid message cursor");
+            let value: MessageCursor = serde_json::from_str(value)
+                .map_err(|_| anyhow::anyhow!("invalid message cursor"))?;
+            ensure!(
+                value.version == 1
+                    && value.session_id == session_id
+                    && value.from_seq <= value.next_seq
+                    && value.next_seq <= value.to_seq
+                    && value.next_id >= 0
+                    && value.byte_offset <= i64::MAX as usize,
+                "invalid message cursor"
+            );
+            ensure!(
+                value.snapshot == snapshot,
+                "message cursor is stale; search or select the window again"
+            );
+            value
+        } else {
+            let (from_seq, to_seq) = read.window.bounds(&tx, session_id)?;
+            MessageCursor {
+                version: 1,
+                session_id: session_id.to_string(),
+                snapshot,
+                from_seq,
+                to_seq,
+                role: read.role.map(str::to_string),
+                next_seq: from_seq,
+                next_id: 0,
+                byte_offset: 0,
+            }
+        };
+        let mut messages = Vec::new();
+        let first_message_byte_offset = cursor.byte_offset;
+        let mut remaining = read.max_chars;
+        let mut stmt = tx.prepare(
+            "SELECT id, seq, role, timestamp, length(CAST(content AS BLOB)),
+                    COALESCE(substr(CAST(content AS BLOB), ?7 + 1, ?8), X'')
+             FROM messages WHERE session_id = ?1 AND seq BETWEEN ?2 AND ?3
+               AND (?4 IS NULL OR role = ?4)
+               AND (seq > ?5 OR (seq = ?5 AND id >= ?6))
+             ORDER BY seq, id LIMIT 1",
+        )?;
+        let has_more = loop {
+            let row = stmt
+                .query_row(
+                    params![
+                        session_id,
+                        cursor.from_seq,
+                        cursor.to_seq,
+                        cursor.role,
+                        cursor.next_seq,
+                        cursor.next_id,
+                        cursor.byte_offset as i64,
+                        (remaining.max(1) * 4) as i64
+                    ],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, u32>(1)?,
+                            row.get::<_, String>(2)?.parse().unwrap_or(Role::User),
+                            row.get(3)?,
+                            row.get::<_, usize>(4)?,
+                            row.get::<_, Vec<u8>>(5)?,
+                        ))
+                    },
+                )
+                .optional()?;
+            let Some((id, seq, role, timestamp, total_bytes, bytes)) = row else {
+                break false;
+            };
+            cursor.next_id = id;
+            cursor.next_seq = seq;
+            if remaining == 0 || messages.len() >= read.max_messages {
+                break true;
+            }
+            ensure!(cursor.byte_offset <= total_bytes, "invalid message cursor offset");
+            let text = match std::str::from_utf8(&bytes) {
+                Ok(text) => text,
+                Err(error) if error.error_len().is_none() => {
+                    std::str::from_utf8(&bytes[..error.valid_up_to()])?
+                }
+                Err(_) => bail!("invalid message cursor offset or message encoding"),
+            };
+            let content: String = text.chars().take(remaining).collect();
+            remaining -= content.chars().count();
+            cursor.byte_offset += content.len();
+            messages.push(Message {
+                session_id: session_id.to_string(),
+                seq,
+                role,
+                timestamp,
+                content,
+            });
+            if cursor.byte_offset < total_bytes {
+                break true;
+            }
+            cursor.next_id =
+                id.checked_add(1).ok_or_else(|| anyhow::anyhow!("message id overflow"))?;
+            cursor.byte_offset = 0;
+        };
+        Ok(MessagePage {
+            messages,
+            first_message_byte_offset,
+            next_cursor: has_more.then(|| serde_json::to_string(&cursor)).transpose()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with_messages(messages: &[(u32, &str)]) -> Store {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        store.conn.execute("INSERT INTO sessions (id, source, source_id, title, started_at) VALUES ('s', 'test', 's', 'Test', 0)", []).unwrap();
+        for (seq, content) in messages {
+            store.conn.execute("INSERT INTO messages (session_id, seq, role, content) VALUES ('s', ?1, 'assistant', ?2)", params![seq, content]).unwrap();
+        }
+        store
+    }
+
+    #[test]
+    fn around_counts_messages_across_gaps_and_stops_at_edges() {
+        let store = store_with_messages(&[(0, "a"), (10, "b"), (40, "c"), (90, "d"), (100, "e")]);
+        let window = MessageWindow {
+            around_seq: Some(40),
+            before: Some(1),
+            after: Some(1),
+            ..Default::default()
+        };
+        let messages = store.get_messages_in_window("s", &window, None, 100, false).unwrap();
+        assert_eq!(messages.iter().map(|m| m.seq).collect::<Vec<_>>(), vec![10, 40, 90]);
+        let window = MessageWindow {
+            around_seq: Some(0),
+            before: Some(3),
+            after: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(store.get_messages_in_window("s", &window, None, 100, false).unwrap().len(), 1);
+        let missing = MessageWindow { around_seq: Some(11), ..Default::default() };
+        assert!(store.get_messages_in_window("s", &missing, None, 100, false).is_err());
+        let conflict =
+            MessageWindow { around_seq: Some(40), from_seq: Some(0), ..Default::default() };
+        assert!(store.get_messages_in_window("s", &conflict, None, 100, false).is_err());
+        store.conn.execute("INSERT INTO messages (session_id, seq, role, content) VALUES ('s', 40, 'user', 'duplicate')", []).unwrap();
+        assert!(
+            store
+                .get_messages_in_window(
+                    "s",
+                    &MessageWindow { around_seq: Some(40), ..Default::default() },
+                    None,
+                    100,
+                    false
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn pages_preserve_unicode_nul_empty_and_duplicate_sequence_messages() {
+        let input = [
+            (2, "\u{4f60}\u{597d}🦀e\u{301}\0end"),
+            (2, "second"),
+            (9, ""),
+            (100, "\u{6700}\u{540e}"),
+        ];
+        let store = store_with_messages(&input);
+        for budget in 1..=12 {
+            let mut cursor = None;
+            let mut text = String::new();
+            let mut pages = 0;
+            loop {
+                let page = store
+                    .read_message_page(
+                        "s",
+                        &MessageRead {
+                            window: &MessageWindow::default(),
+                            role: None,
+                            max_messages: 2,
+                            max_chars: budget,
+                            cursor: cursor.as_deref(),
+                        },
+                    )
+                    .unwrap();
+                assert!(page.messages.len() <= 2);
+                assert!(
+                    page.messages.iter().map(|m| m.content.chars().count()).sum::<usize>()
+                        <= budget
+                );
+                for message in page.messages {
+                    text.push_str(&message.content);
+                }
+                pages += 1;
+                assert!(pages < 100);
+                cursor = page.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
+            }
+            assert_eq!(text, input.iter().map(|(_, s)| *s).collect::<String>());
+        }
+    }
+
+    #[test]
+    fn cursor_keeps_selection_and_rejects_reindexed_messages() {
+        let store = store_with_messages(&[(0, "outside"), (5, "abcdefghij"), (10, "outside")]);
+        let window = MessageWindow { from_seq: Some(5), to_seq: Some(5), ..Default::default() };
+        let page = store
+            .read_message_page(
+                "s",
+                &MessageRead {
+                    window: &window,
+                    role: None,
+                    max_messages: 2,
+                    max_chars: 3,
+                    cursor: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(page.messages[0].content, "abc");
+        let read = MessageRead {
+            window: &MessageWindow::default(),
+            role: None,
+            max_messages: 2,
+            max_chars: 32,
+            cursor: page.next_cursor.as_deref(),
+        };
+        let rest = store.read_message_page("s", &read).unwrap();
+        assert_eq!(rest.first_message_byte_offset, 3);
+        assert_eq!(rest.messages.len(), 1);
+        assert_eq!(rest.messages[0].content, "defghij");
+        assert!(rest.next_cursor.is_none());
+        assert!(store.read_message_page("other", &read).is_err());
+        store.conn.execute("DELETE FROM messages WHERE session_id = 's' AND seq = 5", []).unwrap();
+        store.conn.execute("INSERT INTO messages (session_id, seq, role, content) VALUES ('s', 5, 'assistant', 'abcdefghij')", []).unwrap();
+        assert!(store.read_message_page("s", &read).is_err());
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod event_store;
+pub(crate) mod message_store;
 pub(crate) mod project_store;
 pub(crate) mod schema;
 pub(crate) mod search;

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -119,9 +119,93 @@ struct Hit {
     snippet: Option<String>,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct MessageHit {
+    pub(crate) session_id: String,
+    pub(crate) source_session_id: String,
+    pub(crate) source: String,
+    pub(crate) title: String,
+    pub(crate) seq: u32,
+    pub(crate) role: String,
+    pub(crate) timestamp: Option<i64>,
+    pub(crate) excerpt: String,
+}
+
 impl<'a> SearchEngine<'a> {
     pub(crate) fn new(conn: &'a Connection) -> Self {
         Self { conn }
+    }
+
+    pub(crate) fn search_messages(
+        &self,
+        query: &str,
+        filters: &SearchFilters,
+        session_id: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<MessageHit>> {
+        anyhow::ensure!((1..=50).contains(&limit), "limit must be between 1 and 50");
+        let tokens = tokenize_query(query);
+        let trigram = crate::db::schema::has_trigram_fts(self.conn)?;
+        let queries = [
+            ("messages_fts", unicode61_fts5_query(&tokens, trigram)),
+            (
+                "messages_fts_trigram",
+                if trigram { trigram_fts5_query(&tokens) } else { String::new() },
+            ),
+        ];
+        let mut hits: HashMap<i64, (MessageHit, f64)> = HashMap::new();
+        for (table, query) in queries {
+            if query.is_empty() {
+                continue;
+            }
+            let mut sql = format!(
+                "SELECT m.id, m.session_id, s.source_id, s.source, s.title, m.seq, m.role,
+                        m.timestamp, snippet({table}, 0, char(1), char(2), '…', 48)
+                 FROM {table} JOIN messages m ON m.id = {table}.rowid
+                 JOIN sessions s ON s.id = m.session_id WHERE {table} MATCH ?1"
+            );
+            let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(query)];
+            let mut param_idx = 2;
+            apply_filters(&mut sql, &mut params, &mut param_idx, filters);
+            if let Some(id) = session_id {
+                sql.push_str(&format!(" AND m.session_id = ?{param_idx}"));
+                params.push(Box::new(id.to_string()));
+            }
+            sql.push_str(&format!(
+                " ORDER BY {table}.rank, m.session_id, m.seq, m.id LIMIT {limit}"
+            ));
+            let refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|p| p.as_ref()).collect();
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map(refs.as_slice(), |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    MessageHit {
+                        session_id: row.get(1)?,
+                        source_session_id: row.get(2)?,
+                        source: row.get(3)?,
+                        title: row.get::<_, String>(4)?.chars().take(200).collect(),
+                        seq: row.get(5)?,
+                        role: row.get(6)?,
+                        timestamp: row.get(7)?,
+                        excerpt: message_excerpt(&row.get::<_, String>(8)?),
+                    },
+                ))
+            })?;
+            for (rank, row) in rows.enumerate() {
+                let (id, hit) = row?;
+                hits.entry(id).or_insert((hit, 0.0)).1 += 1.0 / (60 + rank) as f64;
+            }
+        }
+        let mut hits: Vec<_> = hits.into_iter().collect();
+        hits.sort_by(|a, b| {
+            b.1.1
+                .total_cmp(&a.1.1)
+                .then_with(|| a.1.0.session_id.cmp(&b.1.0.session_id))
+                .then_with(|| a.1.0.seq.cmp(&b.1.0.seq))
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        Ok(hits.into_iter().take(limit).map(|(_, (hit, _))| hit).collect())
     }
 
     pub(crate) fn hybrid_search(
@@ -488,6 +572,17 @@ fn rrf_merge(fts_hits: &[Hit], vec_hits: &[Hit], k: u32) -> Vec<(String, f64, Ma
 
 const FTS_TRIGRAM_MIN_CHARS: usize = 3;
 
+fn message_excerpt(marked: &str) -> String {
+    let hit = marked.find('\u{1}').map_or(0, |position| marked[..position].chars().count());
+    let start = hit.saturating_sub(160);
+    let mut excerpt: String =
+        marked.chars().filter(|c| !matches!(c, '\u{1}' | '\u{2}')).skip(start).take(400).collect();
+    if start > 0 {
+        excerpt.insert(0, '…');
+    }
+    excerpt
+}
+
 fn tokenize_query(query: &str) -> Vec<String> {
     query
         .split_whitespace()
@@ -797,5 +892,42 @@ mod tests {
         assert_eq!(hits[0].session.id, "s3");
         assert_eq!(hits[0].timestamp, None);
         assert_eq!(hits[1].timestamp, Some(8_000));
+    }
+    #[test]
+    fn message_search_returns_distinct_anchors_and_match_centered_excerpts() {
+        crate::db::schema::register_sqlite_vec();
+        let store = Store::open_in_memory().unwrap();
+        store.conn.execute_batch("INSERT INTO sessions (id, source, source_id, title, started_at) VALUES ('s', 'codex', 'native', 'Test', 1), ('other', 'claude-code', 'other', 'Other', 2);").unwrap();
+        let long = format!("{} evidencekeyword fixes the lock", "ordinary preamble ".repeat(100));
+        for (id, seq, content) in [
+            ("s", 83, long.as_str()),
+            ("s", 90, "evidencekeyword verified"),
+            ("other", 2, "evidencekeyword unrelated"),
+        ] {
+            store.conn.execute("INSERT INTO messages (session_id, seq, role, content) VALUES (?1, ?2, 'assistant', ?3)", rusqlite::params![id, seq, content]).unwrap();
+        }
+        let filters = SearchFilters {
+            sources: None,
+            time_range: TimeRange::All,
+            scope: ProjectScope::Global,
+            thread_role: None,
+            excluded_session_id: None,
+        };
+        let engine = SearchEngine::new(&store.conn);
+        let hits = engine.search_messages("evidencekeyword", &filters, Some("s"), 10).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().all(|h| h.session_id == "s"
+            && h.role == "assistant"
+            && h.excerpt.contains("evidencekeyword")));
+        let mut seqs = hits.iter().map(|h| h.seq).collect::<Vec<_>>();
+        seqs.sort_unstable();
+        assert_eq!(seqs, vec![83, 90]);
+        let excluded = SearchFilters { excluded_session_id: Some("s".into()), ..filters.clone() };
+        assert_eq!(
+            engine.search_messages("evidencekeyword", &excluded, None, 10).unwrap()[0].session_id,
+            "other"
+        );
+        let filtered = SearchFilters { sources: Some(vec!["codex".into()]), ..filters };
+        assert_eq!(engine.search_messages("evidencekeyword", &filtered, None, 1).unwrap().len(), 1);
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::adapters;
+use crate::db::message_store::{MessageRead, MessageWindow};
 use crate::db::search::{SearchEngine, SearchFilters, SessionEventQuery, TimeRange};
 use crate::db::store::Store;
 use crate::project_scope::ProjectScope;
@@ -65,7 +66,7 @@ struct SearchSessionsArgs {
     invocation_nonce: Option<String>,
 }
 
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 struct GetSessionArgs {
     /// Recall session id from search_sessions or list_recent_sessions.
     session_id: String,
@@ -84,6 +85,47 @@ struct GetSessionArgs {
         description = "Include up to 50 structured events anchored to the returned message range, plus unanchored events. Each event string field is capped at 200 characters and all event string fields at 10000 characters total. Defaults to false."
     )]
     include_events: bool,
+    #[serde(default)]
+    #[schemars(
+        description = "First message sequence to read; incompatible with around_seq and cursor."
+    )]
+    from_seq: Option<u32>,
+    #[serde(default)]
+    #[schemars(description = "Last message sequence to read, inclusive.")]
+    to_seq: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Read this message and its neighbors. Missing or ambiguous sequences are errors. Defaults to three messages before and after."
+    )]
+    around_seq: Option<u32>,
+    #[serde(default)]
+    #[schemars(description = "Actual messages before around_seq, excluding the anchor.")]
+    before: Option<u32>,
+    #[serde(default)]
+    #[schemars(description = "Actual messages after around_seq, excluding the anchor.")]
+    after: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Unicode character budget for paged message content, default 6000, maximum 6000. Also enables paging without a sequence selector.",
+        range(min = 1, max = 6000)
+    )]
+    max_chars: Option<u32>,
+    #[serde(default)]
+    #[schemars(
+        description = "Opaque next_cursor copied from the previous page. Use with session_id, without sequence selectors or tail. Reindexing invalidates cursors."
+    )]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SearchMessagesArgs {
+    #[serde(flatten)]
+    search: SearchSessionsArgs,
+    #[serde(default)]
+    #[schemars(
+        description = "Optional Recall session_id to search exactly this session, including the invoking session."
+    )]
+    session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -310,6 +352,10 @@ struct SessionDetail {
     truncated: bool,
     messages: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    next_cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_message_byte_offset: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     events: Option<Vec<SessionEventDetail>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     returned_events: Option<usize>,
@@ -454,7 +500,26 @@ impl RecallMcp {
     }
 
     #[tool(
-        description = "Load one indexed session by Recall session_id. Use after search_sessions or list_recent_sessions when you need the conversation itself. Each message is truncated at 2000 characters; the combined message text is capped at 32000 characters. Set include_events only when structured evidence is needed; it returns at most 50 events anchored to the returned message range plus unanchored events, caps each event string field at 200 characters and all event string fields at 10000 characters total, and never returns raw arguments, results, source paths, or parser internals. Returns metadata, including source-native source_session_id and the first_message_seq and last_message_seq represented by the response, plus messages as plain text in sequence order.",
+        description = "Search message text by keywords and return individual matches with session_id, source_session_id, source, title, seq, role, timestamp (Unix milliseconds), and an excerpt around the match. This uses full-text search, not embeddings. Prefer this for specific historical evidence; use get_session with around_seq set to a returned seq for context. Limit defaults to 10, maximum 50. Pass project for project-scoped discovery and a fresh invocation_nonce for self-exclusion. Explicit session_id searches include that session even when it is the invoking session. Sequence anchors refer to the current index, not permanent source identities.",
+        annotations(
+            title = "Search messages",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    fn search_messages(
+        &self,
+        Parameters(args): Parameters<SearchMessagesArgs>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(json_result(
+            search_message_matches(&lock_index(&self.index), &args, &self.current_session)
+                .map_err(|message| serde_json::json!({"message": message, "matches": []})),
+        ))
+    }
+
+    #[tool(
+        description = "Load one indexed session by Recall session_id. After search_messages, pass around_seq to read the matched message and its neighbors (default three before and after). Alternatively use inclusive from_seq/to_seq. These selectors cannot be combined with tail. Selected reads return up to 50 messages and 6000 Unicode content characters, with first_message_byte_offset and next_cursor for lossless continuation. Resume using session_id and cursor without selectors; reindexing invalidates cursors. Without selectors, cursor, or max_chars, the legacy head/tail behavior follows. Use after search_sessions or list_recent_sessions when you need the conversation itself. Each message is truncated at 2000 characters; the combined message text is capped at 32000 bytes. Set include_events only when structured evidence is needed; it returns at most 50 events anchored to the returned message range plus unanchored events, caps each event string field at 200 characters and all event string fields at 10000 characters total, and never returns raw arguments, results, source paths, or parser internals. Returns metadata, including source-native source_session_id and the first_message_seq and last_message_seq represented by the response, plus messages as plain text in sequence order.",
         annotations(
             title = "Get session",
             read_only_hint = true,
@@ -538,6 +603,7 @@ impl GetSessionBenchmark {
                 max_messages: Some(self.max_messages),
                 tail: self.tail,
                 include_events: false,
+                ..Default::default()
             }))
             .expect("benchmark get_session");
         serde_json::to_vec(&result).expect("serialize benchmark get_session")
@@ -697,6 +763,46 @@ fn search_ready(
     })
 }
 
+fn search_message_matches(
+    index: &IndexState,
+    args: &SearchMessagesArgs,
+    context: &CurrentSessionContext,
+) -> std::result::Result<Value, String> {
+    let store = match index {
+        IndexState::Ready(store) => store,
+        IndexState::Unavailable { message, .. } => return Err(message.clone()),
+    };
+    if let Some(id) = args.session_id.as_deref()
+        && store.get_session_by_id(id).map_err(|e| e.to_string())?.is_none()
+    {
+        return Err(format!("{SESSION_NOT_FOUND} {id}"));
+    }
+    let current = context.resolve(store, args.search.invocation_nonce.as_deref());
+    let (scope, sources) =
+        resolve_filters(store, args.search.project.as_deref(), args.search.source.as_deref())?;
+    let filters = SearchFilters {
+        sources,
+        scope,
+        time_range: TimeRange::All,
+        thread_role: None,
+        excluded_session_id: if args.session_id.is_none() {
+            current.session_id.clone()
+        } else {
+            None
+        },
+    };
+    let matches = SearchEngine::new(&store.conn)
+        .search_messages(
+            &args.search.query,
+            &filters,
+            args.session_id.as_deref(),
+            clamp_limit(args.search.limit, SEARCH_LIMIT_DEFAULT, SEARCH_LIMIT_MAX),
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(serde_json::json!({"matches": matches, "current_session": current,
+        "current_session_excluded": filters.excluded_session_id.is_some()}))
+}
+
 #[cfg(test)]
 fn list_recent_sessions(
     index: &IndexState,
@@ -837,10 +943,72 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
         };
         return Err(message);
     };
-    let max_messages = clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, u32::MAX);
-    let messages = store.get_messages(&session.id).map_err(|error| error.to_string())?;
-    let (text, returned, truncated, first_message_seq, last_message_seq) =
-        render_messages(&messages, max_messages, args.tail);
+    let window = MessageWindow {
+        from_seq: args.from_seq,
+        to_seq: args.to_seq,
+        around_seq: args.around_seq,
+        before: args.before,
+        after: args.after,
+    };
+    window.validate().map_err(|e| e.to_string())?;
+    let paging = window.is_selected() || args.cursor.is_some() || args.max_chars.is_some();
+    let mut next_cursor = None;
+    let mut first_message_byte_offset = None;
+    let (text, returned, truncated, first_message_seq, last_message_seq) = if paging {
+        if args.tail {
+            return Err("tail cannot be combined with message selection or cursor".to_string());
+        }
+        let max_chars = args.max_chars.unwrap_or(6000);
+        if !(1..=6000).contains(&max_chars) {
+            return Err("max_chars must be between 1 and 6000".to_string());
+        }
+        let page = store
+            .read_message_page(
+                &session.id,
+                &MessageRead {
+                    window: &window,
+                    role: None,
+                    max_messages: clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, 50),
+                    max_chars: max_chars as usize,
+                    cursor: args.cursor.as_deref(),
+                },
+            )
+            .map_err(|e| e.to_string())?;
+        first_message_byte_offset = Some(page.first_message_byte_offset);
+        let first = page.messages.first().map(|m| m.seq);
+        let last = page.messages.last().map(|m| m.seq);
+        let text = page
+            .messages
+            .iter()
+            .map(|m| format!("[{}][{}] {}", m.seq, role_label(&m.role), m.content))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let truncated = page.next_cursor.is_some();
+        next_cursor = page.next_cursor;
+        (text, page.messages.len(), truncated, first, last)
+    } else {
+        let max_messages = clamp_limit(args.max_messages, GET_MAX_MESSAGES_DEFAULT, u32::MAX);
+        let messages = store
+            .get_messages_in_window(
+                &session.id,
+                &window,
+                None,
+                max_messages.min(GET_RESPONSE_CHAR_CAP / 7 + 1),
+                args.tail,
+            )
+            .map_err(|e| e.to_string())?;
+        let total: usize = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?1",
+                [&session.id],
+                |row| row.get(0),
+            )
+            .map_err(|e| e.to_string())?;
+        let (text, returned, truncated, first, last) =
+            render_messages(&messages, max_messages, args.tail);
+        (text, returned, truncated || total > messages.len(), first, last)
+    };
     let (events, returned_events, events_truncated) = if args.include_events {
         let records = store
             .list_session_events_for_session(&session.id)
@@ -867,6 +1035,8 @@ fn get_ready(store: &Store, args: &GetSessionArgs) -> std::result::Result<Sessio
         last_message_seq,
         truncated,
         messages: text,
+        next_cursor,
+        first_message_byte_offset,
         events,
         returned_events,
         events_truncated,
@@ -889,6 +1059,8 @@ fn empty_detail(message: Option<String>) -> SessionDetail {
         last_message_seq: None,
         truncated: false,
         messages: String::new(),
+        next_cursor: None,
+        first_message_byte_offset: None,
         events: None,
         returned_events: None,
         events_truncated: None,
@@ -1572,6 +1744,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1671,6 +1844,7 @@ mod tests {
                 max_messages: Some(1),
                 tail: false,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1707,6 +1881,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1748,6 +1923,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1783,6 +1959,7 @@ mod tests {
                 max_messages: Some(2),
                 tail: true,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1820,6 +1997,7 @@ mod tests {
                 max_messages: Some(20),
                 tail: true,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1846,6 +2024,7 @@ mod tests {
             max_messages: None,
             tail: false,
             include_events: false,
+            ..Default::default()
         };
 
         let index = ready(store);
@@ -1900,6 +2079,7 @@ mod tests {
                 max_messages: Some(2),
                 tail: false,
                 include_events: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1917,6 +2097,7 @@ mod tests {
                 max_messages: Some(2),
                 tail: true,
                 include_events: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1964,6 +2145,7 @@ mod tests {
                     max_messages: None,
                     tail,
                     include_events: true,
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -2000,6 +2182,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -2030,6 +2213,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -2049,6 +2233,7 @@ mod tests {
             max_messages: None,
             tail: false,
             include_events: false,
+            ..Default::default()
         };
         let error = get_session(&index, &args).expect_err("missing session");
         assert!(error.contains(SESSION_NOT_FOUND));
@@ -2161,6 +2346,7 @@ mod tests {
                 max_messages: None,
                 tail: false,
                 include_events: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -2193,6 +2379,7 @@ mod tests {
     fn tools_advertise_read_only_closed_world() {
         for notes in [
             RecallMcp::search_sessions_tool_attr().annotations.unwrap(),
+            RecallMcp::search_messages_tool_attr().annotations.unwrap(),
             RecallMcp::get_session_tool_attr().annotations.unwrap(),
             RecallMcp::list_recent_sessions_tool_attr().annotations.unwrap(),
             RecallMcp::file_history_tool_attr().annotations.unwrap(),
@@ -2564,5 +2751,92 @@ mod tests {
         let summary = list.events[0].summary.as_deref().unwrap();
         assert_eq!(summary.chars().count(), EXCERPT_CHAR_CAP);
         assert!(summary.ends_with('…'));
+    }
+    #[test]
+    fn message_search_opens_sparse_context_and_preserves_explicit_current_session_reads() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "Evidence", 2000)).unwrap();
+        store
+            .insert_messages(&[
+                message("s1", Role::User, "What fixed it?", 0),
+                message("s1", Role::Assistant, "evidencekeyword fixed it", 83),
+                message("s1", Role::User, "Confirmed", 100),
+            ])
+            .unwrap();
+        let index = ready(store);
+        let args: SearchMessagesArgs =
+            serde_json::from_value(serde_json::json!({"query": "evidencekeyword"})).unwrap();
+        let ctx = context("codex", "src-s1");
+        let hidden = search_message_matches(&index, &args, &ctx).unwrap();
+        assert!(hidden["matches"].as_array().unwrap().is_empty());
+        let args = SearchMessagesArgs { session_id: Some("s1".into()), ..args };
+        let hits = search_message_matches(&index, &args, &ctx).unwrap();
+        assert_eq!(hits["matches"][0]["seq"], 83);
+        assert_eq!(hits["current_session_excluded"], false);
+        let detail = get_session(
+            &index,
+            &GetSessionArgs { session_id: "s1".into(), around_seq: Some(83), ..Default::default() },
+        )
+        .unwrap();
+        assert_eq!((detail.first_message_seq, detail.last_message_seq), (Some(0), Some(100)));
+        assert_eq!(detail.returned_messages, 3);
+        assert!(detail.messages.contains("[83][assistant] evidencekeyword"));
+        assert!(!detail.truncated);
+        assert!(
+            get_session(
+                &index,
+                &GetSessionArgs {
+                    session_id: "s1".into(),
+                    around_seq: Some(82),
+                    ..Default::default()
+                }
+            )
+            .is_err()
+        );
+        assert!(
+            get_session(
+                &index,
+                &GetSessionArgs {
+                    session_id: "s1".into(),
+                    around_seq: Some(83),
+                    tail: true,
+                    ..Default::default()
+                }
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn get_session_cursor_reads_the_rest_of_a_long_message() {
+        let store = setup();
+        store.insert_session(&session("s1", "codex", "Long", 2000)).unwrap();
+        let original = "\u{4f60}\u{597d}🦀end".repeat(500);
+        store.insert_messages(&[message("s1", Role::Assistant, &original, 83)]).unwrap();
+        let index = ready(store);
+        let mut args = GetSessionArgs {
+            session_id: "s1".into(),
+            around_seq: Some(83),
+            max_chars: Some(731),
+            ..Default::default()
+        };
+        let mut text = String::new();
+        loop {
+            let page = get_session(&index, &args).unwrap();
+            assert_eq!(page.first_message_byte_offset, Some(text.len()));
+            text.push_str(page.messages.strip_prefix("[83][assistant] ").unwrap());
+            let Some(cursor) = page.next_cursor else {
+                assert!(!page.truncated);
+                break;
+            };
+            assert!(page.truncated);
+            args = GetSessionArgs {
+                session_id: "s1".into(),
+                cursor: Some(cursor),
+                max_chars: Some(731),
+                ..Default::default()
+            };
+        }
+        assert_eq!(text, original);
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -14,6 +14,57 @@ pub(crate) enum SearchFormat {
     Json,
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_message_search(
+    query: &str,
+    source: Option<&str>,
+    time: Option<&str>,
+    project: Option<&str>,
+    repo: Option<&str>,
+    session_id: Option<&str>,
+    limit: usize,
+    format: SearchFormat,
+) -> Result<()> {
+    let store = Store::open()?;
+    if let Some(id) = session_id {
+        anyhow::ensure!(store.get_session_by_id(id)?.is_some(), "session not found: {id}");
+    }
+    let scope = if session_id.is_some() && project.is_none() && repo.is_none() {
+        crate::project_scope::ProjectScope::Global
+    } else {
+        store.resolve_scope(project, repo)?.announce()
+    };
+    let filters = SearchFilters {
+        sources: resolve_source_filter(source, &adapters::source_labels())?,
+        time_range: parse_time_range(time)?,
+        scope,
+        thread_role: None,
+        excluded_session_id: None,
+    };
+    let matches =
+        SearchEngine::new(&store.conn).search_messages(query, &filters, session_id, limit)?;
+    match format {
+        SearchFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "protocol_version": crate::PROTOCOL_VERSION, "matches": matches,
+            }))?
+        ),
+        SearchFormat::Text => {
+            for hit in &matches {
+                println!(
+                    "{} #{} [{}] {}\n  {}",
+                    hit.session_id, hit.seq, hit.role, hit.title, hit.excerpt
+                );
+            }
+            if matches.is_empty() {
+                println!("No matching messages.");
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn run_search(
     query: &str,
     source_filter: Option<&str>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::adapters;
 use crate::config::AppConfig;
+use crate::db::message_store::{MessageRead, MessageWindow};
 use crate::db::search::{SearchEngine, SearchFilters, ThreadRoleFilter, TimeRange};
 use crate::db::store::{SessionListSort, Store};
 use crate::export::{ExportIncludes, ExportOptions};
@@ -11,7 +12,7 @@ use crate::project_scope::ProjectScope;
 use crate::query::{parse_time_range, query_embedding, resolve_source_filter};
 use crate::semantic;
 use crate::session_action::{self, SessionAction};
-use crate::types::{MatchSource, Message, Role, Session, SessionTopology};
+use crate::types::{MatchSource, Session, SessionTopology};
 use crate::{sync::SyncRunOptions, sync::run_sync_job_inner, transcript};
 use anyhow::Result;
 use clap::{Subcommand, ValueEnum};
@@ -61,6 +62,16 @@ pub(crate) enum SessionCommands {
         from_seq: Option<u32>,
         #[arg(long, help = "Last message sequence to include")]
         to_seq: Option<u32>,
+        #[arg(long, conflicts_with_all = ["from_seq", "to_seq", "cursor"], help = "Show a message and its neighbors (default 3 before and 3 after)")]
+        around_seq: Option<u32>,
+        #[arg(long, requires = "around_seq", help = "Number of messages before the anchor")]
+        before: Option<u32>,
+        #[arg(long, requires = "around_seq", help = "Number of messages after the anchor")]
+        after: Option<u32>,
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=32000), help = "Page message content within this Unicode character budget")]
+        max_chars: Option<u32>,
+        #[arg(long, conflicts_with_all = ["from_seq", "to_seq", "around_seq", "before", "after", "role"], help = "Continue a previous message page")]
+        cursor: Option<String>,
         #[arg(long, value_enum, default_value_t = SessionRoleFilter::All)]
         role: SessionRoleFilter,
         #[arg(long, value_enum, default_value_t = SessionDetailFormat::Text)]
@@ -230,6 +241,11 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             include,
             from_seq,
             to_seq,
+            around_seq,
+            before,
+            after,
+            max_chars,
+            cursor,
             role,
             format,
         } => cmd_session_show(
@@ -238,8 +254,9 @@ pub(crate) fn cmd_session(command: SessionCommands) -> Result<()> {
             source_id.as_deref(),
             messages,
             include.as_deref(),
-            from_seq,
-            to_seq,
+            MessageWindow { from_seq, to_seq, around_seq, before, after },
+            max_chars,
+            cursor.as_deref(),
             role,
             format,
         ),
@@ -430,8 +447,9 @@ fn cmd_session_show(
     source_id: Option<&str>,
     messages_flag: bool,
     include: Option<&str>,
-    from_seq: Option<u32>,
-    to_seq: Option<u32>,
+    window: MessageWindow,
+    max_chars: Option<u32>,
+    cursor: Option<&str>,
     role: SessionRoleFilter,
     format: SessionDetailFormat,
 ) -> Result<()> {
@@ -439,10 +457,33 @@ fn cmd_session_show(
     let sources = adapters::source_labels();
     let session = resolve_session_ref(&store, &sources, id, source_filter, source_id)?;
     let includes = parse_session_includes(include, messages_flag, format)?;
-    let messages = if includes.messages {
-        filter_session_messages(store.get_messages(&session.id)?, from_seq, to_seq, role)
+    window.validate()?;
+    let paging = window.around_seq.is_some() || max_chars.is_some() || cursor.is_some();
+    anyhow::ensure!(
+        !(window.is_selected() || paging) || includes.messages,
+        "message selection requires --messages or --include messages"
+    );
+    let role = match role {
+        SessionRoleFilter::All => None,
+        SessionRoleFilter::User => Some("user"),
+        SessionRoleFilter::Assistant => Some("assistant"),
+    };
+    let (messages, next_cursor, first_message_byte_offset) = if paging {
+        let page = store.read_message_page(
+            &session.id,
+            &MessageRead {
+                window: &window,
+                role,
+                max_messages: 1000,
+                max_chars: max_chars.unwrap_or(6000) as usize,
+                cursor,
+            },
+        )?;
+        (page.messages, page.next_cursor, Some(page.first_message_byte_offset))
+    } else if includes.messages {
+        (store.get_messages_in_window(&session.id, &window, role, usize::MAX, false)?, None, None)
     } else {
-        Vec::new()
+        (Vec::new(), None, None)
     };
     let usage_events =
         if includes.usage { store.list_usage_events_for_session(&session.id)? } else { Vec::new() };
@@ -461,28 +502,30 @@ fn cmd_session_show(
             if !events.is_empty() {
                 println!("Session events: {}", events.len());
             }
+            if let Some(cursor) = next_cursor {
+                eprintln!("Continue with --cursor '{}'.", cursor.replace('\'', "'\\''"));
+            }
         }
-        SessionDetailFormat::Json => {
+        SessionDetailFormat::Json | SessionDetailFormat::Jsonl => {
             let topology = store.session_topology(&session.id)?;
-            let value = crate::export::session_record_value(
+            let mut value = crate::export::session_record_value(
                 session,
                 topology,
                 messages,
                 usage_events,
                 events,
             )?;
-            println!("{}", serde_json::to_string_pretty(&value)?);
-        }
-        SessionDetailFormat::Jsonl => {
-            let topology = store.session_topology(&session.id)?;
-            let value = crate::export::session_record_value(
-                session,
-                topology,
-                messages,
-                usage_events,
-                events,
-            )?;
-            println!("{}", serde_json::to_string(&value)?);
+            if paging {
+                value["next_cursor"] = serde_json::json!(next_cursor);
+                value["truncated"] = serde_json::json!(next_cursor.is_some());
+                value["first_message_byte_offset"] = serde_json::json!(first_message_byte_offset);
+            }
+            let output = if matches!(format, SessionDetailFormat::Json) {
+                serde_json::to_string_pretty(&value)?
+            } else {
+                serde_json::to_string(&value)?
+            };
+            println!("{output}");
         }
     }
     Ok(())
@@ -774,24 +817,6 @@ fn parse_session_includes(
         return Ok(includes);
     };
     crate::export::apply_include_filter(includes, include)
-}
-
-fn filter_session_messages(
-    messages: Vec<Message>,
-    from_seq: Option<u32>,
-    to_seq: Option<u32>,
-    role: SessionRoleFilter,
-) -> Vec<Message> {
-    messages
-        .into_iter()
-        .filter(|message| from_seq.is_none_or(|seq| message.seq >= seq))
-        .filter(|message| to_seq.is_none_or(|seq| message.seq <= seq))
-        .filter(|message| match role {
-            SessionRoleFilter::All => true,
-            SessionRoleFilter::User => matches!(message.role, Role::User),
-            SessionRoleFilter::Assistant => matches!(message.role, Role::Assistant),
-        })
-        .collect()
 }
 
 fn print_session_list_table(rows: &[SessionListRow], sources: &[(String, String)]) {


### PR DESCRIPTION
### What's changed?

- Add message-level keyword search through `recall search --messages` and MCP `search_messages`, returning sequence anchors and match-centered excerpts.
- Add `session show --around-seq --before --after` and matching MCP `get_session` inputs. Bounded pages and continuation cursors support long messages, while existing range reads and default output remain compatible.
- Update the embedded Recall skill and protocol documentation with the search-to-context workflow and cursor invalidation behavior.

### Why

Agents can find a relevant message and read its surrounding context without loading the entire session. The implementation reuses the existing FTS index and SQLite storage without adding model calls or a schema migration.

### Validation

- `make check`: passed, including 807 core tests and the workspace suites.
- Eight CLI/MCP runtime checks passed, covering message search, sparse sequence windows, Unicode pagination, stale cursors, legacy output, JSON/JSONL formatting, and text continuation on stderr.
