### PR TITLE
fix(rx): respect shell completion argument contexts

### DIFF
--- a/crates/rx/src/completions.rs
+++ b/crates/rx/src/completions.rs
@@ -34,7 +34,6 @@ _rx_has_provider() {
   local i w
   for ((i = 1; i < COMP_CWORD; i++)); do
     w=${COMP_WORDS[i]}
-    [[ $w == -- ]] && return 1
     [[ $w == --provider || $w == --provider=* ]] && return 0
   done
   return 1
@@ -44,10 +43,9 @@ _rx_positionals() {
   local i=1 pending=0 w
   while ((i < COMP_CWORD)); do
     w=${COMP_WORDS[i]}
-    if [[ $w == -- ]]; then
-      break
-    elif [[ $w == --provider ]]; then
+    if [[ $w == --provider ]]; then
       pending=1
+      [[ ${COMP_WORDS[i + 1]} == = ]] && i=$((i + 1))
     elif [[ $w == --provider=* ]]; then
       :
     elif ((pending)); then
@@ -66,11 +64,21 @@ _rx() {
   prev=${COMP_WORDS[COMP_CWORD - 1]}
   COMPREPLY=()
 
+  local i
+  for ((i = 1; i < COMP_CWORD; i++)); do
+    [[ ${COMP_WORDS[i]} == -- ]] && return
+  done
+
   if [[ $cur == --provider=* ]]; then
     _rx_ids --targets
     return
   fi
   if [[ $prev == --provider ]]; then
+    [[ $cur == = ]] && cur=
+    _rx_ids --targets
+    return
+  fi
+  if [[ $prev == = && ${COMP_WORDS[COMP_CWORD - 2]} == --provider ]]; then
     _rx_ids --targets
     return
   fi
@@ -179,7 +187,6 @@ _rx_ids() {
 _rx_has_provider() {
   local w
   for w in $words[2,CURRENT-1]; do
-    [[ $w == -- ]] && return 1
     [[ $w == --provider || $w == --provider=* ]] && return 0
   done
   return 1
@@ -190,9 +197,7 @@ _rx_positionals() {
   local i=2 pending=0 w
   while (( i < CURRENT )); do
     w=$words[i]
-    if [[ $w == -- ]]; then
-      break
-    elif [[ $w == --provider ]]; then
+    if [[ $w == --provider ]]; then
       pending=1
     elif [[ $w == --provider=* ]]; then
       :
@@ -210,6 +215,11 @@ _rx() {
   local cur=$words[CURRENT]
   local prev=$words[CURRENT-1]
   local cmd=${words[1]:t}
+
+  local i
+  for ((i = 2; i < CURRENT; i++)); do
+    [[ $words[i] == -- ]] && return
+  done
 
   if [[ $cur == --provider=* ]]; then
     _rx_ids --targets

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -225,7 +225,6 @@ fn bare_rx_with_provider_is_harness_picker() {
 fn rx_help_and_version() {
     assert_eq!(parse_line(&["rx", "--help"]), Command::Help);
     assert_eq!(parse_line(&["rx", "-V"]), Command::Version);
-    assert!(!crate::help_text().contains("rx config"));
     assert!(crate::help_text().contains("rx --provider <provider> <harness>"));
     assert!(crate::help_text().contains("rx --provider none <harness>"));
     assert!(crate::help_text().contains("rx providers <list|login|logout|use>"));
@@ -233,7 +232,6 @@ fn rx_help_and_version() {
     assert!(crate::help_text().contains("rx completions <bash|zsh|fish>"));
     assert!(!crate::help_text().contains("rx providers list\n"));
     assert!(!crate::help_text().contains("rx completions --providers"));
-    assert!(!crate::help_text().contains("rx debug"));
 }
 
 #[test]
@@ -278,36 +276,66 @@ fn completions_rejects_provider_flag_and_extra_args() {
     assert!(unknown.to_string().contains("unknown completions command: powershell"), "{unknown}");
 }
 
+#[cfg(unix)]
 #[test]
-fn completions_scripts_cover_rx_surface() {
-    for shell in [CompletionShell::Bash, CompletionShell::Zsh, CompletionShell::Fish] {
-        let script = crate::completions::script(shell);
-        for needle in [
-            "claude",
-            "codex",
-            "opencode",
-            "pi",
-            "dsh",
-            "kimi",
-            "providers",
-            "update",
-            "completions",
-            "--provider",
-            "--configured",
-            "--providers",
-            "--targets",
-            "rxc",
-            "rxx",
-            "rxo",
-            "rxp",
-            "rxd",
-            "rxk",
-        ] {
-            assert!(script.contains(needle), "{shell:?} missing {needle}");
-        }
-        assert!(!script.contains("search"), "{shell:?} leaked recall commands");
+fn bash_completions_follow_argument_context() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("rx");
+    fs::write(
+        &bin,
+        "#!/bin/sh\ncase \"$*\" in\n'completions --targets') printf 'openrouter\\nnone\\n';;\n'completions --providers') echo all-provider;;\n'completions --configured') echo configured-provider;;\n*) exit 1;;\nesac\n",
+    )
+    .unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o700)).unwrap();
+    let script = format!(
+        "{}\nCOMP_WORDS=(\"$@\"); COMP_CWORD=$(($# - 1)); _rx; if ((${{#COMPREPLY[@]}})); then printf '%s\\n' \"${{COMPREPLY[@]}}\"; fi",
+        crate::completions::script(CompletionShell::Bash)
+    );
+    let cases: &[(&[&str], &[&str])] = &[
+        (&["rx", "co"], &["codex", "completions"]),
+        (&["rx", "codex", "--prov"], &["--provider"]),
+        (&["rx", "--provider", "open"], &["openrouter"]),
+        (&["rx", "--provider=open"], &["--provider=openrouter"]),
+        (&["rx", "--provider", "=", "open"], &["openrouter"]),
+        (&["rx", "--provider", "="], &["openrouter", "none"]),
+        (&["rx", "--provider", "=", "none", "co"], &["codex"]),
+        (&["rx", "--provider=none", "co"], &["codex"]),
+        (&["rx", "codex", "--", "--prov"], &[]),
+        (&["rx", "codex", "--", "--provider", "open"], &[]),
+        (&["rx", "codex", "--", "--provider=open"], &[]),
+        (&["rx", "--provider", "none", "codex", "--", "--prov"], &[]),
+        (&["rx", "providers", "lo"], &["login", "logout"]),
+        (&["rx", "providers", "login", "all"], &["all-provider"]),
+        (&["rx", "providers", "logout", "conf"], &["configured-provider"]),
+        (&["rx", "providers", "use", "open"], &["openrouter"]),
+        (&["rx", "providers", "models", "update", "conf"], &["configured-provider"]),
+        (&["rx", "completions", "z"], &["zsh"]),
+        (&["rx", "update", "--y"], &["--yes"]),
+        (&["rx", "codex", "--provider", "none", "--prov"], &[]),
+    ];
+    let check = |words: &[&str], expected: &[&str]| {
+        let output = std::process::Command::new("bash")
+            .args(["--noprofile", "--norc", "-c", &script, "completion-test"])
+            .args(words)
+            .env_clear()
+            .env("HOME", dir.path())
+            .env("PATH", format!("{}:/usr/bin:/bin", dir.path().display()))
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{words:?}: {}", String::from_utf8_lossy(&output.stderr));
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(stdout.lines().collect::<Vec<_>>(), expected, "{words:?}");
+    };
+    for (words, expected) in cases {
+        check(words, expected);
     }
-    assert!(crate::completions::script(CompletionShell::Zsh).contains("#compdef rx"));
+    for alias in ["rxc", "rxx", "rxo", "rxp", "rxd", "rxk"] {
+        check(&[alias, "--prov"], &["--provider"]);
+        check(&[alias, "--", "--prov"], &[]);
+        check(&[alias, "--provider", "=", "open"], &["openrouter"]);
+    }
 }
 
 #[test]
@@ -2307,12 +2335,6 @@ fn real_claude_plan_uses_seeded_generated_route() {
         plan.env_set.iter().any(|(key, value)| key == "ANTHROPIC_AUTH_TOKEN" && value == "sk-test")
     );
     assert!(config_dir.path().join(".claude.json").is_file());
-}
-
-#[test]
-fn debug_is_not_a_harness() {
-    let error = parse(&args(&["rx", "debug", "models"])).unwrap_err();
-    assert!(error.to_string().contains("unknown harness: debug"), "{error}");
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

Bash and zsh completion stop offering rx options and provider IDs after a literal `--`. Bash also handles its default `=` word splitting when completing provider values and the following harness.

Replace completion-script keyword checks with 38 real Bash completion scenarios, and remove obsolete command-name tombstone assertions. Existing parser and native passthrough tests remain.

### Why

`rx codex -- --prov<Tab>` incorrectly offered `--provider` inside native arguments. Bash could also suggest `opencode` instead of a configured provider for `rx --provider=open<Tab>`.

### Validation

- `make check`: dependency audit, formatting, workspace Clippy, and 993 tests passed; 1 ignored.
- `cargo test -p rx`: 146 passed, 1 ignored.
- The new regression test fails on the base revision with `opencode` instead of `openrouter`.
- Six real zsh TTY completion scenarios passed using the freshly built binary and an isolated environment with synthetic credentials.
