### PR TITLE
fix(rx): preserve active native catalog identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,27 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo install cargo-audit --locked --version 0.22.2
       - run: make check
+
+  kimi-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kimi-windows
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: cargo test -p rx
+      - name: Install pinned native Kimi Code
+        shell: pwsh
+        run: |
+          $env:KIMI_VERSION = '0.39.1'
+          $env:KIMI_NO_MODIFY_PATH = '1'
+          irm https://code.kimi.com/kimi-code/install.ps1 | iex
+          "$env:USERPROFILE\.kimi-code\bin" >> $env:GITHUB_PATH
+      - name: Verify native lease lifetime after launcher termination
+        run: cargo test -p rx native_kimi_lease_survives_launcher_exit -- --ignored --nocapture

--- a/crates/rx/DESIGN.md
+++ b/crates/rx/DESIGN.md
@@ -46,11 +46,30 @@ read `recall.db`.
 | OpenCode config | launch | Prefer `OPENCODE_CONFIG_CONTENT`; only warn about native auth conflicts. |
 | Pi `models.json` | shared | Own the selected provider entry; preserve the rest; reject malformed roots. |
 | DSH install and profile | user | Use the user's npm prefix and native `DSH_HOME` (`~/.dsh` by default); routing uses a launch overlay. Hosted mode does not override `DSH_HOME`. |
-| Kimi `config.toml` | shared | Use rx-prefixed marked entries; preserve collisions and user edits. Its required literal credential uses secret mode. |
+| Kimi `config.toml` | shared | Use rx-prefixed marked entries; preserve collisions and user edits. Launch leases protect active catalog identities. Its required literal credential uses secret mode. |
 | Hosted state | host caller | Runtime state for the selected harness only; never an installation root. |
 
 Injection preference is: flags or environment, immutable launch config, then a
 narrowly merged owned entry. Convenience never justifies persistent mutation.
+
+Kimi launches hold shared file leases across native execution: inherited `flock`
+locks on Unix and inherited read handles denying write sharing on Windows.
+Identical complete
+catalog snapshots share one immutable lease identity derived from the snapshot
+fingerprint. The catalog marker records active and current snapshots; historical
+lease files alone never establish config ownership. A later launch may reclaim
+an exited snapshot's entries only when its lease permits an exclusive probe and
+the entries still match their ownership records. Active identities retain their
+original aliases; conflicting changes fail closed. Missing or malformed lease
+records do not prove that a launch exited. Empty lease files are retained and
+reused, so file growth follows distinct snapshots rather than launch count.
+rx never truncates or deletes lease files and has no automatic cleanup command.
+
+Before migrating a version 1 Kimi catalog marker, the user must close every
+Kimi session started by an older rx and explicitly confirm migration in a
+terminal. rx never terminates those sessions. Non-interactive launches refuse
+migration, and older rx versions cannot write the migrated marker. Rolling
+back rx must preserve the new marker so older writers continue to fail closed.
 
 Hosted order is: select harness, discover or install in the user environment,
 build selected-harness state, validate route conflicts, execute with scoped

--- a/crates/rx/README.md
+++ b/crates/rx/README.md
@@ -24,6 +24,19 @@ rx kimi
 Running `rx` without a harness opens the picker. Arguments after the harness name are passed to that harness.
 For Kimi Code, `rx` seeds the selected provider and its cached models as `rx-<provider>/<model>` aliases in Kimi's native catalog. `--model <id>` selects one of those models. Without it or a provider-level `model` in `rx.toml`, `rx` uses the first cached provider model and reports that choice on stderr. RX-owned entries are refreshed only while their payload remains unchanged; native and user-edited entries are preserved. Kimi requires catalog credentials in its config, so the selected provider key is also stored in Kimi's local `config.toml` with secret-only file permissions.
 
+Concurrent `rx kimi` launches retain their catalog aliases until they exit. A later
+launch reclaims unchanged entries no longer used by a running launch. Changing
+an active alias to a different route fails; close the launch using that alias
+before retrying. Identical catalog snapshots reuse a shared lease file; empty
+lease files are retained as catalogs change, without automatic cleanup.
+
+When upgrading from a version 1 Kimi catalog marker, first close all Kimi
+sessions started by older rx versions. Run the same `rx kimi` command in a
+terminal and type `migrate` when prompted to confirm those sessions have exited.
+Declining the prompt or running without a terminal leaves the existing catalog
+unchanged. Older rx versions cannot update the migrated catalog. Keep the
+catalog marker and lease files in place, including when rolling back rx.
+
 | Harness | Commands |
 | --- | --- |
 | Claude Code | `rx claude`, `rxc` |

