### PR TITLE
fix(rx): enforce provider catalog admission contracts

### DIFF
--- a/crates/rx/scripts/probe-rx-provider
+++ b/crates/rx/scripts/probe-rx-provider
@@ -66,16 +66,40 @@ preview() {
   }'
 }
 
-looks_like_sse() {
-  awk '
-    NF {
-      line = $0
-      sub(/^[ \t\r]+/, "", line)
-      if (line ~ /^(data:|event:|:)/) found = 1
-      exit
-    }
-    END { if (!found) exit 1 }
-  ' "$1"
+stream_succeeded() {
+  jq -Rse --arg protocol "$2" '
+    def text: type == "string" and length > 0;
+    gsub("\r\n"; "\n") | split("\n\n")
+    | if last | test("[^\n]") then error("unterminated SSE frame") else .[:-1] end
+    | map(split("\n")
+        | {event: (map(select(startswith("event:")) | ltrimstr("event:") | ltrimstr(" ")) | last),
+           data: (map(select(startswith("data:")) | ltrimstr("data:") | ltrimstr(" ")) | join("\n"))}
+        | if .event == "error" then error("SSE error") else . end
+        | select(.data != "")
+        | if .data == "[DONE]" then {type: "done"}
+          else . as $frame | .data | fromjson
+          | if type != "object" then error("invalid SSE data")
+            elif $frame.event != null and $frame.event != "message" and $frame.event != .type
+            then error("SSE event type mismatch") else . end end)
+    | if any(.error != null or .response.error != null or .type == "error" or .type == "response.failed"
+        or .type == "response.incomplete") then false
+      elif $protocol == "chat_completions" then
+        last.type == "done"
+        and any(.object == "chat.completion.chunk"
+          and any(.choices[]?; .index == 0 and (.delta.content | text)))
+        and any(.object == "chat.completion.chunk"
+          and any(.choices[]?; .index == 0 and (.finish_reason == "stop" or .finish_reason == "length")))
+      elif $protocol == "responses" then
+        last.type == "response.completed" and last.response.status == "completed"
+        and any(.type == "response.output_text.delta" and (.delta | text))
+      elif $protocol == "messages" then
+        last.type == "message_stop"
+        and any(.type == "message_start" and .message.role == "assistant")
+        and any(.type == "content_block_delta" and .delta.type == "text_delta" and (.delta.text | text))
+        and any(.type == "message_delta" and
+          (.delta.stop_reason == "end_turn" or .delta.stop_reason == "max_tokens" or .delta.stop_reason == "stop_sequence"))
+      else false end
+  ' "$1" >/dev/null 2>&1
 }
 
 looks_like_json() {
@@ -192,6 +216,7 @@ curl_stream() {
   : >"$body"
   : >"$hdr"
   : >"$err"
+  stream_exit=0
   curl -sS -N --max-time 8 -D "$hdr" -o "$body" \
     -H "Authorization: Bearer ${api_key}" \
     -H "User-Agent: ${USER_AGENT}" \
@@ -199,21 +224,7 @@ curl_stream() {
     -H "Accept: text/event-stream" \
     "$@" \
     -d "$payload" \
-    "$url" >/dev/null 2>"$err" &
-  pid=$!
-  n=0
-  while [ "$n" -lt 8 ]; do
-    if [ -s "$body" ]; then
-      break
-    fi
-    if ! kill -0 "$pid" 2>/dev/null; then
-      break
-    fi
-    n=$((n + 1))
-    sleep 1
-  done
-  kill "$pid" 2>/dev/null || true
-  wait "$pid" || true
+    "$url" >/dev/null 2>"$err" || stream_exit=$?
   status=$(http_status "$hdr")
   if [ "$status" = "401" ]; then
     fail_auth
@@ -239,15 +250,31 @@ check_stream() {
     record "$name" 0 "HTTP ${status}: $(preview "$body")"
     return 0
   fi
-  if looks_like_sse "$body"; then
-    record "$name" 1 "SSE ${label}"
+  if [ "$stream_exit" -ne 0 ]; then
+    record "$name" 0 "stream request failed: $(preview "$err")"
+    return 0
+  fi
+  if ! awk '
+    toupper($1) ~ /^HTTP\// { media_type = "" }
+    tolower($0) ~ /^content-type:/ {
+      media_type = tolower($0)
+      sub(/^content-type:[ \t]*/, "", media_type)
+      sub(/[; \t\r].*$/, "", media_type)
+    }
+    END { exit (media_type != "text/event-stream") }
+  ' "$hdr"; then
+    record "$name" 0 "expected Content-Type text/event-stream"
+    return 0
+  fi
+  if stream_succeeded "$body" "$name"; then
+    record "$name" 1 "completed SSE text ${label}"
     return 0
   fi
   if looks_like_json "$body"; then
     record "$name" 0 "non-streaming JSON; Codex/Claude require SSE"
     return 0
   fi
-  record "$name" 0 "no SSE frame: $(preview "$body")"
+  record "$name" 0 "no successful ${name} SSE completion"
 }
 
 base_url=${RX_PROVIDER_URL:-${RX_PROVIDER_BASE_URL:-}}

--- a/crates/rx/scripts/test-probe-rx-provider.py
+++ b/crates/rx/scripts/test-probe-rx-provider.py
@@ -1,0 +1,180 @@
+import http.server
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+
+PROBE = Path(__file__).with_name("probe-rx-provider")
+
+
+def frame(data, event=None):
+    prefix = f"event: {event}\n" if event else ""
+    return prefix + "data: " + json.dumps(data) + "\n\n"
+
+
+STREAMS = {
+    "chat_completions": frame({
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {"content": "pong"}, "finish_reason": None}],
+    }) + frame({
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    }) + "data: [DONE]\n\n",
+    "responses": frame({"type": "response.output_text.delta", "delta": "pong"},
+                       "response.output_text.delta")
+    + frame({"type": "response.completed", "response": {"status": "completed"}},
+            "response.completed"),
+    "messages": frame({"type": "message_start", "message": {"role": "assistant"}},
+                      "message_start")
+    + frame({"type": "content_block_delta", "index": 0,
+             "delta": {"type": "text_delta", "text": "pong"}}, "content_block_delta")
+    + frame({"type": "message_delta", "delta": {"stop_reason": "end_turn"}}, "message_delta")
+    + frame({"type": "message_stop"}, "message_stop"),
+}
+ERROR = frame({"error": {"message": "unsupported protocol"}}, "error")
+
+
+class ProbeTests(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.TemporaryDirectory()
+        self.addCleanup(self.home.cleanup)
+        Path(self.home.name, ".curlrc").write_text("")
+        self.streams = dict(STREAMS)
+        self.status = 200
+        self.content_type = "text/event-stream"
+        self.interim_sse = False
+        self.delay = 0
+        self.prefix = ": heartbeat\n\n"
+        self.truncated = False
+        self.models = [{"id": "test-model"}]
+        case = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_GET(self):
+                self.send_response(case.status)
+                self.end_headers()
+                self.wfile.write(json.dumps({"data": case.models}).encode())
+
+            def do_POST(self):
+                self.rfile.read(int(self.headers["Content-Length"]))
+                protocol = "chat_completions" if self.path.endswith("/chat/completions") else self.path.rsplit("/", 1)[-1]
+                body = case.streams[protocol].encode()
+                if case.interim_sse:
+                    self.wfile.write(b"HTTP/1.1 103 Early Hints\r\nContent-Type: text/event-stream\r\n\r\n")
+                self.send_response(case.status)
+                if case.content_type is not None:
+                    self.send_header("Content-Type", case.content_type)
+                if case.truncated:
+                    self.send_header("Content-Length", str(len(body) + 100))
+                self.end_headers()
+                try:
+                    if case.delay:
+                        self.wfile.write(case.prefix.encode())
+                        self.wfile.flush()
+                        time.sleep(case.delay)
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.addCleanup(self.server.server_close)
+        self.addCleanup(self.server.shutdown)
+
+    def probe(self, admitted, failed=()):
+        env = {"PATH": os.defpath, "HOME": self.home.name,
+               "CURL_HOME": self.home.name, "RX_PROVIDER_KEY": "synthetic"}
+        result = subprocess.run(
+            ["sh", str(PROBE), "--base-url", f"http://127.0.0.1:{self.server.server_port}/v1", "--json"],
+            env=env, capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0 if admitted else 1, result.stderr + result.stdout)
+        document = json.loads(result.stdout)
+        self.assertEqual(document["verdict"], "ADMIT" if admitted else "REJECT")
+        checks = {check["id"]: check["pass"] for check in document["checks"]}
+        for protocol in failed:
+            self.assertFalse(checks[protocol], document)
+
+    def test_requires_final_sse_media_type(self):
+        for media_type in ("application/json", "text/plain", None):
+            with self.subTest(media_type=media_type):
+                self.content_type = media_type
+                self.probe(False, STREAMS)
+        self.interim_sse = True
+        self.probe(False, STREAMS)
+
+    def test_accepts_media_type_parameters(self):
+        self.content_type = "Text/Event-Stream; charset=utf-8"
+        self.probe(True)
+
+    def test_success_after_heartbeat(self):
+        self.delay = 1.1
+        self.probe(True)
+
+    def test_rejects_delayed_error_after_content(self):
+        self.prefix = STREAMS["chat_completions"].split("\n\n")[0] + "\n\n"
+        self.delay = 1.1
+        self.streams = dict.fromkeys(STREAMS, ERROR)
+        self.probe(False, STREAMS)
+
+    def test_crlf_multiline_data_and_unknown_events(self):
+        self.streams = {
+            protocol: (frame({"type": "future.event"}, "future.event") + body)
+            .replace('"delta": "pong"', '"delta":\ndata: "pong"').replace("\n", "\r\n")
+            for protocol, body in STREAMS.items()
+        }
+        self.probe(True)
+
+    def test_rejects_empty_error_heartbeat_json_and_malformed_streams(self):
+        for body in ("", ERROR, "event: error\n\n", ": heartbeat\n\n",
+                     frame({"type": "ping"}, "ping"), '{"output":"pong"}',
+                     "data: {bad json}\n\n", "data: [DONE]\n\n"):
+            with self.subTest(body=body):
+                self.streams = dict.fromkeys(STREAMS, body)
+                self.probe(False, STREAMS)
+
+    def test_rejects_partial_and_failed_streams(self):
+        for transform in (
+            lambda body: body[:body.rfind("\n\n", 0, len(body) - 2) + 2],
+            lambda body: body.rstrip("\n"),
+            lambda body: body + ERROR,
+            lambda body: body.replace("pong", ""),
+        ):
+            with self.subTest(transform=transform):
+                self.streams = {protocol: transform(body) for protocol, body in STREAMS.items()}
+                self.probe(False, STREAMS)
+
+    def test_rejects_wrong_protocol_and_incomplete_response(self):
+        for protocol in STREAMS:
+            with self.subTest(protocol=protocol):
+                self.streams = dict(STREAMS)
+                other = "messages" if protocol != "messages" else "responses"
+                self.streams[protocol] = STREAMS[other]
+                self.probe(False, [protocol])
+        self.streams = dict(STREAMS)
+        self.streams["responses"] = STREAMS["responses"].replace("completed", "incomplete")
+        self.probe(False, ["responses"])
+
+    def test_rejects_transport_failure_after_success_frames(self):
+        self.truncated = True
+        self.probe(False, STREAMS)
+
+    def test_requires_models_and_successful_http_status(self):
+        self.models = []
+        self.probe(False, ["openai_models"])
+        self.models = [{"id": "test-model"}]
+        self.status = 500
+        self.probe(False, STREAMS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/rx/src/claude_catalog.rs
+++ b/crates/rx/src/claude_catalog.rs
@@ -56,7 +56,6 @@ pub(crate) struct UserModel {
     pub name: Option<String>,
     pub context_length: Option<i64>,
     pub canonical_slug: Option<String>,
-    pub supported_efforts: Vec<String>,
     pub pricing: Option<Pricing>,
 }
 
@@ -79,7 +78,6 @@ pub(crate) struct ModelOption {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ModelAccess {
     pub api_name: String,
-    pub max_effort_level: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -163,7 +161,6 @@ fn from_listed_models(provider_id: &str, models: &[ListedModel]) -> Vec<UserMode
                 model.context_length.unwrap_or(catalog::fallback_context(provider_id)),
             ),
             canonical_slug: None,
-            supported_efforts: Vec::new(),
             pricing: None,
         })
         .collect()
@@ -171,10 +168,6 @@ fn from_listed_models(provider_id: &str, models: &[ListedModel]) -> Vec<UserMode
 
 fn parse_user_catalog(body: &str) -> Result<Vec<UserModel>> {
     let value: Value = serde_json::from_str(body).context("catalog response is not JSON")?;
-    parse_user_catalog_value(&value)
-}
-
-fn parse_user_catalog_value(value: &Value) -> Result<Vec<UserModel>> {
     let Some(data) = value.get("data").and_then(Value::as_array) else {
         bail!("catalog JSON has no data array");
     };
@@ -193,14 +186,6 @@ fn parse_user_model(entry: &Value) -> Option<UserModel> {
         .or_else(|| entry.get("max_input_tokens"))
         .and_then(Value::as_i64);
     let canonical_slug = entry.get("canonical_slug").and_then(Value::as_str).map(str::to_string);
-    let supported_efforts = entry
-        .get("reasoning")
-        .and_then(|value| value.get("supported_efforts"))
-        .and_then(Value::as_array)
-        .map(|items| {
-            items.iter().filter_map(|item| item.as_str().map(str::to_string)).collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
     let pricing = entry.get("pricing").map(|pricing| Pricing {
         prompt: pricing.get("prompt").and_then(Value::as_str).map(str::to_string),
         completion: pricing.get("completion").and_then(Value::as_str).map(str::to_string),
@@ -214,7 +199,7 @@ fn parse_user_model(entry: &Value) -> Option<UserModel> {
             .map(str::to_string),
         web_search: pricing.get("web_search").and_then(Value::as_str).map(str::to_string),
     });
-    Some(UserModel { id, name, context_length, canonical_slug, supported_efforts, pricing })
+    Some(UserModel { id, name, context_length, canonical_slug, pricing })
 }
 
 pub(crate) fn build_seed(models: &[UserModel]) -> SeedCaches {
@@ -242,13 +227,9 @@ pub(crate) fn build_seed(models: &[UserModel]) -> SeedCaches {
             description: context_label(capped),
         });
         let compact_window = auto_compact_window(&stripped, capped);
-        let max_effort = max_effort_level(&model.supported_efforts);
         for api_name in &api_names {
             auto_compact_windows.insert(api_name.clone(), compact_window);
-            model_access.push(ModelAccess {
-                api_name: api_name.clone(),
-                max_effort_level: max_effort.clone(),
-            });
+            model_access.push(ModelAccess { api_name: api_name.clone() });
         }
         if let Some(costs) = model_costs(model) {
             for key in cost_keys(&stripped, &picker_value, model.canonical_slug.as_deref()) {
@@ -429,13 +410,7 @@ fn model_access_values(caches: &SeedCaches) -> Vec<Value> {
     caches
         .model_access
         .iter()
-        .map(|access| {
-            let mut entry = json!({ "apiName": access.api_name, "entitled": true });
-            if let Some(level) = &access.max_effort_level {
-                entry["maxEffortLevel"] = json!(level);
-            }
-            entry
-        })
+        .map(|access| json!({ "apiName": access.api_name, "entitled": true }))
         .collect()
 }
 
@@ -648,12 +623,6 @@ fn context_label(context: i64) -> String {
 fn auto_compact_window(id: &str, context: i64) -> i64 {
     let window = if id.starts_with("openai/") { OPENAI_COMPACT_WINDOW } else { context };
     context.min(window)
-}
-
-fn max_effort_level(supported: &[String]) -> Option<String> {
-    const LEVELS: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
-    let supported: HashSet<&str> = supported.iter().map(String::as_str).collect();
-    LEVELS.iter().rev().find(|level| supported.contains(*level)).map(|level| (*level).to_string())
 }
 
 fn cost_keys(stripped: &str, picker: &str, canonical: Option<&str>) -> Vec<String> {

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -2199,7 +2199,7 @@ fn claude_seed_uses_openai_models_and_merges_from_cache() {
     let (_dir, paths) = temp_paths();
     let config_dir = tempfile::tempdir().unwrap();
     let (base_url, server) = serve_openai_models(
-        r#"{"data":[{"id":"claude-sonnet-5","display_name":"Sonnet 5","max_input_tokens":200000}]}"#,
+        r#"{"data":[{"id":"claude-sonnet-5","display_name":"Sonnet 5","max_input_tokens":200000,"reasoning":{"supported_efforts":["max"]}}]}"#,
     );
     let env = EnvLookup::isolated(HashMap::from([(
         "CLAUDE_CONFIG_DIR".to_string(),
@@ -2219,18 +2219,48 @@ fn claude_seed_uses_openai_models_and_merges_from_cache() {
     )
     .unwrap();
     assert_eq!(cached.provider_id, "openrouter");
-    let second = crate::claude_catalog::try_seed_user_catalog(
-        &paths,
-        "openrouter",
-        &base_url,
-        "sk-test",
-        &env,
-    );
-    assert_eq!(second, crate::claude_catalog::SeedOutcome::Seeded);
-    let document: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(config_dir.path().join(".claude.json")).unwrap())
-            .unwrap();
-    assert_eq!(document["additionalModelOptionsCache"][0]["value"], "claude-sonnet-5");
+    let config_path = config_dir.path().join(".claude.json");
+    let mut document: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert_eq!(document["modelAccessCache"][0]["entitled"], true);
+    assert!(document["modelAccessCache"][0].get("maxEffortLevel").is_none());
+    document["modelAccessCache"][0]["maxEffortLevel"] = serde_json::json!("max");
+    document["rxSeededCatalog"]["modelAccessCache"]["claude-sonnet-5"]["payload"] =
+        document["modelAccessCache"][0].clone();
+    document["modelAccessCache"].as_array_mut().unwrap().push(serde_json::json!({
+        "apiName": "user-model", "entitled": true, "maxEffortLevel": "high"
+    }));
+    fs::write(&config_path, serde_json::to_vec(&document).unwrap()).unwrap();
+    let cache_path = paths.dir.join("catalogs/openrouter.claude.json");
+    let mut cached = serde_json::to_value(cached).unwrap();
+    cached["model_access"][0]["max_effort_level"] = serde_json::json!("max");
+    fs::write(&cache_path, serde_json::to_vec(&cached).unwrap()).unwrap();
+    for stale in [false, true] {
+        if stale {
+            let meta_path = paths.dir.join("catalogs/openrouter.meta.json");
+            let mut meta: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+            meta["fetched_at"] = serde_json::json!(0);
+            fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
+        }
+        let outcome = crate::claude_catalog::try_seed_user_catalog(
+            &paths,
+            "openrouter",
+            &base_url,
+            "sk-test",
+            &env,
+        );
+        assert_eq!(outcome, crate::claude_catalog::SeedOutcome::Seeded);
+        let document: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(document["additionalModelOptionsCache"][0]["value"], "claude-sonnet-5");
+        let access = document["modelAccessCache"].as_array().unwrap();
+        let owned = access.iter().find(|entry| entry["apiName"] == "claude-sonnet-5").unwrap();
+        assert_eq!(owned["entitled"], true);
+        assert!(owned.get("maxEffortLevel").is_none());
+        let unowned = access.iter().find(|entry| entry["apiName"] == "user-model").unwrap();
+        assert_eq!(unowned["maxEffortLevel"], "high");
+    }
 }
 
 #[test]
@@ -2349,7 +2379,6 @@ fn openrouter_seed_builds_picker_and_denylist() {
             name: Some("Sonnet 5".to_string()),
             context_length: Some(200_000),
             canonical_slug: Some("anthropic/claude-sonnet-5".to_string()),
-            supported_efforts: vec!["high".to_string()],
             pricing: None,
         },
         crate::claude_catalog::UserModel {
@@ -2357,7 +2386,6 @@ fn openrouter_seed_builds_picker_and_denylist() {
             name: Some("GPT 5.6 Sol".to_string()),
             context_length: Some(400_000),
             canonical_slug: None,
-            supported_efforts: vec![],
             pricing: None,
         },
     ];
@@ -2383,7 +2411,6 @@ fn openrouter_seed_writes_claude_json() {
         name: Some("Gemini".to_string()),
         context_length: Some(200_000),
         canonical_slug: None,
-        supported_efforts: vec![],
         pricing: None,
     }]);
     crate::claude_catalog::write_seed(&config_path, &caches).unwrap();
@@ -2521,7 +2548,6 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
             name: Some("Current Old".to_string()),
             context_length: Some(200_000),
             canonical_slug: None,
-            supported_efforts: vec!["high".to_string()],
             pricing: Some(crate::claude_catalog::Pricing {
                 prompt: Some("0.000001".to_string()),
                 completion: Some("0.000003".to_string()),
@@ -2535,7 +2561,6 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
             name: Some("Removed".to_string()),
             context_length: Some(200_000),
             canonical_slug: None,
-            supported_efforts: vec![],
             pricing: Some(crate::claude_catalog::Pricing {
                 prompt: Some("0.000001".to_string()),
                 completion: Some("0.000003".to_string()),
@@ -2552,7 +2577,6 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
         name: Some("Current New".to_string()),
         context_length: Some(300_000),
         canonical_slug: None,
-        supported_efforts: vec!["max".to_string()],
         pricing: Some(crate::claude_catalog::Pricing {
             prompt: Some("0.000002".to_string()),
             completion: Some("0.000004".to_string()),
@@ -2575,9 +2599,9 @@ fn claude_seed_refreshes_and_removes_unmodified_owned_payloads() {
 
     let access = document["modelAccessCache"].as_array().unwrap();
     assert!(
-        access.iter().any(|entry| {
-            entry["apiName"] == "claude-current" && entry["maxEffortLevel"] == "max"
-        })
+        access
+            .iter()
+            .any(|entry| { entry["apiName"] == "claude-current" && entry["entitled"] == true })
     );
     assert!(!access.iter().any(|entry| entry["apiName"] == "claude-removed"));
     assert_eq!(document["additionalModelCostsCache"]["claude-current"]["inputTokens"], 2.0);
@@ -2600,7 +2624,6 @@ fn claude_seed_reclaims_modified_owned_payloads_and_preserves_unowned() {
         name: Some("RX".to_string()),
         context_length: Some(200_000),
         canonical_slug: None,
-        supported_efforts: vec!["high".to_string()],
         pricing: Some(crate::claude_catalog::Pricing {
             prompt: Some("0.000001".to_string()),
             completion: Some("0.000003".to_string()),
@@ -2662,7 +2685,6 @@ fn claude_seed_recreates_deleted_owned_payloads() {
         name: Some("Deleted".to_string()),
         context_length: Some(200_000),
         canonical_slug: None,
-        supported_efforts: vec!["high".to_string()],
         pricing: Some(crate::claude_catalog::Pricing {
             prompt: Some("0.000001".to_string()),
             completion: Some("0.000003".to_string()),
@@ -2735,7 +2757,6 @@ fn claude_seed_does_not_claim_unmarked_matching_identity() {
         name: Some("RX".to_string()),
         context_length: Some(200_000),
         canonical_slug: None,
-        supported_efforts: vec![],
         pricing: None,
     }]);
     crate::claude_catalog::write_seed(&config_path, &seed).unwrap();
@@ -2773,7 +2794,6 @@ fn concurrent_claude_seed_writes_leave_one_complete_catalog() {
             name: Some(id.to_string()),
             context_length: Some(200_000),
             canonical_slug: None,
-            supported_efforts: vec![],
             pricing: None,
         }]);
         writers.push(thread::spawn(move || {
@@ -2819,7 +2839,6 @@ fn claude_seed_remerges_external_config_changes() {
         name: Some("Race RX".to_string()),
         context_length: Some(200_000),
         canonical_slug: None,
-        supported_efforts: vec![],
         pricing: None,
     }]);
     let external_path = config_path.clone();


### PR DESCRIPTION
### What's changed?

Require successful HTTP transfers, a final `text/event-stream` response, nonempty protocol-specific text, and completion events before admitting a provider. Error frames, heartbeats, incomplete streams, and failed transfers now fail the probe.

Remove Claude effort limits derived from live model metadata and legacy cached seeds. Preserve model availability, marked ownership, and unowned configuration.

### Why

An HTTP 200 SSE error or heartbeat could previously pass every streaming check and produce `ADMIT`. Live reasoning metadata could also enable Claude controls without a matching bundled capability admission.

### Verification

- `make check`: 994 tests passed; the existing live-provider test remains ignored.
- `uv run --no-project python crates/rx/scripts/test-probe-rx-provider.py`: 10 local HTTP fixture tests passed.
- Freshly built rx passed isolated fresh/stale legacy-cache upgrade and provider-none passthrough probes using synthetic credentials.
