### PR TITLE
feat(remote): report sync progress and upload objects concurrently

### DIFF
--- a/docs/remote-sync.md
+++ b/docs/remote-sync.md
@@ -111,7 +111,7 @@ Every synchronization starts a full paginated enumeration, including empty pages
 with a continuation cursor. Repeated cursors and malformed or unsupported objects
 fail the operation. There is no high-water mark or remote deletion. Missing
 objects within the upload scope are restored from the retained local bytes.
-Each data object is limited to 64 MiB and each sync transport operation has a
+Each data object is limited to 512 MiB and each sync transport operation has a
 120-second deadline. Configuration probes have a 30-second deadline.
 
 Downloaded objects are verified before caching; applying revisions and metadata

--- a/src/db/remote_store.rs
+++ b/src/db/remote_store.rs
@@ -12,7 +12,9 @@ use crate::host::Location;
 use crate::project_scope::ProjectScope;
 use crate::types::Session;
 
-pub(crate) const OBJECT_LIMIT: usize = 64 * 1024 * 1024;
+const SQLITE_MAX_LENGTH: usize = 1_000_000_000;
+pub(crate) const OBJECT_LIMIT: usize = 512 * 1024 * 1024;
+const _: () = assert!(OBJECT_LIMIT < SQLITE_MAX_LENGTH);
 
 pub(crate) fn is_zero(value: &u32) -> bool {
     *value == 0
@@ -94,14 +96,20 @@ impl Store {
         Ok(sync_id)
     }
 
-    pub(crate) fn prepare_remote(&self, scope: &ProjectScope) -> Result<()> {
+    pub(crate) fn prepare_remote(
+        &self,
+        scope: &ProjectScope,
+        on_progress: &mut dyn FnMut(usize, usize),
+    ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         let sessions =
             self.list_export_sessions(None, super::search::TimeRange::All, scope, None, None)?;
         for session in &sessions {
             self.remote_identity(&session.id)?;
         }
-        for session in sessions {
+        let total = sessions.len();
+        for (index, session) in sessions.into_iter().enumerate() {
+            on_progress(index + 1, total);
             let id = session.id.clone();
             let sync_id = self.remote_identity(&id)?;
             let current: Option<String> = self.conn.query_row(
@@ -181,8 +189,20 @@ impl Store {
             .optional()?)
     }
 
+    pub(crate) fn cached_remote_size(&self, key: &str) -> Result<Option<u64>> {
+        let (table, hash) = object_parts(key)?;
+        Ok(self
+            .conn
+            .query_row(
+                &format!("SELECT LENGTH(body) FROM {table} WHERE digest = ?1"),
+                [hash],
+                |row| row.get(0),
+            )
+            .optional()?)
+    }
+
     pub(crate) fn cache_remote(&self, key: &str, body: &[u8]) -> Result<()> {
-        ensure!(body.len() <= OBJECT_LIMIT, "remote object exceeds 64 MiB");
+        ensure!(body.len() <= OBJECT_LIMIT, "remote object exceeds 512 MiB");
         let (table, hash) = object_parts(key)?;
         ensure!(digest(body) == hash, "remote object content hash mismatch");
         if table == "sync_revisions" {
@@ -298,7 +318,11 @@ impl Store {
         let tx = self.conn.unchecked_transaction()?;
         let hashes = self
             .conn
-            .prepare("SELECT digest FROM sync_revisions ORDER BY digest")?
+            .prepare(
+                "SELECT digest FROM sync_revisions r
+                 WHERE NOT EXISTS (SELECT 1 FROM sync_aliases a WHERE a.sync_id = r.sync_id)
+                 ORDER BY digest",
+            )?
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         for hash in &hashes {
@@ -514,11 +538,16 @@ impl Store {
                 .query_map([&session.id], |row| row.get::<_, String>(0))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             identities.extend(aliases);
-            keys.extend(
-                self.session_revisions(&session.id)?
-                    .keys()
-                    .map(|hash| format!("v1/revisions/{hash}.json")),
-            );
+            let digests = self
+                .conn
+                .prepare(
+                    "SELECT r.digest FROM sync_revisions r
+                     JOIN sync_aliases a ON a.sync_id = r.sync_id
+                     WHERE a.session_id = ?1",
+                )?
+                .query_map([&session.id], |row| row.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            keys.extend(digests.into_iter().map(|hash| format!("v1/revisions/{hash}.json")));
         }
         let metadata = self
             .conn

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::ffi::OsString;
 use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, ensure};
@@ -121,6 +123,8 @@ pub(crate) fn run(command: RemoteCommands) -> Result<()> {
     }
 }
 
+const UPLOAD_CONCURRENCY: usize = 16;
+
 #[derive(Default, Serialize)]
 struct SyncSummary {
     downloaded: usize,
@@ -134,15 +138,18 @@ fn synchronize(format: crate::info::InfoFormat) -> Result<()> {
         load_settings()?.context("remote is not connected; run recall remote connect")?;
     let connection =
         settings.connection.context("remote is disconnected; run recall remote connect")?;
+    let mut progress = crate::sync_progress::SyncProgress::for_phases();
+    progress.phase("Scanning sources");
     crate::sync::scan_remote_scope(connection.scope.clone())?;
     let store = Store::open()?;
-    let summary = exchange(&store, &connection, &mut |operation| {
+    let summary = exchange(&store, &connection, &mut progress, &|operation| {
         crate::extension::transport::invoke(
             &connection.provider,
             operation,
             Duration::from_secs(120),
         )
     })?;
+    progress.finish();
     match format {
         crate::info::InfoFormat::Json => println!("{}", serde_json::to_string(&summary)?),
         crate::info::InfoFormat::Text => println!(
@@ -156,9 +163,14 @@ fn synchronize(format: crate::info::InfoFormat) -> Result<()> {
 fn exchange(
     store: &Store,
     connection: &Connection,
-    transport: &mut dyn FnMut(&Operation) -> Result<Reply>,
+    progress: &mut crate::sync_progress::SyncProgress,
+    transport: &(dyn Fn(&Operation) -> Result<Reply> + Sync),
 ) -> Result<SyncSummary> {
-    store.prepare_remote(&connection.scope)?;
+    progress.phase("Preparing sessions");
+    store.prepare_remote(&connection.scope, &mut |done, total| {
+        progress.detail(format!("Preparing sessions {done}/{total}"))
+    })?;
+    progress.phase("Enumerating remote objects");
     let mut summary = SyncSummary::default();
     let mut cursor = None;
     let mut cursors = HashSet::new();
@@ -166,21 +178,21 @@ fn exchange(
     let temporary = tempfile::tempdir()?;
     loop {
         let Reply::Listed(page) =
-            transport(&Operation::List { prefix: "v1/".into(), cursor, page_size: 500 })?
+            transport(&Operation::List { prefix: "v1/".into(), cursor, page_size: 1000 })?
         else {
             anyhow::bail!("provider returned an invalid list result");
         };
         for object in page.objects {
             ensure!(
                 object.size <= crate::db::remote_store::OBJECT_LIMIT as u64,
-                "remote object exceeds 64 MiB"
+                "remote object exceeds 512 MiB"
             );
             if !remote_keys.insert(object.key.clone()) {
                 continue;
             }
-            if let Some(cached) = store.cached_remote(&object.key)? {
+            if let Some(cached) = store.cached_remote_size(&object.key)? {
                 ensure!(
-                    cached.len() as u64 == object.size,
+                    cached == object.size,
                     "remote object size differs from its cached content"
                 );
                 continue;
@@ -202,6 +214,11 @@ fn exchange(
             ensure!(body.len() as u64 == size, "downloaded object length mismatch");
             store.cache_remote(&object.key, &body)?;
             summary.downloaded += 1;
+            progress.detail(format!(
+                "Remote objects: {} listed, {} downloaded",
+                remote_keys.len(),
+                summary.downloaded
+            ));
         }
         cursor = page.next_cursor;
         if let Some(cursor) = &cursor {
@@ -210,27 +227,136 @@ fn exchange(
             break;
         }
     }
+    progress.phase("Merging revisions");
     summary.sessions_with_alternatives = store.merge_remote()?;
-    for key in store.remote_uploads(&connection.scope)? {
-        if remote_keys.contains(&key) {
-            continue;
-        }
-        let body =
-            store.cached_remote(&key)?.context("remote recovery object is missing locally")?;
-        let path = temporary.path().join("upload.json");
-        std::fs::write(&path, &body)?;
-        ensure!(
-            transport(&Operation::Put {
-                key,
-                input_path: path,
-                size: body.len() as u64,
-                sha256: crate::db::remote_store::digest(&body)
-            })? == Reply::Published,
-            "provider returned an invalid put result"
-        );
-        summary.uploaded += 1;
-    }
+    let uploads: Vec<String> = store
+        .remote_uploads(&connection.scope)?
+        .into_iter()
+        .filter(|key| !remote_keys.contains(key))
+        .collect();
+    progress.phase("Uploading objects");
+    summary.uploaded = upload_objects(store, progress, transport, uploads, temporary.path())?;
     Ok(summary)
+}
+
+struct Upload {
+    key: String,
+    path: PathBuf,
+    size: u64,
+    sha256: String,
+}
+
+fn stage_upload(store: &Store, directory: &Path, index: usize, key: String) -> Result<Upload> {
+    let body = store.cached_remote(&key)?.context("remote recovery object is missing locally")?;
+    let path = directory.join(format!("upload-{index}.json"));
+    std::fs::write(&path, &body)?;
+    let sha256 = crate::db::remote_store::digest(&body);
+    Ok(Upload { key, path, size: body.len() as u64, sha256 })
+}
+
+fn upload_objects(
+    store: &Store,
+    progress: &mut crate::sync_progress::SyncProgress,
+    transport: &(dyn Fn(&Operation) -> Result<Reply> + Sync),
+    uploads: Vec<String>,
+    directory: &Path,
+) -> Result<usize> {
+    let pending = uploads.len();
+    if pending == 0 {
+        return Ok(0);
+    }
+    let workers = UPLOAD_CONCURRENCY.min(pending);
+    let (sender, receiver) = std::sync::mpsc::sync_channel::<Upload>(workers);
+    let receiver = Mutex::new(receiver);
+    let uploaded = AtomicUsize::new(0);
+    let transferred = AtomicU64::new(0);
+    let aborted = AtomicBool::new(false);
+    let failure = Mutex::new(None);
+    let line = |done: usize, bytes: u64| {
+        format!(
+            "Uploading objects {done}/{pending} ({})",
+            crate::sync_progress::format_bytes(bytes)
+        )
+    };
+
+    std::thread::scope(|scope| -> Result<usize> {
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                scope.spawn(|| {
+                    while let Ok(upload) = receiver.lock().expect("upload queue").recv() {
+                        if aborted.load(Ordering::Relaxed) {
+                            continue;
+                        }
+                        let published = (|| -> Result<()> {
+                            let reply = transport(&Operation::Put {
+                                key: upload.key,
+                                input_path: upload.path.clone(),
+                                size: upload.size,
+                                sha256: upload.sha256,
+                            })?;
+                            ensure!(
+                                reply == Reply::Published,
+                                "provider returned an invalid put result"
+                            );
+                            std::fs::remove_file(&upload.path)?;
+                            Ok(())
+                        })();
+                        match published {
+                            Ok(()) => {
+                                uploaded.fetch_add(1, Ordering::Relaxed);
+                                transferred.fetch_add(upload.size, Ordering::Relaxed);
+                            }
+                            Err(error) => {
+                                aborted.store(true, Ordering::Relaxed);
+                                failure.lock().expect("upload failure").get_or_insert(error);
+                            }
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        let mut staging = Ok(());
+        for (index, key) in uploads.into_iter().enumerate() {
+            if aborted.load(Ordering::Relaxed) {
+                break;
+            }
+            match stage_upload(store, directory, index, key) {
+                Ok(upload) => {
+                    if sender.send(upload).is_err() {
+                        break;
+                    }
+                    progress.detail(line(
+                        uploaded.load(Ordering::Relaxed),
+                        transferred.load(Ordering::Relaxed),
+                    ));
+                }
+                Err(error) => {
+                    staging = Err(error);
+                    break;
+                }
+            }
+        }
+        drop(sender);
+
+        while !handles.iter().all(|handle| handle.is_finished()) {
+            progress.detail(line(
+                uploaded.load(Ordering::Relaxed),
+                transferred.load(Ordering::Relaxed),
+            ));
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        for handle in handles {
+            handle.join().map_err(|_| anyhow::anyhow!("upload worker panicked"))?;
+        }
+        staging?;
+        if let Some(error) = failure.lock().expect("upload failure").take() {
+            return Err(error);
+        }
+        progress
+            .detail(line(uploaded.load(Ordering::Relaxed), transferred.load(Ordering::Relaxed)));
+        Ok(uploaded.load(Ordering::Relaxed))
+    })
 }
 
 fn connect(
@@ -363,10 +489,13 @@ mod tests {
     }
 
     fn transfer(store: &Store, cloud: &mut BTreeMap<String, Vec<u8>>) -> Result<SyncSummary> {
+        let cloud = Mutex::new(cloud);
         exchange(
             store,
             &Connection { provider: "r2".into(), scope: ProjectScope::Global },
-            &mut |operation| {
+            &mut crate::sync_progress::SyncProgress::disabled(),
+            &|operation| {
+                let mut cloud = cloud.lock().expect("synthetic cloud");
                 Ok(match operation {
                     Operation::List { cursor, .. } => {
                         if cursor.is_none() {
@@ -408,6 +537,40 @@ mod tests {
                 })
             },
         )
+    }
+
+    #[test]
+    fn remote_large_revision_preserves_complete_events_and_recovers_objects() {
+        crate::db::schema::register_sqlite_vec();
+        let a = Store::open_in_memory().unwrap();
+        let b = Store::open_in_memory().unwrap();
+        let id = seed(&a, "large event snapshot", true);
+        let attrs = serde_json::json!({"payload": "x".repeat(64 * 1024 * 1024 + 1)}).to_string();
+        a.conn
+            .execute(
+                "UPDATE session_events SET attrs_json = ?1 WHERE session_id = ?2",
+                rusqlite::params![attrs, id],
+            )
+            .unwrap();
+        let mut cloud = BTreeMap::new();
+        transfer(&a, &mut cloud).unwrap();
+        assert!(cloud.values().any(|body| body.len() > 64 * 1024 * 1024));
+        transfer(&b, &mut cloud).unwrap();
+        let received = b.list_recent_sessions(1).unwrap().pop().unwrap();
+        let actual: String = b
+            .conn
+            .query_row(
+                "SELECT attrs_json FROM session_events WHERE session_id = ?1",
+                [&received.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(actual, attrs);
+        assert_eq!(transfer(&b, &mut cloud).unwrap().uploaded, 0);
+        let key = cloud.iter().max_by_key(|(_, body)| body.len()).unwrap().0.clone();
+        let lost = cloud.remove(&key).unwrap();
+        assert_eq!(transfer(&b, &mut cloud).unwrap().uploaded, 1);
+        assert_eq!(cloud[&key], lost);
     }
 
     #[test]

--- a/src/sync_progress.rs
+++ b/src/sync_progress.rs
@@ -27,7 +27,15 @@ impl SyncProgress {
     }
 
     pub(crate) fn for_terminal(total: usize) -> Self {
-        if total == 0 || !io::stderr().is_terminal() {
+        if total == 0 { Self::disabled() } else { Self::rendering(total) }
+    }
+
+    pub(crate) fn for_phases() -> Self {
+        Self::rendering(0)
+    }
+
+    fn rendering(total: usize) -> Self {
+        if !io::stderr().is_terminal() {
             return Self { total, index: 0, line: None, stop: None, ticker: None };
         }
         let line = Arc::new(Mutex::new(Line {
@@ -47,6 +55,15 @@ impl SyncProgress {
             })
         };
         Self { total, index: 0, line: Some(line), stop: Some(stop), ticker: Some(ticker) }
+    }
+
+    pub(crate) fn phase(&mut self, text: &str) {
+        let text = text.to_string();
+        self.with_line(|line| line.set_transient(text, true));
+    }
+
+    pub(crate) fn detail(&mut self, text: String) {
+        self.with_line(|line| line.set_transient(text, false));
     }
 
     pub(crate) fn begin_source(&mut self, label: &str) {
@@ -152,8 +169,17 @@ impl Line {
 pub(crate) fn format_bytes(bytes: u64) -> String {
     const GIB: f64 = (1u64 << 30) as f64;
     const MIB: f64 = (1u64 << 20) as f64;
+    const KIB: f64 = (1u64 << 10) as f64;
     let bytes = bytes as f64;
-    if bytes >= GIB { format!("{:.1} GiB", bytes / GIB) } else { format!("{:.0} MiB", bytes / MIB) }
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.0} MiB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.0} KiB", bytes / KIB)
+    } else {
+        format!("{bytes:.0} B")
+    }
 }
 
 pub(crate) fn format_elapsed(elapsed_ms: u128) -> String {


### PR DESCRIPTION
### What's changed?

- Render transient stderr progress for `recall remote sync`: phase lines for scanning, preparing, enumerating, merging and uploading, plus per-session and per-object detail.
- Upload objects across 16 workers behind a bounded queue. A failed put aborts the batch while workers keep draining, so the producer never blocks on a full channel with no consumer.
- Raise the per-object limit from 64 MiB to 512 MiB and update `docs/remote-sync.md`.
- Trim the incremental path: `merge_remote` skips revisions whose identity is already aliased, `remote_uploads` selects digests instead of materializing revision bodies, enumeration compares sizes via `LENGTH()`, and listing pages 1000 keys instead of 500.
- Extend `format_bytes` with KiB and B tiers so sub-megabyte totals no longer render as `0 MiB`. This also affects the `recall sync` compaction messages.

### Why

- A multi-minute sync printed nothing between start and finish, so it was indistinguishable from a hang.
- Each transport invocation forks a fresh provider process with a new TLS handshake. Serial uploads projected a 16k-object first sync at over four hours; measured end to end at 28 minutes with concurrency.
- A session revision carrying a large event snapshot exceeded 64 MiB and failed the entire sync, so an index containing one could not be published at all.
- Repeat syncs are the common case, and the incremental run is what users feel. Measured on a 9537-session index (6.58 GB of revision bodies, ~16k remote objects): 122s total, of which scanning 9s, preparing 44s, enumerating 35s, merging 11s, uploading 22s.