### PR TITLE
refactor(usage)!: fold stats card into usage --card

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,19 +80,27 @@ enum Commands {
     },
     #[command(about = "Show token usage reports")]
     Usage {
-        #[arg(long, help = "Output usage report as JSON")]
+        #[arg(long, help = "Output usage report as JSON", conflicts_with = "card")]
         json: bool,
-        #[arg(long, help = "Filter by source id or label")]
+        #[arg(long, help = "Filter by source id or label", conflicts_with = "card")]
         source: Option<String>,
-        #[arg(long, value_parser = crate::query::parse_time_range_arg, help = "Filter by time range")]
+        #[arg(
+            long,
+            value_parser = crate::query::parse_time_range_arg,
+            help = "Filter by time range",
+            conflicts_with = "card"
+        )]
         time: Option<String>,
-    },
-    #[command(about = "Print a shareable usage stats card")]
-    Wrapped {
-        #[arg(long, value_enum, default_value_t = crate::wrapped::WrappedPeriod::Week)]
+        #[arg(long, help = "Print a shareable usage stats card")]
+        card: bool,
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = crate::wrapped::WrappedPeriod::Week,
+            requires = "card",
+            help = "Card time window"
+        )]
         period: crate::wrapped::WrappedPeriod,
-        #[arg(long, value_enum, default_value_t = crate::wrapped::WrappedFormat::Text)]
-        format: crate::wrapped::WrappedFormat,
     },
     #[command(about = "Export session records as JSON Lines")]
     Export {
@@ -337,10 +345,9 @@ pub(crate) fn run() -> Result<()> {
                 )?
             }
         }