--- a/crates/rx/scripts/probe-kimi-windows-leases.py
+++ b/crates/rx/scripts/probe-kimi-windows-leases.py
@@ -1,0 +1,148 @@
+import argparse
+import ctypes
+import json
+import os
+from pathlib import Path
+import queue
+import shutil
+import subprocess
+import tempfile
+import threading
+import tomllib
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--launcher', type=Path, required=True)
+args = parser.parse_args()
+launcher = [str(args.launcher.resolve()), '--exact', 'kimi::tests::native_kimi_lease_survives_launcher_exit', '--ignored', '--nocapture', '--format', 'terse']
+if os.name != 'nt':
+    raise SystemExit('This probe requires Windows')
+if not shutil.which('kimi'):
+    raise SystemExit('Install native Kimi Code before running this probe')
+
+kernel = ctypes.WinDLL('kernel32', use_last_error=True)
+kernel.CreateFileW.argtypes = [ctypes.c_wchar_p, ctypes.c_uint32, ctypes.c_uint32,
+                              ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint32,
+                              ctypes.c_void_p]
+kernel.CreateFileW.restype = ctypes.c_void_p
+kernel.CloseHandle.argtypes = [ctypes.c_void_p]
+
+
+def writable(path):
+    handle = kernel.CreateFileW(str(path), 0x40000000, 7, None, 3, 0, None)
+    if handle == ctypes.c_void_p(-1).value:
+        error = ctypes.get_last_error()
+        assert error == 32, error
+        return False
+    kernel.CloseHandle(handle)
+    return True
+
+
+def read_replies(stream, replies):
+    for line in stream:
+        try:
+            replies.put(json.loads(line))
+        except ValueError:
+            pass
+
+
+def request(process, replies, ident, method, params):
+    process.stdin.write(json.dumps(dict(jsonrpc='2.0', id=ident, method=method, params=params)) + '\n')
+    process.stdin.flush()
+    while True:
+        reply = replies.get(timeout=60)
+        if reply.get('id') == ident:
+            assert 'error' not in reply, reply
+            return reply['result']
+
+
+def native_pid(parent):
+    result = subprocess.run([
+        'powershell', '-NoProfile', '-Command',
+        f'Get-CimInstance Win32_Process -Filter "ParentProcessId = {parent}" | Select-Object -ExpandProperty ProcessId'
+    ], capture_output=True, text=True, check=True, timeout=30)
+    children = result.stdout.split()
+    assert len(children) == 1, result.stdout
+    return int(children[0])
+
+
+def stop_native(pid):
+    subprocess.run(['taskkill', '/PID', str(pid), '/T', '/F'], capture_output=True, timeout=30)
+
+
+with tempfile.TemporaryDirectory(prefix='rx-kimi-native-') as temporary:
+    root = Path(temporary)
+    home = root / 'home'
+    (home / '.recall').mkdir(parents=True)
+    khome = home / '.kimi-code'
+    khome.mkdir()
+    config = khome / 'config.toml'
+    marker = khome / 'config.toml.rx-catalog.json'
+    config.write_text('telemetry=false\ndefault_model="rx-first/model-a"\n', encoding='utf-8')
+    (home / '.recall/rx.toml').write_text(''.join(
+        f'[provider.{provider}]\nbase_url="http://127.0.0.1:1"\nenv="TEST_KEY"\nauth="env"\n'
+        for provider in ('first', 'second')
+    ), encoding='utf-8')
+    env = dict(os.environ, RX_TEST_KIMI_HOME=str(home), KIMI_CODE_HOME=str(khome),
+               TEST_KEY='synthetic-only', RX_NO_INSTALL='1', RX_NO_UPDATE='1', RX_NO_YOLO='1',
+               HTTP_PROXY='http://127.0.0.1:1', HTTPS_PROXY='http://127.0.0.1:1',
+               NO_PROXY='127.0.0.1,localhost')
+    parents = []
+    children = []
+    errors = []
+
+    def seed(provider):
+        result = subprocess.run(launcher,
+                                env=dict(env, RX_TEST_KIMI_PROVIDER=provider), cwd=root, capture_output=True, text=True, timeout=60)
+        assert result.returncode == 0, result.stderr
+        return tomllib.loads(config.read_text(encoding='utf-8'))
+
+    try:
+        for index in range(2):
+            stderr = open(root / f'native-{index}.stderr', 'w+', encoding='utf-8')
+            errors.append(stderr)
+            process = subprocess.Popen(launcher,
+                                       env=dict(env, RX_TEST_KIMI_PROVIDER='first', RX_TEST_KIMI_ACP='1'), cwd=root, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                       stderr=stderr, text=True, encoding='utf-8')
+            parents.append(process)
+            replies = queue.Queue()
+            threading.Thread(target=read_replies, args=(process.stdout, replies), daemon=True).start()
+            initialized = request(process, replies, 1, 'initialize', dict(protocolVersion=1, clientCapabilities={}))
+            session = request(process, replies, 2, 'session/new', dict(cwd=str(root), mcpServers=[]))
+            options = next(option for option in session['configOptions'] if option['id'] == 'model')
+            assert options['currentValue'] == 'rx-first/model-a', options
+            children.append(native_pid(process.pid))
+        records = json.loads(marker.read_text(encoding='utf-8'))['catalogs']
+        assert len(records) == 1
+        lease = khome / next(iter(records))
+        assert len(list(khome.glob('.rx-kimi-*'))) == 1
+        assert not writable(lease)
+        for parent in parents:
+            parent.kill()
+            parent.wait(timeout=10)
+        assert not writable(lease)
+        assert 'rx-first/model-a' in seed('second')['models']
+        stop_native(children[0])
+        assert not writable(lease)
+        assert 'rx-first/model-a' in seed('second')['models']
+        stop_native(children[1])
+        assert writable(lease)
+        assert 'rx-first/model-a' not in seed('second')['models']
+        for _ in range(3):
+            seed('first')
+            seed('second')
+        assert len(list(khome.glob('.rx-kimi-*'))) == 2
+        assert len(json.loads(marker.read_text(encoding='utf-8'))['catalogs']) == 1
+        print(json.dumps(dict(native=initialized['agentInfo'], parents_terminated=True,
+                              native_survived_parent=True, first_exit_retained=True,
+                              last_exit_reclaimed=True, repeated_snapshot_files=2)))
+    finally:
+        for parent in parents:
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait(timeout=10)
+        for child in children:
+            stop_native(child)
+        for stderr in errors:
+            stderr.seek(0)
+            print(stderr.read())
+            stderr.close()

