### PR TITLE
fix(remote): release upload queue lock before transfer

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -283,7 +283,9 @@ fn upload_objects(
         let handles: Vec<_> = (0..workers)
             .map(|_| {
                 scope.spawn(|| {
-                    while let Ok(upload) = receiver.lock().expect("upload queue").recv() {
+                    loop {
+                        let next = receiver.lock().expect("upload queue").recv();
+                        let Ok(upload) = next else { break };
                         if aborted.load(Ordering::Relaxed) {
                             continue;
                         }


### PR DESCRIPTION
### What's changed?

- Release the upload queue mutex before each remote transfer so upload workers can run concurrently.

### Why

- The previous `while let` temporary kept the receiver lock alive across the loop body and serialized all uploads.