### PR TITLE
refactor(rx): remove unreachable dsh shell installer spec

### DIFF
--- a/crates/rx/src/install.rs
+++ b/crates/rx/src/install.rs
@@ -19,8 +19,8 @@ pub(crate) struct InstallSpec {
     pub shell: &'static str,
 }
 
-pub(crate) fn spec(harness: Harness) -> InstallSpec {
-    match harness {
+pub(crate) fn spec(harness: Harness) -> Option<InstallSpec> {
+    Some(match harness {
         Harness::Claude => InstallSpec {
             program: "claude",
             display: "Claude Code",
@@ -45,19 +45,14 @@ pub(crate) fn spec(harness: Harness) -> InstallSpec {
             url: "https://pi.dev/install.sh",
             shell: "sh",
         },
-        Harness::Dsh => InstallSpec {
-            program: "dsh",
-            display: "DeepSeek Harness",
-            url: "https://www.npmjs.com/package/@deepseek-ai/dsh",
-            shell: "sh",
-        },
+        Harness::Dsh => return None,
         Harness::Kimi => InstallSpec {
             program: "kimi",
             display: "Kimi Code",
             url: "https://code.kimi.com/kimi-code/install.sh",
             shell: "bash",
         },
-    }
+    })
 }
 
 pub(crate) fn command_line(spec: &InstallSpec) -> String {
@@ -65,13 +60,12 @@ pub(crate) fn command_line(spec: &InstallSpec) -> String {
 }
 
 pub(crate) fn ensure(harness: Harness, env: &EnvLookup) -> Result<PathBuf> {
-    if matches!(harness, Harness::Dsh) {
+    let Some(spec) = spec(harness) else {
         return ensure_dsh(env);
-    }
+    };
     if !env.is_real() {
         return Ok(PathBuf::from(harness.as_str()));
     }
-    let spec = spec(harness);
     if let Some(path) = lookup(spec.program) {
         return Ok(path);
     }

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -3162,7 +3162,7 @@ fn live_openrouter_seed_populates_claude_json() {
 
 #[test]
 fn install_specs_use_official_urls() {
-    let claude = crate::install::spec(Harness::Claude);
+    let claude = crate::install::spec(Harness::Claude).unwrap();
     assert_eq!(claude.url, "https://claude.ai/install.sh");
     assert_eq!(claude.shell, "bash");
     assert_eq!(
@@ -3170,23 +3170,19 @@ fn install_specs_use_official_urls() {
         "curl -fsSL https://claude.ai/install.sh | bash"
     );
 
-    let codex = crate::install::spec(Harness::Codex);
+    let codex = crate::install::spec(Harness::Codex).unwrap();
     assert_eq!(codex.url, "https://chatgpt.com/codex/install.sh");
     assert_eq!(codex.shell, "sh");
 
-    let opencode = crate::install::spec(Harness::OpenCode);
+    let opencode = crate::install::spec(Harness::OpenCode).unwrap();
     assert_eq!(opencode.url, "https://opencode.ai/install");
     assert_eq!(opencode.shell, "bash");
 
-    let pi = crate::install::spec(Harness::Pi);
+    let pi = crate::install::spec(Harness::Pi).unwrap();
     assert_eq!(pi.url, "https://pi.dev/install.sh");
     assert_eq!(pi.shell, "sh");
 
-    let dsh = crate::install::spec(Harness::Dsh);
-    assert_eq!(dsh.program, "dsh");
-    assert_eq!(dsh.display, "DeepSeek Harness");
-
-    let kimi = crate::install::spec(Harness::Kimi);
+    let kimi = crate::install::spec(Harness::Kimi).unwrap();
     assert_eq!(kimi.program, "kimi");
     assert_eq!(kimi.display, "Kimi Code");
     assert_eq!(kimi.url, "https://code.kimi.com/kimi-code/install.sh");


### PR DESCRIPTION
### What's changed?

Return an optional shell installer specification and dispatch DSH through its existing dedicated npm/profile installer. Remove the unreachable specification that treated an npm package page as a shell install script, and adapt the existing installer-spec test callers.

### Why

The internal specification now matches the supported installer paths. Installation commands, discovery, prompts, and profile setup remain unchanged.

### Verification

- `cargo test -p rx`: 155 passed, 1 ignored.
- `make check`: passed.
- Isolated process-routing checks with stub npm/DSH executables: fresh installation, profile setup for an existing DSH binary, ready-installation reuse, and `RX_NO_INSTALL` refusal all passed.
