### PR TITLE
fix(rx)!: stop redirecting harness homes in hosted mode

### DIFF
--- a/crates/rx/DESIGN.md
+++ b/crates/rx/DESIGN.md
@@ -27,11 +27,12 @@ read `recall.db`.
 | RX-ARGS-001 | Preserve argv and executable paths as OS strings. Treat everything after `--` as literal. |
 | RX-ROUTE-001 | `--provider none` or no provider means native passthrough without provider or model injection. |
 | RX-ROUTE-002 | Inject only the selected route, credential reference, model, and permission policy; preserve unrelated native behavior. |
+| RX-MINIMAL-001 | Injection is launch-scoped (flags, child environment, launch overlays). rx never redirects, replaces, or hides a harness's user-owned home or configuration discovery path in any mode, and never mutates user-owned configuration beyond marker-owned entries. |
 | RX-CATALOG-001 | Runtime model discovery decides availability only. Protocol-scoped model capabilities come from the bundled provider snapshot and apply only to the matching provider endpoint; unknown capabilities are never inferred. |
 | RX-OWN-001 | Mutate only explicitly rx-owned identities, preserve unowned data, follow each surface's owned-edit rule, lock, write atomically, and fail closed on malformed input. |
 | RX-SECRET-001 | Never put credentials in argv, logs, or broad-permission files. Persist only when unavoidable and owner-approved. |
 | RX-LIFECYCLE-001 | Install policy, planning controls, and child environment are separate scopes; rx-only controls never reach the child. |
-| RX-HOST-001 | Hosted mode isolates only the selected harness after install; it never creates or overrides unrelated harness homes. |
+| RX-HOST-001 | Hosted mode injects the same launch-scoped route as a native rx launch; it never overrides any harness home, and hosted state holds rx-internal runtime state only. |
 | RX-CONCURRENCY-001 | Concurrent launches cannot retarget, corrupt, or delete another launch or user edit. |
 | RX-FAIL-001 | Non-interactive runs never install or destructively repair without approval; malformed user config is preserved and reported. |
 
@@ -45,9 +46,9 @@ read `recall.db`.
 | Codex config | launch | Prefer `-c` and environment injection. |
 | OpenCode config | launch | Prefer `OPENCODE_CONFIG_CONTENT`; only warn about native auth conflicts. |
 | Pi `models.json` | shared | Own the selected provider entry; preserve the rest; reject malformed roots. |
-| DSH install and profile | user | Use the user's npm prefix and native `DSH_HOME` (`~/.dsh` by default); routing uses a launch overlay. Hosted mode does not override `DSH_HOME`. |
+| DSH install and profile | user | Use the user's npm prefix and native `DSH_HOME` (`~/.dsh` by default); routing uses a launch overlay. |
 | Kimi `config.toml` | shared | Use rx-prefixed marked entries; preserve collisions and user edits. Launch leases protect active catalog identities. Its required literal credential uses secret mode. |
-| Hosted state | host caller | Runtime state for the selected harness only; never an installation root. |
+| Hosted state | host caller | rx-internal runtime state only (catalog cache); harness homes are never redirected into it; never an installation root. |
 
 Injection preference is: flags or environment, immutable launch config, then a
 narrowly merged owned entry. Convenience never justifies persistent mutation.
@@ -72,8 +73,8 @@ migration, and older rx versions cannot write the migrated marker. Rolling
 back rx must preserve the new marker so older writers continue to fail closed.
 
 Hosted order is: select harness, discover or install in the user environment,
-build selected-harness state, validate route conflicts, execute with scoped
-runtime state. Route checks stop at `--`.
+validate route conflicts, execute with the same launch-scoped route injection
+as a native rx launch. Route checks stop at `--`.
 
 ## Adding a harness
 
@@ -90,8 +91,8 @@ Implementation must cover:
 
 Acceptance must prove native behavior, manual/rx install parity, reuse of an
 existing installation, passthrough and provider routing, preservation of
-unowned config, hosted isolation, real-TTY alias/picker behavior, and both
-`cargo test -p rx` and `make check`.
+unowned config, hosted route integrity, real-TTY alias/picker behavior, and
+both `cargo test -p rx` and `make check`.
 
 ## Change authority
 

--- a/crates/rx/HOSTING.md
+++ b/crates/rx/HOSTING.md
@@ -15,7 +15,7 @@ Handshake (no request environment set):
 
 ```
 $ rx host
-{"protocol":{"major":1,"minor":0},"version":"0.5.7","harnesses":["claude","codex","opencode","pi","dsh","kimi"]}
+{"protocol":{"major":1,"minor":1},"version":"0.6.0","harnesses":["claude","codex","opencode","pi","dsh","kimi"]}
 ```
 
 Launch: `rx host -- <native harness args>` with two environment variables:
@@ -43,10 +43,11 @@ Rules the request must satisfy — rx rejects violations instead of guessing:
 
 - Unknown fields are rejected (`deny_unknown_fields`). Never add fields
   without a protocol version bump on the rx side.
