### PR TITLE
feat(extension): add Cloudflare R2 remote transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +133,423 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d7b388a9fc3a6db15a5ec778c38b354eff1364882c94d08e0252f7a47dcaa4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.2",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.145.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e6320417a37c8a62f78b443d0b4cf628b57cd340a09b0eb56173d47cc94e93"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "lru 0.18.4",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef45745026107ec30c4ef86bd8ae4b002e7e5f6a86e4225240bdf6b06a0b944a"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.2",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +560,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -181,6 +617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -239,6 +684,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "candle-core"
@@ -446,6 +901,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codspeed"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +1038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +1116,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
 ]
 
 [[package]]
@@ -718,6 +1213,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "cudaforge"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +1243,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "walkdir",
  "which",
@@ -925,8 +1438,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -990,6 +1515,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1220,6 +1751,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1641,7 +2178,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1702,6 +2239,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1725,6 +2267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,7 +2280,7 @@ checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "futures",
- "http",
+ "http 1.4.2",
  "indicatif",
  "libc",
  "log",
@@ -1749,6 +2297,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,12 +2328,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1776,8 +2355,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1786,6 +2365,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1798,8 +2386,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1814,10 +2402,11 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1849,8 +2438,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -2115,7 +2704,7 @@ checksum = "490a1b89ac8fa33dbd4f81b39a51c8f09c47b33f0bdae18674326793f272142c"
 dependencies = [
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2231,6 +2820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2636,6 +3244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +3304,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2884,7 +3504,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -2963,7 +3583,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlite-vec",
  "tar",
  "tempfile",
@@ -2987,7 +3607,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "ureq",
  "url",
@@ -2996,6 +3616,22 @@ dependencies = [
 [[package]]
 name = "recall-probe"
 version = "0.1.0"
+
+[[package]]
+name = "recall-r2"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
+ "clap",
+ "dirs",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "recall-reflect"
@@ -3094,8 +3730,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3189,6 +3825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3865,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3227,6 +3873,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3244,6 +3902,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3269,7 +3928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "toml",
@@ -3488,14 +4147,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3582,6 +4263,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spm_precompiled"
@@ -4048,8 +4735,8 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -4307,7 +4994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -4323,6 +5010,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-zero"
@@ -4370,6 +5063,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4891,6 +5590,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/samzong/Recall"
 publish = false
 
 [workspace]
-members = [".", "crates/rx", "extensions/recall-probe", "extensions/recall-reflect", "extensions/recall-powercontext"]
+members = [".", "crates/rx", "extensions/recall-probe", "extensions/recall-reflect", "extensions/recall-powercontext", "extensions/recall-r2"]
 default-members = ["."]
 resolver = "2"
 

--- a/extensions/recall-r2/Cargo.toml
+++ b/extensions/recall-r2/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "recall-r2"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94.1"
+license = "MIT"
+description = "Cloudflare R2 transport for Recall remote synchronization"
+repository = "https://github.com/samzong/Recall"
+publish = false
+
+[dependencies]
+aws-sdk-s3 = { version = "1.145.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-config = { version = "1.12.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros", "fs", "io-util", "time"] }
+url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["net"] }

--- a/extensions/recall-r2/README.md
+++ b/extensions/recall-r2/README.md
@@ -1,0 +1,140 @@
+# recall-r2
+
+Cloudflare R2 transport for Recall's manual remote synchronization. The plugin
+stores one R2 destination and exchanges objects through the S3 API. Recall core
+owns session identity, merging, the local index, and readable source hosts.
+
+This extension requires Recall 0.6.0 or newer and is not yet installable from
+the official catalog. No cloud resources are created by configuration or the
+read probe.
+
+## Connect
+
+With the companion remote-sync core implementation, run `recall remote connect`
+and follow its prompts. Core collects the session scope and host name; the
+plugin collects:
+
+- The R2 S3 account endpoint from the Cloudflare dashboard, including the
+  bucket's jurisdiction when applicable.
+- An existing bucket and a directory within it. The interactive default is
+  `recall/`, confirmed before saving. Reserve this directory for Recall objects;
+  nonconforming keys cause an integrity error instead of being silently hidden.
+- The name of an existing local credential profile, normally `recall-r2`.
+
+Daily synchronization uses `recall remote sync`. The existing `recall sync`
+continues to scan local sessions. A disconnected installation retains its
+provider configuration and indexed sessions.
+
+Use the R2 S3 endpoint, such as
+`https://<account-id>.r2.cloudflarestorage.com`, not a public bucket URL or a
+cached custom domain. The plugin validates the endpoint before loading
+credentials. Configuration lives in `recall/r2.json` under the platform's
+configuration directory, alongside Recall's configuration. It contains only
+the endpoint, bucket, prefix, and credential profile name.
+
+## Credentials
+
+Use existing R2 S3 credentials scoped to the intended bucket. Object Read &
+Write permissions are sufficient for the intended object operations; the
+plugin does not need bucket-creation permission. See Cloudflare's
+[authentication instructions](https://developers.cloudflare.com/r2/api/tokens/).
+Creating credentials, enabling paid services, or creating a bucket are separate
+user actions.
+
+Store the credentials locally in an AWS shared credentials file using a local
+editor, preserving any existing profiles:
+
+```ini
+[recall-r2]
+aws_access_key_id = YOUR_R2_ACCESS_KEY_ID
+aws_secret_access_key = YOUR_R2_SECRET_ACCESS_KEY
+```
+
+The default file is `~/.aws/credentials`; `AWS_SHARED_CREDENTIALS_FILE` can point
+to a dedicated file. Temporary credentials can include `aws_session_token`.
+Restrict the file to the local user. Do not put keys into command arguments,
+Recall configuration, or session data. An AWS account and AWS CLI installation
+are not required.
+
+The plugin explicitly loads the selected profile. Unrelated access-key
+environment variables do not override it. SSO and external credential-process
+features are not enabled. A failed credential lookup reports `authentication`
+without printing the underlying secret or service payload.
+
+Saving configuration does not prove access. The probe performs a scoped
+`ListObjectsV2` request with at most one result and proves only that this list
+operation succeeded. Get/put permissions require a separate authorized object
+round trip.
+
+## Build and verify
+
+From the repository root:
+
+```sh
+cargo build -p recall-r2 --locked
+cargo test -p recall-r2 --locked
+cargo clippy -p recall-r2 --all-targets --locked -- -D warnings
+```
+
+The pinned AWS dependencies require Rust 1.94.1 or newer. SDK dependencies stay
+in this package. The default HTTPS client and Tokio runtime are enabled;
+SigV4a, SSO, and the legacy HTTP/TLS client are not needed.
+
+Tests use synthetic data and a local HTTP server with the real AWS SDK. They
+cover pagination, permission and missing-object distinctions, complete bounded
+downloads, immutable writes, lost responses, and identical concurrent writes.
+They do not establish compatibility with a live R2 account or two-machine
+acceptance.
+
+Before publication, use an isolated configuration/data directory to test the
+managed executable layout with exact core and plugin binary checksums. The
+public `recall ext install r2` path becomes usable only after compatible release
+assets and the generated official catalog entry exist. Do not add a PATH
+discovery workaround or modify the generated catalog for local testing.
+
+## Internal interfaces
+
+`--recall-remote-configure` inherits the terminal for the interactive wizard.
+Scripts must provide all four flags: `--endpoint`, `--bucket`, `--prefix`, and
+`--credential-profile`. Missing flags in a non-interactive process fail
+immediately. Exit status zero means configuration was saved; internal help
+exits nonzero. Explicit script input may replace the single stored destination;
+interactive replacement requires confirmation. The configuration process does
+not access the service or save keys.
+
+`--recall-remote-transport` reads one JSON object from stdin and writes one JSON
+object to stdout. It implements transport version 1 with `probe`, `list`, `get`,
+and `put`. See the companion core's `docs/remote-sync.md` for the complete
+contract. Requests and responses are bounded to 2 MiB; object data uses
+core-owned absolute temporary paths and an independent byte limit.
+
+Keys are relative to the configured directory. Each path segment uses lowercase
+ASCII letters, digits, `_`, `-`, and `.`. Empty, `.` and `..` segments are
+rejected; list prefixes are empty or end in `/`. The complete R2 key, including
+the configured directory, must fit within 1024 bytes.
+
+Immutable writes use `If-None-Match: *`. A precondition failure triggers a read
+and comparison of actual bytes, length, and SHA-256 before reporting success.
+ETags are not content digests. SDK retries are bounded to three attempts; the
+caller-provided deadline also covers body streaming and conflict verification.
+A timeout does not prove that a remote write failed to commit. Repeating the
+same key with the same bytes is safe; different existing content is a conflict.
+
+Downloads publish the output file only after receiving the full bounded body.
+Core verifies its expected digest before import. Permission errors, ambiguous
+HTTP errors, and missing buckets never mean an empty library.
+
+## Release and acceptance
+
+The package participates in the existing independent extension release workflow.
+Adding its initial version can trigger publication when merged. Merge requires
+joint acceptance, explicit release authorization, and an available compatible
+core 0.6.0 release. The manifest declares CLI protocol 2 and minimum core 0.6.0;
+the object transport independently uses version 1.
+
+Release acceptance includes the normal manifest, four target archives,
+checksums, and generated catalog installation. Live service acceptance also
+requires an explicitly authorized R2 test space and synthetic objects: initial
+write/read, duplicate writes, concurrent writes, interruption/retry, denied
+access, and object restoration. Remote deletion, private-session uploads, and
+cloud resource creation are not part of local verification.

--- a/extensions/recall-r2/src/config.rs
+++ b/extensions/recall-r2/src/config.rs
@@ -1,0 +1,283 @@
+use std::fs;
+use std::io::{self, IsTerminal, Read, Write};
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::protocol::{Failure, MESSAGE_LIMIT, Result, validate_key};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Target {
+    pub endpoint: String,
+    pub bucket: String,
+    pub prefix: String,
+    pub credential_profile: String,
+}
+
+#[derive(Parser)]
+#[command(name = "recall-r2 --recall-remote-configure")]
+pub(crate) struct Configure {
+    #[arg(long)]
+    endpoint: Option<String>,
+    #[arg(long)]
+    bucket: Option<String>,
+    #[arg(long)]
+    prefix: Option<String>,
+    #[arg(long)]
+    credential_profile: Option<String>,
+}
+
+pub(crate) fn path() -> Result<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("recall").join("r2.json")).ok_or_else(Failure::io)
+}
+
+impl Target {
+    pub fn load(path: &Path) -> Result<Self> {
+        if fs::metadata(path).is_ok_and(|metadata| !metadata.is_file()) {
+            return Err(Failure::invalid("R2 configuration must be a regular file"));
+        }
+        let file = fs::File::open(path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                Failure::new("not_configured", "R2 is not configured; run recall remote connect")
+            } else {
+                Failure::io()
+            }
+        })?;
+        let mut bytes = Vec::new();
+        file.take(MESSAGE_LIMIT + 1).read_to_end(&mut bytes).map_err(|_| Failure::io())?;
+        if bytes.len() as u64 > MESSAGE_LIMIT {
+            return Err(Failure::invalid("R2 configuration is too large"));
+        }
+        let target: Self = serde_json::from_slice(&bytes).map_err(|_| {
+            Failure::invalid("R2 configuration is invalid; run recall remote connect")
+        })?;
+        target.validate()?;
+        Ok(target)
+    }
+
+    fn validate(&self) -> Result<()> {
+        let endpoint = Url::parse(&self.endpoint).map_err(|_| {
+            Failure::invalid("use the R2 S3 endpoint from the Cloudflare dashboard")
+        })?;
+        let labels: Vec<_> = endpoint.host_str().unwrap_or_default().split('.').collect();
+        let account = labels.first().copied().unwrap_or_default();
+        let suffix = &labels[1.min(labels.len())..];
+        let r2_host = suffix == ["r2", "cloudflarestorage", "com"]
+            || matches!(suffix, ["eu" | "us" | "fedramp", "r2", "cloudflarestorage", "com"]);
+        if endpoint.scheme() != "https"
+            || !endpoint.username().is_empty()
+            || endpoint.password().is_some()
+            || endpoint.port().is_some()
+            || endpoint.path() != "/"
+            || endpoint.query().is_some()
+            || endpoint.fragment().is_some()
+            || !r2_host
+            || account.len() != 32
+            || !account.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(Failure::invalid(
+                "use an HTTPS R2 S3 account endpoint without a path or credentials",
+            ));
+        }
+        if !(3..=63).contains(&self.bucket.len())
+            || !self
+                .bucket
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+            || self.bucket.starts_with('-')
+            || self.bucket.ends_with('-')
+        {
+            return Err(Failure::invalid("invalid R2 bucket name"));
+        }
+        validate_key(&self.prefix, true)?;
+        if self.prefix.len() >= 1024 {
+            return Err(Failure::invalid("R2 directory leaves no space for an object key"));
+        }
+        if self.credential_profile.is_empty()
+            || self.credential_profile.chars().any(char::is_control)
+        {
+            return Err(Failure::invalid(
+                "credential profile must be a nonempty local profile name",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn full_key(&self, relative: &str, prefix: bool) -> Result<String> {
+        validate_key(relative, prefix)?;
+        let key = format!("{}{relative}", self.prefix);
+        if key.len() > 1024 {
+            return Err(Failure::invalid("R2 object key exceeds 1024 bytes"));
+        }
+        Ok(key)
+    }
+
+    fn save(&self, path: &Path) -> Result<()> {
+        self.validate()?;
+        let parent = path.parent().ok_or_else(Failure::io)?;
+        fs::create_dir_all(parent).map_err(|_| Failure::io())?;
+        let mut file = tempfile::NamedTempFile::new_in(parent).map_err(|_| Failure::io())?;
+        serde_json::to_writer_pretty(&mut file, self).map_err(|_| Failure::io())?;
+        file.flush().map_err(|_| Failure::io())?;
+        file.as_file().sync_all().map_err(|_| Failure::io())?;
+        file.persist(path).map_err(|_| Failure::io())?;
+        #[cfg(unix)]
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| Failure::io())?;
+        Ok(())
+    }
+}
+
+impl Configure {
+    pub fn run(self) -> Result<()> {
+        let path = path()?;
+        let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+        let complete = self.endpoint.is_some()
+            && self.bucket.is_some()
+            && self.prefix.is_some()
+            && self.credential_profile.is_some();
+        if !interactive && !complete {
+            return Err(Failure::invalid(
+                "non-interactive configuration requires --endpoint, --bucket, --prefix and --credential-profile",
+            ));
+        }
+        let existing = match Target::load(&path) {
+            Ok(target) => Some(target),
+            Err(error) if error.code == "not_configured" => None,
+            Err(error) => {
+                eprintln!("{}; replacing the configuration requires complete input", error.message);
+                None
+            }
+        };
+        let endpoint = field(
+            self.endpoint,
+            "R2 S3 endpoint",
+            existing.as_ref().map(|c| c.endpoint.as_str()),
+            interactive,
+        )?;
+        let bucket = field(
+            self.bucket,
+            "Bucket",
+            existing.as_ref().map(|c| c.bucket.as_str()),
+            interactive,
+        )?;
+        let prefix = field(
+            self.prefix,
+            "Directory",
+            Some(existing.as_ref().map_or("recall/", |c| c.prefix.as_str())),
+            interactive,
+        )?;
+        let credential_profile = field(
+            self.credential_profile,
+            "Local credential profile",
+            Some(existing.as_ref().map_or("recall-r2", |c| c.credential_profile.as_str())),
+            interactive,
+        )?;
+        let prefix =
+            if prefix.is_empty() || prefix.ends_with('/') { prefix } else { format!("{prefix}/") };
+        let target = Target { endpoint, bucket, prefix, credential_profile };
+        target.validate()?;
+        if interactive {
+            eprintln!(
+                "\nR2 endpoint: {}\nBucket: {}\nDirectory: {}\nCredential profile: {}",
+                target.endpoint, target.bucket, target.prefix, target.credential_profile
+            );
+            eprint!("Save this R2 destination? [y/N] ");
+            io::stderr().flush().map_err(|_| Failure::io())?;
+            let mut answer = String::new();
+            io::stdin().read_line(&mut answer).map_err(|_| Failure::io())?;
+            if !answer.trim().eq_ignore_ascii_case("y")
+                && !answer.trim().eq_ignore_ascii_case("yes")
+            {
+                return Err(Failure::invalid("R2 configuration cancelled"));
+            }
+        }
+        target.save(&path)?;
+        eprintln!("R2 destination saved. Access has not yet been verified.");
+        Ok(())
+    }
+}
+
+fn field(
+    value: Option<String>,
+    label: &str,
+    default: Option<&str>,
+    interactive: bool,
+) -> Result<String> {
+    if let Some(value) = value {
+        return Ok(value);
+    }
+    if !interactive {
+        return Err(Failure::invalid("missing R2 configuration parameter"));
+    }
+    if let Some(default) = default {
+        eprint!("{label} [{default}]: ");
+    } else {
+        eprint!("{label}: ");
+    }
+    io::stderr().flush().map_err(|_| Failure::io())?;
+    let mut value = String::new();
+    if io::stdin().read_line(&mut value).map_err(|_| Failure::io())? == 0 {
+        return Err(Failure::invalid("R2 configuration cancelled"));
+    }
+    let value = value.trim();
+    Ok(if value.is_empty() { default.unwrap_or_default().to_owned() } else { value.to_owned() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> Target {
+        Target {
+            endpoint: "https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com".into(),
+            bucket: "recall-test".into(),
+            prefix: "foo/".into(),
+            credential_profile: "recall-r2".into(),
+        }
+    }
+
+    #[test]
+    fn credentials_can_only_be_sent_to_an_r2_account_endpoint() {
+        let mut target = target();
+        for endpoint in [
+            "https://example.com",
+            "https://r2.cloudflarestorage.com.evil.example",
+            "http://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com",
+            "https://secret@0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com",
+            "https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com/bucket",
+        ] {
+            target.endpoint = endpoint.into();
+            assert!(target.validate().is_err());
+        }
+        for jurisdiction in ["", "eu.", "us.", "fedramp."] {
+            target.endpoint = format!(
+                "https://0123456789abcdef0123456789abcdef.{jurisdiction}r2.cloudflarestorage.com"
+            );
+            assert!(target.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn target_roundtrips_and_invalid_replacement_preserves_previous_configuration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("r2.json");
+        let mut target = target();
+        target.save(&path).unwrap();
+        assert_eq!(Target::load(&path).unwrap().bucket, "recall-test");
+        target.endpoint = "https://example.com".into();
+        assert!(target.save(&path).is_err());
+        assert_eq!(Target::load(&path).unwrap().bucket, "recall-test");
+    }
+
+    #[test]
+    fn complete_key_limit_includes_target_prefix() {
+        let target = target();
+        assert_eq!(target.full_key("a/b", false).unwrap(), "foo/a/b");
+        assert!(target.full_key(&"a".repeat(1021), false).is_err());
+        assert_eq!(target.full_key("", true).unwrap(), "foo/");
+    }
+}

--- a/extensions/recall-r2/src/main.rs
+++ b/extensions/recall-r2/src/main.rs
@@ -1,0 +1,97 @@
+mod config;
+mod protocol;
+mod transport;
+
+use std::io::{Read, Write};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use clap::Parser;
+use protocol::{Failure, MESSAGE_LIMIT, Request, Result};
+use serde_json::Value;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args_os();
+    let program = args.next().unwrap_or_default();
+    let mode = args.next();
+    match mode.as_deref().and_then(|mode| mode.to_str()) {
+        Some("--recall-remote-configure") => {
+            match config::Configure::try_parse_from(std::iter::once(program).chain(args)) {
+                Ok(configure) => match configure.run() {
+                    Ok(()) => ExitCode::SUCCESS,
+                    Err(error) => {
+                        eprintln!("{}", error.message);
+                        ExitCode::FAILURE
+                    }
+                },
+                Err(error) => {
+                    let _ = error.print();
+                    ExitCode::from(2)
+                }
+            }
+        }
+        Some("--recall-remote-transport") if args.next().is_none() => {
+            let result = run_transport();
+            let (bytes, success) = protocol::response(result);
+            let mut stdout = std::io::stdout().lock();
+            if stdout.write_all(&bytes).and_then(|()| stdout.flush()).is_err() {
+                return ExitCode::FAILURE;
+            }
+            if success { ExitCode::SUCCESS } else { ExitCode::FAILURE }
+        }
+        Some("--recall-extension-manifest") => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "name": "r2",
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "protocol": 2,
+                    "min_recall": "0.6.0"
+                })
+            );
+            ExitCode::SUCCESS
+        }
+        Some("--version" | "-V") => {
+            println!("recall-r2 {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        None | Some("--help" | "-h") => {
+            println!(
+                "Cloudflare R2 transport for Recall\n\nConnect interactively with: recall remote connect\nSynchronize with: recall remote sync\n\nProvider configuration: --endpoint --bucket --prefix --credential-profile\nCredentials come from an existing local AWS credential profile."
+            );
+            ExitCode::SUCCESS
+        }
+        _ => {
+            eprintln!("Unsupported recall-r2 invocation; use recall remote connect.");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_transport() -> Result<Value> {
+    let mut bytes = Vec::new();
+    std::io::stdin().take(MESSAGE_LIMIT + 1).read_to_end(&mut bytes).map_err(|_| Failure::io())?;
+    let request = Request::parse(&bytes)?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| Failure::io())?;
+    let result = runtime.block_on(async {
+        let operation = tokio::task::spawn_blocking(move || {
+            let target = config::Target::load(&config::path()?)?;
+            tokio::runtime::Handle::current()
+                .block_on(transport::execute(&target, request.operation))
+        });
+        tokio::time::timeout(Duration::from_millis(request.timeout_ms), operation)
+            .await
+            .map_err(|_| {
+                Failure::new(
+                    "transient",
+                    "operation deadline expired; remote write outcome may be unknown",
+                )
+            })?
+            .map_err(|_| Failure::io())?
+    });
+    std::mem::forget(runtime);
+    result
+}

--- a/extensions/recall-r2/src/protocol.rs
+++ b/extensions/recall-r2/src/protocol.rs
@@ -1,0 +1,173 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub(crate) const MESSAGE_LIMIT: u64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Request {
+    pub timeout_ms: u64,
+    #[serde(flatten)]
+    pub operation: Operation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub(crate) enum Operation {
+    Probe,
+    List { prefix: String, cursor: Option<String>, page_size: u16 },
+    Get { key: String, output_path: PathBuf, max_bytes: u64 },
+    Put { key: String, input_path: PathBuf, size: u64, sha256: String },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Failure {
+    pub code: &'static str,
+    pub message: &'static str,
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Failure>;
+
+impl Failure {
+    pub fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+
+    pub fn invalid(message: &'static str) -> Self {
+        Self::new("invalid_request", message)
+    }
+
+    pub fn integrity(message: &'static str) -> Self {
+        Self::new("integrity", message)
+    }
+
+    pub fn io() -> Self {
+        Self::new("unavailable", "local file operation failed")
+    }
+}
+
+impl Request {
+    pub fn parse(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() as u64 > MESSAGE_LIMIT {
+            return Err(Failure::invalid("request exceeds the control message limit"));
+        }
+        let envelope: Value = serde_json::from_slice(bytes)
+            .map_err(|_| Failure::invalid("expected one complete JSON request"))?;
+        let version = envelope
+            .get("transport_version")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| Failure::invalid("transport_version must be an integer"))?;
+        if version != 1 {
+            return Err(Failure::new("unsupported_protocol", "transport version is not supported"));
+        }
+        let request: Self = serde_json::from_value(envelope)
+            .map_err(|_| Failure::invalid("invalid operation or request fields"))?;
+        if request.timeout_ms == 0 {
+            return Err(Failure::invalid("timeout_ms must be positive"));
+        }
+        match &request.operation {
+            Operation::Probe => {}
+            Operation::List { prefix, page_size, .. } => {
+                validate_key(prefix, true)?;
+                if !(1..=1000).contains(page_size) {
+                    return Err(Failure::invalid("page_size must be between 1 and 1000"));
+                }
+            }
+            Operation::Get { key, output_path, .. } => {
+                validate_key(key, false)?;
+                if !output_path.is_absolute() {
+                    return Err(Failure::invalid("transfer paths must be absolute"));
+                }
+            }
+            Operation::Put { key, input_path, size, sha256 } => {
+                validate_key(key, false)?;
+                if !input_path.is_absolute() || *size > i64::MAX as u64 {
+                    return Err(Failure::invalid("invalid upload path or size"));
+                }
+                if sha256.len() != 64
+                    || !sha256.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+                {
+                    return Err(Failure::invalid(
+                        "sha256 must be 64 lowercase hexadecimal characters",
+                    ));
+                }
+            }
+        }
+        Ok(request)
+    }
+}
+
+pub(crate) fn response(result: Result<Value>) -> (Vec<u8>, bool) {
+    let success = result.is_ok();
+    let value = match result {
+        Ok(result) => json!({"transport_version": 1, "result": result}),
+        Err(error) => json!({"transport_version": 1, "error": error}),
+    };
+    let bytes = serde_json::to_vec(&value).expect("JSON values serialize");
+    if bytes.len() as u64 > MESSAGE_LIMIT {
+        return response(Err(Failure::integrity("response exceeds the control message limit")));
+    }
+    (bytes, success)
+}
+
+pub(crate) fn validate_key(key: &str, prefix: bool) -> Result<()> {
+    if prefix && key.is_empty() {
+        return Ok(());
+    }
+    let key = if prefix {
+        key.strip_suffix('/').ok_or_else(|| Failure::invalid("list prefix must end with /"))?
+    } else {
+        key
+    };
+    if key.is_empty()
+        || !key
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b"/_-.".contains(&b))
+        || key.split('/').any(|segment| matches!(segment, "" | "." | ".."))
+    {
+        return Err(Failure::invalid("invalid relative object key"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framing_rejects_unsupported_and_trailing_messages() {
+        let unknown =
+            Request::parse(br#"{"transport_version":2,"timeout_ms":1,"operation":"future"}"#)
+                .unwrap_err();
+        assert_eq!(unknown.code, "unsupported_protocol");
+        let extra = br#"{"transport_version":1,"timeout_ms":1,"operation":"probe"} {}"#;
+        assert!(Request::parse(extra).is_err());
+        assert!(Request::parse(&vec![b' '; MESSAGE_LIMIT as usize + 1]).is_err());
+        let request =
+            Request::parse(br#"{"transport_version":1,"timeout_ms":1,"operation":"probe"}"#)
+                .unwrap();
+        assert!(matches!(request.operation, Operation::Probe));
+    }
+
+    #[test]
+    fn oversized_response_fails_without_truncating_a_page() {
+        let (bytes, success) =
+            response(Ok(json!({"objects": ["x".repeat(MESSAGE_LIMIT as usize)]})));
+        assert!(!success);
+        let envelope: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(envelope["error"]["code"], "integrity");
+        assert!(envelope.get("result").is_none());
+    }
+
+    #[test]
+    fn keys_cannot_escape_or_alias_the_target_root() {
+        for key in ["", "/a", "a/", "a//b", "a/../b", "a/./b", "a\\b", "a%2fb", "A", "中"] {
+            assert!(validate_key(key, false).is_err(), "{key}");
+        }
+        assert!(validate_key("revisions/0123.json", false).is_ok());
+        assert!(validate_key("", true).is_ok());
+        assert!(validate_key("revisions/", true).is_ok());
+        assert!(validate_key("revisions", true).is_err());
+    }
+}

--- a/extensions/recall-r2/src/transport.rs
+++ b/extensions/recall-r2/src/transport.rs
@@ -1,0 +1,626 @@
+use std::path::Path;
+
+use aws_config::profile::ProfileFileCredentialsProvider;
+use aws_sdk_s3::Client;
+use aws_sdk_s3::config::retry::RetryConfig;
+use aws_sdk_s3::config::{BehaviorVersion, ProvideCredentials, Region, RequestChecksumCalculation};
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_s3::primitives::ByteStream;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::config::Target;
+use crate::protocol::{Failure, Operation, Result, validate_key};
+
+pub(crate) async fn execute(target: &Target, operation: Operation) -> Result<Value> {
+    let credentials = ProfileFileCredentialsProvider::builder()
+        .profile_name(&target.credential_profile).build().provide_credentials().await
+        .map_err(|_| Failure::new("authentication", "cannot load the local R2 credential profile; configure its access key in the AWS credentials file"))?;
+    let config = aws_sdk_s3::Config::builder()
+        .behavior_version(BehaviorVersion::latest())
+        .region(Region::new("auto"))
+        .endpoint_url(&target.endpoint)
+        .force_path_style(true)
+        .credentials_provider(credentials)
+        .retry_config(RetryConfig::standard().with_max_attempts(3))
+        .request_checksum_calculation(RequestChecksumCalculation::WhenRequired)
+        .build();
+    run(&Client::from_conf(config), target, operation).await
+}
+
+async fn run(client: &Client, target: &Target, operation: Operation) -> Result<Value> {
+    match operation {
+        Operation::Probe => {
+            client
+                .list_objects_v2()
+                .bucket(&target.bucket)
+                .prefix(&target.prefix)
+                .max_keys(1)
+                .send()
+                .await
+                .map_err(sdk_failure)?;
+            Ok(json!({"readable": true}))
+        }
+        Operation::List { prefix, cursor, page_size } => {
+            if !(1..=1000).contains(&page_size) {
+                return Err(Failure::invalid("page_size must be between 1 and 1000"));
+            }
+            let full_prefix = target.full_key(&prefix, true)?;
+            let page = client
+                .list_objects_v2()
+                .bucket(&target.bucket)
+                .prefix(&full_prefix)
+                .set_continuation_token(cursor)
+                .max_keys(i32::from(page_size))
+                .send()
+                .await
+                .map_err(sdk_failure)?;
+            if page.contents().len() > usize::from(page_size) {
+                return Err(Failure::integrity("R2 returned more objects than requested"));
+            }
+            let mut objects = Vec::with_capacity(page.contents().len());
+            for object in page.contents() {
+                let full_key =
+                    object.key().ok_or_else(|| Failure::integrity("R2 object key is missing"))?;
+                if !full_key.starts_with(&full_prefix) || full_key.len() > 1024 {
+                    return Err(Failure::integrity(
+                        "R2 returned a key outside the requested directory",
+                    ));
+                }
+                let key = full_key.strip_prefix(&target.prefix).ok_or_else(|| {
+                    Failure::integrity("R2 returned a key outside the target directory")
+                })?;
+                validate_key(key, false)
+                    .map_err(|_| Failure::integrity("R2 returned an invalid relative key"))?;
+                let size = length(object.size())?;
+                objects.push(json!({"key": key, "size": size}));
+            }
+            let next_cursor = page.next_continuation_token();
+            let truncated = page.is_truncated().ok_or_else(|| {
+                Failure::integrity("R2 did not identify whether the page is complete")
+            })?;
+            if truncated != next_cursor.is_some() || next_cursor.is_some_and(str::is_empty) {
+                return Err(Failure::integrity("R2 returned inconsistent pagination metadata"));
+            }
+            Ok(json!({"objects": objects, "next_cursor": next_cursor}))
+        }
+        Operation::Get { key, output_path, max_bytes } => {
+            absolute_path(&output_path)?;
+            let key = target.full_key(&key, false)?;
+            let object = client
+                .get_object()
+                .bucket(&target.bucket)
+                .key(key)
+                .send()
+                .await
+                .map_err(sdk_failure)?;
+            let expected = length(object.content_length())?;
+            if expected > max_bytes {
+                return Err(Failure::integrity("R2 object exceeds the requested download limit"));
+            }
+            let parent = output_path.parent().ok_or_else(Failure::io)?;
+            let temporary = tempfile::NamedTempFile::new_in(parent).map_err(|_| Failure::io())?;
+            let mut file = File::from_std(temporary.reopen().map_err(|_| Failure::io())?);
+            let (size, _) = read_body(object.body, expected, max_bytes, Some(&mut file)).await?;
+            file.flush().await.map_err(|_| Failure::io())?;
+            file.sync_all().await.map_err(|_| Failure::io())?;
+            drop(file);
+            temporary.persist(&output_path).map_err(|_| Failure::io())?;
+            Ok(json!({"size": size}))
+        }
+        Operation::Put { key, input_path, size, sha256 } => {
+            absolute_path(&input_path)?;
+            let key = target.full_key(&key, false)?;
+            if sha256.len() != 64
+                || !sha256.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+            {
+                return Err(Failure::invalid("sha256 must be 64 lowercase hexadecimal characters"));
+            }
+            let content_length =
+                i64::try_from(size).map_err(|_| Failure::invalid("upload size is too large"))?;
+            if !tokio::fs::metadata(&input_path).await.map_err(|_| Failure::io())?.is_file() {
+                return Err(Failure::invalid("upload input must be a regular file"));
+            }
+            let mut input = File::open(&input_path).await.map_err(|_| Failure::io())?;
+            let mut digest = Sha256::new();
+            let mut count = 0_u64;
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = input.read(&mut buffer).await.map_err(|_| Failure::io())?;
+                if read == 0 {
+                    break;
+                }
+                count = count
+                    .checked_add(read as u64)
+                    .ok_or_else(|| Failure::integrity("upload size overflow"))?;
+                if count > size {
+                    return Err(Failure::integrity("upload length does not match request"));
+                }
+                digest.update(&buffer[..read]);
+            }
+            if count != size || format!("{:x}", digest.finalize()) != sha256 {
+                return Err(Failure::integrity("upload length or SHA-256 does not match request"));
+            }
+            drop(input);
+            let body = ByteStream::from_path(&input_path).await.map_err(|_| Failure::io())?;
+            let uploaded = client
+                .put_object()
+                .bucket(&target.bucket)
+                .key(&key)
+                .if_none_match("*")
+                .content_length(content_length)
+                .body(body)
+                .send()
+                .await;
+            if let Err(error) = uploaded {
+                if error.raw_response().is_some_and(|response| response.status().as_u16() == 412) {
+                    let existing = client
+                        .get_object()
+                        .bucket(&target.bucket)
+                        .key(&key)
+                        .send()
+                        .await
+                        .map_err(sdk_failure)?;
+                    let expected = length(existing.content_length())?;
+                    if expected != size {
+                        return Err(Failure::new(
+                            "conflict",
+                            "immutable key contains different bytes",
+                        ));
+                    }
+                    let (_, digest) = read_body(existing.body, expected, size, None).await?;
+                    if digest != sha256 {
+                        return Err(Failure::new(
+                            "conflict",
+                            "immutable key contains different bytes",
+                        ));
+                    }
+                } else {
+                    return Err(sdk_failure(error));
+                }
+            }
+            Ok(json!({"size": size, "sha256": sha256}))
+        }
+    }
+}
+
+fn absolute_path(path: &Path) -> Result<()> {
+    if !path.is_absolute() {
+        return Err(Failure::invalid("transfer paths must be absolute"));
+    }
+    Ok(())
+}
+
+fn length(value: Option<i64>) -> Result<u64> {
+    value
+        .and_then(|value| u64::try_from(value).ok())
+        .ok_or_else(|| Failure::integrity("R2 returned a missing or invalid object length"))
+}
+
+async fn read_body(
+    mut body: ByteStream,
+    expected: u64,
+    maximum: u64,
+    mut file: Option<&mut File>,
+) -> Result<(u64, String)> {
+    let mut size = 0_u64;
+    let mut digest = Sha256::new();
+    while let Some(bytes) = body.next().await {
+        let bytes = bytes.map_err(|_| Failure::new("transient", "R2 download stream failed"))?;
+        size = size
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| Failure::integrity("download size overflow"))?;
+        if size > maximum || size > expected {
+            return Err(Failure::integrity("R2 download exceeds its length or limit"));
+        }
+        digest.update(&bytes);
+        if let Some(file) = file.as_mut() {
+            file.write_all(&bytes).await.map_err(|_| Failure::io())?;
+        }
+    }
+    if size != expected {
+        return Err(Failure::integrity("R2 download is incomplete"));
+    }
+    Ok((size, format!("{:x}", digest.finalize())))
+}
+
+fn sdk_failure<E: ProvideErrorMetadata>(error: SdkError<E>) -> Failure {
+    let code = error.as_service_error().and_then(ProvideErrorMetadata::code);
+    match code {
+        Some("NoSuchBucket") => Failure::new("target_missing", "R2 bucket does not exist"),
+        Some("NoSuchKey") => Failure::new("object_missing", "R2 object does not exist"),
+        Some(
+            "Unauthorized"
+            | "InvalidAccessKeyId"
+            | "SignatureDoesNotMatch"
+            | "ExpiredToken"
+            | "ExpiredRequest"
+            | "InvalidToken",
+        ) => Failure::new("authentication", "R2 credentials or request signature were rejected"),
+        Some("AccessDenied" | "NotEntitled") => {
+            Failure::new("permission", "R2 denied the requested operation")
+        }
+        Some("PreconditionFailed" | "ConditionalRequestConflict") => {
+            Failure::new("transient", "R2 conditional request conflicted; retry synchronization")
+        }
+        Some("EntityTooLarge" | "InvalidArgument" | "InvalidBucketName" | "InvalidObjectName") => {
+            Failure::invalid("R2 rejected the request parameters")
+        }
+        Some("BadDigest" | "InvalidDigest") => Failure::integrity("R2 rejected the content digest"),
+        _ => {
+            let status = error.raw_response().map(|response| response.status().as_u16());
+            if matches!(error, SdkError::TimeoutError(_) | SdkError::DispatchFailure(_))
+                || matches!(status, Some(408 | 429 | 500..=599))
+            {
+                Failure::new(
+                    "transient",
+                    "R2 request failed or timed out; remote write outcome may be unknown",
+                )
+            } else {
+                Failure::new("unavailable", "R2 request failed without a conclusive service error")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    fn target() -> Target {
+        Target {
+            endpoint: String::new(),
+            bucket: "recall-test".into(),
+            prefix: "foo/".into(),
+            credential_profile: String::new(),
+        }
+    }
+
+    fn reply(status: u16, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status} Response\r\nContent-Length: {}\r\nContent-Type: application/xml\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    async fn server(replies: Vec<String>) -> (Client, JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                let mut requests = Vec::new();
+                for reply in replies {
+                    let (mut stream, _) = listener.accept().await.unwrap();
+                    let mut bytes = Vec::new();
+                    let mut buffer = [0_u8; 4096];
+                    loop {
+                        let count = stream.read(&mut buffer).await.unwrap();
+                        assert!(count > 0);
+                        bytes.extend_from_slice(&buffer[..count]);
+                        if let Some(end) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+                        {
+                            let headers =
+                                String::from_utf8_lossy(&bytes[..end]).to_ascii_lowercase();
+                            let length: usize = headers
+                                .lines()
+                                .find_map(|line| line.strip_prefix("content-length:"))
+                                .unwrap_or("0")
+                                .trim()
+                                .parse()
+                                .unwrap();
+                            if bytes.len() >= end + 4 + length {
+                                break;
+                            }
+                        }
+                    }
+                    requests.push(String::from_utf8(bytes).unwrap());
+                    stream.write_all(reply.as_bytes()).await.unwrap();
+                    stream.shutdown().await.unwrap();
+                }
+                requests
+            })
+            .await
+            .unwrap()
+        });
+        (client(&endpoint), task)
+    }
+
+    fn client(endpoint: &str) -> Client {
+        let config = aws_sdk_s3::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("auto"))
+            .endpoint_url(endpoint)
+            .force_path_style(true)
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "test-id",
+                "test-secret",
+                None,
+                None,
+                "test",
+            ))
+            .retry_config(RetryConfig::standard().with_max_attempts(1))
+            .request_checksum_calculation(RequestChecksumCalculation::WhenRequired)
+            .build();
+        Client::from_conf(config)
+    }
+
+    #[tokio::test]
+    async fn list_preserves_empty_pages_and_cursor_and_scopes_keys() {
+        let xml = "<ListBucketResult><IsTruncated>true</IsTruncated><NextContinuationToken>opaque+/=</NextContinuationToken></ListBucketResult>";
+        let last = "<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>foo/revisions/abc.json</Key><Size>3</Size></Contents></ListBucketResult>";
+        let (client, task) = server(vec![reply(200, xml), reply(200, last)]).await;
+        let page = run(
+            &client,
+            &target(),
+            Operation::List { prefix: "revisions/".into(), cursor: None, page_size: 10 },
+        )
+        .await
+        .unwrap();
+        assert_eq!(page["objects"], json!([]));
+        assert_eq!(page["next_cursor"], "opaque+/=");
+        let page = run(
+            &client,
+            &target(),
+            Operation::List {
+                prefix: "revisions/".into(),
+                cursor: Some("opaque+/=".into()),
+                page_size: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(page["objects"], json!([{"key":"revisions/abc.json","size":3}]));
+        assert!(page["next_cursor"].is_null());
+        let requests = task.await.unwrap();
+        assert!(requests[0].contains("prefix=foo%2Frevisions%2F"));
+        assert!(requests[1].contains("continuation-token=opaque%2B%2F%3D"));
+    }
+
+    #[tokio::test]
+    async fn list_cannot_report_unverified_completion_or_foreign_keys() {
+        for xml in [
+            "<ListBucketResult></ListBucketResult>",
+            "<ListBucketResult><IsTruncated>true</IsTruncated></ListBucketResult>",
+            "<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>foobar/abc</Key><Size>3</Size></Contents></ListBucketResult>",
+        ] {
+            let (client, task) = server(vec![reply(200, xml)]).await;
+            let error = run(
+                &client,
+                &target(),
+                Operation::List { prefix: String::new(), cursor: None, page_size: 10 },
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(error.code, "integrity");
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn service_errors_preserve_missing_and_denied_distinctions() {
+        for (status, code, expected) in [
+            (404, "NoSuchBucket", "target_missing"),
+            (404, "NoSuchKey", "object_missing"),
+            (403, "AccessDenied", "permission"),
+            (403, "SignatureDoesNotMatch", "authentication"),
+            (404, "", "unavailable"),
+            (429, "SlowDown", "transient"),
+            (409, "ConditionalRequestConflict", "transient"),
+        ] {
+            let body = format!(
+                "<Error><Code>{code}</Code><Message>private-service-detail</Message></Error>"
+            );
+            let (client, task) = server(vec![reply(status, &body)]).await;
+            let error = run(&client, &target(), Operation::Probe).await.unwrap_err();
+            assert_eq!(error.code, expected);
+            assert!(!error.message.contains("private-service-detail"));
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn download_only_replaces_output_after_a_complete_bounded_transfer() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("record");
+        std::fs::write(&output, "previous").unwrap();
+        for response in [
+            reply(200, "too-large"),
+            "HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nx".into(),
+        ] {
+            let (client, task) = server(vec![response]).await;
+            assert!(
+                run(
+                    &client,
+                    &target(),
+                    Operation::Get {
+                        key: "record".into(),
+                        output_path: output.clone(),
+                        max_bytes: 3
+                    }
+                )
+                .await
+                .is_err()
+            );
+            assert_eq!(std::fs::read(&output).unwrap(), b"previous");
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+            task.await.unwrap();
+        }
+        let (client, task) = server(vec![reply(200, "new")]).await;
+        assert_eq!(
+            run(
+                &client,
+                &target(),
+                Operation::Get { key: "record".into(), output_path: output.clone(), max_bytes: 3 }
+            )
+            .await
+            .unwrap(),
+            json!({"size":3})
+        );
+        assert_eq!(std::fs::read(&output).unwrap(), b"new");
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn immutable_put_verifies_actual_existing_bytes_after_precondition_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("record");
+        std::fs::write(&input, "content").unwrap();
+        let sha256 = format!("{:x}", Sha256::digest(b"content"));
+        let precondition = reply(412, "<Error><Code>PreconditionFailed</Code></Error>");
+        for (existing, expected) in [("content", None), ("changed", Some("conflict"))] {
+            let (client, task) = server(vec![precondition.clone(), reply(200, existing)]).await;
+            let result = run(
+                &client,
+                &target(),
+                Operation::Put {
+                    key: format!("revisions/{sha256}"),
+                    input_path: input.clone(),
+                    size: 7,
+                    sha256: sha256.clone(),
+                },
+            )
+            .await;
+            if let Some(expected) = expected {
+                assert_eq!(result.unwrap_err().code, expected);
+            } else {
+                assert_eq!(result.unwrap()["sha256"], sha256);
+            }
+            let requests = task.await.unwrap();
+            assert!(requests[0].to_ascii_lowercase().contains("if-none-match: *\r\n"));
+            assert!(requests[0].ends_with("content"));
+            assert!(requests[1].starts_with("GET "));
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_upload_bytes_never_reach_the_service() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("record");
+        std::fs::write(&input, "content").unwrap();
+        let (client, task) = server(vec![]).await;
+        let error = run(
+            &client,
+            &target(),
+            Operation::Put {
+                key: "record".into(),
+                input_path: input,
+                size: 7,
+                sha256: "0".repeat(64),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code, "integrity");
+        assert!(task.await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lost_put_response_retries_identical_bytes_and_verifies_existing_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("record");
+        std::fs::write(&input, "content").unwrap();
+        let sha256 = format!("{:x}", Sha256::digest(b"content"));
+        let (client, task) = server(vec![
+            String::new(),
+            reply(412, "<Error><Code>PreconditionFailed</Code></Error>"),
+            reply(200, "content"),
+        ])
+        .await;
+        let client = Client::from_conf(
+            client
+                .config()
+                .to_builder()
+                .retry_config(RetryConfig::standard().with_max_attempts(3))
+                .build(),
+        );
+        let result = run(
+            &client,
+            &target(),
+            Operation::Put {
+                key: "record".into(),
+                input_path: input,
+                size: 7,
+                sha256: sha256.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result["sha256"], sha256);
+        let requests = task.await.unwrap();
+        assert_eq!(requests.len(), 3);
+        for request in &requests[..2] {
+            assert!(request.starts_with("PUT "));
+            assert!(request.ends_with("content"));
+            assert!(request.to_ascii_lowercase().contains("if-none-match: *\r\n"));
+        }
+        assert!(requests[2].starts_with("GET "));
+    }
+
+    #[tokio::test]
+    async fn concurrent_identical_puts_converge_after_one_conditional_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("record");
+        std::fs::write(&input, "content").unwrap();
+        let sha256 = format!("{:x}", Sha256::digest(b"content"));
+        let (client, task) = server(vec![
+            reply(200, ""),
+            reply(412, "<Error><Code>PreconditionFailed</Code></Error>"),
+            reply(200, "content"),
+        ])
+        .await;
+        let first = Operation::Put {
+            key: "record".into(),
+            input_path: input.clone(),
+            size: 7,
+            sha256: sha256.clone(),
+        };
+        let second = Operation::Put {
+            key: "record".into(),
+            input_path: input,
+            size: 7,
+            sha256: sha256.clone(),
+        };
+        let target = target();
+        let (first, second) =
+            tokio::join!(run(&client, &target, first), run(&client, &target, second));
+        assert_eq!(first.unwrap()["sha256"], sha256);
+        assert_eq!(second.unwrap()["sha256"], sha256);
+        let requests = task.await.unwrap();
+        assert_eq!(requests.iter().filter(|r| r.starts_with("PUT ")).count(), 2);
+        assert_eq!(requests.iter().filter(|r| r.starts_with("GET ")).count(), 1);
+    }
+
+    #[tokio::test]
+    async fn interrupted_body_obeys_the_deadline_without_publishing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("record");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let client = client(&format!("http://{}", listener.local_addr().unwrap()));
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            assert!(stream.read(&mut request).await.unwrap() > 0);
+            stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nx").await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            run(
+                &client,
+                &target(),
+                Operation::Get { key: "record".into(), output_path: output.clone(), max_bytes: 3 },
+            ),
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(!output.exists());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+    }
+}

--- a/extensions/recall-r2/tests/cli.rs
+++ b/extensions/recall-r2/tests/cli.rs
@@ -1,0 +1,116 @@
+#![cfg(unix)]
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::{Value, json};
+
+fn command(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_recall-r2"));
+    command
+        .env_clear()
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env("AWS_CONFIG_FILE", home.join("aws-config"))
+        .env("AWS_SHARED_CREDENTIALS_FILE", home.join("aws-credentials"));
+    command
+}
+
+fn request(home: &Path, value: Value) -> Output {
+    let mut child = command(home)
+        .arg("--recall-remote-transport")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(&serde_json::to_vec(&value).unwrap()).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn configuration_path(home: &Path) -> std::path::PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/recall/r2.json")
+    } else {
+        home.join("config/recall/r2.json")
+    }
+}
+
+#[test]
+fn noninteractive_configuration_requires_explicit_destination_and_preserves_it_on_failure() {
+    let home = tempfile::tempdir().unwrap();
+    let path = configuration_path(home.path());
+    let output = command(home.path())
+        .arg("--recall-remote-configure")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!path.exists());
+    let output = command(home.path())
+        .args(["--recall-remote-configure", "--help"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!path.exists());
+    let args = [
+        "--recall-remote-configure",
+        "--endpoint",
+        "https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com",
+        "--bucket",
+        "recall-test",
+        "--prefix",
+        "recall",
+        "--credential-profile",
+        "recall-test",
+    ];
+    let output = command(home.path()).args(args).stdin(Stdio::null()).output().unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let saved = std::fs::read(&path).unwrap();
+    let config: Value = serde_json::from_slice(&saved).unwrap();
+    assert_eq!(config["prefix"], "recall/");
+    assert_eq!(config["credential_profile"], "recall-test");
+    let output = command(home.path())
+        .args(["--recall-remote-configure", "--bucket", "another-bucket"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&path).unwrap(), saved);
+    let output =
+        request(home.path(), json!({"transport_version":1,"operation":"probe","timeout_ms":1000}));
+    assert!(!output.status.success());
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["error"]["code"], "authentication");
+    assert!(response.get("result").is_none());
+}
+
+#[test]
+fn malformed_requests_fail_before_configuration_or_credentials_are_loaded() {
+    let home = tempfile::tempdir().unwrap();
+    for (operation, expected) in [
+        (
+            json!({"transport_version":8,"operation":"unknown","timeout_ms":1}),
+            "unsupported_protocol",
+        ),
+        (
+            json!({"transport_version":1,"operation":"list","timeout_ms":1,"prefix":"../","cursor":null,"page_size":1}),
+            "invalid_request",
+        ),
+        (
+            json!({"transport_version":1,"operation":"get","timeout_ms":1,"key":"a","output_path":"relative","max_bytes":1}),
+            "invalid_request",
+        ),
+        (json!({"transport_version":1,"operation":"probe","timeout_ms":1000}), "not_configured"),
+    ] {
+        let output = request(home.path(), operation);
+        assert!(!output.status.success());
+        let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(response["transport_version"], 1);
+        assert_eq!(response["error"]["code"], expected);
+        assert!(response.get("result").is_none());
+    }
+    assert!(!configuration_path(home.path()).exists());
+}


### PR DESCRIPTION
Adds `recall-r2` as the managed Cloudflare R2 provider for manual remote synchronization in Recall 0.6.0. The extension stores one non-sensitive destination, loads an existing local credential profile, and implements version 1 `probe`, `list`, `get`, and `put` transport operations. Core retains ownership of session identity, merging, and the index.

Uploads use conditional creation and verify actual existing bytes before treating a duplicate as successful. Downloads publish only complete bounded files. Operation deadlines cover SDK retries, blocking credential reads, streaming, and conflict verification. The configuration wizard saves no access keys and uploads no sessions.

Validation:
- `make check` passed, including the workspace audit, formatting, Clippy, and tests. The four allowed audit warnings concern versions already present in the base lockfile; no existing locked package version was replaced.
- All 17 plugin tests passed, using the real AWS SDK against a local HTTP server for pagination, errors, bounded downloads, retry, and concurrent writes.
- A blocked credential-file probe returned `transient` in 108 ms with a 100 ms budget. A separate 25-trial release test of deadline expiry returned 25 framed failures, with no aborts or panics; the previous runtime teardown aborted in 14 of 25 trials under the same trigger.
- Native macOS ARM64 release build, archive extraction, checksum equality, and extension manifest validation passed. The manifest requires core 0.6.0.

A live Cloudflare R2 round trip also passed with synthetic objects: probe, initial write/read with byte equality, duplicate and concurrent identical writes, different-content conflict with the original object preserved, an observed short-deadline failure followed by retry, missing-object classification, and three one-object listing pages. Three synthetic objects were retained; no remote deletion or user-session upload was performed.

Provider tests do not prove joint core behavior, actual two-machine session synchronization, denied-permission behavior in a live account, or published catalog installation. Joint core and actual two-machine acceptance remain required before merge. The remaining release targets and generated catalog must be verified through the existing release workflow.

Merging the initial extension version can automatically trigger publication. Do not merge until compatible core 0.6.0 is available and joint acceptance is complete.