--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -330,7 +330,7 @@ mod tests {
                 "endpoint": "https://api.tokener.dev/v1",
                 "credential_env": "TOKENER_API_KEY"
             },
-            "state_dir": "/tmp/tokener-agent",
+            "state_dir": std::env::temp_dir().join("tokener-agent"),
             "permission_policy": "standard",
             "install_policy": "prompt"
         })

--- a/crates/rx/src/kimi.rs
+++ b/crates/rx/src/kimi.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -16,13 +16,22 @@ use crate::config::Paths;
 use crate::launch::{EnvLookup, LaunchPlan, ProviderTarget};
 
 const MARKER_VERSION: u32 = 1;
+const LEASE_VERSION: u32 = 2;
 const MAX_WRITE_ATTEMPTS: usize = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct OwnedCatalog {
     version: u32,
     provider: OwnedProvider,
     models: BTreeMap<String, OwnedModel>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum CatalogMarker {
+    Leased { version: u32, catalogs: BTreeMap<String, OwnedCatalog> },
+    Legacy(OwnedCatalog),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -97,10 +106,11 @@ pub(crate) fn prepare(
         });
     }
     let config_path = kimi_config_path(paths, env)?;
-    seed_catalog(&config_path, &provider_alias, target, &models)?;
+    let lease = seed_catalog(&config_path, &provider_alias, target, &models, env.is_real())?;
     args.insert(0, OsString::from(format!("{provider_alias}/{selected_model}")));
     args.insert(0, OsString::from("--model"));
     Ok(LaunchPlan {
+        launch_lease: Some(lease),
         program: PathBuf::from("kimi"),
         args,
         env_set: vec![("KIMI_MODEL_NAME".to_string(), String::new())],
@@ -124,7 +134,8 @@ fn seed_catalog(
     provider_alias: &str,
     target: &ProviderTarget,
     models: &[ListedModel],
-) -> Result<()> {
+    allow_prompt: bool,
+) -> Result<File> {
     let parent = config_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("path has no parent: {}", config_path.display()))?;
@@ -140,23 +151,160 @@ fn seed_catalog(
     lock.lock_exclusive().with_context(|| format!("failed to lock {}", lock_path.display()))?;
     let marker_path = appended_path(config_path, ".rx-catalog.json");
     let desired = desired_catalog(provider_alias, target, models);
+    let lease_name = catalog_lease_name(&desired)?;
+    let mut migration_approved = false;
     for _ in 0..MAX_WRITE_ATTEMPTS {
         let snapshot = read_bytes(config_path)?;
         let mut document = read_document(config_path, snapshot.as_deref())?;
-        let previous = read_marker(&marker_path)?;
-        reconcile(&mut document, previous.as_ref(), &desired, &target.key)?;
+        let mut previous = Vec::new();
+        let mut active = BTreeMap::new();
+        match read_marker(&marker_path)? {
+            Some(CatalogMarker::Legacy(catalog)) => {
+                validate_catalog(&catalog)?;
+                if !migration_approved {
+                    confirm_migration(allow_prompt)?;
+                    migration_approved = true;
+                }
+                previous.push(catalog);
+            }
+            Some(CatalogMarker::Leased { version, catalogs }) => {
+                if version != LEASE_VERSION {
+                    bail!("unsupported Kimi catalog marker version {version}");
+                }
+                for (name, catalog) in catalogs {
+                    validate_catalog(&catalog)?;
+                    if name != catalog_lease_name(&catalog)? {
+                        bail!("invalid Kimi catalog lease identity");
+                    }
+                    if lease_is_active(&parent.join(&name))? {
+                        active.insert(name, catalog.clone());
+                    }
+                    previous.push(catalog);
+                }
+            }
+            None => {}
+        }
+        reconcile(&mut document, &previous, &active, &desired, &target.key)?;
+        let lease_path = parent.join(&lease_name);
+        if !lease_path.try_exists()? {
+            let mut options = OpenOptions::new();
+            options.read(true).write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            match options.open(&lease_path) {
+                Ok(_) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error).context("failed to create Kimi catalog lease"),
+            };
+        }
+        let lease = open_lease(&lease_path, false)?;
+        #[cfg(not(windows))]
+        FileExt::try_lock_shared(&lease).context("failed to share Kimi catalog lease")?;
         let staged_config = stage_secret(config_path, document.to_string().as_bytes())?;
-        let marker =
-            serde_json::to_vec_pretty(&desired).context("failed to serialize Kimi marker")?;
+        active.insert(lease_name.clone(), desired.clone());
+        let marker = serde_json::to_vec_pretty(&CatalogMarker::Leased {
+            version: LEASE_VERSION,
+            catalogs: active,
+        })
+        .context("failed to serialize Kimi marker")?;
         let staged_marker = stage_secret(&marker_path, &marker)?;
         if read_bytes(config_path)?.as_deref() != snapshot.as_deref() {
             continue;
         }
         persist_secret(staged_config, config_path)?;
         persist_secret(staged_marker, &marker_path)?;
-        return Ok(());
+        return Ok(lease);
     }
     bail!("{} changed repeatedly while seeding Kimi catalog", config_path.display())
+}
+
+fn catalog_lease_name(catalog: &OwnedCatalog) -> Result<String> {
+    Ok(format!(".rx-kimi-{:x}", Sha256::digest(serde_json::to_vec(catalog)?)))
+}
+
+fn open_lease(path: &Path, write: bool) -> Result<File> {
+    if !fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect Kimi lease {}", path.display()))?
+        .file_type()
+        .is_file()
+    {
+        bail!("Kimi lease {} is not a regular file", path.display());
+    }
+    let mut options = OpenOptions::new();
+    options.read(true).write(write);
+    #[cfg(windows)]
+    if !write {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_SHARE_READ: u32 = 1;
+        options.share_mode(FILE_SHARE_READ);
+    }
+    options.open(path).with_context(|| format!("failed to open Kimi lease {}", path.display()))
+}
+
+fn lease_is_active(path: &Path) -> Result<bool> {
+    #[cfg(windows)]
+    {
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        match open_lease(path, true) {
+            Ok(_) => Ok(false),
+            Err(error)
+                if error.downcast_ref::<io::Error>().and_then(io::Error::raw_os_error)
+                    == Some(ERROR_SHARING_VIOLATION) =>
+            {
+                Ok(true)
+            }
+            Err(error) => Err(error),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let file = open_lease(path, true)?;
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                FileExt::unlock(&file).context("failed to release Kimi lease probe")?;
+                Ok(false)
+            }
+            Err(error) if error.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
+                Ok(true)
+            }
+            Err(error) => Err(error).context("failed to inspect Kimi lease lock"),
+        }
+    }
+}
+
+fn confirm_migration(allow_prompt: bool) -> Result<()> {
+    let instruction = "close all Kimi sessions started by older rx, then rerun this command in a terminal and type 'migrate' to confirm";
+    if !allow_prompt || !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        bail!("Kimi catalog migration required: {instruction}");
+    }
+    eprint!(
+        "[rx] Kimi catalog migration: all Kimi sessions started by older rx must be closed. Type 'migrate' to confirm they have exited: "
+    );
+    io::stderr().flush()?;
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    if answer.trim() != "migrate" {
+        bail!("Kimi catalog migration declined: {instruction}");
+    }
+    Ok(())
+}
+
+fn validate_catalog(catalog: &OwnedCatalog) -> Result<()> {
+    if catalog.version != MARKER_VERSION {
+        bail!("unsupported Kimi catalog marker version {}", catalog.version);
+    }
+    if !catalog.provider.alias.starts_with("rx-")
+        || catalog.models.iter().any(|(alias, model)| {
+            model.provider != catalog.provider.alias
+                || *alias != format!("{}/{}", catalog.provider.alias, model.model)
+        })
+    {
+        bail!("invalid Kimi catalog ownership record");
+    }
+    Ok(())
 }
 
 fn desired_catalog(
@@ -189,17 +337,31 @@ fn desired_catalog(
 
 fn reconcile(
     document: &mut DocumentMut,
-    previous: Option<&OwnedCatalog>,
+    previous: &[OwnedCatalog],
+    active: &BTreeMap<String, OwnedCatalog>,
     desired: &OwnedCatalog,
     key: &str,
 ) -> Result<()> {
-    if let Some(previous) = previous {
-        if previous.version != MARKER_VERSION {
-            bail!("unsupported Kimi catalog marker version {}", previous.version);
+    for catalog in active.values() {
+        if catalog.provider.alias == desired.provider.alias && catalog.provider != desired.provider
+        {
+            bail!("Kimi provider alias '{}' is in use by another launch", desired.provider.alias);
         }
+        if let Some(alias) = desired.models.keys().find(|alias| {
+            catalog
+                .models
+                .get(*alias)
+                .is_some_and(|model| Some(model) != desired.models.get(*alias))
+        }) {
+            bail!("Kimi model alias '{alias}' is in use by another launch");
+        }
+    }
+    for previous in previous {
         if let Some(models) = table_mut(document, "models")? {
             for (alias, owned) in &previous.models {
-                if models.get(alias).is_some_and(|item| model_matches(item, owned)) {
+                if !active.values().any(|catalog| catalog.models.contains_key(alias))
+                    && models.get(alias).is_some_and(|item| model_matches(item, owned))
+                {
                     models.remove(alias);
                 }
             }
@@ -213,6 +375,7 @@ fn reconcile(
         let reusable = previous.provider == desired.provider;
         if !provider_referenced
             && !reusable
+            && !active.values().any(|catalog| catalog.provider.alias == previous.provider.alias)
             && let Some(providers) = table_mut(document, "providers")?
             && providers
                 .get(&previous.provider.alias)
@@ -222,16 +385,13 @@ fn reconcile(
         }
     }
 
-    let provider_exists = table(document, "providers")?
-        .is_some_and(|providers| providers.contains_key(&desired.provider.alias));
-    let provider_reusable = if let Some(previous) = previous {
-        previous.provider == desired.provider
-            && table(document, "providers")?
-                .and_then(|providers| providers.get(&desired.provider.alias))
-                .is_some_and(|item| provider_matches(item, &desired.provider))
-    } else {
-        false
-    };
+    let providers = table(document, "providers")?;
+    let provider_exists =
+        providers.is_some_and(|providers| providers.contains_key(&desired.provider.alias));
+    let provider_reusable = previous.iter().any(|previous| previous.provider == desired.provider)
+        && providers
+            .and_then(|providers| providers.get(&desired.provider.alias))
+            .is_some_and(|item| provider_matches(item, &desired.provider));
     if provider_exists && !provider_reusable {
         bail!(
             "Kimi provider alias '{}' already exists outside rx ownership",
@@ -239,7 +399,17 @@ fn reconcile(
         );
     }
     if let Some(models) = table(document, "models")?
-        && let Some(alias) = desired.models.keys().find(|alias| models.contains_key(alias))
+        && let Some(alias) = desired.models.keys().find(|alias| {
+            models.get(alias).is_some_and(|item| {
+                !active.values().any(|catalog| {
+                    catalog.models.get(*alias) == desired.models.get(*alias)
+                        && catalog
+                            .models
+                            .get(*alias)
+                            .is_some_and(|owned| model_matches(item, owned))
+                })
+            })
+        })
     {
         bail!("Kimi model alias '{alias}' already exists outside rx ownership");
     }
@@ -254,6 +424,9 @@ fn reconcile(
     }
     let models = ensure_table(document, "models")?;
     for (alias, model) in &desired.models {
+        if models.contains_key(alias) {
+            continue;
+        }
         let mut entry = Table::new();
         entry["provider"] = value(&model.provider);
         entry["model"] = value(&model.model);
@@ -339,7 +512,7 @@ fn read_document(path: &Path, contents: Option<&[u8]>) -> Result<DocumentMut> {
     body.parse().with_context(|| format!("failed to parse {}", path.display()))
 }
 
-fn read_marker(path: &Path) -> Result<Option<OwnedCatalog>> {
+fn read_marker(path: &Path) -> Result<Option<CatalogMarker>> {
     match fs::read(path) {
         Ok(contents) => serde_json::from_slice(&contents)
             .with_context(|| format!("failed to parse {}", path.display()))
@@ -440,6 +613,41 @@ fn take_model(passthrough: &[OsString]) -> Result<(Option<String>, Vec<OsString>
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires native Kimi Code and Python"]
+    fn native_kimi_lease_survives_launcher_exit() -> Result<()> {
+        if let Some(home) = std::env::var_os("RX_TEST_KIMI_HOME") {
+            let paths = Paths::in_dir(PathBuf::from(home).join(".recall"));
+            let request = args::LaunchRequest {
+                harness: args::Harness::Kimi,
+                provider: Some(std::env::var("RX_TEST_KIMI_PROVIDER")?),
+                passthrough: os(&[
+                    "--model",
+                    "model-a",
+                    if std::env::var_os("RX_TEST_KIMI_ACP").is_some() {
+                        "acp"
+                    } else {
+                        "--version"
+                    },
+                ]),
+            };
+            let plan = crate::launch::plan(&request, &paths, &EnvLookup::real())?;
+            crate::launch::exec(&plan)
+        } else {
+            let status = std::process::Command::new("python")
+                .arg(
+                    Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("scripts/probe-kimi-windows-leases.py"),
+                )
+                .arg("--launcher")
+                .arg(std::env::current_exe()?)
+                .status()?;
+            assert!(status.success(), "native Kimi lease probe failed: {status}");
+            Ok(())
+        }
+    }
+
     fn target(key: &str) -> ProviderTarget {
         let mut provider = crate::provider::find("tokener").unwrap().clone();
         provider.endpoint = "https://provider.test".to_string();
@@ -458,6 +666,24 @@ mod tests {
         argv.iter().map(OsString::from).collect()
     }
 
+    fn run_isolated(name: &str) -> bool {
+        if std::env::var_os("RX_TEST_KIMI_CATALOG_CHILD").is_some() {
+            return false;
+        }
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", name, "--nocapture"])
+            .env("RX_TEST_KIMI_CATALOG_CHILD", "1")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success() && stdout.contains("1 passed"),
+            "{stdout}\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        true
+    }
+
     #[test]
     fn model_flag_selects_catalog_model_and_preserves_literal_arguments() {
         assert_eq!(
@@ -472,6 +698,11 @@ mod tests {
 
     #[test]
     fn catalog_refresh_preserves_user_config_and_replaces_owned_models() {
+        if run_isolated(
+            "kimi::tests::catalog_refresh_preserves_user_config_and_replaces_owned_models",
+        ) {
+            return;
+        }
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         fs::write(
@@ -484,6 +715,7 @@ mod tests {
             "rx-tokener",
             &target("rx-secret"),
             &[listed("model-a", "Model A", 200_000), listed("model-b", "Model B", 300_000)],
+            false,
         )
         .unwrap();
         seed_catalog(
@@ -491,6 +723,7 @@ mod tests {
             "rx-tokener",
             &target("rx-secret"),
             &[listed("model-b", "Model B", 300_000), listed("model-c", "Model C", 400_000)],
+            false,
         )
         .unwrap();
         let body = fs::read_to_string(&path).unwrap();
@@ -524,13 +757,185 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
         let models = [listed("model-a", "Model A", 200_000)];
-        seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models).unwrap();
+        seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models, false).unwrap();
         let mut document = fs::read_to_string(&path).unwrap().parse::<DocumentMut>().unwrap();
         document["models"]["rx-tokener/model-a"]["model"] = value("user-model");
         fs::write(&path, document.to_string()).unwrap();
-        let error = seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models).unwrap_err();
+        let error =
+            seed_catalog(&path, "rx-tokener", &target("rx-secret"), &models, false).unwrap_err();
         assert!(error.to_string().contains("outside rx ownership"), "{error:#}");
         let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(document["models"]["rx-tokener/model-a"]["model"].as_str(), Some("user-model"));
+    }
+
+    #[test]
+    fn overlapping_catalogs_keep_live_routes_and_reclaim_only_exited_launches() {
+        if run_isolated(
+            "kimi::tests::overlapping_catalogs_keep_live_routes_and_reclaim_only_exited_launches",
+        ) {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let first_models = [listed("model-a", "Model A", 200_000)];
+        let second_models = [listed("model-b", "Model B", 300_000)];
+        let first =
+            seed_catalog(&path, "rx-first", &target("first-key"), &first_models, false).unwrap();
+        let same =
+            seed_catalog(&path, "rx-first", &target("first-key"), &first_models, false).unwrap();
+        let second =
+            seed_catalog(&path, "rx-first", &target("first-key"), &second_models, false).unwrap();
+        let third =
+            seed_catalog(&path, "rx-second", &target("second-key"), &first_models, false).unwrap();
+        let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(document["models"]["rx-first/model-a"]["provider"].as_str(), Some("rx-first"));
+        assert_eq!(document["models"]["rx-first/model-b"]["provider"].as_str(), Some("rx-first"));
+        assert_eq!(document["models"]["rx-second/model-a"]["provider"].as_str(), Some("rx-second"));
+        assert_eq!(document["providers"]["rx-first"]["api_key"].as_str(), Some("first-key"));
+        assert_eq!(document["providers"]["rx-second"]["api_key"].as_str(), Some("second-key"));
+
+        drop(first);
+        seed_catalog(&path, "rx-second", &target("second-key"), &first_models, false).unwrap();
+        let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(document["models"].get("rx-first/model-a").is_some());
+        drop(same);
+        let fourth =
+            seed_catalog(&path, "rx-second", &target("second-key"), &first_models, false).unwrap();
+        let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(document["models"].get("rx-first/model-a").is_none());
+        assert!(document["models"].get("rx-first/model-b").is_some());
+        assert!(document["providers"].get("rx-first").is_some());
+
+        drop(second);
+        drop(third);
+        let _fifth =
+            seed_catalog(&path, "rx-second", &target("second-key"), &first_models, false).unwrap();
+        let document: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(document["models"].get("rx-first/model-b").is_none());
+        assert!(document["providers"].get("rx-first").is_none());
+        let marker = read_marker(&appended_path(&path, ".rx-catalog.json")).unwrap().unwrap();
+        let CatalogMarker::Leased { catalogs, .. } = marker else {
+            panic!("expected leased catalog")
+        };
+        assert_eq!(catalogs.len(), 1);
+        assert_eq!(
+            fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with(".rx-kimi-"))
+                .count(),
+            3
+        );
+        drop(fourth);
+    }
+
+    #[test]
+    fn historical_lease_reuse_preserves_files_without_claiming_config() {
+        if run_isolated(
+            "kimi::tests::historical_lease_reuse_preserves_files_without_claiming_config",
+        ) {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let models = [listed("model-a", "Model A", 200_000)];
+        let desired = desired_catalog("rx-first", &target("first-key"), &models);
+        seed_catalog(&path, "rx-first", &target("first-key"), &models, false).unwrap();
+        let lease_path = dir.path().join(catalog_lease_name(&desired).unwrap());
+        assert_eq!(fs::metadata(&lease_path).unwrap().len(), 0);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(fs::metadata(&lease_path).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+        fs::write(&lease_path, b"user bytes").unwrap();
+        for _ in 0..3 {
+            seed_catalog(&path, "rx-second", &target("second-key"), &models, false).unwrap();
+            seed_catalog(&path, "rx-first", &target("first-key"), &models, false).unwrap();
+        }
+        assert_eq!(fs::read(&lease_path).unwrap(), b"user bytes");
+        assert_eq!(
+            fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with(".rx-kimi-"))
+                .count(),
+            2
+        );
+        let owned = fs::read_to_string(&path).unwrap().parse::<DocumentMut>().unwrap();
+        seed_catalog(&path, "rx-second", &target("second-key"), &models, false).unwrap();
+        let mut document = fs::read_to_string(&path).unwrap().parse::<DocumentMut>().unwrap();
+        document["providers"]["rx-first"] = owned["providers"]["rx-first"].clone();
+        fs::write(&path, document.to_string()).unwrap();
+        let before = fs::read(&path).unwrap();
+        let marker_path = appended_path(&path, ".rx-catalog.json");
+        let marker = fs::read(&marker_path).unwrap();
+        assert!(seed_catalog(&path, "rx-first", &target("first-key"), &models, false).is_err());
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert_eq!(fs::read(&marker_path).unwrap(), marker);
+    }
+
+    #[test]
+    fn live_route_conflicts_and_user_edits_leave_catalog_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let models = [listed("model-a", "Model A", 200_000)];
+        let _first = seed_catalog(&path, "rx-first", &target("first-key"), &models, false).unwrap();
+        let marker_path = appended_path(&path, ".rx-catalog.json");
+        let marker = fs::read(&marker_path).unwrap();
+        let before = fs::read(&path).unwrap();
+        assert!(seed_catalog(&path, "rx-first", &target("rotated-key"), &models, false).is_err());
+        assert!(
+            seed_catalog(
+                &path,
+                "rx-first",
+                &target("first-key"),
+                &[listed("model-a", "Model A", 400_000)],
+                false
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert_eq!(fs::read(&marker_path).unwrap(), marker);
+        let mut document = String::from_utf8(before).unwrap().parse::<DocumentMut>().unwrap();
+        document["models"]["rx-first/model-a"]["model"] = value("user-model");
+        fs::write(&path, document.to_string()).unwrap();
+        let edited = fs::read(&path).unwrap();
+        assert!(seed_catalog(&path, "rx-first", &target("first-key"), &models, false).is_err());
+        assert_eq!(fs::read(&path).unwrap(), edited);
+        assert_eq!(fs::read(&marker_path).unwrap(), marker);
+    }
+
+    #[test]
+    fn legacy_and_unverifiable_leases_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let models = [listed("model-a", "Model A", 200_000)];
+        let _lease = seed_catalog(&path, "rx-first", &target("first-key"), &models, false).unwrap();
+        let marker_path = appended_path(&path, ".rx-catalog.json");
+        let before = fs::read(&path).unwrap();
+        let current: serde_json::Value =
+            serde_json::from_slice(&fs::read(&marker_path).unwrap()).unwrap();
+        let legacy = desired_catalog("rx-first", &target("first-key"), &models);
+        let mut missing = current.clone();
+        let name = missing["catalogs"].as_object().unwrap().keys().next().unwrap().clone();
+        let catalog = missing["catalogs"].as_object_mut().unwrap().remove(&name).unwrap();
+        missing["catalogs"][".rx-kimi-missing"] = catalog;
+        let mut invalid = current.clone();
+        invalid["version"] = 999.into();
+        for marker in [serde_json::to_value(legacy).unwrap(), missing, invalid] {
+            fs::write(&marker_path, serde_json::to_vec(&marker).unwrap()).unwrap();
+            let marker_bytes = fs::read(&marker_path).unwrap();
+            assert!(seed_catalog(&path, "rx-first", &target("first-key"), &models, false).is_err());
+            assert_eq!(fs::read(&path).unwrap(), before);
+            assert_eq!(fs::read(&marker_path).unwrap(), marker_bytes);
+        }
+        let marker_bytes = serde_json::to_vec(&current).unwrap();
+        fs::write(&marker_path, &marker_bytes).unwrap();
+        drop(_lease);
+        fs::remove_file(dir.path().join(name)).unwrap();
+        assert!(seed_catalog(&path, "rx-first", &target("first-key"), &models, false).is_err());
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert_eq!(fs::read(&marker_path).unwrap(), marker_bytes);
     }
 }

--- a/crates/rx/src/launch.rs
+++ b/crates/rx/src/launch.rs
@@ -43,8 +43,9 @@ impl EnvLookup {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct LaunchPlan {
+    pub(crate) launch_lease: Option<std::fs::File>,
     pub(crate) program: PathBuf,
     pub(crate) args: Vec<OsString>,
     pub(crate) env_set: Vec<(String, String)>,
@@ -260,6 +261,7 @@ fn push_note(plan: &mut LaunchPlan, note: &str) {
 
 fn passthrough(request: &LaunchRequest, note: String) -> LaunchPlan {
     LaunchPlan {
+        launch_lease: None,
         program: PathBuf::from(request.harness.as_str()),
         args: match request.harness {
             Harness::Dsh => crate::dsh::args(&request.passthrough, None),
@@ -334,6 +336,7 @@ pub(crate) fn inject_claude_openrouter(
         SeedOutcome::Seeded => None,
     };
     LaunchPlan {
+        launch_lease: None,
         program: PathBuf::from("claude"),
         args,
         env_set: claude_openrouter_env(base_url, key, model, seeded),
@@ -406,6 +409,7 @@ pub(crate) fn inject_claude_generated_seeded(
         args.insert(0, OsString::from("--settings"));
     }
     LaunchPlan {
+        launch_lease: None,
         program: PathBuf::from("claude"),
         args,
         env_set: claude_generated_seeded_env(env_key, base_url, key, model),
@@ -472,6 +476,7 @@ fn inject(
     let key = target.key.as_str();
     match request.harness {
         Harness::Claude => Ok(LaunchPlan {
+            launch_lease: None,
             program: PathBuf::from("claude"),
             args: request.passthrough.clone(),
             env_set: claude_env(&provider.env, &crate::provider::claude_base(provider), key, model),
@@ -508,6 +513,7 @@ fn inject(
             }
             args.extend(request.passthrough.iter().cloned());
             Ok(LaunchPlan {
+                launch_lease: None,
                 program: PathBuf::from("codex"),
                 args,
                 env_set: vec![(provider.env.clone(), key.to_string())],
@@ -540,6 +546,7 @@ fn inject(
                 );
             }
             Ok(LaunchPlan {
+                launch_lease: None,
                 program: PathBuf::from("opencode"),
                 args,
                 env_set,
@@ -549,6 +556,7 @@ fn inject(
         Harness::Pi => {
             crate::pi::prepare(provider_id, provider, base_url, key, paths, env)?;
             Ok(LaunchPlan {
+                launch_lease: None,
                 program: PathBuf::from("pi"),
                 args: crate::pi::args(provider_id, model, &request.passthrough),
                 env_set: crate::pi::env_set(&provider.env, key),
@@ -559,6 +567,7 @@ fn inject(
             let patch =
                 crate::dsh::prepare(provider_id, provider, base_url, key, model, paths, env)?;
             Ok(LaunchPlan {
+                launch_lease: None,
                 program: PathBuf::from("dsh"),
                 args: crate::dsh::args(&request.passthrough, Some(&patch)),
                 env_set: crate::dsh::env_set(provider_id, provider, key),
@@ -655,6 +664,7 @@ pub(crate) fn exec(plan: &LaunchPlan) -> Result<()> {
     }
     cmd.stdin(Stdio::inherit()).stdout(Stdio::inherit()).stderr(Stdio::inherit());
 
+    let _lease = plan.launch_lease.as_ref().map(fs2::FileExt::duplicate).transpose()?;
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1170,6 +1170,7 @@ fn exec_scopes_inherited_controls_and_explicit_credentials() {
     const CONTROLS: [&str; 4] = ["RX_HOST_REQUEST", "RX_NO_INSTALL", "RX_NO_UPDATE", "RX_NO_YOLO"];
     if let Ok(credential) = std::env::var("RX_TEST_EXEC_CREDENTIAL") {
         let plan = launch::LaunchPlan {
+            launch_lease: None,
             program: PathBuf::from("/usr/bin/env"),
             args: Vec::new(),
             env_set: if credential.is_empty() {

--- a/crates/rx/src/tests.rs
+++ b/crates/rx/src/tests.rs
@@ -1401,7 +1401,8 @@ agent-default-model:
     assert!(patch.contains("id: llm-deepseek"));
     assert!(patch.contains("disabled: true"));
     let overlay = paths.dir.join("dsh").join("settings.yaml");
-    assert!(patch.contains(&overlay.display().to_string()));
+    let patch: serde_yaml::Value = serde_yaml::from_str(&patch).unwrap();
+    assert_eq!(patch[0]["config"]["path"].as_str(), overlay.to_str());
     let settings: serde_yaml::Value =
         serde_yaml::from_str(&fs::read_to_string(&overlay).unwrap()).unwrap();
     assert_eq!(settings["dsh-tui"]["lang"], "zh");


### PR DESCRIPTION
### What's changed?

Keep Kimi catalog aliases available while native sessions still use them. Identical catalog snapshots reuse a permanent shared lease, with inherited file locks on Unix and inherited file-sharing handles on Windows. Conflicting changes to active aliases fail without overwriting user edits.

Require explicit confirmation that older Kimi sessions have exited before migrating the existing catalog marker. Document retained lease files and rollback behavior.

### Why

A later launch could remove the provider or model aliases needed by an earlier native session. Snapshot leases let catalog reconciliation distinguish active identities from exited sessions without deleting lease files or accumulating one file per launch.

Validation: `make check`; native Kimi Code 0.39.1 on macOS with overlapping provider/model routes, shared-holder exit ordering, session restoration, snapshot reuse, and interactive migration. The Windows CI job exercises the official native executable after terminating its launchers, then checks reclamation after the last native holder exits.