-- `state_dir` must be absolute. rx scopes each harness's runtime state
-  under it (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `XDG_DATA_HOME`,
-  `PI_CODING_AGENT_DIR`, `KIMI_CODE_HOME`) so hosted runs never touch the
-  user's own harness configuration.
+- `state_dir` must be absolute. rx keeps its own runtime state (catalog
+  cache) under it. Harness homes are never redirected: hosted sessions see
+  the user's own harness configuration (skills, agents, settings), exactly
+  like a native launch. Protocol minor 1 marks this semantic; before it,
+  rx scoped harness homes under `state_dir`.
 - `harness` is optional; when omitted, rx shows its interactive picker.
 - `install_policy` is `prompt` or `deny`; `permission_policy` is
   `standard`.
@@ -61,7 +62,13 @@ What rx guarantees in return:
   reimplement or pre-filter these — pass native args through verbatim and
   let rx be the authority.
 - Discovery/installation of the harness binary uses the user-owned harness
-  home; hosted state is runtime-only, never an installation root.
+  home; hosted state is rx-internal runtime state only, never an
+  installation root.
+- Hosted launches use the same launch-scoped injection as native rx
+  launches (flags and child environment). User harness configuration stays
+  visible and is never rewritten beyond marker-owned catalog entries; the
+  gateway route is enforced by injection precedence plus the route guards
+  above.
 - The key is read from the environment and injected into the launch plan;
   it never appears in argv.
 

--- a/crates/rx/src/host.rs
+++ b/crates/rx/src/host.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -89,12 +88,9 @@ pub(crate) fn run(passthrough: Vec<OsString>, env: &EnvLookup) -> Result<()> {
     let launch_request = LaunchRequest { harness, provider: None, passthrough };
     let install_env = EnvLookup::real_with(install_overrides(request.install_policy));
     let program = crate::install::ensure(harness, &install_env)?;
-    let runtime = runtime_overrides(harness, &paths.dir)?;
-    prepare_state(&runtime)?;
-    let planning_env = EnvLookup::real_with(planning_overrides(&runtime));
+    let planning_env = EnvLookup::real_with(planning_overrides());
     let mut plan = crate::launch::plan_target(&launch_request, &paths, &planning_env, &target)?;
     plan.program = program;
-    plan.env_set.extend(runtime);
     if let Some(note) = &plan.stderr_note {
         eprintln!("{note}");
     }
@@ -103,7 +99,7 @@ pub(crate) fn run(passthrough: Vec<OsString>, env: &EnvLookup) -> Result<()> {
 
 fn capabilities_json() -> Result<String> {
     serde_json::to_string(&Capabilities {
-        protocol: Protocol { major: 1, minor: 0 },
+        protocol: Protocol { major: 1, minor: 1 },
         version: crate::RELEASE_VERSION,
         harnesses: Harness::ALL.iter().map(|harness| harness.as_str()).collect(),
     })
@@ -166,37 +162,8 @@ fn install_overrides(policy: InstallPolicy) -> HashMap<String, String> {
     )])
 }
 