-        Some(Commands::Usage { json, source, time }) => {
-            crate::usage::run_cli(json, source.as_deref(), time.as_deref())?
+        Some(Commands::Usage { json, source, time, card, period }) => {
+            crate::usage::run_cli(json, source.as_deref(), time.as_deref(), card, period)?
         }
-        Some(Commands::Wrapped { period, format }) => crate::wrapped::run_cli(period, format)?,
         Some(Commands::Export { source, time, project, repo, thread_role, limit, include }) => {
             crate::export::run_cli(
                 source.as_deref(),
@@ -543,28 +550,21 @@ mod tests {
     }
 
     #[test]
-    fn wrapped_accepts_period_and_format() {
-        let cli = Cli::try_parse_from(["recall", "wrapped"]).unwrap();
+    fn usage_card_owns_period_and_excludes_report_flags() {
+        let cli = Cli::try_parse_from(["recall", "usage", "--card", "--period", "year"]).unwrap();
         match cli.command {
-            Some(Commands::Wrapped { period, format }) => {
-                assert_eq!(period, crate::wrapped::WrappedPeriod::Week);
-                assert_eq!(format, crate::wrapped::WrappedFormat::Text);
-            }
-            _ => panic!("expected wrapped command"),
-        }
-
-        let cli =
-            Cli::try_parse_from(["recall", "wrapped", "--period", "year", "--format", "json"])
-                .unwrap();
-        match cli.command {
-            Some(Commands::Wrapped { period, format }) => {
+            Some(Commands::Usage { card, period, json, .. }) => {
+                assert!(card);
+                assert!(!json);
                 assert_eq!(period, crate::wrapped::WrappedPeriod::Year);
-                assert_eq!(format, crate::wrapped::WrappedFormat::Json);
             }
-            _ => panic!("expected wrapped command"),
+            _ => panic!("expected usage command"),
         }
 
-        assert!(Cli::try_parse_from(["recall", "wrapped", "--period", "today"]).is_err());
+        assert!(Cli::try_parse_from(["recall", "usage", "--period", "year"]).is_err());
+        assert!(Cli::try_parse_from(["recall", "usage", "--card", "--time", "7d"]).is_err());
+        assert!(Cli::try_parse_from(["recall", "usage", "--card", "--json"]).is_err());
+        assert!(Cli::try_parse_from(["recall", "usage", "--card", "--source", "codex"]).is_err());
     }
 
     #[test]
@@ -693,7 +693,6 @@ mod tests {
         assert!(compact_help.contains("sync Scan configured AI coding session sources"));
         assert!(compact_help.contains("search Search indexed coding sessions"));
         assert!(compact_help.contains("usage Show token usage reports"));
-        assert!(compact_help.contains("wrapped Print a shareable usage stats card"));
         assert!(compact_help.contains("export Export session records as JSON Lines"));
         assert!(compact_help.contains("import Import session records from JSON Lines"));
         assert!(compact_help.contains("share Share session pages"));
@@ -841,12 +840,12 @@ mod tests {
         let script = String::from_utf8(output).unwrap();
         assert!(script.contains("#compdef recall"));
         assert!(script.contains("search"));
-        assert!(script.contains("wrapped"));
+        assert!(script.contains("usage"));
     }
 
     #[test]
     fn public_subcommand_help_describes_arguments_and_options() {
-        for subcommand in ["search", "usage", "wrapped", "export", "import"] {
+        for subcommand in ["search", "usage", "export", "import"] {
             let mut command = Cli::command();
             let command = command.find_subcommand_mut(subcommand).unwrap();
             let help = command.render_long_help().to_string();

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -22,7 +22,13 @@ pub(crate) fn run_cli(
     json: bool,
     source_filter: Option<&str>,
     time_filter: Option<&str>,
+    card: bool,
+    period: crate::wrapped::WrappedPeriod,
 ) -> Result<()> {
+    if card {
+        return crate::wrapped::run_card(period);
+    }
+
     let time_range = parse_time_range(time_filter)?;
     let sources = usage_source_labels();
 

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use chrono::{
     DateTime, Datelike, Days, Local, NaiveDate, NaiveDateTime, TimeDelta, TimeZone, Timelike,
 };
-use serde::Serialize;
 use unicode_width::UnicodeWidthStr;
 
 use crate::db::store::Store;
@@ -16,19 +15,12 @@ const INNER: usize = 52;
 const WEEKDAYS: [&str; 7] =
     ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub(crate) enum WrappedPeriod {
     Week,
     Month,
     Year,
     All,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub(crate) enum WrappedFormat {
-    Text,
-    Json,
 }
 
 impl WrappedPeriod {
@@ -70,28 +62,27 @@ fn first_valid_local_millis(
         .expect("local period boundary resolves within 48 hours")
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct WrappedTopModel {
     pub(crate) model: String,
     pub(crate) tokens: i64,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct WrappedTopSource {
     pub(crate) source: String,
     pub(crate) tokens: i64,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct WrappedSourceRow {
     pub(crate) source: String,
     pub(crate) sessions: usize,
     pub(crate) tokens: TokenTotals,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct WrappedReport {
-    pub(crate) protocol_version: u32,
     pub(crate) period: WrappedPeriod,
     pub(crate) empty: bool,
     pub(crate) tokens: TokenTotals,
@@ -187,7 +178,6 @@ impl WrappedAcc {
             };
 
         WrappedReport {
-            protocol_version: crate::PROTOCOL_VERSION,
             period,
             empty,
             tokens: self.tokens,
@@ -203,7 +193,7 @@ impl WrappedAcc {
     }
 }
 
-pub(crate) fn run_cli(period: WrappedPeriod, format: WrappedFormat) -> Result<()> {
+pub(crate) fn run_card(period: WrappedPeriod) -> Result<()> {
     let mut progress = StderrProgress::new();
     let report = crate::sync::run_usage_sync_job_with_progress(&mut |source: &str| {
         progress.show_source(source);
@@ -211,11 +201,7 @@ pub(crate) fn run_cli(period: WrappedPeriod, format: WrappedFormat) -> Result<()
     .and_then(|()| Store::open())
     .and_then(|store| build_wrapped_report(&store, period));
     progress.clear();
-    let report = report?;
-    match format {
-        WrappedFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
-        WrappedFormat::Text => print!("{}", render_card(&report, color_enabled())),
-    }
+    print!("{}", render_card(&report?, color_enabled()));
     Ok(())
 }
 
@@ -969,22 +955,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn json_uses_stable_snake_case_fields() {
-        let report = populated_report();
-        let value = serde_json::to_value(&report).unwrap();
-        assert_eq!(value["protocol_version"], crate::PROTOCOL_VERSION);
-        assert_eq!(value["period"], "month");
-        assert_eq!(value["empty"], false);
-        assert_eq!(value["busiest_weekday"], "thursday");
-        assert_eq!(value["busiest_hour"], 14);
-        assert_eq!(value["top_model"]["model"], "claude-sonnet");
-        assert_eq!(value["top_source"]["source"], "claude-code");
-        assert_eq!(value["tokens"]["input_tokens"], 990_000);
-        assert_eq!(value["by_source"][0]["source"], "claude-code");
-        assert!(value.get("costUsd").is_none());
-    }
-
     fn make_session(id: &str, source: &str) -> Session {
         Session {
             id: id.to_string(),
@@ -1041,14 +1011,6 @@ mod tests {
         assert_eq!(WrappedPeriod::Month.card_label(), "last 30 days");
         assert_eq!(WrappedPeriod::Year.card_label(), "last 365 days");
         assert_eq!(WrappedPeriod::All.card_label(), "all time");
-        let week = serde_json::to_value(WrappedPeriod::Week).unwrap();
-        let month = serde_json::to_value(WrappedPeriod::Month).unwrap();
-        let year = serde_json::to_value(WrappedPeriod::Year).unwrap();
-        let all = serde_json::to_value(WrappedPeriod::All).unwrap();
-        assert_eq!(week, "week");
-        assert_eq!(month, "month");
-        assert_eq!(year, "year");
-        assert_eq!(all, "all");
     }
 
     #[test]
@@ -1068,7 +1030,7 @@ mod tests {
     }
 
     #[test]
-    fn card_sanitizes_model_and_source_labels_json_stays_verbatim() {
+    fn card_sanitizes_model_and_source_labels_report_stays_verbatim() {
         let now = fixture_now();
         let model = "gpt-5\u{1b}]52;c;ZW1iZWQ=\u{07}\n\u{1b}[31m";
         let source = "claude-code\u{1b}[32m\ninjected";
@@ -1076,10 +1038,6 @@ mod tests {
         let report = aggregate_wrapped_events(&events, WrappedPeriod::All, now);
         assert_eq!(report.top_model.as_ref().map(|m| m.model.as_str()), Some(model));
         assert_eq!(report.top_source.as_ref().map(|s| s.source.as_str()), Some(source));
-        let json = serde_json::to_string(&report).unwrap();
-        assert!(json.contains("\\u001b]52;c;ZW1iZWQ=\\u0007"));
-        assert!(json.contains("claude-code\\u001b[32m\\ninjected"));
-
         let card = render_card(&report, false);
         assert!(card.contains("gpt-5"));
         assert!(card.contains("Claude Codeinjected"));


### PR DESCRIPTION
### What's changed?

- Remove the top-level `recall wrapped` command; the stats card now lives at `recall usage --card [--period week|month|year|all]`
- `--card` conflicts with `--json`, `--source`, and `--time`, so a report filter can never be silently ignored in card mode
- Drop the card's JSON output (`wrapped --format json`), along with `WrappedFormat`, the `Serialize` derives, and `WrappedReport::protocol_version`

### Why

- The card is a period-scoped view of usage data, not a separate capability. Two top-level commands were reading the same usage events and rendering them differently.
- The usage aggregation types (`UsageReport`, `TokenTotals`) are consumed by four TUI modules and back the `AppMode::Usage` dashboard, so the data layer has to stay in core. Only the command surface could be collapsed.
- The card keeps its own `--period` instead of reusing `--time`: `WrappedPeriod` aligns to local calendar days while `TimeRange` rolls back 7x24h, so reusing `--time` would have silently changed published card numbers.
- One output shape per mode. With `--card` limited to the rendered card, `--json` keeps a single meaning on this command.

### Verification

- `make check` passes (838 tests, includes `--features bench`)
- Card output diffed against the pre-change binary: `year` and `all` byte-identical; `week`/`month` drift reproduced across two consecutive runs of the same binary, confirming it comes from index growth rather than the change
- Flag conflicts exercised directly: `usage --card --source codex`, `--card --time 7d`, and `--card --json` are all rejected; `usage --json --source codex` and `usage --card --period year` still work

### Breaking change

`recall wrapped` is removed — use `recall usage --card`. The card's `--format json` output is removed with no replacement. `PROTOCOL_VERSION` is left at 2.