### PR TITLE
fix(rx): preserve hosted routes and native launch inputs

### DIFF
--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -74,7 +74,7 @@ pub(crate) fn run(passthrough: Vec<OsString>, env: &EnvLookup) -> Result<()> {
             None => return Ok(()),
         },
     };
-    validate_route_args(harness, &passthrough)?;
+    validate_route_args(harness, &passthrough, &request.gateway.provider_id)?;
     let key = env
         .get(&request.gateway.credential_env)
         .filter(|value| !value.is_empty())
@@ -214,17 +214,21 @@ fn target(profile: &GatewayProfile, key: String) -> ProviderTarget {
     ProviderTarget { provider, key, model: None }
 }
 
-fn validate_route_args(harness: Harness, passthrough: &[OsString]) -> Result<()> {
+fn validate_route_args(
+    harness: Harness,
+    passthrough: &[OsString],
+    provider_id: &str,
+) -> Result<()> {
     let args = args::before_double_dash(passthrough);
     match harness {
         Harness::Claude => reject_flags(args, &["--settings", "--setting-sources"]),
         Harness::Codex => validate_codex(args),
-        Harness::OpenCode => validate_scoped_values(args, &["-m", "--model"], "tokener"),
+        Harness::OpenCode => validate_scoped_values(args, &["-m", "--model"], provider_id),
         Harness::Pi => {
             reject_flags(args, &["--api-key"])?;
-            validate_exact_values(args, &["--provider"], "tokener")?;
-            validate_scoped_values(args, &["-m", "--model"], "tokener")?;
-            validate_list_values(args, &["--models"], "tokener")
+            validate_exact_values(args, &["--provider"], provider_id)?;
+            validate_scoped_values(args, &["-m", "--model"], provider_id)?;
+            validate_list_values(args, &["--models"], provider_id)
         }
         Harness::Dsh => reject_flags(args, &["--profile", "--patch"]),
         Harness::Kimi => Ok(()),
@@ -237,9 +241,10 @@ fn validate_codex(args: &[OsString]) -> Result<()> {
         let key = value.split_once('=').map_or(value, |(key, _)| key).trim();
         if key == "model_provider"
             || key == "openai_base_url"
+            || key == "model_providers"
             || key.starts_with("model_providers.")
         {
-            bail!("{} cannot override the hosted Gateway route", value);
+            bail!("{key} cannot override the hosted Gateway route");
         }
     }
     Ok(())
@@ -295,10 +300,12 @@ fn flag_values<'a>(args: &'a [OsString], flags: &[&str]) -> Vec<&'a str> {
             index += 2;
             continue;
         }
-        if let Some(value) = arg
-            .to_str()
-            .and_then(|arg| flags.iter().find_map(|flag| arg.strip_prefix(&format!("{flag}="))))
-        {
+        if let Some(value) = arg.to_str().and_then(|arg| {
+            flags.iter().find_map(|flag| {
+                arg.strip_prefix(&format!("{flag}="))
+                    .or_else(|| (flag.len() == 2).then(|| arg.strip_prefix(flag)).flatten())
+            })
+        }) {
             values.push(value);
         }
         index += 1;
@@ -368,30 +375,114 @@ mod tests {
 
     #[test]
     fn route_guards_are_harness_specific() {
-        validate_route_args(Harness::Claude, &os(&["--resume", "session", "--tools", "Read"]))
-            .unwrap();
-        assert!(validate_route_args(Harness::Claude, &os(&["--settings", "route.json"])).is_err());
         validate_route_args(
-            Harness::Codex,
-            &os(&["resume", "--last", "-c", "sandbox_mode=read-only"]),
+            Harness::Claude,
+            &os(&["--resume", "session", "--tools", "Read"]),
+            "tokener",
         )
         .unwrap();
         assert!(
-            validate_route_args(Harness::Codex, &os(&["-c", "model_provider=ollama"])).is_err()
+            validate_route_args(Harness::Claude, &os(&["--settings", "route.json"]), "tokener")
+                .is_err()
         );
-        validate_route_args(Harness::OpenCode, &os(&["--model", "tokener/model-a", "--fork"]))
-            .unwrap();
+        validate_route_args(
+            Harness::Codex,
+            &os(&["resume", "--last", "-c", "sandbox_mode=read-only"]),
+            "tokener",
+        )
+        .unwrap();
         assert!(
-            validate_route_args(Harness::OpenCode, &os(&["--model", "openai/model-a"])).is_err()
+            validate_route_args(Harness::Codex, &os(&["-c", "model_provider=ollama"]), "tokener")
+                .is_err()
+        );
+        validate_route_args(
+            Harness::OpenCode,
+            &os(&["--model", "tokener/model-a", "--fork"]),
+            "tokener",
+        )
+        .unwrap();
+        assert!(
+            validate_route_args(Harness::OpenCode, &os(&["--model", "openai/model-a"]), "tokener")
+                .is_err()
         );
         validate_route_args(
             Harness::Pi,
             &os(&["--provider", "tokener", "--model", "model-a", "--resume"]),
+            "tokener",
         )
         .unwrap();
-        assert!(validate_route_args(Harness::Pi, &os(&["--api-key", "secret"])).is_err());
-        assert!(validate_route_args(Harness::Dsh, &os(&["--patch", "other.yml"])).is_err());
-        validate_route_args(Harness::Kimi, &os(&["--session", "session-id", "--plan"])).unwrap();
+        assert!(
+            validate_route_args(Harness::Pi, &os(&["--api-key", "secret"]), "tokener").is_err()
+        );
+        assert!(
+            validate_route_args(Harness::Dsh, &os(&["--patch", "other.yml"]), "tokener").is_err()
+        );
+        validate_route_args(Harness::Kimi, &os(&["--session", "session-id", "--plan"]), "tokener")
+            .unwrap();
+    }
+
+    #[test]
+    fn codex_route_overrides_are_rejected_in_native_config_forms() {
+        for value in [
+            "model_provider=other",
+            "openai_base_url='http://127.0.0.1:1'",
+            "model_providers.acme.base_url='http://127.0.0.1:1'",
+            "model_providers={acme={name='Other',wire_api='responses'}}",
+            "model_providers={acme={experimental_bearer_token='synthetic-gateway-secret'}}",
+        ] {
+            for override_args in [
+                os(&["-c", value]),
+                os(&["--config", value]),
+                os(&[&format!("-c={value}")]),
+                os(&[&format!("--config={value}")]),
+                os(&[&format!("-c{value}")]),
+            ] {
+                let error =
+                    validate_route_args(Harness::Codex, &override_args, "acme").unwrap_err();
+                assert!(!error.to_string().contains("synthetic-gateway-secret"));
+                let mut literal = os(&["--"]);
+                literal.extend(override_args);
+                validate_route_args(Harness::Codex, &literal, "acme").unwrap();
+            }
+        }
+        validate_route_args(Harness::Codex, &os(&["-csandbox_mode='read-only'"]), "acme").unwrap();
+    }
+
+    #[test]
+    fn model_scopes_follow_the_requested_gateway() {
+        for provider in ["acme", "tokener"] {
+            for harness in [Harness::OpenCode, Harness::Pi] {
+                for flag in ["-m", "--model"] {
+                    validate_route_args(
+                        harness,
+                        &os(&[flag, &format!("{provider}/model-a")]),
+                        provider,
+                    )
+                    .unwrap();
+                    assert!(
+                        validate_route_args(harness, &os(&[flag, "other/model-a"]), provider)
+                            .is_err()
+                    );
+                }
+            }
+            validate_route_args(
+                Harness::Pi,
+                &os(&["--provider", provider, "--models", &format!("{provider}/*")]),
+                provider,
+            )
+            .unwrap();
+            assert!(
+                validate_route_args(Harness::Pi, &os(&["--provider", "other"]), provider).is_err()
+            );
+            assert!(
+                validate_route_args(
+                    Harness::Pi,
+                    &os(&["--models", &format!("{provider}/*,other/*")]),
+                    provider,
+                )
+                .is_err()
+            );
+        }
     }
 
     #[test]
@@ -399,6 +490,7 @@ mod tests {
         validate_route_args(
             Harness::Claude,
             &os(&["--resume", "session", "--", "--settings", "literal"]),
+            "tokener",
         )
         .unwrap();
     }

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -478,7 +478,7 @@ fn inject(
             let openai_base = openai_base(base_url);
             let mut args = vec![
                 OsString::from("-c"),
-                OsString::from(format!("model_provider=\"{provider_id}\"")),
+                OsString::from(format!("model_provider={}", toml_edit::Value::from(provider_id))),
                 OsString::from("-c"),
                 OsString::from(codex_provider_override(provider_id, provider, &openai_base)),
             ];
@@ -487,8 +487,10 @@ fn inject(
                     Ok(Some(path)) => {
                         args.push(OsString::from("-c"));
                         args.push(OsString::from(format!(
-                            "model_catalog_json=\"{}\"",
-                            path.display()
+                            "model_catalog_json={}",
+                            toml_edit::Value::from(path.to_str().ok_or_else(|| {
+                                anyhow::anyhow!("Codex model catalog path must be UTF-8")
+                            })?)
                         )));
                     }
                     Ok(None) => {}
@@ -499,7 +501,7 @@ fn inject(
             }
             if let Some(model) = model.filter(|_| !user_sets_model(&request.passthrough)) {
                 args.push(OsString::from("-c"));
-                args.push(OsString::from(format!("model=\"{model}\"")));
+                args.push(OsString::from(format!("model={}", toml_edit::Value::from(model))));
             }
             args.extend(request.passthrough.iter().cloned());
             Ok(LaunchPlan {
@@ -572,26 +574,28 @@ fn inject(
 }
 
 fn codex_provider_override(provider_id: &str, provider: &Provider, openai_base: &str) -> String {
-    format!(
-        "model_providers.{}={{name=\"{}\", base_url=\"{}\", wire_api=\"responses\", supports_websockets=false, {}}}",
-        provider_id,
-        provider.name,
-        openai_base,
-        auth_override(&provider.env)
-    )
-}
-
-fn auth_override(env_key: &str) -> String {
     #[cfg(unix)]
-    {
-        format!("auth={{command=\"sh\", args=[\"-c\", \"printf %s \\\"${env_key}\\\"\"]}}")
-    }
+    let auth = format!(
+        "auth={{command=\"printenv\", args=[\"--\", {}]}}",
+        toml_edit::Value::from(provider.env.as_str())
+    );
     #[cfg(not(unix))]
-    {
+    let auth = {
+        let script = format!(
+            "[Environment]::GetEnvironmentVariable('{}')",
+            provider.env.replace('\'', "''")
+        );
         format!(
-            "auth={{command=\"powershell\", args=[\"-NoProfile\", \"-Command\", \"Write-Output $env:{env_key}\"]}}"
+            "auth={{command=\"powershell\", args=[\"-NoProfile\", \"-Command\", {}]}}",
+            toml_edit::Value::from(script)
         )
-    }
+    };
+    format!(
+        "model_providers.{}={{name={}, base_url={}, wire_api=\"responses\", supports_websockets=false, {auth}}}",
+        provider_id,
+        toml_edit::Value::from(provider.name.as_str()),
+        toml_edit::Value::from(openai_base),
+    )
 }
 
 fn user_sets_opencode_model(passthrough: &[OsString]) -> bool {
@@ -640,6 +644,9 @@ fn user_sets_model(passthrough: &[OsString]) -> bool {
 pub(crate) fn exec(plan: &LaunchPlan) -> Result<()> {
     let mut cmd = Command::new(&plan.program);
     cmd.args(&plan.args);
+    for key in ["RX_HOST_REQUEST", "RX_NO_INSTALL", "RX_NO_UPDATE", "RX_NO_YOLO"] {
+        cmd.env_remove(key);
+    }
     for (key, value) in &plan.env_set {
         cmd.env(key, value);
     }

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1064,10 +1064,120 @@ fn codex_openrouter_overrides_model_and_uses_command_auth() {
     assert!(arg_str(&plan.args[3]).contains("base_url=\"https://openrouter.ai/api/v1\""));
     assert!(arg_str(&plan.args[3]).contains("wire_api=\"responses\""));
     assert!(arg_str(&plan.args[3]).contains("supports_websockets=false"));
-    assert!(arg_str(&plan.args[3]).contains("auth={command=\"sh\""));
     assert!(!arg_str(&plan.args[3]).contains("env_key="));
     assert_eq!(plan.args[5], "model=\"~openai/gpt-latest\"");
     assert_eq!(plan.env_set, vec![("OPENROUTER_API_KEY".to_string(), "sk-or-test".to_string())]);
+}
+
+#[test]
+fn codex_injected_values_round_trip_through_toml() {
+    let (_dir, paths) = temp_paths();
+    let mut provider = crate::provider::find("tokener").unwrap().clone();
+    provider.name = "Gateway \"Beta\"\nC:\\gateway".to_string();
+    provider.endpoint = "http://127.0.0.1:1/\"quoted\\path".to_string();
+    provider.env = "KEY\"'$(exit 9)\\VALUE".to_string();
+    let model = "vendor/\"model\\name\nnext";
+    let target = launch::ProviderTarget {
+        provider: provider.clone(),
+        key: "synthetic-value".to_string(),
+        model: Some(model.to_string()),
+    };
+    let plan = launch::plan_target(
+        &LaunchRequest { harness: Harness::Codex, provider: None, passthrough: Vec::new() },
+        &paths,
+        &EnvLookup::isolated(HashMap::from([("RX_NO_YOLO".to_string(), "1".to_string())])),
+        &target,
+    )
+    .unwrap();
+    let config: toml::Value = arg_str(&plan.args[3]).parse().unwrap();
+    let injected = &config["model_providers"]["tokener"];
+    assert_eq!(injected["name"].as_str(), Some(provider.name.as_str()));
+    assert_eq!(
+        injected["base_url"].as_str(),
+        Some(crate::catalog::openai_base(&provider.endpoint).as_str())
+    );
+    let selection: toml::Value = arg_str(&plan.args[5]).parse().unwrap();
+    assert_eq!(selection["model"].as_str(), Some(model));
+    #[cfg(unix)]
+    {
+        let auth = &injected["auth"];
+        let output = std::process::Command::new(auth["command"].as_str().unwrap())
+            .args(auth["args"].as_array().unwrap().iter().map(|arg| arg.as_str().unwrap()))
+            .env_clear()
+            .env(&provider.env, &target.key)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap().trim_end(), target.key);
+    }
+}
+
+#[test]
+fn codex_catalog_override_preserves_the_generated_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = if cfg!(unix) { "quoted\"\\state" } else { "catalog state" };
+    let paths = Paths::in_dir(dir.path().join(state_dir));
+    let (endpoint, server) = serve_openai_models(r#"{"data":[{"id":"test-model"}]}"#);
+    let mut provider = crate::provider::find("tokener").unwrap().clone();
+    provider.endpoint = endpoint;
+    let plan = launch::plan_target(
+        &LaunchRequest { harness: Harness::Codex, provider: None, passthrough: Vec::new() },
+        &paths,
+        &EnvLookup::real_with(HashMap::from([("RX_NO_YOLO".to_string(), "1".to_string())])),
+        &launch::ProviderTarget { provider, key: "synthetic-key".to_string(), model: None },
+    )
+    .unwrap();
+    server.join().unwrap();
+    let override_arg =
+        plan.args.iter().find(|arg| arg_str(arg).starts_with("model_catalog_json=")).unwrap();
+    let config: toml::Value = arg_str(override_arg).parse().unwrap();
+    let catalog = PathBuf::from(config["model_catalog_json"].as_str().unwrap());
+    assert_eq!(catalog, paths.dir.join("catalogs/tokener.json"));
+    assert!(catalog.is_file());
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_scopes_inherited_controls_and_explicit_credentials() {
+    const CONTROLS: [&str; 4] = ["RX_HOST_REQUEST", "RX_NO_INSTALL", "RX_NO_UPDATE", "RX_NO_YOLO"];
+    if let Ok(credential) = std::env::var("RX_TEST_EXEC_CREDENTIAL") {
+        let plan = launch::LaunchPlan {
+            program: PathBuf::from("/usr/bin/env"),
+            args: Vec::new(),
+            env_set: if credential.is_empty() {
+                Vec::new()
+            } else {
+                vec![(credential, "selected-credential".to_string())]
+            },
+            stderr_note: None,
+        };
+        launch::exec(&plan).unwrap();
+        unreachable!();
+    }
+    for credential in std::iter::once("").chain(CONTROLS) {
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap());
+        child
+            .args([
+                "--exact",
+                "tests::exec_scopes_inherited_controls_and_explicit_credentials",
+                "--nocapture",
+            ])
+            .env_clear()
+            .env("RX_TEST_EXEC_CREDENTIAL", credential)
+            .env("NATIVE_SENTINEL", "preserved");
+        for control in CONTROLS {
+            child.env(control, "parent-control");
+        }
+        let output = child.output().unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.lines().any(|line| line == "NATIVE_SENTINEL=preserved"));
+        for control in CONTROLS {
+            let entry = stdout.lines().find(|line| line.starts_with(&format!("{control}=")));
+            let expected = format!("{control}=selected-credential");
+            assert_eq!(entry, (control == credential).then_some(expected.as_str()));
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
### What's changed?

- Guard attached Codex config overrides and root provider tables, without echoing their values in errors.
- Validate OpenCode and Pi model scopes against the requested gateway provider.
- Encode Codex configuration values as TOML and pass credential variable names as literal command-auth arguments.
- Remove inherited rx controls before applying explicit runtime credentials.

### Why

Hosted launches could override the gateway, reject a valid custom provider scope, or fail when injected values contained quotes or backslashes. Launcher controls also leaked into native processes.

### Validation

- `cargo test -p rx` and `make check`.
- Isolated Codex 0.153.2 config parsing and a localhost Responses request with synthetic credentials.
- Process probes for route guards, literal `--`, custom provider scopes, credential collisions, and inherited environment cleanup.
