### PR TITLE
fix(rx): serialize provider updates and align provider selection

### DIFF
--- a/crates/rx/src/config.rs
+++ b/crates/rx/src/config.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
@@ -90,6 +91,7 @@ pub(crate) fn stored_providers(paths: &Paths) -> Result<BTreeSet<String>> {
 }
 
 pub(crate) fn set_default(paths: &Paths, provider: &str) -> Result<()> {
+    let _lock = mutation_lock(paths)?;
     let mut config = load_or_default(paths)?;
     crate::provider::resolve(provider, config.provider.get(provider))?;
     config.default_provider = Some(provider.to_string());
@@ -97,12 +99,14 @@ pub(crate) fn set_default(paths: &Paths, provider: &str) -> Result<()> {
 }
 
 pub(crate) fn set_none(paths: &Paths) -> Result<()> {
+    let _lock = mutation_lock(paths)?;
     let mut config = load_or_default(paths)?;
     config.default_provider = Some(crate::provider::NONE.to_string());
     save_config(paths, &config)
 }
 
 pub(crate) fn login(paths: &Paths, provider: &str, key: String) -> Result<()> {
+    let _lock = mutation_lock(paths)?;
     let mut config = load_or_default(paths)?;
     crate::provider::resolve(provider, config.provider.get(provider))?;
     let mut keys = load_keys(paths)?;
@@ -115,6 +119,7 @@ pub(crate) fn login(paths: &Paths, provider: &str, key: String) -> Result<()> {
 }
 
 pub(crate) fn logout(paths: &Paths, provider: &str) -> Result<bool> {
+    let _lock = mutation_lock(paths)?;
     let mut config = load_or_default(paths)?;
     crate::provider::resolve(provider, config.provider.get(provider))?;
     let mut keys = load_keys(paths)?;
@@ -127,6 +132,21 @@ pub(crate) fn logout(paths: &Paths, provider: &str) -> Result<bool> {
         save_config(paths, &config)?;
     }
     Ok(removed)
+}
+
+fn mutation_lock(paths: &Paths) -> Result<fs::File> {
+    fs::create_dir_all(&paths.dir)
+        .with_context(|| format!("failed to create {}", paths.dir.display()))?;
+    let lock_path = paths.dir.join("rx.lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    lock.lock_exclusive().with_context(|| format!("failed to lock {}", lock_path.display()))?;
+    Ok(lock)
 }
 
 fn load_keys(paths: &Paths) -> Result<KeyFile> {

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -276,30 +276,33 @@ fn resolve_key(
     paths: &Paths,
     env: &EnvLookup,
 ) -> Result<String> {
-    match auth {
-        AuthMode::Env => env.get(&provider.env).ok_or_else(|| {
-            anyhow::anyhow!(
-                "provider '{}' is set to auth = env, but ${} is not set",
-                provider.id,
-                provider.env
-            )
-        }),
-        AuthMode::ApiKey => {
-            if let Some(key) = crate::config::stored_key(paths, &provider.id)? {
-                return Ok(key);
-            }
-            if crate::provider::find(&provider.id).is_some()
-                && let Some(key) = env.get(&provider.env)
-            {
-                return Ok(key);
-            }
-            bail!(
-                "no API key for provider '{}'; run: rx providers login {} (or set ${})",
-                provider.id,
-                provider.id,
-                provider.env
-            )
+    let stored = if auth == AuthMode::ApiKey {
+        crate::config::stored_key(paths, &provider.id)?
+    } else {
+        None
+    };
+    let environment = env.get(&provider.env);
+    match crate::provider::credential_source(
+        provider,
+        auth,
+        stored.is_some(),
+        environment.is_some(),
+    ) {
+        Some(crate::provider::CredentialSource::Stored) => Ok(stored.expect("stored credential")),
+        Some(crate::provider::CredentialSource::Environment) => {
+            Ok(environment.expect("environment credential"))
         }
+        None if auth == AuthMode::Env => bail!(
+            "provider '{}' is set to auth = env, but ${} is not set",
+            provider.id,
+            provider.env
+        ),
+        None => bail!(
+            "no API key for provider '{}'; run: rx providers login {} (or set ${})",
+            provider.id,
+            provider.id,
+            provider.env
+        ),
     }
 }
 

--- a/crates/rx/src/provider.rs
+++ b/crates/rx/src/provider.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use anyhow::{Result, bail};
 use serde::Deserialize;
 
-use crate::config::{ProviderConfig, RxConfig};
+use crate::config::{AuthMode, ProviderConfig, RxConfig};
 
 pub(crate) const NONE: &str = "none";
 
@@ -189,13 +189,37 @@ pub(crate) fn claude_base(provider: &Provider) -> String {
 }
 
 pub(crate) fn available(config: &RxConfig) -> Result<Vec<Provider>> {
-    let mut providers = catalog().to_vec();
+    let mut providers = catalog()
+        .iter()
+        .map(|provider| resolve(&provider.id, config.provider.get(&provider.id)))
+        .collect::<Result<Vec<_>>>()?;
     for (id, entry) in &config.provider {
         if find(id).is_none() && entry.base_url.is_some() {
             providers.push(resolve(id, Some(entry))?);
         }
     }
     Ok(providers)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialSource {
+    Stored,
+    Environment,
+}
+
+pub(crate) fn credential_source(
+    provider: &Provider,
+    auth: AuthMode,
+    stored: bool,
+    environment: bool,
+) -> Option<CredentialSource> {
+    if auth == AuthMode::ApiKey && stored {
+        Some(CredentialSource::Stored)
+    } else if environment && (auth == AuthMode::Env || find(&provider.id).is_some()) {
+        Some(CredentialSource::Environment)
+    } else {
+        None
+    }
 }
 
 pub(crate) fn is_none(id: &str) -> bool {

--- a/crates/rx/src/providers.rs
+++ b/crates/rx/src/providers.rs
@@ -20,23 +20,22 @@ use crate::provider::Provider;
 
 const PAGE_SIZE: usize = 8;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CredentialSource {
-    Stored,
-    Environment,
-}
-
 #[derive(Debug, Clone)]
 struct ProviderState {
     provider: Provider,
-    credential: Option<CredentialSource>,
+    configured: bool,
+    stored_key: bool,
     environment_active: bool,
     default: bool,
 }
 
 impl ProviderState {
-    fn configured(&self) -> bool {
-        self.credential.is_some()
+    fn selectable(&self, action: Action) -> bool {
+        match action {
+            Action::Login => true,
+            Action::Logout => self.stored_key || self.configured,
+            Action::Use => self.configured,
+        }
     }
 }
 
@@ -111,7 +110,7 @@ impl App {
             .providers
             .iter()
             .enumerate()
-            .filter(|(_, provider)| self.action == Action::Login || provider.configured());
+            .filter(|(_, provider)| provider.selectable(self.action));
         if self.query.is_empty() {
             return candidates.map(|(index, _)| index).collect();
         }
@@ -336,7 +335,7 @@ fn update_models(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Res
         ids.push(id.to_string());
     } else {
         for state in provider_states(paths, env)? {
-            if state.configured() {
+            if state.configured {
                 ids.push(state.provider.id.clone());
             }
         }
@@ -368,7 +367,7 @@ fn update_models(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Res
 
 fn list(paths: &Paths, env: &EnvLookup) -> Result<()> {
     let states = provider_states(paths, env)?;
-    let configured = states.iter().filter(|provider| provider.configured()).collect::<Vec<_>>();
+    let configured = states.iter().filter(|provider| provider.configured).collect::<Vec<_>>();
     if configured.is_empty() {
         println!("No providers configured. Run: rx providers login");
         return Ok(());
@@ -379,7 +378,7 @@ fn list(paths: &Paths, env: &EnvLookup) -> Result<()> {
 
 fn login(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Result<()> {
     let states = provider_states(paths, env)?;
-    let selected = requested.map(|id| provider_index(&states, id, false)).transpose()?;
+    let selected = requested.map(|id| provider_index(&states, id, Action::Login)).transpose()?;
     let outcome = run_ui(Action::Login, states, env, selected)?;
     let Some(Outcome::Login { id, key }) = outcome else {
         return Ok(());
@@ -394,10 +393,10 @@ fn login(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Result<()> 
 fn logout(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Result<()> {
     let states = provider_states(paths, env)?;
     if let Some(id) = requested {
-        let index = provider_index(&states, id, true)?;
+        let index = provider_index(&states, id, Action::Logout)?;
         return logout_provider(paths, &states[index]);
     }
-    if !states.iter().any(ProviderState::configured) {
+    if !states.iter().any(|state| state.selectable(Action::Logout)) {
         println!("No providers configured.");
         return Ok(());
     }
@@ -434,10 +433,10 @@ fn use_provider(paths: &Paths, env: &EnvLookup, requested: Option<&str>) -> Resu
     }
     let states = provider_states(paths, env)?;
     if let Some(id) = requested {
-        let index = provider_index(&states, id, true)?;
+        let index = provider_index(&states, id, Action::Use)?;
         return set_default_provider(paths, &states[index]);
     }
-    if !states.iter().any(ProviderState::configured) {
+    if !states.iter().any(|state| state.configured) {
         println!("No providers configured. Run: rx providers login");
         return Ok(());
     }
@@ -465,7 +464,7 @@ pub(crate) fn completion_ids(
         .filter(|state| match filter {
             crate::args::ProviderIdFilter::All => true,
             crate::args::ProviderIdFilter::Configured | crate::args::ProviderIdFilter::Targets => {
-                state.configured()
+                state.configured
             }
         })
         .map(|state| state.provider.id)
@@ -476,12 +475,12 @@ pub(crate) fn completion_ids(
     Ok(ids)
 }
 
-fn provider_index(states: &[ProviderState], id: &str, configured: bool) -> Result<usize> {
+fn provider_index(states: &[ProviderState], id: &str, action: Action) -> Result<usize> {
     let index = states
         .iter()
         .position(|state| state.provider.id == id)
         .ok_or_else(|| anyhow::anyhow!("unknown provider: {id}"))?;
-    if configured && !states[index].configured() {
+    if !states[index].selectable(action) {
         bail!("provider '{id}' is not configured; run: rx providers login {id}");
     }
     Ok(index)
@@ -494,19 +493,26 @@ fn provider_states(paths: &Paths, env: &EnvLookup) -> Result<Vec<ProviderState>>
         .into_iter()
         .map(|provider| {
             let entry = config.provider.get(&provider.id);
-            let environment_active = env.get(&provider.env).is_some()
-                && (crate::provider::find(&provider.id).is_some()
-                    || entry.is_some_and(|entry| entry.auth == AuthMode::Env));
-            let credential = if stored.contains(&provider.id) {
-                Some(CredentialSource::Stored)
-            } else if environment_active {
-                Some(CredentialSource::Environment)
-            } else {
-                None
-            };
+            let auth = entry.map(|entry| entry.auth).unwrap_or(AuthMode::ApiKey);
+            let environment = env.get(&provider.env).is_some();
+            let environment_active =
+                crate::provider::credential_source(&provider, auth, false, environment).is_some();
+            let configured = crate::provider::credential_source(
+                &provider,
+                auth,
+                stored.contains(&provider.id),
+                environment,
+            )
+            .is_some();
             let default =
                 config.default_provider.as_deref().unwrap_or("openrouter") == provider.id.as_str();
-            ProviderState { provider, credential, environment_active, default }
+            ProviderState {
+                stored_key: stored.contains(&provider.id),
+                provider,
+                configured,
+                environment_active,
+                default,
+            }
         })
         .collect::<Vec<_>>();
     sort_provider_states(&mut states);
@@ -517,7 +523,7 @@ fn sort_provider_states(states: &mut [ProviderState]) {
     states.sort_by(|left, right| {
         pin_rank(&left.provider.id)
             .cmp(&pin_rank(&right.provider.id))
-            .then_with(|| right.configured().cmp(&left.configured()))
+            .then_with(|| right.configured.cmp(&left.configured))
             .then_with(|| {
                 left.provider
                     .name
@@ -704,7 +710,7 @@ fn provider_line(
     };
     let (marker, marker_style) = if state.default {
         ("* ", Style::default().fg(palette.default))
-    } else if state.configured() {
+    } else if state.configured {
         ("• ", Style::default().fg(palette.configured))
     } else {
         ("  ", Style::default().fg(palette.muted))
@@ -771,12 +777,12 @@ fn render_api_key(frame: &mut Frame, area: Rect, app: &App, palette: Palette) {
 
 fn render_logout_confirmation(frame: &mut Frame, area: Rect, app: &App, palette: Palette) {
     let state = &app.providers[app.selected.expect("selected provider")];
-    let detail = match state.credential {
-        Some(CredentialSource::Stored) => "Removes the locally stored API key.",
-        Some(CredentialSource::Environment) => {
-            "The key comes from your environment; rx will show the unset command."
-        }
-        None => "No local credential is configured.",
+    let detail = if state.stored_key {
+        "Removes the locally stored API key."
+    } else if state.environment_active {
+        "The key comes from your environment; rx will show the unset command."
+    } else {
+        "No local credential is configured."
     };
     let lines = vec![
         Line::from(vec![
@@ -837,9 +843,84 @@ mod tests {
                 default_model: None,
                 claude_default_model: None,
             },
-            credential: configured.then_some(CredentialSource::Stored),
+            configured,
+            stored_key: configured,
             environment_active: false,
             default,
+        }
+    }
+
+    #[test]
+    fn provider_selection_matches_launch_credentials_and_overrides() {
+        for id in ["tokener", "custom"] {
+            for auth in [AuthMode::ApiKey, AuthMode::Env] {
+                for stored in [false, true] {
+                    for environment in [false, true] {
+                        let dir = tempfile::tempdir().unwrap();
+                        let paths = Paths::in_dir(dir.path().to_path_buf());
+                        let config = crate::config::RxConfig {
+                            provider: std::collections::BTreeMap::from([(
+                                id.to_string(),
+                                crate::config::ProviderConfig {
+                                    base_url: Some("http://127.0.0.1:1/v1".to_string()),
+                                    env: Some("CUSTOM_TOKEN".to_string()),
+                                    auth,
+                                    ..Default::default()
+                                },
+                            )]),
+                            ..Default::default()
+                        };
+                        std::fs::write(&paths.config, toml::to_string(&config).unwrap()).unwrap();
+                        if stored {
+                            std::fs::write(&paths.keys, format!("{id} = \"stored-key\"")).unwrap();
+                        }
+                        let mut values = std::collections::HashMap::new();
+                        if environment {
+                            values.insert("CUSTOM_TOKEN".to_string(), "env-key".to_string());
+                        }
+                        let env = EnvLookup::isolated(values);
+                        let states = provider_states(&paths, &env).unwrap();
+                        let state = states.iter().find(|state| state.provider.id == id).unwrap();
+                        let expected = match auth {
+                            AuthMode::ApiKey if stored => Some("stored-key"),
+                            AuthMode::Env if environment => Some("env-key"),
+                            AuthMode::ApiKey if environment && id == "tokener" => Some("env-key"),
+                            _ => None,
+                        };
+                        assert_eq!(state.configured, expected.is_some());
+                        assert_eq!(
+                            state.environment_active,
+                            environment && (auth == AuthMode::Env || id == "tokener")
+                        );
+                        assert_eq!(state.provider.endpoint, "http://127.0.0.1:1/v1");
+                        assert_eq!(state.provider.env, "CUSTOM_TOKEN");
+                        let selection = use_provider(&paths, &env, Some(id));
+                        let launched = launch::configured_provider(Some(id), &paths, &env);
+                        if let Some(key) = expected {
+                            selection.unwrap();
+                            let launch::ProviderResolution::Target(target) = launched.unwrap()
+                            else {
+                                panic!("configured provider must launch");
+                            };
+                            assert_eq!(target.provider, state.provider);
+                            assert_eq!(target.key, key);
+                        } else {
+                            assert!(selection.is_err());
+                            assert!(launched.is_err());
+                        }
+                        if stored || expected.is_some() {
+                            let app = App::new(Action::Logout, states);
+                            assert!(
+                                app.filtered_providers()
+                                    .iter()
+                                    .any(|index| app.providers[*index].provider.id == id)
+                            );
+                            logout(&paths, &env, Some(id)).unwrap();
+                            assert!(crate::config::stored_key(&paths, id).unwrap().is_none());
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1618,6 +1618,64 @@ auth = "env"
 }
 
 #[test]
+fn overlapping_provider_mutations_preserve_distinct_updates() {
+    let (_dir, paths) = temp_paths();
+    let ids = (0..24).map(|index| format!("custom-{index}")).collect::<Vec<_>>();
+    fs::write(
+        &paths.config,
+        ids.iter()
+            .map(|id| {
+                format!(
+                    "[provider.{id}]\nbase_url = \"https://provider.test/v1\"\nauth = \"env\"\n"
+                )
+            })
+            .collect::<String>(),
+    )
+    .unwrap();
+    fs::write(
+        &paths.keys,
+        ids[12..].iter().map(|id| format!("{id} = \"old-key\"\n")).collect::<String>(),
+    )
+    .unwrap();
+    let barrier = std::sync::Barrier::new(ids.len() + 2);
+    thread::scope(|scope| {
+        for (index, id) in ids.iter().enumerate() {
+            let paths = &paths;
+            let barrier = &barrier;
+            scope.spawn(move || {
+                barrier.wait();
+                if index < 12 {
+                    config::login(paths, id, format!("key-{id}")).unwrap();
+                } else {
+                    assert!(config::logout(paths, id).unwrap());
+                }
+            });
+        }
+        scope.spawn(|| {
+            barrier.wait();
+            config::set_default(&paths, &ids[0]).unwrap();
+        });
+        scope.spawn(|| {
+            barrier.wait();
+            config::set_none(&paths).unwrap();
+        });
+    });
+    let loaded = config::load_or_default(&paths).unwrap();
+    assert_eq!(loaded.provider.len(), ids.len());
+    for (index, id) in ids.iter().enumerate() {
+        assert_eq!(
+            config::stored_key(&paths, id).unwrap(),
+            (index < 12).then(|| format!("key-{id}"))
+        );
+        assert_eq!(
+            loaded.provider[id].auth,
+            if index < 12 { config::AuthMode::ApiKey } else { config::AuthMode::Env }
+        );
+        assert_eq!(loaded.provider[id].base_url.as_deref(), Some("https://provider.test/v1"));
+    }
+}
+
+#[test]
 fn provider_default_selection_preserves_env_auth() {
     let (_dir, paths) = temp_paths();
     fs::write(


### PR DESCRIPTION
### What's changed?

Serialize provider login, logout, and default-selection mutations with a shared sidecar lock covering the full read-modify-write sequence. Concurrent updates to different providers now preserve each other's configuration and keys, while retaining validation and key-before-config write ordering.

Resolve configured overrides for bundled providers and share credential precedence between provider selection and launch. For example, a Tokener override using `CUSTOM_TOKEN` now appears with its configured endpoint in `providers list` and can be selected with `providers use tokener`. Logout can still remove stored keys when environment authentication is inactive.

### Why

Atomic file replacement alone allowed concurrent successful logouts to lose updates. Provider listing and selection also disagreed with launch when bundled metadata was overridden or environment authentication superseded a stored key.

### Validation

- `make check` passed, including all 149 active rx tests.
- New concurrency and provider-selection regressions failed against the unchanged base implementation and passed with the fix.
- An isolated CLI replay with a local model endpoint and mock harness verified list/use/launch consistency and three rounds of 24 concurrent logouts with no remaining keys.
- Isolated probes verified inactive stored-key removal, malformed-file preservation, and explicit `none` passthrough.