-fn runtime_overrides(harness: Harness, state_dir: &Path) -> Result<HashMap<String, String>> {
-    let Some((key, suffix)) = (match harness {
-        Harness::Claude => Some(("CLAUDE_CONFIG_DIR", "claude")),
-        Harness::Codex => Some(("CODEX_HOME", "codex")),
-        Harness::OpenCode => Some(("XDG_DATA_HOME", "data")),
-        Harness::Pi => Some(("PI_CODING_AGENT_DIR", "pi-agent")),
-        Harness::Dsh => None,
-        Harness::Kimi => Some(("KIMI_CODE_HOME", "kimi-code")),
-    }) else {
-        return Ok(HashMap::new());
-    };
-    let path = state_dir
-        .join(suffix)
-        .to_str()
-        .map(str::to_string)
-        .ok_or_else(|| anyhow::anyhow!("host state_dir must be UTF-8"))?;
-    Ok(HashMap::from([(key.to_string(), path)]))
-}
-
-fn planning_overrides(runtime: &HashMap<String, String>) -> HashMap<String, String> {
-    let mut environment = runtime.clone();
-    environment.insert("RX_NO_YOLO".to_string(), "1".to_string());
-    environment
-}
-
-fn prepare_state(environment: &HashMap<String, String>) -> Result<()> {
-    for path in environment.values() {
-        fs::create_dir_all(path)
-            .with_context(|| format!("failed to create hosted state {path}"))?;
-    }
-    Ok(())
+fn planning_overrides() -> HashMap<String, String> {
+    HashMap::from([("RX_NO_YOLO".to_string(), "1".to_string())])
 }
 
 fn target(profile: &GatewayProfile, key: String) -> ProviderTarget {
@@ -340,7 +307,7 @@ mod tests {
     #[test]
     fn capabilities_are_stable() {
         let value: serde_json::Value = serde_json::from_str(&capabilities_json().unwrap()).unwrap();
-        assert_eq!(value["protocol"], serde_json::json!({"major": 1, "minor": 0}));
+        assert_eq!(value["protocol"], serde_json::json!({"major": 1, "minor": 1}));
         assert_eq!(
             value["harnesses"],
             serde_json::json!(["claude", "codex", "opencode", "pi", "dsh", "kimi"])
@@ -496,27 +463,21 @@ mod tests {
     }
 
     #[test]
-    fn hosted_environment_scopes_are_harness_specific() {
-        let root = tempfile::tempdir().unwrap();
-        let state = root.path().join("tokener-agent");
-        let cases = [
-            (Harness::Claude, Some(("CLAUDE_CONFIG_DIR", "claude"))),
-            (Harness::Codex, Some(("CODEX_HOME", "codex"))),
-            (Harness::OpenCode, Some(("XDG_DATA_HOME", "data"))),
-            (Harness::Pi, Some(("PI_CODING_AGENT_DIR", "pi-agent"))),
-            (Harness::Dsh, None),
-            (Harness::Kimi, Some(("KIMI_CODE_HOME", "kimi-code"))),
-        ];
-        for (harness, expected) in cases {
-            let environment = runtime_overrides(harness, &state).unwrap();
-            assert_eq!(environment.len(), usize::from(expected.is_some()));
-            if let Some((key, suffix)) = expected {
-                assert_eq!(environment[key], state.join(suffix).to_str().unwrap());
-            }
-            prepare_state(&environment).unwrap();
-            assert!(environment.values().all(|path| Path::new(path).is_dir()));
+    fn hosted_launch_never_redirects_harness_homes() {
+        let planning = planning_overrides();
+        assert_eq!(planning, HashMap::from([("RX_NO_YOLO".to_string(), "1".to_string())]));
+        for key in [
+            "CLAUDE_CONFIG_DIR",
+            "CODEX_HOME",
+            "XDG_DATA_HOME",
+            "PI_CODING_AGENT_DIR",
+            "DSH_HOME",
+            "KIMI_CODE_HOME",
+        ] {
+            assert!(!planning.contains_key(key));
+            assert!(!install_overrides(InstallPolicy::Prompt).contains_key(key));
+            assert!(!install_overrides(InstallPolicy::Deny).contains_key(key));
         }
-        assert!(!state.join("dsh-home").exists());
     }
 
     #[test]
@@ -529,10 +490,7 @@ mod tests {
             install_overrides(InstallPolicy::Deny),
             HashMap::from([("RX_NO_INSTALL".to_string(), "1".to_string())])
         );
-        let runtime = runtime_overrides(Harness::Codex, Path::new("/tmp/tokener-agent")).unwrap();
-        assert!(!runtime.contains_key("RX_NO_INSTALL"));
-        assert!(!runtime.contains_key("RX_NO_YOLO"));
-        let planning = planning_overrides(&runtime);
+        let planning = planning_overrides();
         assert_eq!(planning["RX_NO_YOLO"], "1");
         assert!(!planning.contains_key("RX_NO_INSTALL"));
     }


### PR DESCRIPTION
## Problem

Launching Claude Code through `tokener agent claude` (rx host) hid the user's skills, agents, commands, and settings: hosted mode overrode `CLAUDE_CONFIG_DIR` (and `CODEX_HOME`, `XDG_DATA_HOME`, `PI_CODING_AGENT_DIR`, `KIMI_CODE_HOME`) into the host `state_dir`, pointing each harness at an empty config root. Route integrity never depended on this redirection — the gateway route is carried by launch-scoped `--settings`/env injection plus the existing route guards.

## Change

- `rx host` no longer sets any harness home variable; hosted launches use the same launch-scoped injection as a native rx launch. `state_dir` stays wire-compatible and keeps only rx-internal runtime state (catalog cache).
- Host protocol minor bumps to 1.1 to mark the semantic (embedders gate on `major == 1`, minor is additive).
- `DESIGN.md`: new invariant `RX-MINIMAL-001` (injection is launch-scoped; harness homes and configuration discovery are never redirected or hidden in any mode), `RX-HOST-001` rewritten, hosted ownership/order updated. `HOSTING.md` documents the boundary and the minor-1 semantic split.
- Regression test asserts hosted control/planning environments carry no harness home overrides.

## Verification

- `cargo test -p rx` (159 passed) and `make check` (audit, fmt, clippy, workspace tests) green.
- End-to-end through the real tokener CLI with `TOKENER_RX` pointing at this build: the hosted child environment carries no `CLAUDE_CONFIG_DIR`, while `ANTHROPIC_BASE_URL` and the seeded `--settings` route injection are intact against the production gateway endpoint.
- Baseline comparison against the embedded pre-change rx confirms an unrelated pre-existing local credential 403; identical on both builds, not introduced here.

## Follow-ups (out of scope)

- tokener re-embeds a released rx to pick this up; `state_dir` field disposition is deferred to protocol 2.
- Cleanup of non-essential injected env vars (telemetry, system-prompt, max-context) is deferred by owner decision.